### PR TITLE
Expose SemanticContext from analysis pipeline for LSP features

### DIFF
--- a/compiler/plc2x/src/lsp_project.rs
+++ b/compiler/plc2x/src/lsp_project.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use ironplc_analyzer::SemanticContext;
 use ironplc_dsl::core::FileId;
 use ironplc_parser::token::{Token, TokenType};
 use log::error;
@@ -97,6 +98,15 @@ impl LspProject {
         }
 
         vec![]
+    }
+
+    /// Returns the semantic context from the last successful analysis.
+    ///
+    /// This provides access to type, function, and symbol information
+    /// for IDE features like document symbols, go to definition, and hover.
+    #[allow(dead_code)]
+    pub(crate) fn semantic_context(&self) -> Option<&SemanticContext> {
+        self.wrapped.semantic_context()
     }
 }
 


### PR DESCRIPTION
- Modify analyze() to return Result<SemanticContext, Vec<Diagnostic>>
  instead of discarding the context after analysis
- Add semantic_context() method to Project trait
- Update FileBackedProject to cache SemanticContext after successful
  analysis and return it via the new trait method
- Add semantic_context() to LspProject for IDE feature access

This enables LSP features like document symbols, go to definition,
and hover to access type, function, and symbol information.

https://claude.ai/code/session_017qhx5bU96N94MiFzUDT9yC