### PR TITLE
Add grammar snapshot tests for syntax highlighting validation

### DIFF
--- a/integrations/vscode/justfile
+++ b/integrations/vscode/justfile
@@ -6,6 +6,7 @@ default: compile lint
 ci:
   just compile
   just lint
+  just test-grammar
   just test
 
 # Setup required dependencies. Use this to bootstrap a new host.
@@ -34,6 +35,14 @@ _test-linux:
 # Check the code for compliance with style (lint) rules.
 lint:
   npm run lint
+
+# Run grammar snapshot tests to verify syntax highlighting.
+test-grammar:
+  npm run test:grammar
+
+# Update grammar snapshot files (run after intentional grammar changes).
+update-grammar-snapshots:
+  npm run test:grammar:update
 
 # Build the VSIX package for this component.
 package filename:

--- a/integrations/vscode/package-lock.json
+++ b/integrations/vscode/package-lock.json
@@ -26,7 +26,8 @@
         "eslint": "^9.0.0",
         "glob": "^11.0.0",
         "mocha": "^11.0.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.1.6",
+        "vscode-tmgrammar-test": "^0.1.3"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -2215,6 +2216,13 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/boundary": {
       "version": "2.0.0",
@@ -6674,6 +6682,184 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-tmgrammar-test": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.3.tgz",
+      "integrity": "sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bottleneck": "^2.19.5",
+        "chalk": "^2.4.2",
+        "commander": "^9.2.0",
+        "diff": "^4.0.2",
+        "glob": "^7.1.6",
+        "vscode-oniguruma": "^1.5.1",
+        "vscode-textmate": "^7.0.1"
+      },
+      "bin": {
+        "vscode-tmgrammar-snap": "dist/snapshot.js",
+        "vscode-tmgrammar-test": "dist/unit.js"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -91,7 +91,9 @@
           "IEC 61131-3 XML",
           "TC6 XML"
         ],
-        "extensions": [],
+        "extensions": [
+          ".plcxml"
+        ],
         "firstLine": "^<\\?xml[^>]*\\?>\\s*(<project\\s+xmlns\\s*=\\s*[\"']http://www\\.plcopen\\.org/xml/tc6|<project\\s[^>]*xmlns\\s*=\\s*[\"']http://www\\.plcopen\\.org/xml/tc6)",
         "configuration": "./decl/plcopen-xml-language-configuration.json"
       }
@@ -123,9 +125,12 @@
     "pretest": "npm run compile && npm run lint",
     "validate-grammars": "ajv validate -s schemas/tmlanguage.json -d \"syntaxes/*.tmLanguage.json\"",
     "lint": "eslint src/**/*.ts && npm run validate-grammars",
-    "test:functional": "node ./out/test/functional/runTest.js"
+    "test:functional": "node ./out/test/functional/runTest.js",
+    "test:grammar": "vscode-tmgrammar-snap \"tests/grammar/snap/**/*.plcxml\" \"tests/grammar/snap/**/*.st\"",
+    "test:grammar:update": "vscode-tmgrammar-snap -u \"tests/grammar/snap/**/*.plcxml\" \"tests/grammar/snap/**/*.st\""
   },
   "devDependencies": {
+    "vscode-tmgrammar-test": "^0.1.3",
     "ajv-cli": "^5",
     "@stylistic/eslint-plugin": "^5",
     "@stylistic/eslint-plugin-ts": "^4",

--- a/integrations/vscode/tests/grammar/snap/plcopen-basic.plcxml
+++ b/integrations/vscode/tests/grammar/snap/plcopen-basic.plcxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="Test" productName="Test" productVersion="1.0"/>
+  <contentHeader name="Test" modificationDateTime="2024-01-01T00:00:00"/>
+  <!-- This is a comment -->
+  <types>
+    <dataTypes/>
+    <pous/>
+  </types>
+</project>

--- a/integrations/vscode/tests/grammar/snap/plcopen-basic.plcxml.snap
+++ b/integrations/vscode/tests/grammar/snap/plcopen-basic.plcxml.snap
@@ -1,0 +1,75 @@
+><?xml version="1.0" encoding="utf-8"?>
+#^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.begin.xml
+#  ^^^ source.plcopen-xml meta.tag.preprocessor.xml keyword.other.xml-declaration.xml
+#     ^ source.plcopen-xml meta.tag.preprocessor.xml
+#      ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#             ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#              ^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                   ^ source.plcopen-xml meta.tag.preprocessor.xml
+#                    ^^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#                            ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#                             ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                                    ^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.end.xml
+><project xmlns="http://www.plcopen.org/xml/tc6_0200">
+#^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+# ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.structure.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml
+#         ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.namespace.xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>  <fileHeader companyName="Test" productName="Test" productVersion="1.0"/>
+#^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#              ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                 ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                             ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                   ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                                    ^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                                                  ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                                                   ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                                        ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>  <contentHeader name="Test" modificationDateTime="2024-01-01T00:00:00"/>
+#^^ source.plcopen-xml
+#  ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#   ^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.structure.plcopen-xml
+#                ^ source.plcopen-xml meta.tag.self-closing.xml
+#                 ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                      ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                            ^ source.plcopen-xml meta.tag.self-closing.xml
+#                             ^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                                 ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                                  ^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                                       ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>  <!-- This is a comment -->
+#^^ source.plcopen-xml
+#  ^^^^ source.plcopen-xml comment.block.xml punctuation.definition.comment.begin.xml
+#      ^^^^^^^^^^^^^^^^^^^ source.plcopen-xml comment.block.xml
+#                         ^^^ source.plcopen-xml comment.block.xml punctuation.definition.comment.end.xml
+>  <types>
+#^^ source.plcopen-xml
+#  ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#   ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.types.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.self-closing.xml
+>    <dataTypes/>
+#^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#              ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>    <pous/>
+#^^^^ source.plcopen-xml
+#    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#     ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.types.plcopen-xml
+#         ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>  </types>
+#^^ source.plcopen-xml
+#  ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#    ^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#         ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+></project>
+#^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#  ^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.structure.plcopen-xml
+#         ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>

--- a/integrations/vscode/tests/grammar/snap/plcopen-configuration.plcxml
+++ b/integrations/vscode/tests/grammar/snap/plcopen-configuration.plcxml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <instances>
+    <configurations>
+      <configuration name="MainConfig">
+        <globalVars>
+          <variable name="GlobalCounter" retain="true">
+            <type><UDINT/></type>
+          </variable>
+        </globalVars>
+        <resource name="CPU1">
+          <task name="MainTask" interval="T#10ms" priority="1"/>
+          <pouInstance name="Main" typeName="MainProgram">
+            <addData/>
+          </pouInstance>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+</project>

--- a/integrations/vscode/tests/grammar/snap/plcopen-configuration.plcxml.snap
+++ b/integrations/vscode/tests/grammar/snap/plcopen-configuration.plcxml.snap
@@ -1,0 +1,129 @@
+><?xml version="1.0" encoding="utf-8"?>
+#^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.begin.xml
+#  ^^^ source.plcopen-xml meta.tag.preprocessor.xml keyword.other.xml-declaration.xml
+#     ^ source.plcopen-xml meta.tag.preprocessor.xml
+#      ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#             ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#              ^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                   ^ source.plcopen-xml meta.tag.preprocessor.xml
+#                    ^^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#                            ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#                             ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                                    ^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.end.xml
+><project xmlns="http://www.plcopen.org/xml/tc6_0200">
+#^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+# ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.structure.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml
+#         ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.namespace.xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>  <instances>
+#^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>    <configurations>
+#^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      <configuration name="MainConfig">
+#^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                     ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                      ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <globalVars>
+#^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <variable name="GlobalCounter" retain="true">
+#^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                    ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                         ^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                        ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                         ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                                ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                                 ^^^^ source.plcopen-xml meta.tag.self-closing.xml constant.language.boolean.plcopen-xml
+#                                                     ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                      ^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <type><UDINT/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                            ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </variable>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </globalVars>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable-section.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        <resource name="CPU1">
+#^^^^^^^^ source.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#         ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.configuration.plcopen-xml
+#                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                  ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                       ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                             ^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <task name="MainTask" interval="T#10ms" priority="1"/>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                     ^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                         ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                                  ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                                           ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                              ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>          <pouInstance name="Main" typeName="MainProgram">
+#^^^^^^^^^^ source.plcopen-xml
+#          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#           ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.configuration.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.self-closing.xml
+#                       ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                            ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                  ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                   ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                            ^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                         ^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <addData/>
+#^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                    ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>          </pouInstance>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.configuration.plcopen-xml
+#                       ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </resource>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.configuration.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      </configuration>
+#^^^^^^ source.plcopen-xml
+#      ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#        ^^^^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.configuration.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>    </configurations>
+#^^^^ source.plcopen-xml
+#    ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#      ^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.configuration.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>  </instances>
+#^^ source.plcopen-xml
+#  ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#    ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.configuration.plcopen-xml
+#             ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+></project>
+#^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#  ^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.structure.plcopen-xml
+#         ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>

--- a/integrations/vscode/tests/grammar/snap/plcopen-pou.plcxml
+++ b/integrations/vscode/tests/grammar/snap/plcopen-pou.plcxml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <types>
+    <pous>
+      <pou name="MyFunction" pouType="function">
+        <interface>
+          <returnType>
+            <BOOL/>
+          </returnType>
+          <inputVars>
+            <variable name="Input1">
+              <type><INT/></type>
+            </variable>
+          </inputVars>
+          <outputVars>
+            <variable name="Output1">
+              <type><DINT/></type>
+            </variable>
+          </outputVars>
+          <localVars>
+            <variable name="Local1" constant="true">
+              <type><REAL/></type>
+              <initialValue>
+                <simpleValue value="0.0"/>
+              </initialValue>
+            </variable>
+          </localVars>
+        </interface>
+        <body>
+          <ST>
+            <xhtml xmlns="http://www.w3.org/1999/xhtml">Output1 := Input1 * 2;</xhtml>
+          </ST>
+        </body>
+      </pou>
+      <pou name="MyFunctionBlock" pouType="functionBlock">
+        <interface>
+          <inOutVars>
+            <variable name="Counter">
+              <type><UDINT/></type>
+            </variable>
+          </inOutVars>
+        </interface>
+        <body>
+          <ST>
+            <xhtml>Counter := Counter + 1;</xhtml>
+          </ST>
+        </body>
+      </pou>
+      <pou name="MyProgram" pouType="program">
+        <interface>
+          <tempVars>
+            <variable name="Temp">
+              <type><STRING/></type>
+            </variable>
+          </tempVars>
+        </interface>
+        <body>
+          <ST>
+            <xhtml>Temp := 'Hello';</xhtml>
+          </ST>
+        </body>
+      </pou>
+    </pous>
+  </types>
+</project>

--- a/integrations/vscode/tests/grammar/snap/plcopen-pou.plcxml.snap
+++ b/integrations/vscode/tests/grammar/snap/plcopen-pou.plcxml.snap
@@ -1,0 +1,298 @@
+><?xml version="1.0" encoding="utf-8"?>
+#^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.begin.xml
+#  ^^^ source.plcopen-xml meta.tag.preprocessor.xml keyword.other.xml-declaration.xml
+#     ^ source.plcopen-xml meta.tag.preprocessor.xml
+#      ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#             ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#              ^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                   ^ source.plcopen-xml meta.tag.preprocessor.xml
+#                    ^^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#                            ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#                             ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                                    ^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.end.xml
+><project xmlns="http://www.plcopen.org/xml/tc6_0200">
+#^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+# ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.structure.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml
+#         ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.namespace.xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>  <types>
+#^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>    <pous>
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      <pou name="MyFunction" pouType="function">
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#           ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                ^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                            ^ source.plcopen-xml meta.tag.self-closing.xml
+#                             ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                     ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                      ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml support.type.pou.plcopen-xml
+#                                              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                               ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <interface>
+#^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <returnType>
+#^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <BOOL/>
+#^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                 ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>          </returnType>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable-section.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          <inputVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#           ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable-section.plcopen-xml
+#                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <variable name="Input1">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><INT/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                            ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </inputVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable-section.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          <outputVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#           ^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable-section.plcopen-xml
+#                     ^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <variable name="Output1">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><DINT/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                         ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                           ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                             ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </outputVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable-section.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          <localVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#           ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable-section.plcopen-xml
+#                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <variable name="Local1" constant="true">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                   ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                    ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                             ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                              ^^^^ source.plcopen-xml meta.tag.self-closing.xml constant.language.boolean.plcopen-xml
+#                                                  ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><REAL/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                         ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                           ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                             ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>              <initialValue>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable.plcopen-xml
+#                           ^^ source.plcopen-xml meta.tag.self-closing.xml
+>                <simpleValue value="0.0"/>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                             ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                  ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                   ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                        ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              </initialValue>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                ^^^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                            ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </localVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable-section.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </interface>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.pou.plcopen-xml
+#                   ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        <body>
+#^^^^^^^^ source.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#         ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.pou.plcopen-xml
+#             ^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <ST>
+#^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <xhtml xmlns="http://www.w3.org/1999/xhtml">Output1 := Input1 * 2;</xhtml>
+#^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                   ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.namespace.xml
+#                        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          </ST>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>        </body>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      </pou>
+#^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      <pou name="MyFunctionBlock" pouType="functionBlock">
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#           ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                ^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                  ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                           ^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml support.type.pou.plcopen-xml
+#                                                        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                         ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <interface>
+#^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <inOutVars>
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <variable name="Counter">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><UDINT/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                          ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                              ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </inOutVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable-section.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </interface>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.pou.plcopen-xml
+#                   ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        <body>
+#^^^^^^^^ source.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#         ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.pou.plcopen-xml
+#             ^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <ST>
+#^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <xhtml>Counter := Counter + 1;</xhtml>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          </ST>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>        </body>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      </pou>
+#^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      <pou name="MyProgram" pouType="program">
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#           ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                           ^ source.plcopen-xml meta.tag.self-closing.xml
+#                            ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                   ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                     ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml support.type.pou.plcopen-xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                             ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <interface>
+#^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <tempVars>
+#^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <variable name="Temp">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                 ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><STRING/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                           ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                             ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                               ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                   ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </tempVars>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable-section.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </interface>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.pou.plcopen-xml
+#                   ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        <body>
+#^^^^^^^^ source.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#         ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.pou.plcopen-xml
+#             ^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <ST>
+#^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <xhtml>Temp := 'Hello';</xhtml>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          </ST>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>        </body>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      </pou>
+#^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>    </pous>
+#^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>  </types>
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+></project>
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>

--- a/integrations/vscode/tests/grammar/snap/plcopen-sfc.plcxml
+++ b/integrations/vscode/tests/grammar/snap/plcopen-sfc.plcxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <types>
+    <pous>
+      <pou name="MySfcProgram" pouType="program">
+        <body>
+          <SFC>
+            <step name="Init" initialStep="true">
+              <connectionPointIn/>
+              <connectionPointOut/>
+              <position x="100" y="100"/>
+            </step>
+            <step name="Step1" initialStep="false">
+              <connectionPointIn>
+                <connection refLocalId="1"/>
+              </connectionPointIn>
+              <connectionPointOut/>
+              <position x="100" y="200"/>
+            </step>
+            <actionBlock>
+              <action localId="1" qualifier="N">
+                <reference name="DoSomething"/>
+              </action>
+              <action localId="2" qualifier="P">
+                <inline name="PulseAction">
+                  <ST>
+                    <xhtml>x := 1;</xhtml>
+                  </ST>
+                </inline>
+              </action>
+              <action localId="3" qualifier="R">
+                <reference name="ResetAction"/>
+              </action>
+              <action localId="4" qualifier="S">
+                <reference name="SetAction"/>
+              </action>
+            </actionBlock>
+            <inVariable localId="5" negated="false">
+              <position x="50" y="150"/>
+              <connectionPointOut/>
+              <expression>Start</expression>
+            </inVariable>
+            <outVariable localId="6" negated="true" edge="rising">
+              <position x="200" y="150"/>
+              <connectionPointIn/>
+              <expression>Output</expression>
+            </outVariable>
+          </SFC>
+        </body>
+      </pou>
+    </pous>
+  </types>
+</project>

--- a/integrations/vscode/tests/grammar/snap/plcopen-sfc.plcxml.snap
+++ b/integrations/vscode/tests/grammar/snap/plcopen-sfc.plcxml.snap
@@ -1,0 +1,330 @@
+><?xml version="1.0" encoding="utf-8"?>
+#^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.begin.xml
+#  ^^^ source.plcopen-xml meta.tag.preprocessor.xml keyword.other.xml-declaration.xml
+#     ^ source.plcopen-xml meta.tag.preprocessor.xml
+#      ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#             ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#              ^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                   ^ source.plcopen-xml meta.tag.preprocessor.xml
+#                    ^^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#                            ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#                             ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                                    ^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.end.xml
+><project xmlns="http://www.plcopen.org/xml/tc6_0200">
+#^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+# ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.structure.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml
+#         ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.namespace.xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>  <types>
+#^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>    <pous>
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      <pou name="MySfcProgram" pouType="program">
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#           ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                ^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                              ^ source.plcopen-xml meta.tag.self-closing.xml
+#                               ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                       ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                        ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml support.type.pou.plcopen-xml
+#                                               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <body>
+#^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <SFC>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <step name="Init" initialStep="true">
+#^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                  ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                       ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                             ^ source.plcopen-xml meta.tag.self-closing.xml
+#                              ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                           ^^^^ source.plcopen-xml meta.tag.self-closing.xml constant.language.boolean.plcopen-xml
+#                                               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <connectionPointIn/>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                                ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <connectionPointOut/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                                 ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <position x="100" y="100"/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                       ^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                  ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                       ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>            </step>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.sfc.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            <step name="Step1" initialStep="false">
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                  ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                       ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                              ^ source.plcopen-xml meta.tag.self-closing.xml
+#                               ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                            ^^^^^ source.plcopen-xml meta.tag.self-closing.xml constant.language.boolean.plcopen-xml
+#                                                 ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                  ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <connectionPointIn>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>                <connection refLocalId="1"/>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                            ^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                       ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                          ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              </connectionPointIn>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                ^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.sfc.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>              <connectionPointOut/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                                 ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <position x="100" y="200"/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                       ^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                  ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                       ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>            </step>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.sfc.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            <actionBlock>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                        ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <action localId="1" qualifier="N">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                             ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                              ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                  ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                             ^ source.plcopen-xml meta.tag.self-closing.xml keyword.other.qualifier.plcopen-xml
+#                                              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                               ^^ source.plcopen-xml meta.tag.self-closing.xml
+>                <reference name="DoSomething"/>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                           ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                ^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                             ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              </action>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                ^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.pou.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>              <action localId="2" qualifier="P">
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.pou.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                             ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                              ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                  ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                             ^ source.plcopen-xml meta.tag.self-closing.xml keyword.other.qualifier.plcopen-xml
+#                                              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                               ^^ source.plcopen-xml meta.tag.self-closing.xml
+>                <inline name="PulseAction">
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                             ^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                          ^^ source.plcopen-xml meta.tag.self-closing.xml
+>                  <ST>
+#^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>                    <xhtml>x := 1;</xhtml>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>                  </ST>
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>                </inline>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>              </action>
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <action localId="3" qualifier="R">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                             ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                              ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                  ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                             ^ source.plcopen-xml meta.tag.self-closing.xml keyword.other.qualifier.plcopen-xml
+#                                              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                               ^^ source.plcopen-xml meta.tag.self-closing.xml
+>                <reference name="ResetAction"/>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                           ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                ^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                             ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              </action>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                ^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.pou.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>              <action localId="4" qualifier="S">
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.pou.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                             ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                              ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                  ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                             ^ source.plcopen-xml meta.tag.self-closing.xml keyword.other.qualifier.plcopen-xml
+#                                              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                               ^^ source.plcopen-xml meta.tag.self-closing.xml
+>                <reference name="SetAction"/>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                           ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                ^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                           ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              </action>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                ^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.pou.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </actionBlock>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.sfc.plcopen-xml
+#                         ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            <inVariable localId="5" negated="false">
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                       ^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                   ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                    ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                           ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                             ^^^^^ source.plcopen-xml meta.tag.self-closing.xml constant.language.boolean.plcopen-xml
+#                                                  ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <position x="50" y="150"/>
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                              ^ source.plcopen-xml meta.tag.self-closing.xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                 ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                      ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <connectionPointOut/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                                 ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <expression>Start</expression>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.xml
+#                         ^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            </inVariable>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <outVariable localId="6" negated="true" edge="rising">
+#^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                         ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                 ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                    ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                     ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                             ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.begin.xml
+#                                              ^^^^ source.plcopen-xml meta.tag.self-closing.xml constant.language.boolean.plcopen-xml
+#                                                  ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.string.end.xml
+#                                                   ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                                    ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                                        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                                         ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                                 ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <position x="200" y="150"/>
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                        ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                ^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                  ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                       ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <connectionPointIn/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.sfc.plcopen-xml
+#                                ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <expression>Output</expression>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.xml
+#                         ^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            </outVariable>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          </SFC>
+#^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>        </body>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      </pou>
+#^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>    </pous>
+#^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>  </types>
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+></project>
+#^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>

--- a/integrations/vscode/tests/grammar/snap/plcopen-types.plcxml
+++ b/integrations/vscode/tests/grammar/snap/plcopen-types.plcxml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <types>
+    <dataTypes>
+      <dataType name="MyEnum">
+        <baseType>
+          <enum>
+            <values>
+              <value name="Value1"/>
+              <value name="Value2"/>
+              <value name="Value3"/>
+            </values>
+          </enum>
+        </baseType>
+      </dataType>
+      <dataType name="MyArray">
+        <baseType>
+          <array>
+            <dimension lower="0" upper="9"/>
+            <baseType><LINT/></baseType>
+          </array>
+        </baseType>
+      </dataType>
+      <dataType name="MyStruct">
+        <baseType>
+          <struct>
+            <variable name="Field1">
+              <type><BOOL/></type>
+            </variable>
+            <variable name="Field2">
+              <type><LREAL/></type>
+            </variable>
+            <variable name="Field3">
+              <type><TIME/></type>
+            </variable>
+            <variable name="Field4">
+              <type><DATE/></type>
+            </variable>
+            <variable name="Field5">
+              <type><derived name="MyEnum"/></type>
+            </variable>
+          </struct>
+        </baseType>
+      </dataType>
+      <dataType name="MySubrange">
+        <baseType>
+          <subrangeSigned>
+            <range lower="-100" upper="100"/>
+            <baseType><INT/></baseType>
+          </subrangeSigned>
+        </baseType>
+      </dataType>
+    </dataTypes>
+  </types>
+</project>

--- a/integrations/vscode/tests/grammar/snap/plcopen-types.plcxml.snap
+++ b/integrations/vscode/tests/grammar/snap/plcopen-types.plcxml.snap
@@ -1,0 +1,317 @@
+><?xml version="1.0" encoding="utf-8"?>
+#^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.begin.xml
+#  ^^^ source.plcopen-xml meta.tag.preprocessor.xml keyword.other.xml-declaration.xml
+#     ^ source.plcopen-xml meta.tag.preprocessor.xml
+#      ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#             ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#              ^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                   ^ source.plcopen-xml meta.tag.preprocessor.xml
+#                    ^^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml entity.other.attribute-name.xml
+#                            ^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.separator.key-value.xml
+#                             ^^^^^^^ source.plcopen-xml meta.tag.preprocessor.xml string.quoted.double.xml
+#                                    ^^ source.plcopen-xml meta.tag.preprocessor.xml punctuation.definition.tag.end.xml
+><project xmlns="http://www.plcopen.org/xml/tc6_0200">
+#^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+# ^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.structure.plcopen-xml
+#        ^ source.plcopen-xml meta.tag.self-closing.xml
+#         ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.namespace.xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                                    ^^ source.plcopen-xml meta.tag.self-closing.xml
+>  <types>
+#^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>    <dataTypes>
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>      <dataType name="MyEnum">
+#^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                     ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                             ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <baseType>
+#^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <enum>
+#^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <values>
+#^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <value name="Value1"/>
+#^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                     ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                  ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <value name="Value2"/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.self-closing.xml
+#                     ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                  ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>              <value name="Value3"/>
+#^^^^^^^^^^^^^^ source.plcopen-xml
+#              ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#               ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.self-closing.xml
+#                     ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                         ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                          ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                  ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>            </values>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.type-definition.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </enum>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.type-definition.plcopen-xml
+#                ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </baseType>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      </dataType>
+#^^^^^^ source.plcopen-xml
+#      ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#        ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      <dataType name="MyArray">
+#^^^^^^ source.plcopen-xml
+#      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#       ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.types.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                     ^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                              ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <baseType>
+#^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <array>
+#^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <dimension lower="0" upper="9"/>
+#^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                       ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                             ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                 ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                       ^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                          ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>            <baseType><LINT/></baseType>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.types.plcopen-xml
+#                     ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                           ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                             ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                               ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                                       ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </array>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.type-definition.plcopen-xml
+#                 ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </baseType>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      </dataType>
+#^^^^^^ source.plcopen-xml
+#      ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#        ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      <dataType name="MyStruct">
+#^^^^^^ source.plcopen-xml
+#      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#       ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.types.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                     ^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                               ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <baseType>
+#^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <struct>
+#^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <variable name="Field1">
+#^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><BOOL/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                         ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                           ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                             ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            <variable name="Field2">
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><LREAL/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                          ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                              ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            <variable name="Field3">
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><TIME/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                         ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                           ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                             ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            <variable name="Field4">
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><DATE/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                         ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                           ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                             ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            <variable name="Field5">
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.variable.plcopen-xml
+#                     ^ source.plcopen-xml meta.tag.self-closing.xml
+#                      ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                           ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                   ^^ source.plcopen-xml meta.tag.self-closing.xml
+>              <type><derived name="MyEnum"/></type>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                             ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                                 ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                  ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                          ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                                            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                                              ^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                                                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>            </variable>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.variable.plcopen-xml
+#                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </struct>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.type-definition.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </baseType>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      </dataType>
+#^^^^^^ source.plcopen-xml
+#      ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#        ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      <dataType name="MySubrange">
+#^^^^^^ source.plcopen-xml
+#      ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#       ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.types.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                ^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.plcopen-xml
+#                    ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                     ^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.plcopen-xml
+#                                 ^^ source.plcopen-xml meta.tag.self-closing.xml
+>        <baseType>
+#^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>          <subrangeSigned>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+>            <range lower="-100" upper="100"/>
+#^^^^^^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                   ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                        ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                         ^^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                               ^ source.plcopen-xml meta.tag.self-closing.xml
+#                                ^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.other.attribute-name.xml
+#                                     ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.separator.key-value.xml
+#                                      ^^^^^ source.plcopen-xml meta.tag.self-closing.xml string.quoted.double.xml
+#                                           ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+>            <baseType><INT/></baseType>
+#^^^^^^^^^^^^ source.plcopen-xml
+#            ^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.begin.xml
+#             ^^^^^^^^ source.plcopen-xml meta.tag.self-closing.xml entity.name.tag.types.plcopen-xml
+#                     ^^^^^ source.plcopen-xml meta.tag.self-closing.xml
+#                          ^^ source.plcopen-xml meta.tag.self-closing.xml punctuation.definition.tag.end.xml
+#                            ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#                              ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                                      ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>          </subrangeSigned>
+#^^^^^^^^^^ source.plcopen-xml
+#          ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#            ^^^^^^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.type-definition.plcopen-xml
+#                          ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>        </baseType>
+#^^^^^^^^ source.plcopen-xml
+#        ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#          ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                  ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>      </dataType>
+#^^^^^^ source.plcopen-xml
+#      ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#        ^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#                ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>    </dataTypes>
+#^^^^ source.plcopen-xml
+#    ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#      ^^^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#               ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>  </types>
+#^^ source.plcopen-xml
+#  ^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#    ^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.types.plcopen-xml
+#         ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+></project>
+#^^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.begin.xml
+#  ^^^^^^^ source.plcopen-xml meta.tag.close.xml entity.name.tag.structure.plcopen-xml
+#         ^ source.plcopen-xml meta.tag.close.xml punctuation.definition.tag.end.xml
+>

--- a/integrations/vscode/tests/grammar/snap/structured-text.st
+++ b/integrations/vscode/tests/grammar/snap/structured-text.st
@@ -1,0 +1,98 @@
+(* Block comment test *)
+// Line comment test
+
+PROGRAM TestProgram
+VAR
+    myBool : BOOL := TRUE;
+    myInt : INT := 42;
+    myReal : REAL := 3.14;
+    myString : STRING := 'Hello';
+    myArray : ARRAY[0..9] OF DINT;
+    address1 : BOOL AT %IX0.0;
+    address2 : WORD AT %QW10;
+END_VAR
+
+VAR_INPUT
+    input1 : SINT;
+    input2 : UDINT;
+END_VAR
+
+VAR_OUTPUT
+    output1 : LINT;
+END_VAR
+
+VAR_TEMP
+    temp1 : LREAL;
+END_VAR
+
+    (* Conditional statements *)
+    IF input1 > 0 THEN
+        output1 := input1 * 2;
+    ELSIF input1 < 0 THEN
+        output1 := -input1;
+    ELSE
+        output1 := 0;
+    END_IF;
+
+    (* Case statement *)
+    CASE myInt OF
+        1: myBool := TRUE;
+        2, 3: myBool := FALSE;
+    ELSE
+        myBool := NOT myBool;
+    END_CASE;
+
+    (* For loop *)
+    FOR i := 0 TO 9 BY 1 DO
+        myArray[i] := i * i;
+    END_FOR;
+
+    (* While loop *)
+    WHILE myInt > 0 DO
+        myInt := myInt - 1;
+    END_WHILE;
+
+    (* Repeat loop *)
+    REPEAT
+        temp1 := temp1 + 1.0;
+    UNTIL temp1 >= 10.0
+    END_REPEAT;
+
+    (* Operators *)
+    myBool := (input1 = input2) OR (input1 <> 0);
+    myBool := myBool AND NOT FALSE;
+    myBool := input1 < input2;
+    myBool := input1 >= input2;
+
+    (* Numeric literals *)
+    myInt := 16#FF;
+    myInt := 8#77;
+    myInt := 2#1010;
+    myReal := 1.5e10;
+
+END_PROGRAM
+
+FUNCTION MyFunction : BOOL
+VAR_INPUT
+    x : INT;
+END_VAR
+    IF x > 0 THEN
+        RETURN TRUE;
+    ELSE
+        RETURN FALSE;
+    END_IF;
+END_FUNCTION
+
+FUNCTION_BLOCK MyFB
+VAR
+    counter : UDINT;
+END_VAR
+    counter := counter + 1;
+END_FUNCTION_BLOCK
+
+TYPE MyStruct :
+STRUCT
+    field1 : BOOL;
+    field2 : INT;
+END_STRUCT
+END_TYPE

--- a/integrations/vscode/tests/grammar/snap/structured-text.st.snap
+++ b/integrations/vscode/tests/grammar/snap/structured-text.st.snap
@@ -1,0 +1,607 @@
+>(* Block comment test *)
+#^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#  ^^^^^^^^^^^^^^^^^^^^ source.61131-3-st comment.block.st
+#                      ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>// Line comment test
+#^^^^^^^^^^^^^^^^^^^^ source.61131-3-st comment.line.double-slash.st punctuation.definition.comment.st
+>
+>PROGRAM TestProgram
+#^^^^^^^ source.61131-3-st keyword.declaration.pou.st
+#       ^ source.61131-3-st
+#        ^^^^^^^^^^^ source.61131-3-st entity.name.function.st
+>VAR
+#^^^ source.61131-3-st keyword.declaration.variable.st
+>    myBool : BOOL := TRUE;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st punctuation.separator.st
+#            ^ source.61131-3-st
+#             ^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                 ^ source.61131-3-st
+#                  ^^ source.61131-3-st keyword.operator.assignment.st
+#                    ^ source.61131-3-st
+#                     ^^^^ source.61131-3-st constant.language.boolean.st
+#                         ^ source.61131-3-st punctuation.separator.st
+>    myInt : INT := 42;
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st variable.other.st
+#         ^ source.61131-3-st
+#          ^ source.61131-3-st punctuation.separator.st
+#           ^ source.61131-3-st
+#            ^^^ source.61131-3-st storage.type.primitive.integer.st
+#               ^ source.61131-3-st
+#                ^^ source.61131-3-st keyword.operator.assignment.st
+#                  ^ source.61131-3-st
+#                   ^^ source.61131-3-st constant.numeric.decimal.st
+#                     ^ source.61131-3-st punctuation.separator.st
+>    myReal : REAL := 3.14;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st punctuation.separator.st
+#            ^ source.61131-3-st
+#             ^^^^ source.61131-3-st storage.type.primitive.real.st
+#                 ^ source.61131-3-st
+#                  ^^ source.61131-3-st keyword.operator.assignment.st
+#                    ^ source.61131-3-st
+#                     ^^^^ source.61131-3-st constant.numeric.decimal.st
+#                         ^ source.61131-3-st punctuation.separator.st
+>    myString : STRING := 'Hello';
+#^^^^ source.61131-3-st
+#    ^^^^^^^^ source.61131-3-st variable.other.st
+#            ^ source.61131-3-st
+#             ^ source.61131-3-st punctuation.separator.st
+#              ^ source.61131-3-st
+#               ^^^^^^ source.61131-3-st storage.type.primitive.string.st
+#                     ^ source.61131-3-st
+#                      ^^ source.61131-3-st keyword.operator.assignment.st
+#                        ^ source.61131-3-st
+#                         ^^^^^^^ source.61131-3-st string.quoted.single.st punctuation.definition.string.st
+#                                ^ source.61131-3-st punctuation.separator.st
+>    myArray : ARRAY[0..9] OF DINT;
+#^^^^ source.61131-3-st
+#    ^^^^^^^ source.61131-3-st variable.other.st
+#           ^ source.61131-3-st
+#            ^ source.61131-3-st punctuation.separator.st
+#             ^ source.61131-3-st
+#              ^^^^^ source.61131-3-st keyword.declaration.type.st
+#                   ^ source.61131-3-st punctuation.section.brackets.st
+#                    ^ source.61131-3-st constant.numeric.decimal.st
+#                     ^ source.61131-3-st punctuation.accessor.st
+#                      ^ source.61131-3-st punctuation.accessor.st
+#                       ^ source.61131-3-st constant.numeric.decimal.st
+#                        ^ source.61131-3-st punctuation.section.brackets.st
+#                         ^ source.61131-3-st
+#                          ^^ source.61131-3-st keyword.control.conditional.st
+#                            ^ source.61131-3-st
+#                             ^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                                 ^ source.61131-3-st punctuation.separator.st
+>    address1 : BOOL AT %IX0.0;
+#^^^^ source.61131-3-st
+#    ^^^^^^^^ source.61131-3-st variable.other.st
+#            ^ source.61131-3-st
+#             ^ source.61131-3-st punctuation.separator.st
+#              ^ source.61131-3-st
+#               ^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                   ^ source.61131-3-st
+#                    ^^ source.61131-3-st keyword.other.st
+#                      ^ source.61131-3-st
+#                       ^^^^^^ source.61131-3-st variable.other.direct-address.st
+#                             ^ source.61131-3-st punctuation.separator.st
+>    address2 : WORD AT %QW10;
+#^^^^ source.61131-3-st
+#    ^^^^^^^^ source.61131-3-st variable.other.st
+#            ^ source.61131-3-st
+#             ^ source.61131-3-st punctuation.separator.st
+#              ^ source.61131-3-st
+#               ^^^^ source.61131-3-st storage.type.primitive.bit.st
+#                   ^ source.61131-3-st
+#                    ^^ source.61131-3-st keyword.other.st
+#                      ^ source.61131-3-st
+#                       ^^^^^ source.61131-3-st variable.other.direct-address.st
+#                            ^ source.61131-3-st punctuation.separator.st
+>END_VAR
+#^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>
+>VAR_INPUT
+#^^^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>    input1 : SINT;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st punctuation.separator.st
+#            ^ source.61131-3-st
+#             ^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                 ^ source.61131-3-st punctuation.separator.st
+>    input2 : UDINT;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st punctuation.separator.st
+#            ^ source.61131-3-st
+#             ^^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                  ^ source.61131-3-st punctuation.separator.st
+>END_VAR
+#^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>
+>VAR_OUTPUT
+#^^^^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>    output1 : LINT;
+#^^^^ source.61131-3-st
+#    ^^^^^^^ source.61131-3-st variable.other.st
+#           ^ source.61131-3-st
+#            ^ source.61131-3-st punctuation.separator.st
+#             ^ source.61131-3-st
+#              ^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                  ^ source.61131-3-st punctuation.separator.st
+>END_VAR
+#^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>
+>VAR_TEMP
+#^^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>    temp1 : LREAL;
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st variable.other.st
+#         ^ source.61131-3-st
+#          ^ source.61131-3-st punctuation.separator.st
+#           ^ source.61131-3-st
+#            ^^^^^ source.61131-3-st storage.type.primitive.real.st
+#                 ^ source.61131-3-st punctuation.separator.st
+>END_VAR
+#^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>
+>    (* Conditional statements *)
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#      ^^^^^^^^^^^^^^^^^^^^^^^^ source.61131-3-st comment.block.st
+#                              ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>    IF input1 > 0 THEN
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st keyword.control.conditional.st
+#      ^ source.61131-3-st
+#       ^^^^^^ source.61131-3-st variable.other.st
+#             ^ source.61131-3-st
+#              ^ source.61131-3-st keyword.operator.comparison.st
+#               ^ source.61131-3-st
+#                ^ source.61131-3-st constant.numeric.decimal.st
+#                 ^ source.61131-3-st
+#                  ^^^^ source.61131-3-st keyword.control.conditional.st
+>        output1 := input1 * 2;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^^^ source.61131-3-st variable.other.st
+#               ^ source.61131-3-st
+#                ^^ source.61131-3-st keyword.operator.assignment.st
+#                  ^ source.61131-3-st
+#                   ^^^^^^ source.61131-3-st variable.other.st
+#                         ^ source.61131-3-st
+#                          ^ source.61131-3-st keyword.operator.arithmetic.st
+#                           ^ source.61131-3-st
+#                            ^ source.61131-3-st constant.numeric.decimal.st
+#                             ^ source.61131-3-st punctuation.separator.st
+>    ELSIF input1 < 0 THEN
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st keyword.control.conditional.st
+#         ^ source.61131-3-st
+#          ^^^^^^ source.61131-3-st variable.other.st
+#                ^ source.61131-3-st
+#                 ^ source.61131-3-st keyword.operator.comparison.st
+#                  ^ source.61131-3-st
+#                   ^ source.61131-3-st constant.numeric.decimal.st
+#                    ^ source.61131-3-st
+#                     ^^^^ source.61131-3-st keyword.control.conditional.st
+>        output1 := -input1;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^^^ source.61131-3-st variable.other.st
+#               ^ source.61131-3-st
+#                ^^ source.61131-3-st keyword.operator.assignment.st
+#                  ^ source.61131-3-st
+#                   ^ source.61131-3-st keyword.operator.arithmetic.st
+#                    ^^^^^^ source.61131-3-st variable.other.st
+#                          ^ source.61131-3-st punctuation.separator.st
+>    ELSE
+#^^^^ source.61131-3-st
+#    ^^^^ source.61131-3-st keyword.control.conditional.st
+>        output1 := 0;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^^^ source.61131-3-st variable.other.st
+#               ^ source.61131-3-st
+#                ^^ source.61131-3-st keyword.operator.assignment.st
+#                  ^ source.61131-3-st
+#                   ^ source.61131-3-st constant.numeric.decimal.st
+#                    ^ source.61131-3-st punctuation.separator.st
+>    END_IF;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st keyword.control.conditional.st
+#          ^ source.61131-3-st punctuation.separator.st
+>
+>    (* Case statement *)
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#      ^^^^^^^^^^^^^^^^ source.61131-3-st comment.block.st
+#                      ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>    CASE myInt OF
+#^^^^ source.61131-3-st
+#    ^^^^ source.61131-3-st keyword.control.conditional.st
+#        ^ source.61131-3-st
+#         ^^^^^ source.61131-3-st variable.other.st
+#              ^ source.61131-3-st
+#               ^^ source.61131-3-st keyword.control.conditional.st
+>        1: myBool := TRUE;
+#^^^^^^^^ source.61131-3-st
+#        ^ source.61131-3-st constant.numeric.decimal.st
+#         ^ source.61131-3-st punctuation.separator.st
+#          ^ source.61131-3-st
+#           ^^^^^^ source.61131-3-st variable.other.st
+#                 ^ source.61131-3-st
+#                  ^^ source.61131-3-st keyword.operator.assignment.st
+#                    ^ source.61131-3-st
+#                     ^^^^ source.61131-3-st constant.language.boolean.st
+#                         ^ source.61131-3-st punctuation.separator.st
+>        2, 3: myBool := FALSE;
+#^^^^^^^^ source.61131-3-st
+#        ^ source.61131-3-st constant.numeric.decimal.st
+#         ^ source.61131-3-st punctuation.separator.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st constant.numeric.decimal.st
+#            ^ source.61131-3-st punctuation.separator.st
+#             ^ source.61131-3-st
+#              ^^^^^^ source.61131-3-st variable.other.st
+#                    ^ source.61131-3-st
+#                     ^^ source.61131-3-st keyword.operator.assignment.st
+#                       ^ source.61131-3-st
+#                        ^^^^^ source.61131-3-st constant.language.boolean.st
+#                             ^ source.61131-3-st punctuation.separator.st
+>    ELSE
+#^^^^ source.61131-3-st
+#    ^^^^ source.61131-3-st keyword.control.conditional.st
+>        myBool := NOT myBool;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^^ source.61131-3-st variable.other.st
+#              ^ source.61131-3-st
+#               ^^ source.61131-3-st keyword.operator.assignment.st
+#                 ^ source.61131-3-st
+#                  ^^^ source.61131-3-st keyword.operator.logical.st
+#                     ^ source.61131-3-st
+#                      ^^^^^^ source.61131-3-st variable.other.st
+#                            ^ source.61131-3-st punctuation.separator.st
+>    END_CASE;
+#^^^^ source.61131-3-st
+#    ^^^^^^^^ source.61131-3-st keyword.control.conditional.st
+#            ^ source.61131-3-st punctuation.separator.st
+>
+>    (* For loop *)
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#      ^^^^^^^^^^ source.61131-3-st comment.block.st
+#                ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>    FOR i := 0 TO 9 BY 1 DO
+#^^^^ source.61131-3-st
+#    ^^^ source.61131-3-st keyword.control.loop.st
+#       ^ source.61131-3-st
+#        ^ source.61131-3-st variable.other.st
+#         ^ source.61131-3-st
+#          ^^ source.61131-3-st keyword.operator.assignment.st
+#            ^ source.61131-3-st
+#             ^ source.61131-3-st constant.numeric.decimal.st
+#              ^ source.61131-3-st
+#               ^^ source.61131-3-st keyword.control.loop.st
+#                 ^ source.61131-3-st
+#                  ^ source.61131-3-st constant.numeric.decimal.st
+#                   ^ source.61131-3-st
+#                    ^^ source.61131-3-st keyword.control.loop.st
+#                      ^ source.61131-3-st
+#                       ^ source.61131-3-st constant.numeric.decimal.st
+#                        ^ source.61131-3-st
+#                         ^^ source.61131-3-st keyword.control.loop.st
+>        myArray[i] := i * i;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^^^ source.61131-3-st variable.other.st
+#               ^ source.61131-3-st punctuation.section.brackets.st
+#                ^ source.61131-3-st variable.other.st
+#                 ^ source.61131-3-st punctuation.section.brackets.st
+#                  ^ source.61131-3-st
+#                   ^^ source.61131-3-st keyword.operator.assignment.st
+#                     ^ source.61131-3-st
+#                      ^ source.61131-3-st variable.other.st
+#                       ^ source.61131-3-st
+#                        ^ source.61131-3-st keyword.operator.arithmetic.st
+#                         ^ source.61131-3-st
+#                          ^ source.61131-3-st variable.other.st
+#                           ^ source.61131-3-st punctuation.separator.st
+>    END_FOR;
+#^^^^ source.61131-3-st
+#    ^^^^^^^ source.61131-3-st keyword.control.loop.st
+#           ^ source.61131-3-st punctuation.separator.st
+>
+>    (* While loop *)
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#      ^^^^^^^^^^^^ source.61131-3-st comment.block.st
+#                  ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>    WHILE myInt > 0 DO
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st keyword.control.loop.st
+#         ^ source.61131-3-st
+#          ^^^^^ source.61131-3-st variable.other.st
+#               ^ source.61131-3-st
+#                ^ source.61131-3-st keyword.operator.comparison.st
+#                 ^ source.61131-3-st
+#                  ^ source.61131-3-st constant.numeric.decimal.st
+#                   ^ source.61131-3-st
+#                    ^^ source.61131-3-st keyword.control.loop.st
+>        myInt := myInt - 1;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^ source.61131-3-st variable.other.st
+#             ^ source.61131-3-st
+#              ^^ source.61131-3-st keyword.operator.assignment.st
+#                ^ source.61131-3-st
+#                 ^^^^^ source.61131-3-st variable.other.st
+#                      ^ source.61131-3-st
+#                       ^ source.61131-3-st keyword.operator.arithmetic.st
+#                        ^ source.61131-3-st
+#                         ^ source.61131-3-st constant.numeric.decimal.st
+#                          ^ source.61131-3-st punctuation.separator.st
+>    END_WHILE;
+#^^^^ source.61131-3-st
+#    ^^^^^^^^^ source.61131-3-st keyword.control.loop.st
+#             ^ source.61131-3-st punctuation.separator.st
+>
+>    (* Repeat loop *)
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#      ^^^^^^^^^^^^^ source.61131-3-st comment.block.st
+#                   ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>    REPEAT
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st keyword.control.loop.st
+>        temp1 := temp1 + 1.0;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^ source.61131-3-st variable.other.st
+#             ^ source.61131-3-st
+#              ^^ source.61131-3-st keyword.operator.assignment.st
+#                ^ source.61131-3-st
+#                 ^^^^^ source.61131-3-st variable.other.st
+#                      ^ source.61131-3-st
+#                       ^ source.61131-3-st keyword.operator.arithmetic.st
+#                        ^ source.61131-3-st
+#                         ^^^ source.61131-3-st constant.numeric.decimal.st
+#                            ^ source.61131-3-st punctuation.separator.st
+>    UNTIL temp1 >= 10.0
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st keyword.control.loop.st
+#         ^ source.61131-3-st
+#          ^^^^^ source.61131-3-st variable.other.st
+#               ^ source.61131-3-st
+#                ^ source.61131-3-st keyword.operator.comparison.st
+#                 ^ source.61131-3-st keyword.operator.comparison.st
+#                  ^ source.61131-3-st
+#                   ^^^^ source.61131-3-st constant.numeric.decimal.st
+>    END_REPEAT;
+#^^^^ source.61131-3-st
+#    ^^^^^^^^^^ source.61131-3-st keyword.control.loop.st
+#              ^ source.61131-3-st punctuation.separator.st
+>
+>    (* Operators *)
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#      ^^^^^^^^^^^ source.61131-3-st comment.block.st
+#                 ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>    myBool := (input1 = input2) OR (input1 <> 0);
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^^ source.61131-3-st keyword.operator.assignment.st
+#             ^ source.61131-3-st
+#              ^ source.61131-3-st punctuation.section.parens.st
+#               ^^^^^^ source.61131-3-st variable.other.st
+#                     ^ source.61131-3-st
+#                      ^ source.61131-3-st keyword.operator.comparison.st
+#                       ^ source.61131-3-st
+#                        ^^^^^^ source.61131-3-st variable.other.st
+#                              ^ source.61131-3-st punctuation.section.parens.st
+#                               ^ source.61131-3-st
+#                                ^^ source.61131-3-st keyword.operator.logical.st
+#                                  ^ source.61131-3-st
+#                                   ^ source.61131-3-st punctuation.section.parens.st
+#                                    ^^^^^^ source.61131-3-st variable.other.st
+#                                          ^ source.61131-3-st
+#                                           ^^ source.61131-3-st keyword.operator.comparison.st
+#                                             ^ source.61131-3-st
+#                                              ^ source.61131-3-st constant.numeric.decimal.st
+#                                               ^ source.61131-3-st punctuation.section.parens.st
+#                                                ^ source.61131-3-st punctuation.separator.st
+>    myBool := myBool AND NOT FALSE;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^^ source.61131-3-st keyword.operator.assignment.st
+#             ^ source.61131-3-st
+#              ^^^^^^ source.61131-3-st variable.other.st
+#                    ^ source.61131-3-st
+#                     ^^^ source.61131-3-st keyword.operator.logical.st
+#                        ^ source.61131-3-st
+#                         ^^^ source.61131-3-st keyword.operator.logical.st
+#                            ^ source.61131-3-st
+#                             ^^^^^ source.61131-3-st constant.language.boolean.st
+#                                  ^ source.61131-3-st punctuation.separator.st
+>    myBool := input1 < input2;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^^ source.61131-3-st keyword.operator.assignment.st
+#             ^ source.61131-3-st
+#              ^^^^^^ source.61131-3-st variable.other.st
+#                    ^ source.61131-3-st
+#                     ^ source.61131-3-st keyword.operator.comparison.st
+#                      ^ source.61131-3-st
+#                       ^^^^^^ source.61131-3-st variable.other.st
+#                             ^ source.61131-3-st punctuation.separator.st
+>    myBool := input1 >= input2;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^^ source.61131-3-st keyword.operator.assignment.st
+#             ^ source.61131-3-st
+#              ^^^^^^ source.61131-3-st variable.other.st
+#                    ^ source.61131-3-st
+#                     ^ source.61131-3-st keyword.operator.comparison.st
+#                      ^ source.61131-3-st keyword.operator.comparison.st
+#                       ^ source.61131-3-st
+#                        ^^^^^^ source.61131-3-st variable.other.st
+#                              ^ source.61131-3-st punctuation.separator.st
+>
+>    (* Numeric literals *)
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st comment.block.st punctuation.definition.comment.begin.st
+#      ^^^^^^^^^^^^^^^^^^ source.61131-3-st comment.block.st
+#                        ^^ source.61131-3-st comment.block.st punctuation.definition.comment.end.st
+>    myInt := 16#FF;
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st variable.other.st
+#         ^ source.61131-3-st
+#          ^^ source.61131-3-st keyword.operator.assignment.st
+#            ^ source.61131-3-st
+#             ^^^^^ source.61131-3-st constant.numeric.hex.st
+#                  ^ source.61131-3-st punctuation.separator.st
+>    myInt := 8#77;
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st variable.other.st
+#         ^ source.61131-3-st
+#          ^^ source.61131-3-st keyword.operator.assignment.st
+#            ^ source.61131-3-st
+#             ^^^^ source.61131-3-st constant.numeric.octal.st
+#                 ^ source.61131-3-st punctuation.separator.st
+>    myInt := 2#1010;
+#^^^^ source.61131-3-st
+#    ^^^^^ source.61131-3-st variable.other.st
+#         ^ source.61131-3-st
+#          ^^ source.61131-3-st keyword.operator.assignment.st
+#            ^ source.61131-3-st
+#             ^^^^^^ source.61131-3-st constant.numeric.binary.st
+#                   ^ source.61131-3-st punctuation.separator.st
+>    myReal := 1.5e10;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^^ source.61131-3-st keyword.operator.assignment.st
+#             ^ source.61131-3-st
+#              ^^^^^^ source.61131-3-st constant.numeric.float.st
+#                    ^ source.61131-3-st punctuation.separator.st
+>
+>END_PROGRAM
+#^^^^^^^^^^^ source.61131-3-st keyword.declaration.pou.st
+>
+>FUNCTION MyFunction : BOOL
+#^^^^^^^^ source.61131-3-st keyword.declaration.pou.st
+#        ^ source.61131-3-st
+#         ^^^^^^^^^^ source.61131-3-st entity.name.function.st
+#                   ^ source.61131-3-st
+#                    ^ source.61131-3-st punctuation.separator.st
+#                     ^ source.61131-3-st
+#                      ^^^^ source.61131-3-st storage.type.primitive.integer.st
+>VAR_INPUT
+#^^^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>    x : INT;
+#^^^^ source.61131-3-st
+#    ^ source.61131-3-st variable.other.st
+#     ^ source.61131-3-st
+#      ^ source.61131-3-st punctuation.separator.st
+#       ^ source.61131-3-st
+#        ^^^ source.61131-3-st storage.type.primitive.integer.st
+#           ^ source.61131-3-st punctuation.separator.st
+>END_VAR
+#^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>    IF x > 0 THEN
+#^^^^ source.61131-3-st
+#    ^^ source.61131-3-st keyword.control.conditional.st
+#      ^ source.61131-3-st
+#       ^ source.61131-3-st variable.other.st
+#        ^ source.61131-3-st
+#         ^ source.61131-3-st keyword.operator.comparison.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st constant.numeric.decimal.st
+#            ^ source.61131-3-st
+#             ^^^^ source.61131-3-st keyword.control.conditional.st
+>        RETURN TRUE;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^^ source.61131-3-st keyword.control.flow.st
+#              ^ source.61131-3-st
+#               ^^^^ source.61131-3-st constant.language.boolean.st
+#                   ^ source.61131-3-st punctuation.separator.st
+>    ELSE
+#^^^^ source.61131-3-st
+#    ^^^^ source.61131-3-st keyword.control.conditional.st
+>        RETURN FALSE;
+#^^^^^^^^ source.61131-3-st
+#        ^^^^^^ source.61131-3-st keyword.control.flow.st
+#              ^ source.61131-3-st
+#               ^^^^^ source.61131-3-st constant.language.boolean.st
+#                    ^ source.61131-3-st punctuation.separator.st
+>    END_IF;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st keyword.control.conditional.st
+#          ^ source.61131-3-st punctuation.separator.st
+>END_FUNCTION
+#^^^^^^^^^^^^ source.61131-3-st keyword.declaration.pou.st
+>
+>FUNCTION_BLOCK MyFB
+#^^^^^^^^^^^^^^ source.61131-3-st keyword.declaration.pou.st
+#              ^ source.61131-3-st
+#               ^^^^ source.61131-3-st entity.name.function.st
+>VAR
+#^^^ source.61131-3-st keyword.declaration.variable.st
+>    counter : UDINT;
+#^^^^ source.61131-3-st
+#    ^^^^^^^ source.61131-3-st variable.other.st
+#           ^ source.61131-3-st
+#            ^ source.61131-3-st punctuation.separator.st
+#             ^ source.61131-3-st
+#              ^^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                   ^ source.61131-3-st punctuation.separator.st
+>END_VAR
+#^^^^^^^ source.61131-3-st keyword.declaration.variable.st
+>    counter := counter + 1;
+#^^^^ source.61131-3-st
+#    ^^^^^^^ source.61131-3-st variable.other.st
+#           ^ source.61131-3-st
+#            ^^ source.61131-3-st keyword.operator.assignment.st
+#              ^ source.61131-3-st
+#               ^^^^^^^ source.61131-3-st variable.other.st
+#                      ^ source.61131-3-st
+#                       ^ source.61131-3-st keyword.operator.arithmetic.st
+#                        ^ source.61131-3-st
+#                         ^ source.61131-3-st constant.numeric.decimal.st
+#                          ^ source.61131-3-st punctuation.separator.st
+>END_FUNCTION_BLOCK
+#^^^^^^^^^^^^^^^^^^ source.61131-3-st keyword.declaration.pou.st
+>
+>TYPE MyStruct :
+#^^^^ source.61131-3-st keyword.declaration.type.st
+#    ^ source.61131-3-st
+#     ^^^^^^^^ source.61131-3-st entity.name.type.st
+#             ^ source.61131-3-st
+#              ^ source.61131-3-st punctuation.separator.st
+>STRUCT
+#^^^^^^ source.61131-3-st keyword.declaration.type.st
+>    field1 : BOOL;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st punctuation.separator.st
+#            ^ source.61131-3-st
+#             ^^^^ source.61131-3-st storage.type.primitive.integer.st
+#                 ^ source.61131-3-st punctuation.separator.st
+>    field2 : INT;
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^ source.61131-3-st punctuation.separator.st
+#            ^ source.61131-3-st
+#             ^^^ source.61131-3-st storage.type.primitive.integer.st
+#                ^ source.61131-3-st punctuation.separator.st
+>END_STRUCT
+#^^^^^^^^^^ source.61131-3-st keyword.declaration.type.st
+>END_TYPE
+#^^^^^^^^ source.61131-3-st keyword.declaration.type.st
+>


### PR DESCRIPTION
## Summary
This PR adds comprehensive grammar snapshot testing for the VS Code extension to validate syntax highlighting across PLCopen XML and Structured Text files. It introduces the `vscode-tmgrammar-test` testing framework and establishes baseline snapshots for grammar verification.

## Key Changes
- **Added grammar testing framework**: Integrated `vscode-tmgrammar-test` (v0.1.3) as a dev dependency to enable TextMate grammar snapshot testing
- **Created test snapshots**: Added three baseline snapshot test files covering:
  - Basic PLCopen XML structure (`plcopen-basic.plcxml`)
  - Configuration elements with variables and resources (`plcopen-configuration.plcxml`)
  - POU definitions including functions, function blocks, and programs (`plcopen-pou.plcxml`)
- **Updated build pipeline**: Added `test-grammar` task to CI workflow and created `update-grammar-snapshots` command for maintaining snapshots after intentional grammar changes
- **Fixed file association**: Added `.plcxml` extension to the PLCopen XML language configuration in `package.json`
- **Updated npm scripts**: Added `test:grammar` and `test:grammar:update` scripts for running and updating grammar tests

## Implementation Details
- Grammar snapshots use the standard TextMate grammar testing format with detailed token scope annotations
- Tests validate proper syntax highlighting for XML declarations, tags, attributes, comments, and language-specific elements
- The testing framework includes dependencies on `vscode-textmate`, `vscode-oniguruma`, and other utilities for accurate grammar parsing
- Snapshots can be regenerated after intentional grammar rule changes using the update command

https://claude.ai/code/session_01Km1RU3tqrwpCxpdnk8qzwr