### PR TITLE
Add TextMate grammar schema validation to VS Code extension build

### DIFF
--- a/integrations/vscode/package-lock.json
+++ b/integrations/vscode/package-lock.json
@@ -21,6 +21,7 @@
         "@typescript-eslint/parser": "^8.0.0",
         "@vscode/test-electron": "^2.2.3",
         "@vscode/vsce": "^3.0.0",
+        "ajv-cli": "^5",
         "esbuild": "^0.25.0",
         "eslint": "^9.0.0",
         "glob": "^11.0.0",
@@ -1958,6 +1959,103 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "ajv": "dist/index.js"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-cli/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/ajv-cli/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/ajv-cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ajv-cli/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/ajv-cli/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
@@ -3135,6 +3233,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3228,6 +3340,26 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3428,6 +3560,13 @@
       "engines": {
         "node": ">=14.14"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3844,6 +3983,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -4073,6 +4224,16 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -4520,7 +4681,6 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4789,7 +4949,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5123,6 +5282,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -5871,6 +6040,13 @@
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -6659,8 +6835,7 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -121,10 +121,12 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
-    "lint": "eslint src/**/*.ts",
+    "validate-grammars": "ajv validate -s schemas/tmlanguage.json -d \"syntaxes/*.tmLanguage.json\"",
+    "lint": "eslint src/**/*.ts && npm run validate-grammars",
     "test:functional": "node ./out/test/functional/runTest.js"
   },
   "devDependencies": {
+    "ajv-cli": "^5",
     "@stylistic/eslint-plugin": "^5",
     "@stylistic/eslint-plugin-ts": "^4",
     "@types/mocha": "^10.0.0",

--- a/integrations/vscode/schemas/tmlanguage.json
+++ b/integrations/vscode/schemas/tmlanguage.json
@@ -1,0 +1,290 @@
+{
+  "$comment": "Source: https://github.com/martinring/tmlanguage - MIT License (c) 2016 Martin Ring",
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "$ref": "#/definitions/root",
+  "definitions": {
+    "root": {
+      "allOf": [
+        { "$ref": "#/definitions/grammar" },
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "scopeName": {
+              "description": "this should be a unique name for the grammar, following the convention of being a dot-separated name where each new (left-most) part specializes the name. Normally it would be a two-part name where the first is either text or source and the second is the name of the language or document type. But if you are specializing an existing type, you probably want to derive the name from the type you are specializing. For example Markdown is text.html.markdown and Ruby on Rails (rhtml files) is text.html.rails. The advantage of deriving it from (in this case) text.html is that everything which works in the text.html scope will also work in the text.html.«something» scope (but with a lower precedence than something specifically targeting text.html.«something»).",
+              "type": "string",
+              "pattern": "^(text|source)(\\.[\\w0-9-]+)+$"
+            },
+            "foldingStartMarker": {
+              "description": "regular expressions that lines (in the document) are matched against. If a line matches one of the patterns (but not both), it becomes a folding marker (see the foldings section for more info).",
+              "type": "string"
+            },
+            "foldingStopMarker": {
+              "description": "regular expressions that lines (in the document) are matched against. If a line matches one of the patterns (but not both), it becomes a folding marker (see the foldings section for more info).",
+              "type": "string"
+            },
+            "fileTypes": {
+              "description": "this is an array of file type extensions that the grammar should (by default) be used with. This is referenced when TextMate does not know what grammar to use for a file the user opens. If however the user selects a grammar from the language pop-up in the status bar, TextMate will remember that choice.",
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "uuid": { "type": "string" },
+            "firstLineMatch": { "type": "string" }
+          },
+          "required": [ "scopeName" ]
+        }
+      ]
+    },
+    "grammar": {
+      "type": "object",
+        "properties": {
+          "patterns": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/pattern" },
+            "default": [ ]
+          },
+          "repository": {
+            "description": "a dictionary (i.e. key/value pairs) of rules which can be included from other places in the grammar. The key is the name of the rule and the value is the actual rule. Further explanation (and example) follow with the description of the include rule key.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/pattern"
+            }
+          }
+        },
+        "required": [
+          "patterns"
+        ]
+    },
+    "captures": {
+      "type": "object",
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/name" },
+            "patterns": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/pattern" },
+              "default": [ ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "pattern": {
+      "type": "object",
+      "properties": {
+        "comment": { "type": "string" },
+        "disabled": { "type": "integer", "minimum": 0, "maximum": 1, "description": "set this property to 1 to disable the current pattern" },
+        "include": {
+          "description": "this allows you to reference a different language, recursively reference the grammar itself or a rule declared in this file's repository.",
+          "type": "string"
+        },
+        "match": {
+          "description": "a regular expression which is used to identify the portion of text to which the name should be assigned. Example: '\\b(true|false)\\b'.",
+          "type": "string"
+        },
+        "name": {
+          "description": "the name which gets assigned to the portion matched. This is used for styling and scope-specific settings and actions, which means it should generally be derived from one of the standard names.",
+          "$ref": "#/definitions/name"
+        },
+        "contentName": {
+          "description": "this key is similar to the name key but only assigns the name to the text between what is matched by the begin/end patterns.",
+          "$ref": "#/definitions/name"
+        },
+        "begin": {
+          "description": "these keys allow matches which span several lines and must both be mutually exclusive with the match key. Each is a regular expression pattern. begin is the pattern that starts the block and end is the pattern which ends the block. Captures from the begin pattern can be referenced in the end pattern by using normal regular expression back-references. This is often used with here-docs. A begin/end rule can have nested patterns using the patterns key.",
+          "type": "string"
+        },
+        "end": {
+          "description": "these keys allow matches which span several lines and must both be mutually exclusive with the match key. Each is a regular expression pattern. begin is the pattern that starts the block and end is the pattern which ends the block. Captures from the begin pattern can be referenced in the end pattern by using normal regular expression back-references. This is often used with here-docs. A begin/end rule can have nested patterns using the patterns key.",
+          "type": "string"
+        },
+        "while": {
+          "description": "these keys allow matches which span several lines and must both be mutually exclusive with the match key. Each is a regular expression pattern. begin is the pattern that starts the block and while continues it.",
+          "type": "string"
+        },
+        "captures": {
+          "description": "allows you to assign attributes to the captures of the match pattern. Using the captures key for a begin/end rule is short-hand for giving both beginCaptures and endCaptures with same values.",
+          "$ref": "#/definitions/captures"
+        },
+        "beginCaptures": {
+          "description": "allows you to assign attributes to the captures of the begin pattern. Using the captures key for a begin/end rule is short-hand for giving both beginCaptures and endCaptures with same values.",
+          "$ref": "#/definitions/captures"
+        },
+        "endCaptures": {
+          "description": "allows you to assign attributes to the captures of the end pattern. Using the captures key for a begin/end rule is short-hand for giving both beginCaptures and endCaptures with same values.",
+          "$ref": "#/definitions/captures"
+        },
+        "whileCaptures": {
+          "description": "allows you to assign attributes to the captures of the while pattern. Using the captures key for a begin/while rule is short-hand for giving both beginCaptures and whileCaptures with same values.",
+          "$ref": "#/definitions/captures"
+        },
+        "patterns": {
+          "description": "applies to the region between the begin and end matches",
+          "type": "array",
+          "items": { "$ref": "#/definitions/pattern" },
+          "default": [ ]
+        },
+        "applyEndPatternLast": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
+        }
+      },
+      "dependencies": {
+        "begin": {
+          "anyOf": [{ "required": [ "end" ] }, { "required": [ "while" ] }]
+        },
+        "end": [ "begin" ],
+        "while": [ "begin" ],
+        "contentName": {
+          "anyOf": [
+            { "required": [ "begin", "end" ] },
+            { "required": [ "begin", "while" ] }
+          ]
+        },
+        "beginCaptures": {
+          "anyOf": [
+            { "required": [ "begin", "end" ] },
+            { "required": [ "begin", "while" ] }
+          ]
+        },
+        "whileCaptures": [ "begin", "while" ],
+        "endCaptures": [ "begin", "end" ],
+        "applyEndPatternLast": [ "end" ]
+      },
+      "not": {
+        "$comment": "match and patterns are mutually exclusive - patterns only applies to begin/end blocks",
+        "required": [ "match", "patterns" ]
+      }
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "comment",
+            "comment.block",
+            "comment.block.documentation",
+            "comment.line",
+            "comment.line.double-dash",
+            "comment.line.double-slash",
+            "comment.line.number-sign",
+            "comment.line.percentage",
+            "constant",
+            "constant.character",
+            "constant.character.escape",
+            "constant.language",
+            "constant.numeric",
+            "constant.other",
+            "constant.regexp",
+            "constant.rgb-value",
+            "constant.sha.git-rebase",
+            "emphasis",
+            "entity",
+            "entity.name",
+            "entity.name.class",
+            "entity.name.function",
+            "entity.name.method",
+            "entity.name.section",
+            "entity.name.selector",
+            "entity.name.tag",
+            "entity.name.type",
+            "entity.other",
+            "entity.other.attribute-name",
+            "entity.other.inherited-class",
+            "header",
+            "invalid",
+            "invalid.deprecated",
+            "invalid.illegal",
+            "keyword",
+            "keyword.control",
+            "keyword.control.less",
+            "keyword.operator",
+            "keyword.operator.new",
+            "keyword.other",
+            "keyword.other.unit",
+            "markup",
+            "markup.bold",
+            "markup.changed",
+            "markup.deleted",
+            "markup.heading",
+            "markup.inline.raw",
+            "markup.inserted",
+            "markup.italic",
+            "markup.list",
+            "markup.list.numbered",
+            "markup.list.unnumbered",
+            "markup.other",
+            "markup.punctuation.list.beginning",
+            "markup.punctuation.quote.beginning",
+            "markup.quote",
+            "markup.raw",
+            "markup.underline",
+            "markup.underline.link",
+            "meta",
+            "meta.cast",
+            "meta.parameter.type.variable",
+            "meta.preprocessor",
+            "meta.preprocessor.numeric",
+            "meta.preprocessor.string",
+            "meta.return-type",
+            "meta.selector",
+            "meta.structure.dictionary.key.python",
+            "meta.tag",
+            "meta.type.annotation",
+            "meta.type.name",
+            "metatag.php",
+            "storage",
+            "storage.modifier",
+            "storage.modifier.import.java",
+            "storage.modifier.package.java",
+            "storage.type",
+            "storage.type.cs",
+            "storage.type.java",
+            "string",
+            "string.html",
+            "string.interpolated",
+            "string.jade",
+            "string.other",
+            "string.quoted",
+            "string.quoted.double",
+            "string.quoted.other",
+            "string.quoted.single",
+            "string.quoted.triple",
+            "string.regexp",
+            "string.unquoted",
+            "string.xml",
+            "string.yaml",
+            "strong",
+            "support",
+            "support.class",
+            "support.constant",
+            "support.function",
+            "support.function.git-rebase",
+            "support.other",
+            "support.property-value",
+            "support.type",
+            "support.type.property-name",
+            "support.type.property-name.css",
+            "support.type.property-name.less",
+            "support.type.property-name.scss",
+            "support.variable",
+            "variable",
+            "variable.language",
+            "variable.name",
+            "variable.other",
+            "variable.parameter"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/integrations/vscode/syntaxes/61131-3-st.tmLanguage.json
+++ b/integrations/vscode/syntaxes/61131-3-st.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "$schema": "../schemas/tmlanguage.json",
   "name": "IEC 61131-3 Structured Text",
   "scopeName": "source.61131-3-st",
   "patterns": [

--- a/integrations/vscode/syntaxes/plcopen-xml.tmLanguage.json
+++ b/integrations/vscode/syntaxes/plcopen-xml.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "$schema": "../schemas/tmlanguage.json",
   "name": "PLCopen XML",
   "scopeName": "source.plcopen-xml",
   "patterns": [
@@ -191,12 +191,16 @@
       "name": "meta.tag.close.xml",
       "patterns": [
         {
-          "match": "[a-zA-Z_][a-zA-Z0-9_\\-\\.]*",
-          "patterns": [
-            {
-              "include": "#tag-name"
+          "match": "([a-zA-Z_][a-zA-Z0-9_\\-\\.]*)",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#tag-name"
+                }
+              ]
             }
-          ]
+          }
         }
       ]
     },


### PR DESCRIPTION
- Add local copy of tmlanguage.json schema (MIT License, Martin Ring)
- Enhance schema to enforce mutual exclusivity of match and patterns
- Add ajv-cli for JSON schema validation during lint
- Fix PLCopen XML grammar: use captures instead of patterns with match
- Update grammar files to reference local schema

This prevents future regressions where invalid TextMate grammar patterns go undetected. The schema now correctly validates that 'patterns' can only be used with begin/end blocks, not with 'match'.

https://claude.ai/code/session_01K6vCGUCJiEw2MZzfgGRntq