### PR TITLE
test(vm): add multi-task, scope isolation, and watchdog tests (Phase 3)

### DIFF
--- a/compiler/vm/tests/scenarios.rs
+++ b/compiler/vm/tests/scenarios.rs
@@ -1,7 +1,7 @@
-//! Phase 2: Multi-scan scenario tests.
+//! Scenario integration tests for the VM.
 //!
-//! These verify that programs accumulate state correctly across scan cycles
-//! and that the VM lifecycle transitions work with repeated execution.
+//! Phase 2: Multi-scan state accumulation and fault handling.
+//! Phase 3: Multi-task execution, variable scope isolation, and watchdog.
 
 use ironplc_container::{ContainerBuilder, ProgramInstanceEntry, TaskEntry, TaskType};
 use ironplc_vm::error::Trap;
@@ -171,4 +171,190 @@ fn scenario_when_variables_read_after_fault_then_accessible() {
     // The store before the fault is visible on the faulted VM
     let faulted = vm.fault(ctx);
     assert_eq!(faulted.read_variable(0).unwrap(), 42);
+}
+
+// Phase 3: Multi-task and variable scope tests.
+
+/// Helper to build a freewheeling task entry.
+fn freewheeling_task(task_id: u16, priority: u16, watchdog_us: u64) -> TaskEntry {
+    TaskEntry {
+        task_id,
+        priority,
+        task_type: TaskType::Freewheeling,
+        flags: 0x01, // enabled
+        interval_us: 0,
+        single_var_index: 0xFFFF,
+        watchdog_us,
+        input_image_offset: 0,
+        output_image_offset: 0,
+        reserved: [0; 4],
+    }
+}
+
+/// Helper to build a program instance entry.
+fn program_instance(
+    instance_id: u16,
+    task_id: u16,
+    function_id: u16,
+    var_offset: u16,
+    var_count: u16,
+) -> ProgramInstanceEntry {
+    ProgramInstanceEntry {
+        instance_id,
+        task_id,
+        entry_function_id: function_id,
+        var_table_offset: var_offset,
+        var_table_count: var_count,
+        fb_instance_offset: 0,
+        fb_instance_count: 0,
+        reserved: 0,
+    }
+}
+
+/// Two freewheeling tasks with separate variable partitions both execute
+/// in a single round.
+///
+/// Layout:
+///   4 variables, shared globals: 0
+///   Task 0 (priority 0) → function 0 → stores 10 to var[0]
+///   Task 1 (priority 1) → function 1 → stores 20 to var[2]
+#[test]
+fn scenario_when_two_freewheeling_tasks_then_both_execute() {
+    #[rustfmt::skip]
+    let fn0_bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (10)
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    #[rustfmt::skip]
+    let fn1_bytecode: Vec<u8> = vec![
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (20)
+        0x18, 0x02, 0x00,  // STORE_VAR_I32 var[2]
+        0xB5,              // RET_VOID
+    ];
+
+    let container = ContainerBuilder::new()
+        .num_variables(4)
+        .add_i32_constant(10)
+        .add_i32_constant(20)
+        .add_function(0, &fn0_bytecode, 1, 2)
+        .add_function(1, &fn1_bytecode, 1, 2)
+        .add_task(freewheeling_task(0, 0, 0))
+        .add_task(freewheeling_task(1, 1, 0))
+        .add_program_instance(program_instance(0, 0, 0, 0, 2))
+        .add_program_instance(program_instance(1, 1, 1, 2, 2))
+        .build();
+
+    let mut vm = Vm::new().load(container).start();
+    vm.run_round().unwrap();
+
+    assert_eq!(vm.read_variable(0).unwrap(), 10); // set by task 0
+    assert_eq!(vm.read_variable(2).unwrap(), 20); // set by task 1
+}
+
+/// Two tasks communicate through a shared global variable.
+///
+/// Layout:
+///   4 variables, shared globals: 1 (var[0] is global)
+///   Task 0 (priority 0) → writes 99 to var[0] (global)
+///   Task 1 (priority 1) → reads var[0] (global), stores to var[2] (private)
+///
+/// Task 0 runs first (lower priority number), so task 1 sees the value.
+#[test]
+fn scenario_when_tasks_share_global_then_communication_works() {
+    // Function 0: store 99 to var[0]
+    #[rustfmt::skip]
+    let fn0_bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (99)
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    // Function 1: copy var[0] to var[2]
+    #[rustfmt::skip]
+    let fn1_bytecode: Vec<u8> = vec![
+        0x10, 0x00, 0x00,  // LOAD_VAR_I32 var[0]   (global)
+        0x18, 0x02, 0x00,  // STORE_VAR_I32 var[2]  (private)
+        0xB5,              // RET_VOID
+    ];
+
+    let container = ContainerBuilder::new()
+        .num_variables(4)
+        .shared_globals_size(1)
+        .add_i32_constant(99)
+        .add_function(0, &fn0_bytecode, 1, 1)
+        .add_function(1, &fn1_bytecode, 1, 2)
+        .add_task(freewheeling_task(0, 0, 0))
+        .add_task(freewheeling_task(1, 1, 0))
+        .add_program_instance(program_instance(0, 0, 0, 1, 1)) // task 0: private [1,2)
+        .add_program_instance(program_instance(1, 1, 1, 2, 2)) // task 1: private [2,4)
+        .build();
+
+    let mut vm = Vm::new().load(container).start();
+    vm.run_round().unwrap();
+
+    assert_eq!(vm.read_variable(0).unwrap(), 99); // global, written by task 0
+    assert_eq!(vm.read_variable(2).unwrap(), 99); // task 1 read the global
+}
+
+/// A program instance that accesses a variable outside its scope is trapped.
+///
+/// Layout:
+///   4 variables, shared globals: 0
+///   Program instance 0 scope: variables [2, 4)
+///   Bytecode: LOAD_VAR_I32 var[0] — index 0 is outside [2, 4)
+#[test]
+fn scenario_when_scope_violation_then_trap() {
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x10, 0x00, 0x00,  // LOAD_VAR_I32 var[0]  (outside scope)
+    ];
+
+    let container = ContainerBuilder::new()
+        .num_variables(4)
+        .add_function(0, &bytecode, 1, 2)
+        .add_task(freewheeling_task(0, 0, 0))
+        .add_program_instance(program_instance(0, 0, 0, 2, 2)) // scope [2, 4)
+        .build();
+
+    let mut vm = Vm::new().load(container).start();
+    let result = vm.run_round();
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().trap, Trap::InvalidVariableIndex(0));
+}
+
+/// A task whose execution exceeds its watchdog timeout is trapped.
+///
+/// Uses watchdog_us: 1 (1 microsecond) which is impossibly short for any
+/// real execution. The program generates hundreds of instructions so that
+/// the elapsed time (measured via `as_micros()`) is guaranteed > 1μs even
+/// on fast machines.
+#[test]
+fn scenario_when_watchdog_exceeded_then_trap() {
+    // Generate a long program: LOAD_CONST, then 500× (LOAD_CONST + ADD),
+    // then STORE_VAR + RET_VOID. Total: ~1503 bytes, ~501 arithmetic ops.
+    // This ensures execution takes well over 1μs.
+    let mut bytecode: Vec<u8> = Vec::new();
+    // Initial value on stack
+    bytecode.extend_from_slice(&[0x01, 0x00, 0x00]); // LOAD_CONST_I32 pool[0]
+    for _ in 0..500 {
+        bytecode.extend_from_slice(&[0x01, 0x00, 0x00]); // LOAD_CONST_I32 pool[0]
+        bytecode.push(0x30); // ADD_I32
+    }
+    bytecode.extend_from_slice(&[0x18, 0x00, 0x00]); // STORE_VAR_I32 var[0]
+    bytecode.push(0xB5); // RET_VOID
+
+    let container = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i32_constant(1)
+        .add_function(0, &bytecode, 2, 1)
+        .add_task(freewheeling_task(0, 0, 1)) // watchdog_us: 1
+        .add_program_instance(program_instance(0, 0, 0, 0, 1))
+        .build();
+
+    let mut vm = Vm::new().load(container).start();
+    let result = vm.run_round();
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().trap, Trap::WatchdogTimeout(0));
 }


### PR DESCRIPTION
Add 4 scenario tests to compiler/vm/tests/scenarios.rs that exercise the scheduler driving multiple tasks with separate variable scopes, and the watchdog timeout mechanism.

Tests added:
- scenario_when_two_freewheeling_tasks_then_both_execute: two tasks with separate variable partitions both write in one round
- scenario_when_tasks_share_global_then_communication_works: task 0 writes to shared global, task 1 reads it (cross-task comms)
- scenario_when_scope_violation_then_trap: program instance accesses variable outside its scope, caught at runtime
- scenario_when_watchdog_exceeded_then_trap: 1μs watchdog triggers WatchdogTimeout trap

Also extracts freewheeling_task() and program_instance() helpers to reduce boilerplate in multi-task test setup.

https://claude.ai/code/session_018QW5RMD3Wfnss8Nf2yXgeH