### PR TITLE
Add numeric stdlib functions (ABS, SQRT, MIN, MAX, LIMIT)

### DIFF
--- a/compiler/analyzer/src/function_environment.rs
+++ b/compiler/analyzer/src/function_environment.rs
@@ -316,8 +316,8 @@ mod tests {
         let env = FunctionEnvironmentBuilder::new()
             .with_stdlib_functions()
             .build();
-        // Should have 90 stdlib type conversion functions
-        assert_eq!(env.len(), 90);
+        // Should have 90 conversion + 5 numeric = 95 stdlib functions
+        assert_eq!(env.len(), 95);
         // Should be able to find conversion functions
         assert!(env.contains(&Id::from("INT_TO_REAL")));
         assert!(env.contains(&Id::from("REAL_TO_INT")));

--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -1,8 +1,9 @@
 //! Standard library function definitions for IEC 61131-3.
 //!
 //! This module defines the standard library functions specified in
-//! IEC 61131-3 Section 2.5.1.5, including:
+//! IEC 61131-3 Section 2.5.1, including:
 //! - Type conversion functions (INT_TO_REAL, REAL_TO_INT, etc.)
+//! - Numeric functions (ABS, SQRT, MIN, MAX, LIMIT)
 //!
 //! These functions are automatically available in the function environment
 //! and do not need to be declared by the user.
@@ -155,6 +156,55 @@ fn get_real_to_real_conversions() -> Vec<FunctionSignature> {
 }
 
 // =============================================================================
+// Numeric Function Definitions (IEC 61131-3 Section 2.5.1.5.2)
+// =============================================================================
+
+/// Returns standard numeric function definitions.
+///
+/// These functions are defined in IEC 61131-3 as operating on generic
+/// type categories (ANY_NUM, ANY_REAL). Parameter and return types use
+/// the generic type names so that future type validation can check
+/// compatibility via `GenericTypeName::is_compatible_with()`.
+fn get_numeric_functions() -> Vec<FunctionSignature> {
+    vec![
+        // ABS: absolute value (ANY_NUM -> ANY_NUM)
+        FunctionSignature::stdlib(
+            "ABS",
+            TypeName::from("ANY_NUM"),
+            vec![input_param("IN", "ANY_NUM")],
+        ),
+        // SQRT: square root (ANY_REAL -> ANY_REAL)
+        FunctionSignature::stdlib(
+            "SQRT",
+            TypeName::from("ANY_REAL"),
+            vec![input_param("IN", "ANY_REAL")],
+        ),
+        // MIN: minimum of two values (ANY_NUM, ANY_NUM -> ANY_NUM)
+        FunctionSignature::stdlib(
+            "MIN",
+            TypeName::from("ANY_NUM"),
+            vec![input_param("IN1", "ANY_NUM"), input_param("IN2", "ANY_NUM")],
+        ),
+        // MAX: maximum of two values (ANY_NUM, ANY_NUM -> ANY_NUM)
+        FunctionSignature::stdlib(
+            "MAX",
+            TypeName::from("ANY_NUM"),
+            vec![input_param("IN1", "ANY_NUM"), input_param("IN2", "ANY_NUM")],
+        ),
+        // LIMIT: clamp value to range (ANY_NUM, ANY_NUM, ANY_NUM -> ANY_NUM)
+        FunctionSignature::stdlib(
+            "LIMIT",
+            TypeName::from("ANY_NUM"),
+            vec![
+                input_param("MN", "ANY_NUM"),
+                input_param("IN", "ANY_NUM"),
+                input_param("MX", "ANY_NUM"),
+            ],
+        ),
+    ]
+}
+
+// =============================================================================
 // Public API
 // =============================================================================
 
@@ -171,6 +221,9 @@ pub fn get_all_stdlib_functions() -> Vec<FunctionSignature> {
     functions.extend(get_real_to_int_conversions());
     functions.extend(get_real_to_real_conversions());
 
+    // Numeric functions
+    functions.extend(get_numeric_functions());
+
     functions
 }
 
@@ -186,8 +239,9 @@ mod tests {
         // Int-to-real: 4 signed × 2 reals + 4 unsigned × 2 reals = 8 + 8 = 16
         // Real-to-int: 2 reals × 4 signed + 2 reals × 4 unsigned = 8 + 8 = 16
         // Real-to-real: 2 × 1 = 2
-        // Total: 56 + 16 + 16 + 2 = 90
-        assert_eq!(functions.len(), 90);
+        // Numeric functions: ABS, SQRT, MIN, MAX, LIMIT = 5
+        // Total: 56 + 16 + 16 + 2 + 5 = 95
+        assert_eq!(functions.len(), 95);
     }
 
     #[test]
@@ -271,6 +325,88 @@ mod tests {
         assert!(functions
             .iter()
             .any(|f| f.name.original() == "LREAL_TO_REAL"));
+    }
+
+    #[test]
+    fn get_numeric_functions_when_called_then_contains_all_functions() {
+        let functions = get_numeric_functions();
+
+        assert_eq!(functions.len(), 5);
+
+        assert!(functions.iter().any(|f| f.name.original() == "ABS"));
+        assert!(functions.iter().any(|f| f.name.original() == "SQRT"));
+        assert!(functions.iter().any(|f| f.name.original() == "MIN"));
+        assert!(functions.iter().any(|f| f.name.original() == "MAX"));
+        assert!(functions.iter().any(|f| f.name.original() == "LIMIT"));
+    }
+
+    #[test]
+    fn get_numeric_functions_when_abs_then_has_one_input() {
+        let functions = get_numeric_functions();
+        let abs = functions
+            .iter()
+            .find(|f| f.name.original() == "ABS")
+            .unwrap();
+
+        assert_eq!(abs.input_parameter_count(), 1);
+        assert_eq!(abs.parameters[0].name.original(), "IN");
+        assert!(abs.is_stdlib());
+    }
+
+    #[test]
+    fn get_numeric_functions_when_sqrt_then_has_one_input() {
+        let functions = get_numeric_functions();
+        let sqrt = functions
+            .iter()
+            .find(|f| f.name.original() == "SQRT")
+            .unwrap();
+
+        assert_eq!(sqrt.input_parameter_count(), 1);
+        assert_eq!(sqrt.parameters[0].name.original(), "IN");
+        assert!(sqrt.is_stdlib());
+    }
+
+    #[test]
+    fn get_numeric_functions_when_min_then_has_two_inputs() {
+        let functions = get_numeric_functions();
+        let min = functions
+            .iter()
+            .find(|f| f.name.original() == "MIN")
+            .unwrap();
+
+        assert_eq!(min.input_parameter_count(), 2);
+        assert_eq!(min.parameters[0].name.original(), "IN1");
+        assert_eq!(min.parameters[1].name.original(), "IN2");
+        assert!(min.is_stdlib());
+    }
+
+    #[test]
+    fn get_numeric_functions_when_max_then_has_two_inputs() {
+        let functions = get_numeric_functions();
+        let max = functions
+            .iter()
+            .find(|f| f.name.original() == "MAX")
+            .unwrap();
+
+        assert_eq!(max.input_parameter_count(), 2);
+        assert_eq!(max.parameters[0].name.original(), "IN1");
+        assert_eq!(max.parameters[1].name.original(), "IN2");
+        assert!(max.is_stdlib());
+    }
+
+    #[test]
+    fn get_numeric_functions_when_limit_then_has_three_inputs() {
+        let functions = get_numeric_functions();
+        let limit = functions
+            .iter()
+            .find(|f| f.name.original() == "LIMIT")
+            .unwrap();
+
+        assert_eq!(limit.input_parameter_count(), 3);
+        assert_eq!(limit.parameters[0].name.original(), "MN");
+        assert_eq!(limit.parameters[1].name.original(), "IN");
+        assert_eq!(limit.parameters[2].name.original(), "MX");
+        assert!(limit.is_stdlib());
     }
 
     #[test]

--- a/compiler/analyzer/src/rule_function_call_declared.rs
+++ b/compiler/analyzer/src/rule_function_call_declared.rs
@@ -204,6 +204,119 @@ END_FUNCTION_BLOCK";
     }
 
     #[test]
+    fn apply_when_abs_called_then_ok() {
+        let program = "
+FUNCTION_BLOCK CALLER
+VAR
+    result : INT;
+    value : INT;
+END_VAR
+    result := ABS(value);
+END_FUNCTION_BLOCK";
+
+        let (library, context) = parse_and_resolve_types_with_context(program);
+        let result = apply(&library, &context);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_when_sqrt_called_then_ok() {
+        let program = "
+FUNCTION_BLOCK CALLER
+VAR
+    result : REAL;
+    value : REAL;
+END_VAR
+    result := SQRT(value);
+END_FUNCTION_BLOCK";
+
+        let (library, context) = parse_and_resolve_types_with_context(program);
+        let result = apply(&library, &context);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_when_min_called_then_ok() {
+        let program = "
+FUNCTION_BLOCK CALLER
+VAR
+    result : INT;
+    a : INT;
+    b : INT;
+END_VAR
+    result := MIN(a, b);
+END_FUNCTION_BLOCK";
+
+        let (library, context) = parse_and_resolve_types_with_context(program);
+        let result = apply(&library, &context);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_when_max_called_then_ok() {
+        let program = "
+FUNCTION_BLOCK CALLER
+VAR
+    result : INT;
+    a : INT;
+    b : INT;
+END_VAR
+    result := MAX(a, b);
+END_FUNCTION_BLOCK";
+
+        let (library, context) = parse_and_resolve_types_with_context(program);
+        let result = apply(&library, &context);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_when_limit_called_then_ok() {
+        let program = "
+FUNCTION_BLOCK CALLER
+VAR
+    result : INT;
+    low : INT;
+    value : INT;
+    high : INT;
+END_VAR
+    result := LIMIT(low, value, high);
+END_FUNCTION_BLOCK";
+
+        let (library, context) = parse_and_resolve_types_with_context(program);
+        let result = apply(&library, &context);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_when_limit_called_with_wrong_arg_count_then_error() {
+        let program = "
+FUNCTION_BLOCK CALLER
+VAR
+    result : INT;
+    a : INT;
+    b : INT;
+END_VAR
+    result := LIMIT(a, b);
+END_FUNCTION_BLOCK";
+
+        let (library, context) = parse_and_resolve_types_with_context(program);
+        let result = apply(&library, &context);
+
+        assert!(result.is_err());
+        let diagnostics = result.unwrap_err();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            Problem::FunctionCallWrongArgCount.code()
+        );
+    }
+
+    #[test]
     fn apply_when_too_few_args_then_error() {
         let program = "
 FUNCTION ADD_INTS : INT


### PR DESCRIPTION
## Summary
This PR adds support for five standard numeric functions defined in IEC 61131-3 Section 2.5.1.5.2: ABS, SQRT, MIN, MAX, and LIMIT. These functions are now automatically available in the standard library function environment.

## Key Changes
- **New `get_numeric_functions()` function**: Defines signatures for ABS, SQRT, MIN, MAX, and LIMIT using generic type names (ANY_NUM, ANY_REAL) to support future type validation
  - ABS: Takes one ANY_NUM parameter, returns ANY_NUM
  - SQRT: Takes one ANY_REAL parameter, returns ANY_REAL
  - MIN/MAX: Take two ANY_NUM parameters, return ANY_NUM
  - LIMIT: Takes three ANY_NUM parameters (minimum, input, maximum), returns ANY_NUM

- **Integration into stdlib**: Updated `get_all_stdlib_functions()` to include the new numeric functions, bringing the total from 90 to 95 stdlib functions

- **Documentation updates**: 
  - Corrected IEC 61131-3 section reference in module documentation (2.5.1.5 → 2.5.1)
  - Added numeric functions to the module-level documentation

- **Comprehensive test coverage**: Added 6 new tests in `stdlib_function.rs` verifying:
  - All 5 numeric functions are present
  - Each function has correct parameter count and names
  - All are marked as stdlib functions

- **Integration tests**: Added 6 new tests in `rule_function_call_declared.rs` verifying:
  - ABS, SQRT, MIN, MAX, LIMIT can be called successfully with correct arguments
  - LIMIT properly rejects incorrect argument counts

- **Updated test assertions**: Adjusted function count assertions from 90 to 95 in both test modules

## Implementation Details
The numeric functions use generic type names (ANY_NUM, ANY_REAL) rather than concrete types, allowing the type validation system to check compatibility through `GenericTypeName::is_compatible_with()` in future enhancements. This design follows the same pattern as existing type conversion functions.

https://claude.ai/code/session_01CvWTHwqHPRnJ1yJ2Q8fXZD