### PR TITLE
Add mock-based unit tests for editor provider logic

### DIFF
--- a/integrations/vscode/src/iplcEditorLogic.ts
+++ b/integrations/vscode/src/iplcEditorLogic.ts
@@ -1,0 +1,70 @@
+import { DisassemblyResult, getErrorHtml, getDisassemblyHtml } from './iplcRendering';
+
+// Numeric values match vscode-languageclient's State enum.
+export const STATE_RUNNING = 2;
+export const STATE_STOPPED = 1;
+
+/** Minimal subset of LanguageClient used by the editor provider, enabling
+ *  unit tests to supply a mock without depending on vscode-languageclient. */
+export interface LanguageClientLike {
+  isRunning(): boolean;
+  sendRequest(method: string, params: unknown): Promise<unknown>;
+  onDidChangeState(listener: (e: { newState: number }) => void): { dispose(): void };
+}
+
+/** Wait for the language client to reach the Running state.
+ *  Resolves `true` if the client starts, `false` if it stops or the
+ *  timeout expires. Returns immediately if the client is already running. */
+export function waitForClient(client: LanguageClientLike, timeoutMs: number): Promise<boolean> {
+  if (client.isRunning()) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      disposable.dispose();
+      resolve(false);
+    }, timeoutMs);
+
+    const disposable = client.onDidChangeState((e) => {
+      if (e.newState === STATE_RUNNING) {
+        clearTimeout(timer);
+        disposable.dispose();
+        resolve(true);
+      }
+      else if (e.newState === STATE_STOPPED) {
+        clearTimeout(timer);
+        disposable.dispose();
+        resolve(false);
+      }
+    });
+  });
+}
+
+/** Produce the HTML content for an .iplc custom editor.
+ *  Waits for the client if it is not yet running, sends a disassemble
+ *  request, and returns rendered HTML (or an error page on failure). */
+export async function resolveEditorContent(
+  client: LanguageClientLike,
+  documentUri: string,
+  timeoutMs: number = 5000,
+): Promise<string> {
+  if (!client.isRunning()) {
+    const ready = await waitForClient(client, timeoutMs);
+    if (!ready) {
+      return getErrorHtml(
+        'E0002 - IronPLC compiler not found. Install the compiler to view .iplc files.',
+      );
+    }
+  }
+
+  try {
+    const result = await client.sendRequest('ironplc/disassemble', {
+      uri: documentUri,
+    });
+    return getDisassemblyHtml(result as DisassemblyResult);
+  }
+  catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return getErrorHtml(`E0003 - Failed to disassemble .iplc file: ${message}`);
+  }
+}

--- a/integrations/vscode/src/iplcEditorProvider.ts
+++ b/integrations/vscode/src/iplcEditorProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { LanguageClient, State } from 'vscode-languageclient/node';
-import { DisassemblyResult, getErrorHtml, getDisassemblyHtml } from './iplcRendering';
+import { LanguageClient } from 'vscode-languageclient/node';
+import { LanguageClientLike, resolveEditorContent } from './iplcEditorLogic';
 
 interface IplcDocument extends vscode.CustomDocument {
   readonly uri: vscode.Uri;
@@ -9,7 +9,7 @@ interface IplcDocument extends vscode.CustomDocument {
 export class IplcEditorProvider implements vscode.CustomReadonlyEditorProvider<IplcDocument> {
   public static readonly viewType = 'ironplc.iplcViewer';
 
-  constructor(private readonly client: LanguageClient) {}
+  constructor(private readonly client: LanguageClientLike) {}
 
   public static register(_context: vscode.ExtensionContext, client: LanguageClient): vscode.Disposable {
     const provider = new IplcEditorProvider(client);
@@ -29,53 +29,9 @@ export class IplcEditorProvider implements vscode.CustomReadonlyEditorProvider<I
     webviewPanel: vscode.WebviewPanel,
   ): Promise<void> {
     webviewPanel.webview.options = { enableScripts: false };
-
-    // The LSP client may still be starting when the custom editor opens.
-    // Wait briefly for it to reach the Running state.
-    if (!this.client.isRunning()) {
-      const ready = await this.waitForClient(5000);
-      if (!ready) {
-        webviewPanel.webview.html = getErrorHtml(
-          'E0002 - IronPLC compiler not found. Install the compiler to view .iplc files.',
-        );
-        return;
-      }
-    }
-
-    try {
-      const result = await this.client.sendRequest('ironplc/disassemble', {
-        uri: document.uri.toString(),
-      });
-      webviewPanel.webview.html = getDisassemblyHtml(result as DisassemblyResult);
-    }
-    catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      webviewPanel.webview.html = getErrorHtml(`E0003 - Failed to disassemble .iplc file: ${message}`);
-    }
-  }
-
-  private waitForClient(timeoutMs: number): Promise<boolean> {
-    if (this.client.isRunning()) {
-      return Promise.resolve(true);
-    }
-    return new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        disposable.dispose();
-        resolve(false);
-      }, timeoutMs);
-
-      const disposable = this.client.onDidChangeState((e) => {
-        if (e.newState === State.Running) {
-          clearTimeout(timer);
-          disposable.dispose();
-          resolve(true);
-        }
-        else if (e.newState === State.Stopped) {
-          clearTimeout(timer);
-          disposable.dispose();
-          resolve(false);
-        }
-      });
-    });
+    webviewPanel.webview.html = await resolveEditorContent(
+      this.client,
+      document.uri.toString(),
+    );
   }
 }

--- a/integrations/vscode/src/test/unit/iplcEditorLogic.test.ts
+++ b/integrations/vscode/src/test/unit/iplcEditorLogic.test.ts
@@ -1,0 +1,136 @@
+import * as assert from 'assert';
+import { waitForClient, resolveEditorContent } from '../../iplcEditorLogic';
+import {
+  createMockClient,
+  createTestDisassemblyResult,
+  STATE_RUNNING,
+  STATE_STOPPED,
+} from './testHelpers';
+
+suite('waitForClient', () => {
+  test('waitForClient_when_already_running_then_resolves_true_immediately', async () => {
+    const client = createMockClient({ isRunning: () => true });
+    const result = await waitForClient(client, 5000);
+    assert.strictEqual(result, true);
+  });
+
+  test('waitForClient_when_starts_before_timeout_then_resolves_true', async () => {
+    let stateListener: ((e: { newState: number }) => void) | undefined;
+    const client = createMockClient({
+      isRunning: () => false,
+      onDidChangeState: (listener) => {
+        stateListener = listener;
+        return { dispose: () => {} };
+      },
+    });
+
+    const promise = waitForClient(client, 5000);
+    stateListener!({ newState: STATE_RUNNING });
+    const result = await promise;
+    assert.strictEqual(result, true);
+  });
+
+  test('waitForClient_when_stops_before_timeout_then_resolves_false', async () => {
+    let stateListener: ((e: { newState: number }) => void) | undefined;
+    const client = createMockClient({
+      isRunning: () => false,
+      onDidChangeState: (listener) => {
+        stateListener = listener;
+        return { dispose: () => {} };
+      },
+    });
+
+    const promise = waitForClient(client, 5000);
+    stateListener!({ newState: STATE_STOPPED });
+    const result = await promise;
+    assert.strictEqual(result, false);
+  });
+
+  test('waitForClient_when_timeout_expires_then_resolves_false', async () => {
+    const client = createMockClient({
+      isRunning: () => false,
+      onDidChangeState: () => ({ dispose: () => {} }),
+    });
+
+    const result = await waitForClient(client, 10);
+    assert.strictEqual(result, false);
+  });
+});
+
+suite('resolveEditorContent', () => {
+  test('resolveEditorContent_when_client_running_and_request_succeeds_then_renders_disassembly', async () => {
+    const client = createMockClient({
+      isRunning: () => true,
+      sendRequest: () => Promise.resolve(createTestDisassemblyResult()),
+    });
+
+    const html = await resolveEditorContent(client, 'file:///test.iplc');
+    assert.ok(html.includes('IPLC Bytecode Viewer'));
+  });
+
+  test('resolveEditorContent_when_client_running_and_request_fails_then_renders_error', async () => {
+    const client = createMockClient({
+      isRunning: () => true,
+      sendRequest: () => Promise.reject(new Error('connection lost')),
+    });
+
+    const html = await resolveEditorContent(client, 'file:///test.iplc');
+    assert.ok(html.includes('E0003'));
+    assert.ok(html.includes('connection lost'));
+  });
+
+  test('resolveEditorContent_when_client_running_and_result_has_error_then_renders_error', async () => {
+    const client = createMockClient({
+      isRunning: () => true,
+      sendRequest: () => Promise.resolve({ error: 'invalid bytecode' }),
+    });
+
+    const html = await resolveEditorContent(client, 'file:///test.iplc');
+    assert.ok(html.includes('invalid bytecode'));
+    assert.ok(html.includes('class="error"'));
+  });
+
+  test('resolveEditorContent_when_client_not_running_and_starts_within_timeout_then_renders_disassembly', async () => {
+    let stateListener: ((e: { newState: number }) => void) | undefined;
+    const client = createMockClient({
+      isRunning: () => false,
+      sendRequest: () => Promise.resolve(createTestDisassemblyResult()),
+      onDidChangeState: (listener) => {
+        stateListener = listener;
+        return { dispose: () => {} };
+      },
+    });
+
+    const promise = resolveEditorContent(client, 'file:///test.iplc');
+    stateListener!({ newState: STATE_RUNNING });
+    const html = await promise;
+    assert.ok(html.includes('IPLC Bytecode Viewer'));
+  });
+
+  test('resolveEditorContent_when_client_not_running_and_times_out_then_renders_compiler_not_found', async () => {
+    const client = createMockClient({
+      isRunning: () => false,
+      onDidChangeState: () => ({ dispose: () => {} }),
+    });
+
+    const html = await resolveEditorContent(client, 'file:///test.iplc', 10);
+    assert.ok(html.includes('E0002'));
+    assert.ok(html.includes('compiler not found'));
+  });
+
+  test('resolveEditorContent_when_client_not_running_and_stops_then_renders_compiler_not_found', async () => {
+    let stateListener: ((e: { newState: number }) => void) | undefined;
+    const client = createMockClient({
+      isRunning: () => false,
+      onDidChangeState: (listener) => {
+        stateListener = listener;
+        return { dispose: () => {} };
+      },
+    });
+
+    const promise = resolveEditorContent(client, 'file:///test.iplc');
+    stateListener!({ newState: STATE_STOPPED });
+    const html = await promise;
+    assert.ok(html.includes('E0002'));
+  });
+});

--- a/integrations/vscode/src/test/unit/testHelpers.ts
+++ b/integrations/vscode/src/test/unit/testHelpers.ts
@@ -4,6 +4,19 @@ import {
   DisassemblyFunction,
   DisassemblyResult,
 } from '../../iplcRendering';
+import { LanguageClientLike, STATE_RUNNING, STATE_STOPPED } from '../../iplcEditorLogic';
+
+// Re-export state constants for test use.
+export { STATE_RUNNING, STATE_STOPPED };
+
+export function createMockClient(overrides?: Partial<LanguageClientLike>): LanguageClientLike {
+  return {
+    isRunning: () => true,
+    sendRequest: () => Promise.resolve(createTestDisassemblyResult()),
+    onDidChangeState: () => ({ dispose: () => {} }),
+    ...overrides,
+  };
+}
 
 export function createTestHeader(overrides?: Partial<DisassemblyHeader>): DisassemblyHeader {
   return {


### PR DESCRIPTION
Extract waitForClient and resolveEditorContent into pure iplcEditorLogic module with LanguageClientLike interface for dependency injection. Adds 10 unit tests covering client lifecycle (running, starting, stopping, timeout) and disassembly request outcomes (success, failure, error field).