### PR TITLE
Add E0002 and E0003 error codes for IPLC bytecode viewer

### DIFF
--- a/docs/vscode/problems/E0002.rst
+++ b/docs/vscode/problems/E0002.rst
@@ -1,0 +1,27 @@
+=====
+E0002
+=====
+
+.. problem-summary:: E0002
+
+The IPLC Bytecode Viewer could not find the IronPLC compiler when opening an :file:`.iplc` file.
+
+When you open an :file:`.iplc` bytecode file, the VS Code extension uses the IronPLC compiler
+to disassemble the binary contents. If the compiler has not started within a few seconds of
+opening the file, the viewer displays this error.
+
+This is similar to :doc:`E0001`, but occurs specifically in the bytecode viewer rather than
+during general extension activation.
+
+**Solutions**:
+
+1. **Verify installation**: Open a terminal and run :program:`ironplcc --version`. If this
+   fails, the compiler is not installed or not in your PATH.
+
+2. **Install the compiler**: See the :doc:`/quickstart/installation` guide.
+
+3. **Configure the path manually**: If the compiler is installed in a non-standard
+   location, set the ``ironplc.path`` setting to the full path of the executable.
+
+4. **Reload the window**: If the compiler was recently installed, run
+   "Developer: Reload Window" from the Command Palette to restart the extension.

--- a/docs/vscode/problems/E0003.rst
+++ b/docs/vscode/problems/E0003.rst
@@ -1,0 +1,32 @@
+=====
+E0003
+=====
+
+.. problem-summary:: E0003
+
+The IronPLC compiler failed to disassemble an :file:`.iplc` bytecode file.
+
+When you open an :file:`.iplc` file, the VS Code extension asks the compiler to disassemble
+the binary contents so they can be displayed in a human-readable form. This error means the
+compiler was found and running, but the disassembly request failed.
+
+Common causes include:
+
+- The file is corrupted or truncated
+- The file was created by an incompatible compiler version
+- The file is not a valid IPLC bytecode file despite having the :file:`.iplc` extension
+
+**Solutions**:
+
+1. **Check the file**: Ensure the file is a valid IPLC bytecode file produced by
+   the IronPLC compiler.
+
+2. **Recompile**: If the file was produced by an older compiler version, recompile
+   the source to produce an updated bytecode file.
+
+3. **Check for corruption**: If the file was transferred over a network or extracted
+   from an archive, verify it was not corrupted during transfer.
+
+4. **Report the issue**: If the file should be valid, open an issue on
+   `GitHub <https://github.com/ironplc/ironplc/issues>`_ with the error details
+   shown in the message.

--- a/docs/vscode/problems/index.rst
+++ b/docs/vscode/problems/index.rst
@@ -6,3 +6,5 @@ Problem Codes
    :maxdepth: 1
 
    E0001 <E0001>
+   E0002 <E0002>
+   E0003 <E0003>

--- a/integrations/vscode/resources/problem-codes.csv
+++ b/integrations/vscode/resources/problem-codes.csv
@@ -1,2 +1,4 @@
 Code,Name,Message
 E0001,NoCompiler,Unable to locate IronPLC compiler
+E0002,ViewerCompilerNotFound,IronPLC compiler not found when opening .iplc file
+E0003,DisassemblyFailed,Failed to disassemble .iplc bytecode file

--- a/integrations/vscode/src/iplcEditorProvider.ts
+++ b/integrations/vscode/src/iplcEditorProvider.ts
@@ -35,7 +35,7 @@ export class IplcEditorProvider implements vscode.CustomReadonlyEditorProvider<I
       const ready = await this.waitForClient(5000);
       if (!ready) {
         webviewPanel.webview.html = this.getErrorHtml(
-          'IronPLC compiler not found. Install the compiler to view .iplc files.',
+          'E0002 - IronPLC compiler not found. Install the compiler to view .iplc files.',
         );
         return;
       }
@@ -49,7 +49,7 @@ export class IplcEditorProvider implements vscode.CustomReadonlyEditorProvider<I
     }
     catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      webviewPanel.webview.html = this.getErrorHtml(`Failed to disassemble: ${message}`);
+      webviewPanel.webview.html = this.getErrorHtml(`E0003 - Failed to disassemble .iplc file: ${message}`);
     }
   }
 

--- a/specs/steering/problem-code-management.md
+++ b/specs/steering/problem-code-management.md
@@ -1,13 +1,22 @@
 # Problem Code Management
 
-This steering file provides specific guidance for managing problem codes in the IronPLC compiler. It applies when working with files in the `compiler/problems/` directory or when adding new error handling.
+This steering file provides specific guidance for managing problem codes in IronPLC. It applies when working with error handling in the compiler or the VS Code extension.
 
 > **Note**: This file covers the technical implementation of error handling. For general development workflow and build processes, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Fundamental Rule
+
+**Every user-facing error message MUST have a unique problem code.** This applies to all components — the compiler, the VS Code extension, and any other tooling. Error codes allow users to look up documentation, search for solutions, and report issues precisely. Never display an error to the user without an associated code.
+
+- **Compiler errors** use the `P####` prefix (e.g., P2016)
+- **VS Code extension errors** use the `E####` prefix (e.g., E0001)
 
 ## Applies To
 
 This guidance is particularly relevant when working with:
 - Files in `compiler/problems/*`
+- Files in `integrations/vscode/src/*` (extension error handling)
+- Files in `integrations/vscode/resources/problem-codes.csv`
 
 ## Problem Code Lifecycle
 
@@ -68,25 +77,74 @@ To fix this error, [specific guidance]:
 
 ## Problem Code Categories
 
-### Parsing Errors (P0001-P1999)
+### Compiler Problem Codes (P-prefix)
+
+#### Parsing Errors (P0001-P1999)
 - Syntax errors, unexpected tokens, malformed input
 - Examples: P0001 (OpenComment), P0002 (SyntaxError)
 
-### Type System Errors (P2000-P3999)
+#### Type System Errors (P2000-P3999)
 - Type declaration issues, type compatibility problems
 - Examples: P2002 (SubrangeMinStrictlyLessMax), P2016 (SubrangeOutOfBounds)
 
-### Semantic Analysis Errors (P4000-P5999)
+#### Semantic Analysis Errors (P4000-P5999)
 - Variable scoping, function calls, semantic validation
 - Examples: P4007 (VariableUndefined), P4012 (FunctionBlockNotInScope)
 
-### File System Errors (P6000-P7999)
+#### File System Errors (P6000-P7999)
 - File I/O, path resolution, encoding issues
 - Examples: P6001 (CannotCanonicalizePath), P6004 (CannotReadFile)
 
-### Internal Errors (P9000+)
+#### Internal Errors (P9000+)
 - Compiler bugs and unimplemented features
 - Examples: P9998 (InternalError), P9999 (NotImplemented)
+
+### VS Code Extension Error Codes (E-prefix)
+
+Extension errors use the `E####` format and are tracked separately from compiler problem codes.
+
+- **Registry**: `integrations/vscode/resources/problem-codes.csv`
+- **Documentation**: `docs/vscode/problems/E####.rst`
+- **Index**: `docs/vscode/problems/index.rst`
+
+#### Adding New Extension Error Codes
+
+1. **Choose the next available code**: Use the next sequential E#### number
+2. **Add to CSV**: Update `integrations/vscode/resources/problem-codes.csv`
+3. **Create documentation**: Add `docs/vscode/problems/E####.rst`
+4. **Update index**: Add the new entry to `docs/vscode/problems/index.rst`
+5. **Use the code in the error message**: Prefix user-facing messages with the code (e.g., `'E0002 - ...'`)
+
+#### Extension Error Message Pattern
+
+Error messages displayed to the user must include the code prefix:
+
+```typescript
+// In VS Code notification messages:
+vscode.window.showErrorMessage('E0001 - Unable to locate IronPLC compiler. ...');
+
+// In webview HTML error displays:
+this.getErrorHtml('E0002 - IronPLC compiler not found. ...');
+```
+
+#### Extension Error Documentation Template
+
+Create `docs/vscode/problems/E####.rst`:
+
+```rst
+=====
+E####
+=====
+
+.. problem-summary:: E####
+
+[Clear description of when this error occurs]
+
+**Solutions**:
+
+1. [First solution with clear steps]
+2. [Additional solutions]
+```
 
 ## Implementation Patterns
 
@@ -211,7 +269,9 @@ Problem codes are part of the public API:
 
 ## Quality Checklist
 
-Before adding a new problem code:
+### Compiler Problem Codes (P-prefix)
+
+Before adding a new compiler problem code:
 
 - [ ] Code follows P#### format
 - [ ] Name is descriptive and follows PascalCase
@@ -222,6 +282,17 @@ Before adding a new problem code:
 - [ ] Test exists that verifies the error is generated
 - [ ] Test verifies the correct problem code is returned
 - [ ] Build passes with new problem code
+
+### Extension Error Codes (E-prefix)
+
+Before adding a new extension error code:
+
+- [ ] Code follows E#### format
+- [ ] Added to `integrations/vscode/resources/problem-codes.csv`
+- [ ] Documentation file created in `docs/vscode/problems/E####.rst`
+- [ ] Added to `docs/vscode/problems/index.rst`
+- [ ] Error message in code is prefixed with the code (e.g., `'E0002 - ...'`)
+- [ ] Documentation describes the error condition and solutions
 
 ## Common Patterns
 


### PR DESCRIPTION
The bytecode viewer was missing error codes on its two user-facing error
messages. Add E0002 (compiler not found when opening .iplc file) and
E0003 (disassembly failure), with documentation for each.

Also update the problem-code-management steering file to require that
every user-facing error message has a unique code, and add guidance for
the E-prefix extension error code lifecycle.

https://claude.ai/code/session_01AUiLoNrEFzwdAvrjXSgjCV