### PR TITLE
Remove dead commented code for Retentive/NonRetentive variants

### DIFF
--- a/compiler/parser/src/vars.rs
+++ b/compiler/parser/src/vars.rs
@@ -128,9 +128,6 @@ pub enum VarDeclarations {
     Var(Vec<VarDecl>),
     // external_declarations
     External(Vec<VarDecl>),
-    // TODO
-    // Retentive(Vec<VarDecl>),
-    // NonRetentive(Vec<VarDecl>),
     Incomplete(Vec<IncomplVarDecl>),
     ProgramAccess(Vec<ProgramAccessDecl>),
     ConfigAccess(Vec<AccessDeclaration>),


### PR DESCRIPTION
The commented code represented an alternative design approach for
retentive variables that was not used. The actual implementation
uses VarDeclarations::Var with DeclarationQualifier::Retain and
DeclarationQualifier::NonRetain instead of separate enum variants.

https://claude.ai/code/session_013XNMeqCCY1BMqojx2zszum