### PR TITLE
Add branch-and-PR workflow requirement to steering files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,18 @@ Before making changes, read the relevant steering files in `specs/steering/`:
 - **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules (especially relevant for `**/analyzer/**` files)
 - **[Steering File Guidelines](specs/steering/steering-file-guidelines.md)** - How to create and maintain steering files (for AI assistants updating documentation)
 
-## MANDATORY: Before Creating a PR
+## MANDATORY: Git Workflow
+
+**NEVER commit or push directly to `main`.** Always create a feature branch and open a pull request. This ensures CI validates all changes before they reach main.
+
+### Workflow
+
+1. Create a feature branch from `main`
+2. Make changes and commit to the feature branch
+3. Run the full CI pipeline: `cd compiler && just`
+4. Push the feature branch and create a PR via `gh pr create`
+
+### Before Creating a PR
 
 **You MUST run the full CI pipeline and verify it passes before creating any PR:**
 
@@ -51,8 +62,9 @@ See [specs/steering/common-tasks.md](specs/steering/common-tasks.md) for complet
 - `docs/` - Sphinx documentation website
 
 ### Critical Rules
-1. **Run `cd compiler && just` before creating any PR** - This runs clippy, tests, and all checks
-2. **BDD-style test names**: `function_when_condition_then_result`
-3. **Module size limit**: Max 1000 lines per module
-4. **Problem codes**: Must be documented in `docs/compiler/problems/P####.rst`
-5. **Version numbers**: Automatically managed - do not edit manually
+1. **NEVER push directly to `main`** - Always use a feature branch and pull request
+2. **Run `cd compiler && just` before creating any PR** - This runs clippy, tests, and all checks
+3. **BDD-style test names**: `function_when_condition_then_result`
+4. **Module size limit**: Max 1000 lines per module
+5. **Problem codes**: Must be documented in `docs/compiler/problems/P####.rst`
+6. **Version numbers**: Automatically managed - do not edit manually

--- a/specs/steering/common-tasks.md
+++ b/specs/steering/common-tasks.md
@@ -15,6 +15,18 @@ IronPLC uses [just](https://github.com/casey/just) as its command runner. All bu
 - **`docs/justfile`**: Documentation build and publishing
 - **`integrations/vscode/justfile`**: VS Code extension tasks
 
+## CRITICAL: Git Workflow
+
+**NEVER commit or push directly to `main`.** Always create a feature branch and open a pull request. This ensures CI validates all changes before they reach main.
+
+```bash
+git checkout -b feature/my-change    # Create a feature branch
+# ... make changes, commit ...
+cd compiler && just                   # Run full CI pipeline
+git push -u origin feature/my-change  # Push the branch
+gh pr create                          # Open a pull request
+```
+
 ## CRITICAL: Pre-PR Requirements
 
 **Before creating any pull request, you MUST run the full CI pipeline and ensure all checks pass.**

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -245,7 +245,9 @@ Use `just` for all build tasks. Key commands:
 
 For complete setup and development workflow instructions, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-### CRITICAL: Pre-PR Quality Gate
+### CRITICAL: Git Workflow and Pre-PR Quality Gate
+
+**NEVER commit or push directly to `main`.** Always create a feature branch and open a pull request. This ensures CI validates all changes before they reach main.
 
 **Before creating any pull request, you MUST run and pass the full CI pipeline:**
 
@@ -256,6 +258,7 @@ cd compiler && just
 This runs compile, test, coverage, and lint. The **lint step includes clippy**, which catches common Rust issues. PRs that fail clippy will be rejected by CI.
 
 **Do not:**
+- Push directly to `main` — always use a feature branch and PR
 - Skip running `just` before creating a PR
 - Suppress clippy warnings with `#[allow(...)]` unless justified
 - Create a PR if any check fails


### PR DESCRIPTION
Explicitly require feature branches and pull requests for all changes — never push directly to main. This ensures CI validates changes before they reach the default branch.