### PR TITLE
Extract compiler discovery into testable module with unit tests

### DIFF
--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -167,7 +167,7 @@
     "pretest": "npm run compile && npm run lint",
     "validate-grammars": "ajv validate -s schemas/tmlanguage.json -d \"syntaxes/*.tmLanguage.json\"",
     "lint": "eslint src/**/*.ts && npm run validate-grammars",
-    "test:unit": "c8 --check-coverage --lines 80 --include 'out/iplcRendering.js' mocha --ui tdd 'out/test/unit/**/*.test.js'",
+    "test:unit": "c8 --check-coverage --lines 80 --include 'out/*.js' mocha --ui tdd 'out/test/unit/**/*.test.js'",
     "test:functional": "node ./out/test/functional/runTest.js",
     "test:grammar": "vscode-tmgrammar-snap -s source.plcopen-xml \"tests/grammar/snap/**/*.xml\" && vscode-tmgrammar-snap \"tests/grammar/snap/**/*.st\"",
     "test:grammar:update": "vscode-tmgrammar-snap -u -s source.plcopen-xml \"tests/grammar/snap/**/*.xml\" && vscode-tmgrammar-snap -u \"tests/grammar/snap/**/*.st\""

--- a/integrations/vscode/src/compilerDiscovery.ts
+++ b/integrations/vscode/src/compilerDiscovery.ts
@@ -1,0 +1,66 @@
+import * as path from 'path';
+
+export interface CompilerEnvironment {
+  platform: string;
+  existsSync: (path: string) => boolean;
+  getEnv: (name: string) => string | undefined;
+  getConfig: (key: string) => string | undefined;
+}
+
+export interface CompilerDiscoveryResult {
+  path: string;
+  source: string;
+}
+
+export function findCompilerPath(env: CompilerEnvironment): CompilerDiscoveryResult | undefined {
+  const ext = env.platform === 'win32' ? '.exe' : '';
+
+  const trialGenerator: (() => [string | undefined, string])[] = [
+    () => {
+      // Try to get from configuration
+      return [env.getConfig('path'), 'configuration'];
+    },
+    () => {
+      // Try to get from environment variable. Not generally set.
+      return [env.getEnv('IRONPLC'), 'environment'];
+    },
+    () => {
+      // Mac well known directory
+      const homebrewDir = env.platform === 'darwin' ? '/opt/homebrew/bin' : undefined;
+      return [homebrewDir, 'homebrew'];
+    },
+    () => {
+      // Windows user-install well-known path
+      const name = 'localappdata';
+      const localAppData = env.getEnv('LOCALAPPDATA');
+
+      if (env.platform !== 'win32' || !localAppData) {
+        return [undefined, name];
+      }
+      const winAppDataDir = path.join(localAppData, 'Programs', 'IronPLC Compiler', 'bin');
+      return [winAppDataDir, name];
+    },
+  ];
+
+  const triedLocations: string[] = [];
+
+  for (const trial of trialGenerator) {
+    const result = trial();
+    const testDir = result[0];
+    const trialType = result[1];
+
+    if (!testDir) {
+      continue;
+    }
+
+    const testExe = path.join(testDir, 'ironplcc' + ext);
+    if (!env.existsSync(testExe)) {
+      triedLocations.push(trialType + ': (' + testExe + ')');
+      continue;
+    }
+
+    return { path: testExe, source: trialType };
+  }
+
+  return undefined;
+}

--- a/integrations/vscode/src/test/unit/compilerDiscovery.test.ts
+++ b/integrations/vscode/src/test/unit/compilerDiscovery.test.ts
@@ -1,0 +1,117 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { CompilerEnvironment, findCompilerPath } from '../../compilerDiscovery';
+
+function createTestEnv(overrides?: Partial<CompilerEnvironment>): CompilerEnvironment {
+  return {
+    platform: 'linux',
+    existsSync: () => false,
+    getEnv: () => undefined,
+    getConfig: () => undefined,
+    ...overrides,
+  };
+}
+
+suite('findCompilerPath', () => {
+  test('findCompilerPath_when_config_path_exists_then_returns_config_path', () => {
+    const env = createTestEnv({
+      getConfig: key => key === 'path' ? '/custom/dir' : undefined,
+      existsSync: p => p === '/custom/dir/ironplcc',
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.strictEqual(result.path, '/custom/dir/ironplcc');
+    assert.strictEqual(result.source, 'configuration');
+  });
+
+  test('findCompilerPath_when_config_path_missing_then_tries_env', () => {
+    const env = createTestEnv({
+      getConfig: () => undefined,
+      getEnv: name => name === 'IRONPLC' ? '/env/dir' : undefined,
+      existsSync: p => p === '/env/dir/ironplcc',
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.strictEqual(result.path, '/env/dir/ironplcc');
+    assert.strictEqual(result.source, 'environment');
+  });
+
+  test('findCompilerPath_when_env_var_exists_then_returns_env_path', () => {
+    const env = createTestEnv({
+      getEnv: name => name === 'IRONPLC' ? '/my/compiler' : undefined,
+      existsSync: p => p === '/my/compiler/ironplcc',
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.strictEqual(result.path, '/my/compiler/ironplcc');
+    assert.strictEqual(result.source, 'environment');
+  });
+
+  test('findCompilerPath_when_env_var_missing_then_tries_platform_paths', () => {
+    const env = createTestEnv({
+      platform: 'darwin',
+      existsSync: p => p === '/opt/homebrew/bin/ironplcc',
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.strictEqual(result.path, '/opt/homebrew/bin/ironplcc');
+    assert.strictEqual(result.source, 'homebrew');
+  });
+
+  test('findCompilerPath_when_darwin_and_homebrew_exists_then_returns_homebrew_path', () => {
+    const env = createTestEnv({
+      platform: 'darwin',
+      existsSync: p => p === '/opt/homebrew/bin/ironplcc',
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.strictEqual(result.path, '/opt/homebrew/bin/ironplcc');
+    assert.strictEqual(result.source, 'homebrew');
+  });
+
+  test('findCompilerPath_when_win32_and_localappdata_exists_then_returns_windows_path', () => {
+    const localAppData = '/tmp/appdata';
+    const expected = path.join(localAppData, 'Programs', 'IronPLC Compiler', 'bin', 'ironplcc.exe');
+    const env = createTestEnv({
+      platform: 'win32',
+      getEnv: name => name === 'LOCALAPPDATA' ? localAppData : undefined,
+      existsSync: p => p === expected,
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.ok(result.path.includes('IronPLC Compiler'));
+    assert.ok(result.path.endsWith('ironplcc.exe'));
+    assert.strictEqual(result.source, 'localappdata');
+  });
+
+  test('findCompilerPath_when_nothing_found_then_returns_undefined', () => {
+    const env = createTestEnv();
+    const result = findCompilerPath(env);
+    assert.strictEqual(result, undefined);
+  });
+
+  test('findCompilerPath_when_win32_then_uses_exe_extension', () => {
+    const configDir = '/tmp/compiler';
+    const expected = path.join(configDir, 'ironplcc.exe');
+    const env = createTestEnv({
+      platform: 'win32',
+      getConfig: key => key === 'path' ? configDir : undefined,
+      existsSync: p => p === expected,
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.ok(result.path.endsWith('.exe'));
+  });
+
+  test('findCompilerPath_when_linux_then_no_exe_extension', () => {
+    const env = createTestEnv({
+      platform: 'linux',
+      getConfig: key => key === 'path' ? '/usr/bin' : undefined,
+      existsSync: p => p === '/usr/bin/ironplcc',
+    });
+    const result = findCompilerPath(env);
+    assert.ok(result);
+    assert.ok(!result.path.endsWith('.exe'));
+    assert.ok(result.path.endsWith('ironplcc'));
+  });
+});


### PR DESCRIPTION
Separate compiler path discovery logic from VS Code API dependencies by introducing a CompilerEnvironment interface for dependency injection. Adds 9 unit tests covering all discovery paths (config, env var, homebrew, Windows AppData, platform-specific exe extensions).