### PR TITLE
Fix bugs and gaps found in bytecode VM spec review

### DIFF
--- a/specs/adrs/0004-separate-type-families-over-polymorphic-opcodes.md
+++ b/specs/adrs/0004-separate-type-families-over-polymorphic-opcodes.md
@@ -36,10 +36,10 @@ Specifically:
 ### Consequences
 
 * Good, because a `buf_idx` value can never be consumed by an FB_* opcode (or vice versa) — the verifier rejects it statically
-* Good, because a STRING buffer can never be silently passed to a WSTR_* opcode — the verifier rejects it statically, and the VM can trap on mismatch as defense-in-depth
+* Good, because a STRING buffer can never be silently passed to a WSTR_* opcode — the verifier rejects it statically. As defense-in-depth, the VM maintains a one-byte encoding tag (narrow/wide) per buffer entry in the buffer table and asserts that STR_* opcodes always receive narrow-tagged buffers and WSTR_* opcodes always receive wide-tagged buffers, trapping immediately on mismatch. This tag costs one byte per buffer (not per stack value) and is only checked at string opcode entry points — a negligible overhead compared to the string operation itself.
 * Good, because the verifier does not need runtime type tags to prove type safety — the opcode itself encodes the expected type
 * Good, because this eliminates the entire class of "confused reference type" vulnerabilities that have led to sandbox escapes in the JVM and arbitrary code execution in Lua
-* Bad, because the WSTRING family adds 13 opcodes (one per STRING opcode), bringing the total from 163 to 176 — consuming 69% of the 256-opcode budget
+* Bad, because the WSTRING family adds 13 opcodes (one per STRING opcode), bringing the total from 163 to 176 — consuming 69% of the 256-opcode budget (178 with string constant opcodes from the instruction set spec)
 * Bad, because the interpreter has 13 additional dispatch handlers, most of which are near-identical to their STRING counterparts (differing only in character width)
 * Neutral, because the opcode budget still has 80 free slots after this decision, sufficient for planned future extensions (OOP method dispatch, pointer/reference operations)
 
@@ -104,4 +104,5 @@ Separate opcode families for STRING (`STR_*`), WSTRING (`WSTR_*`), and FB instan
 | Add WSTRING family (STR_* → STR_* + WSTR_*) | +13 | 163 | 93 |
 | Other decisions (arrays, TIME) | +4 | 167 | 89 |
 | Relocate debug opcodes | +0 | 167 | 89 |
-| Final total (with all changes) | | 176 | 80 |
+| Add string constant opcodes (LOAD_CONST_STR, LOAD_CONST_WSTR) | +2 | 169 | 87 |
+| Final total (with all changes) | | 178 | 78 |

--- a/specs/adrs/0005-safety-first-design-principle.md
+++ b/specs/adrs/0005-safety-first-design-principle.md
@@ -11,7 +11,7 @@ The bytecode instruction set design repeatedly encounters trade-offs between opc
 
 * **PLC programs control physical processes** — a VM bug that corrupts memory or silently produces wrong values can cause physical damage (equipment destruction, safety hazards)
 * **PLC programs run unattended for years** — a latent bug triggered by a rare input combination has years of opportunity to manifest, unlike desktop software that is frequently restarted
-* **Opcode budget has room** — at 176 of 256 opcodes used, there are 80 slots available; economy is not a binding constraint
+* **Opcode budget has room** — at 178 of 256 opcodes used, there are 78 slots available; economy is not a binding constraint
 * **Interpreter complexity is manageable** — the interpreter runs in Rust, so additional dispatch handlers add flash size but not memory safety risk
 * **Verification is planned** — a bytecode verifier (ADR-0006) relies on the instruction set encoding enough type information to verify statically; safety-oriented design directly reduces verifier complexity
 
@@ -42,7 +42,7 @@ The principle is: **when a design choice improves safety (verification, type che
 * Good, because every type distinction is statically verifiable from the opcode stream — the verifier is simpler and more trustworthy
 * Good, because the VM enforces invariants (bounds, types) even if the verifier has a bug — defense-in-depth
 * Good, because the principle provides a clear, repeatable decision framework for future extensions — contributors don't need to re-derive the reasoning each time
-* Good, because the opcode budget (80 remaining slots) can absorb many more safety-oriented additions before becoming a constraint
+* Good, because the opcode budget (78 remaining slots) can absorb many more safety-oriented additions before becoming a constraint
 * Bad, because the interpreter binary is larger than a minimal design — estimated ~10 KB additional flash for the WSTRING family and array/TIME handlers
 * Bad, because the principle occasionally rejects designs that are safe in practice but not provably safe by the verifier (e.g., polymorphic string ops with correct runtime tags are safe, but we reject them because "correct runtime tags" is an assumption, not a proof)
 * Neutral, because this principle can be overridden for specific decisions when the safety cost is genuinely minimal and the economy benefit is large — it is a default, not an absolute rule

--- a/specs/adrs/0007-dual-signature-integrity-model.md
+++ b/specs/adrs/0007-dual-signature-integrity-model.md
@@ -53,6 +53,7 @@ Two signatures:
 * Bad, because key management is required — the PLC must have a trusted public key (or certificate) to verify signatures against
 * Bad, because two signatures means two verification checks at load time — though the debug signature is optional and only verified when debug info is used
 * Bad, because the source hash is only useful if the engineer has access to the original source and computes the hash independently — it's a verification mechanism, not a display mechanism
+* Bad, because the source hash does not protect against a Stuxnet-style attacker who controls the communication channel between the PLC and the engineer — if the attacker can intercept reads from the PLC, they can present a fake source_hash. The source_hash is effective against offline tampering (someone modifies the bytecode file on disk) but not against an attacker with MITM access to the PLC communication protocol. An out-of-band verification channel (e.g., physical access to read flash contents) is needed for the strongest assurance.
 
 ### Confirmation
 


### PR DESCRIPTION
Addresses issues found during critical review of the bytecode VM specs and ADRs: internal contradictions, missing opcodes, underspecified verifier rules, and undocumented limitations.