### PR TITLE
Add mandatory pre-PR quality gate documentation for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,34 @@ Before making changes, read the relevant steering files in `specs/steering/`:
 - **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules (especially relevant for `**/analyzer/**` files)
 - **[Steering File Guidelines](specs/steering/steering-file-guidelines.md)** - How to create and maintain steering files (for AI assistants updating documentation)
 
+## MANDATORY: Before Creating a PR
+
+**You MUST run the full CI pipeline and verify it passes before creating any PR:**
+
+```bash
+cd compiler && just
+```
+
+This runs compile, test, coverage, AND lint (clippy + fmt). **All checks must pass.**
+
+If any check fails:
+1. Fix the issues
+2. Re-run `cd compiler && just`
+3. Only create the PR after all checks pass
+
+**Common failures:**
+- **Clippy warnings** - Fix all clippy issues; the lint step runs `cargo clippy`
+- **Format issues** - Run `cd compiler && just format` to auto-fix
+- **Coverage below 85%** - Add tests for uncovered code
+
 ## Quick Reference
 
 ### Key Commands
-- `cd compiler && just` - Run full CI pipeline (compile, test, coverage, lint)
+- `cd compiler && just` - **Run full CI pipeline (REQUIRED before PR)**
 - `cd compiler && just compile` - Build the compiler
 - `cd compiler && just test` - Run all tests
 - `cd compiler && just coverage` - Run tests with coverage (requires 85%)
+- `cd compiler && just lint` - Run clippy and format checks
 - `just devenv-smoke` - Quick environment check
 
 See [specs/steering/common-tasks.md](specs/steering/common-tasks.md) for complete command reference.
@@ -30,7 +51,8 @@ See [specs/steering/common-tasks.md](specs/steering/common-tasks.md) for complet
 - `docs/` - Sphinx documentation website
 
 ### Critical Rules
-1. **BDD-style test names**: `function_when_condition_then_result`
-2. **Module size limit**: Max 1000 lines per module
-3. **Problem codes**: Must be documented in `docs/compiler/problems/P####.rst`
-4. **Version numbers**: Automatically managed - do not edit manually
+1. **Run `cd compiler && just` before creating any PR** - This runs clippy, tests, and all checks
+2. **BDD-style test names**: `function_when_condition_then_result`
+3. **Module size limit**: Max 1000 lines per module
+4. **Problem codes**: Must be documented in `docs/compiler/problems/P####.rst`
+5. **Version numbers**: Automatically managed - do not edit manually

--- a/specs/steering/common-tasks.md
+++ b/specs/steering/common-tasks.md
@@ -15,6 +15,63 @@ IronPLC uses [just](https://github.com/casey/just) as its command runner. All bu
 - **`docs/justfile`**: Documentation build and publishing
 - **`integrations/vscode/justfile`**: VS Code extension tasks
 
+## CRITICAL: Pre-PR Requirements
+
+**Before creating any pull request, you MUST run the full CI pipeline and ensure all checks pass.**
+
+### For Compiler Changes (Most Common)
+
+```bash
+cd compiler && just
+```
+
+This single command runs **all required checks**:
+1. `compile` - Build the compiler
+2. `test` - Run all tests
+3. `coverage` - Verify 85% line coverage threshold
+4. `lint` - Run **clippy** and **rustfmt** checks
+
+**All four checks must pass before creating a PR.** CI will reject PRs that fail any of these checks.
+
+### What Each Check Does
+
+| Check | Command | What it validates |
+|-------|---------|-------------------|
+| Compile | `cargo build` | Code compiles without errors |
+| Test | `cargo test --all-targets` | All tests pass |
+| Coverage | `cargo llvm-cov ...` | Line coverage ≥ 85% |
+| **Lint** | `cargo clippy` + `cargo fmt --check` | No clippy warnings, code is formatted |
+
+### Fixing Common Failures
+
+**Clippy failures:**
+```bash
+cd compiler && cargo clippy  # See warnings
+# Fix the issues manually, OR:
+cd compiler && just format   # Auto-fix some issues
+```
+
+**Format failures:**
+```bash
+cd compiler && just format   # Auto-fix formatting
+```
+
+**Coverage failures:**
+```bash
+cd compiler && just coverage  # Shows missing lines
+# Add tests for uncovered code paths
+```
+
+### Pre-PR Checklist for AI Assistants
+
+Before creating a PR, verify:
+- [ ] `cd compiler && just` completes successfully
+- [ ] All clippy warnings are resolved (not suppressed)
+- [ ] Code is properly formatted
+- [ ] Coverage threshold is met
+- [ ] For VS Code extension changes: `cd integrations/vscode && just ci`
+- [ ] For documentation changes: `cd docs && just`
+
 ## Most Common Commands
 
 **All components support these standard commands:**
@@ -24,7 +81,7 @@ cd [component]   # compiler, docs, or integrations/vscode
 just             # Run the default CI pipeline for this component
 just compile     # Build the component
 just test        # Run tests (or validation for docs)
-just lint        # Check for style/formatting issues
+just lint        # Check for style/formatting issues (includes clippy for Rust)
 just clean       # Remove build artifacts
 ```
 
@@ -196,7 +253,8 @@ The commit workflow runs:
 1. Compilation of all components
 2. Full test suite
 3. Coverage check (85% threshold)
-4. Linting and formatting checks
-5. Documentation build
+4. **Linting checks (including clippy for Rust code)**
+5. Format checks (rustfmt)
+6. Documentation build
 
-All of these can be run locally with `just` commands before pushing.
+**All of these checks run on every PR. Run `cd compiler && just` locally before creating a PR to catch issues early.**

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -195,12 +195,30 @@ The compiler supports various levels of IEC 61131-3 compliance:
 
 ### Just Commands
 Use `just` for all build tasks. Key commands:
-- `just` - Run tests for the current component
+- `just` - Run full CI pipeline for the current component
 - `just compile` - Build the component
-- `just ci` - Run full CI pipeline
+- `just test` - Run tests
+- `just lint` - Run linting (clippy + fmt for Rust)
 - `just devenv-smoke` - Quick environment check
 
 For complete setup and development workflow instructions, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+### CRITICAL: Pre-PR Quality Gate
+
+**Before creating any pull request, you MUST run and pass the full CI pipeline:**
+
+```bash
+cd compiler && just
+```
+
+This runs compile, test, coverage, and lint. The **lint step includes clippy**, which catches common Rust issues. PRs that fail clippy will be rejected by CI.
+
+**Do not:**
+- Skip running `just` before creating a PR
+- Suppress clippy warnings with `#[allow(...)]` unless justified
+- Create a PR if any check fails
+
+See [common-tasks.md](./common-tasks.md) for detailed pre-PR requirements and troubleshooting.
 
 ### Version Management
 **Version numbers are generated and incremented automatically** - no manual version management is required:


### PR DESCRIPTION
Add prominent "MANDATORY: Before Creating a PR" sections to steering files
to ensure AI agents always run clippy and the full CI pipeline before
creating pull requests.

Changes:
- CLAUDE.md: Add prominent pre-PR section with explicit clippy mention
- common-tasks.md: Add detailed pre-PR requirements with checklist
- development-standards.md: Add CRITICAL pre-PR quality gate section

The documentation now explicitly states that `cd compiler && just` must
pass (which includes clippy via `just lint`) before any PR is created.

https://claude.ai/code/session_01Jw8oMntryWhi4ZcJt7tRBq