### PR TITLE
Update VS Code extension README and add steering for README sync

### DIFF
--- a/integrations/vscode/README.md
+++ b/integrations/vscode/README.md
@@ -3,7 +3,7 @@
 IronPLC brings IEC 61131-3 support to Visual Studio Code.
 
 ⚠ This project's capabilities are limited to a parser, semantic analyzer, and
-Visual Studio Code Extension that are that are building blocks for a complete
+Visual Studio Code Extension that are building blocks for a complete
 IEC 61131-3 runtime and development environment.
 
 ## Quick Start
@@ -12,24 +12,76 @@ IEC 61131-3 runtime and development environment.
 on your system.
 * **Step 2.** Open or create an IEC 61131-3 file and start coding.
 
-## Useful commands
+## Supported File Types
+
+| **File Type** | **Extensions** | **Description** |
+|---------------|----------------|-----------------|
+| Structured Text | `.st`, `.iec` | IEC 61131-3 Structured Text source files |
+| PLCopen XML | Auto-detected | PLCopen TC6 XML project files with embedded Structured Text |
+
+## Features
+
+### Syntax Highlighting
+
+Full syntax highlighting for IEC 61131-3 Structured Text including:
+
+* Keywords (PROGRAM, FUNCTION, FUNCTION_BLOCK, VAR, IF, FOR, WHILE, etc.)
+* Data types (BOOL, INT, REAL, STRING, TIME, etc.)
+* Operators and literals
+* Comments (`(* block comments *)`)
+
+PLCopen XML files are also highlighted with embedded Structured Text support.
+
+### Real-Time Analysis
+
+As you type, IronPLC analyzes your code and reports:
+
+* Syntax errors
+* Semantic errors (type mismatches, undefined variables, etc.)
+* Warnings for potential issues
+
+Diagnostics appear inline and in the Problems panel.
+
+### Auto-Closing Pairs
+
+The extension automatically closes:
+
+* **Brackets and strings**: `[]`, `()`, `''`, `""`
+* **Comments**: `(* *)`
+* **Control structures**: `IF`/`END_IF`, `FOR`/`END_FOR`, `WHILE`/`END_WHILE`, `CASE`/`END_CASE`, `REPEAT`/`END_REPEAT`
+* **Program units**: `PROGRAM`/`END_PROGRAM`, `FUNCTION`/`END_FUNCTION`, `FUNCTION_BLOCK`/`END_FUNCTION_BLOCK`
+* **Variable blocks**: `VAR`/`END_VAR`, `VAR_INPUT`/`END_VAR`, `VAR_OUTPUT`/`END_VAR`, and other VAR types
+* **Other blocks**: `STRUCT`/`END_STRUCT`, `ACTION`/`END_ACTION`, `CONFIGURATION`/`END_CONFIGURATION`
+
+### Bracket Colorization
+
+Matching brackets are colorized to help visualize nesting levels.
+
+## Commands
 
 Open the Command Palette (Command+Shift+P on macOS and Ctrl+Shift+P
 on Windows) and type in one of the following commands:
 
 | **Command** | **Description** |
 |-------------|-----------------|
-| `New Structured Text File` | Create a new IEC 61131-3 structured text file. |
-
-## Features
-
-* Automatic closing of brackets and keywords
-* Syntax highlighting (limited)
-* Syntax checking (limited)
+| `IronPLC: New Structured Text File` | Create a new IEC 61131-3 structured text file |
 
 ## Extension Settings
 
-| **Setting**     | **Description**       |
-|-----------------|-----------------------|
-| `ironplc.path`  | The path to the IronPLC compiler. |
-| `ironplc.logLevel` | The log level for the IronPLC compiler. |
+| **Setting** | **Description** | **Default** |
+|-------------|-----------------|-------------|
+| `ironplc.path` | Path to the IronPLC compiler executable. If empty, discovers based on PATH. | (empty) |
+| `ironplc.logLevel` | Log level for the compiler: ERROR, WARN, INFO, DEBUG, or TRACE | ERROR |
+| `ironplc.logFile` | Path to write compiler logs. If empty, logs are not written to file. | (empty) |
+
+## Platform Support
+
+The extension works on:
+
+* Windows
+* macOS
+* Linux
+
+## Learn More
+
+Visit [ironplc.com](https://www.ironplc.com) for documentation, tutorials, and guides.

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -168,6 +168,23 @@ To fix this error, [solution]:
    [Corrected example]
 ```
 
+### README Synchronization
+The project has multiple README files that must stay synchronized:
+
+- **Root `README.md`**: Main project overview, mission, progress, and capabilities
+- **`integrations/vscode/README.md`**: VS Code Extension specific documentation for the Marketplace
+
+**When updating the main README:**
+1. Review if the extension README needs corresponding updates
+2. The extension README should reflect the same capabilities/limitations
+3. Keep the "warning" banner (`⚠`) consistent between both files
+4. Ensure feature lists match (e.g., syntax highlighting, analysis capabilities)
+
+**When updating the extension README:**
+1. Keep it focused on VS Code-specific usage and features
+2. Include extension settings, commands, and configuration
+3. Reference the main documentation website for detailed information
+
 ### Code Documentation
 - **Best effort** documentation for now, but focus on public APIs
 - Use Rust doc comments (`///`) for public functions and types


### PR DESCRIPTION
- Expand extension README with detailed feature documentation including
  syntax highlighting, real-time analysis, auto-closing pairs, and
  supported file types
- Add platform support and extension settings documentation
- Fix typo in warning banner ("that are that are" -> "that are")
- Add README synchronization guidelines to development-standards.md
  steering file to ensure main and extension READMEs stay in sync

https://claude.ai/code/session_014YbUevscfSxr7gyRE9UcMV