### PR TITLE
Remove redundant test step from CI pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Before making changes, read the relevant steering files in `specs/steering/`:
 cd compiler && just
 ```
 
-This runs compile, test, coverage, AND lint (clippy + fmt). **All checks must pass.**
+This runs compile, coverage (which includes tests), AND lint (clippy + fmt). **All checks must pass.**
 
 If any check fails:
 1. Fix the issues

--- a/compiler/justfile
+++ b/compiler/justfile
@@ -1,7 +1,8 @@
 set windows-shell := ["powershell.exe", "-c"]
 
 alias ci := default
-default: compile test coverage lint
+# Coverage runs all tests with instrumentation, so separate test step is redundant
+default: compile coverage lint
 
 setup:
   cargo install cargo-release

--- a/specs/steering/common-tasks.md
+++ b/specs/steering/common-tasks.md
@@ -27,19 +27,17 @@ cd compiler && just
 
 This single command runs **all required checks**:
 1. `compile` - Build the compiler
-2. `test` - Run all tests
-3. `coverage` - Verify 85% line coverage threshold
-4. `lint` - Run **clippy** and **rustfmt** checks
+2. `coverage` - Run all tests and verify 85% line coverage threshold
+3. `lint` - Run **clippy** and **rustfmt** checks
 
-**All four checks must pass before creating a PR.** CI will reject PRs that fail any of these checks.
+**All three checks must pass before creating a PR.** CI will reject PRs that fail any of these checks.
 
 ### What Each Check Does
 
 | Check | Command | What it validates |
 |-------|---------|-------------------|
 | Compile | `cargo build` | Code compiles without errors |
-| Test | `cargo test --all-targets` | All tests pass |
-| Coverage | `cargo llvm-cov ...` | Line coverage ≥ 85% |
+| Coverage | `cargo llvm-cov ...` | All tests pass and line coverage ≥ 85% |
 | **Lint** | `cargo clippy` + `cargo fmt --check` | No clippy warnings, code is formatted |
 
 ### Fixing Common Failures
@@ -91,7 +89,8 @@ just clean       # Remove build artifacts
 
 ```bash
 cd compiler
-just             # Runs: compile, test, coverage, lint
+just             # Runs: compile, coverage, lint
+just test        # Run tests only (without coverage instrumentation)
 just coverage    # Run tests with coverage (requires 85% line coverage)
 just format      # Auto-fix linting errors
 just clean       # Remove build artifacts (target/, lcov.info)


### PR DESCRIPTION
The coverage step (cargo llvm-cov) already runs all tests with
instrumentation, so running tests separately beforehand was redundant.
This change reduces CI build time by eliminating duplicate test runs.

The standalone `just test` command remains available for quick local
testing without coverage instrumentation.

https://claude.ai/code/session_01HNTsGgs4abC9iMN38w2DbK