### PR TITLE
Add functional tests for TwinCAT language detection

### DIFF
--- a/integrations/vscode/src/test/functional/resources/valid.TcDUT
+++ b/integrations/vscode/src/test/functional/resources/valid.TcDUT
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.0">
+  <DUT Name="MyStruct" Id="{00000000-0000-0000-0000-000000000002}">
+    <Declaration><![CDATA[TYPE MyStruct :
+STRUCT
+END_STRUCT
+END_TYPE]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/integrations/vscode/src/test/functional/resources/valid.TcGVL
+++ b/integrations/vscode/src/test/functional/resources/valid.TcGVL
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.0">
+  <GVL Name="GVL_Main" Id="{00000000-0000-0000-0000-000000000001}">
+    <Declaration><![CDATA[VAR_GLOBAL
+END_VAR]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/integrations/vscode/src/test/functional/resources/valid.TcPOU
+++ b/integrations/vscode/src/test/functional/resources/valid.TcPOU
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.0">
+  <POU Name="MAIN" Id="{00000000-0000-0000-0000-000000000000}">
+    <Declaration><![CDATA[PROGRAM MAIN
+VAR
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[;]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/integrations/vscode/src/test/functional/suite/extension.test.ts
+++ b/integrations/vscode/src/test/functional/suite/extension.test.ts
@@ -25,6 +25,33 @@ suite('Extension Test Suite', () => {
     assert.equal(languageId, '61131-3-st');
   });
 
+  test('detects TcPOU extension as twincat-pou', async () => {
+    const filePath = testResourcePath('valid.TcPOU');
+    const textDocument = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(textDocument);
+    const file = vscode.window.activeTextEditor!.document as any | undefined;
+
+    assert.equal(file.languageId, 'twincat-pou');
+  });
+
+  test('detects TcGVL extension as twincat-gvl', async () => {
+    const filePath = testResourcePath('valid.TcGVL');
+    const textDocument = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(textDocument);
+    const file = vscode.window.activeTextEditor!.document as any | undefined;
+
+    assert.equal(file.languageId, 'twincat-gvl');
+  });
+
+  test('detects TcDUT extension as twincat-dut', async () => {
+    const filePath = testResourcePath('valid.TcDUT');
+    const textDocument = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(textDocument);
+    const file = vscode.window.activeTextEditor!.document as any | undefined;
+
+    assert.equal(file.languageId, 'twincat-dut');
+  });
+
   test('does not detect non-ST extension as 61131-3-st', async () => {
     const filePath = testResourcePath('invalid-ext.notst');
     const textDocument = await vscode.workspace.openTextDocument(filePath);


### PR DESCRIPTION
Add test fixtures and tests verifying that .TcPOU, .TcGVL, and .TcDUT files are detected as their respective language IDs, following the existing pattern for .st file detection.