### PR TITLE
Fix ArrayVariable Display format to use proper bracket notation

### DIFF
--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -42,10 +42,35 @@ impl ConstantKind {
     }
 }
 
+impl fmt::Display for ConstantKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConstantKind::IntegerLiteral(lit) => write!(f, "{}", lit),
+            ConstantKind::RealLiteral(lit) => write!(f, "{}", lit),
+            ConstantKind::Boolean(lit) => write!(f, "{}", lit),
+            ConstantKind::CharacterString(lit) => write!(f, "{}", lit),
+            ConstantKind::Duration(lit) => write!(f, "{}", lit),
+            ConstantKind::TimeOfDay(lit) => write!(f, "{}", lit),
+            ConstantKind::Date(lit) => write!(f, "{}", lit),
+            ConstantKind::DateAndTime(lit) => write!(f, "{}", lit),
+            ConstantKind::BitStringLiteral(lit) => write!(f, "{}", lit),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Boolean {
     True,
     False,
+}
+
+impl fmt::Display for Boolean {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Boolean::True => write!(f, "TRUE"),
+            Boolean::False => write!(f, "FALSE"),
+        }
+    }
 }
 
 // Numeric liberals declared by 2.2.1. Numeric literals define
@@ -328,6 +353,15 @@ pub struct IntegerLiteral {
     pub data_type: Option<ElementaryTypeName>,
 }
 
+impl fmt::Display for IntegerLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.data_type {
+            Some(dt) => write!(f, "{}#{}", dt, self.value),
+            None => write!(f, "{}", self.value),
+        }
+    }
+}
+
 /// The fixed point structure represents a fixed point number.
 ///
 /// The structure keeps the whole and decimal parts as integers so that
@@ -437,6 +471,15 @@ impl RealLiteral {
     }
 }
 
+impl fmt::Display for RealLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.data_type {
+            Some(dt) => write!(f, "{}#{}", dt, self.value),
+            None => write!(f, "{}", self.value),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct BooleanLiteral {
     pub value: Boolean,
@@ -445,6 +488,12 @@ pub struct BooleanLiteral {
 impl BooleanLiteral {
     pub fn new(value: Boolean) -> Self {
         Self { value }
+    }
+}
+
+impl fmt::Display for BooleanLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value)
     }
 }
 
@@ -460,12 +509,28 @@ impl CharacterStringLiteral {
     }
 }
 
+impl fmt::Display for CharacterStringLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s: String = self.value.iter().collect();
+        write!(f, "'{}'", s)
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct BitStringLiteral {
     pub value: Integer,
     // TODO restrict to valid float type names
     #[recurse(ignore)]
     pub data_type: Option<ElementaryTypeName>,
+}
+
+impl fmt::Display for BitStringLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.data_type {
+            Some(dt) => write!(f, "{}#{}", dt, self.value),
+            None => write!(f, "{}", self.value),
+        }
+    }
 }
 
 /// Implements a type identifier.
@@ -596,6 +661,12 @@ impl ElementaryTypeName {
             ElementaryTypeName::LWORD => Id::from("LWORD"),
             ElementaryTypeName::WSTRING => Id::from("WSTRING"),
         }
+    }
+}
+
+impl fmt::Display for ElementaryTypeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_id())
     }
 }
 
@@ -965,6 +1036,15 @@ impl Located for EnumeratedValue {
         match &self.type_name {
             Some(name) => SourceSpan::join2(name, &self.value),
             None => self.value.span.clone(),
+        }
+    }
+}
+
+impl fmt::Display for EnumeratedValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.type_name {
+            Some(type_name) => write!(f, "{}#{}", type_name, self.value),
+            None => write!(f, "{}", self.value),
         }
     }
 }

--- a/compiler/dsl/src/time.rs
+++ b/compiler/dsl/src/time.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use time::{
     convert::{Day, Hour, Minute, Second},
     Date, Duration, PrimitiveDateTime, Time,
@@ -135,6 +136,12 @@ impl DurationLiteral {
     }
 }
 
+impl fmt::Display for DurationLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TIME#{}ms", self.interval.whole_milliseconds())
+    }
+}
+
 // See section 2.2.3
 #[derive(Debug, PartialEq, Clone)]
 pub struct TimeOfDayLiteral {
@@ -149,6 +156,13 @@ impl TimeOfDayLiteral {
     /// Returns the hour, minute, second and millisecond from the literal.
     pub fn hmsm(&self) -> (u8, u8, u8, u32) {
         self.value.as_hms_micro()
+    }
+}
+
+impl fmt::Display for TimeOfDayLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (h, m, s, _) = self.hmsm();
+        write!(f, "TIME_OF_DAY#{:02}:{:02}:{:02}", h, m, s)
     }
 }
 
@@ -169,6 +183,13 @@ impl DateLiteral {
         let month = self.value.month();
         let day = self.value.day();
         (year, month.into(), day)
+    }
+}
+
+impl fmt::Display for DateLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (y, m, d) = self.ymd();
+        write!(f, "DATE#{}-{:02}-{:02}", y, m, d)
     }
 }
 
@@ -194,5 +215,17 @@ impl DateAndTimeLiteral {
     /// Returns the hour, minute, second and millisecond from the literal.
     pub fn hmsm(&self) -> (u8, u8, u8, u32) {
         self.value.as_hms_micro()
+    }
+}
+
+impl fmt::Display for DateAndTimeLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (y, m, d) = self.ymd();
+        let (h, min, s, _) = self.hmsm();
+        write!(
+            f,
+            "DATE_AND_TIME#{}-{:02}-{:02}-{:02}:{:02}:{:02}",
+            y, m, d, h, min, s
+        )
     }
 }


### PR DESCRIPTION
Changed ArrayVariable::fmt to output proper IEC 61131-3 array access syntax (e.g., "data[0]" or "matrix[1, 2]") instead of debug format.

This required implementing Display for several supporting types:
- ExprKind and all expression variants (CompareExpr, BinaryExpr, UnaryExpr)
- ConstantKind and all literal types (IntegerLiteral, RealLiteral, etc.)
- Time-related types (DurationLiteral, DateLiteral, etc.)
- Operators (CompareOp, Operator, UnaryOp)
- EnumeratedValue, ElementaryTypeName, Function, LateBound

Added tests to verify the ArrayVariable Display format works correctly for single subscripts, multiple subscripts, and variable subscripts.

https://claude.ai/code/session_011iK9tkqTJ4ykgoiFhn1deZ