### PR TITLE
refactor(vm): extract test helpers to reduce boilerplate (Phase 5)

### DIFF
--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -379,6 +379,27 @@ mod tests {
     use super::*;
     use ironplc_container::ContainerBuilder;
 
+    /// Builds a container with one function from the given bytecode,
+    /// with `num_vars` variables and the given constants.
+    /// Uses a generous max_stack_depth (16) suitable for most tests.
+    fn single_function_container(bytecode: &[u8], num_vars: u16, constants: &[i32]) -> Container {
+        let mut builder = ContainerBuilder::new().num_variables(num_vars);
+        for &c in constants {
+            builder = builder.add_i32_constant(c);
+        }
+        builder.add_function(0, bytecode, 16, num_vars).build()
+    }
+
+    /// Asserts that a run_round produces a specific trap.
+    fn assert_trap(vm: &mut VmRunning, expected: Trap) {
+        let result = vm.run_round();
+        assert!(
+            result.is_err(),
+            "expected trap {expected} but run_round succeeded"
+        );
+        assert_eq!(result.unwrap_err().trap, expected);
+    }
+
     fn steel_thread_container() -> Container {
         #[rustfmt::skip]
         let bytecode: Vec<u8> = vec![
@@ -421,19 +442,10 @@ mod tests {
 
     #[test]
     fn vm_run_round_when_invalid_opcode_then_trap() {
-        let bytecode = vec![0xFF]; // invalid opcode
-        let container = ContainerBuilder::new()
-            .num_variables(0)
-            .add_function(0, &bytecode, 1, 0)
-            .build();
-
+        let container = single_function_container(&[0xFF], 0, &[]);
         let mut vm = Vm::new().load(container).start();
 
-        let result = vm.run_round();
-
-        assert!(result.is_err());
-        let ctx = result.unwrap_err();
-        assert!(matches!(ctx.trap, Trap::InvalidInstruction(0xFF)));
+        assert_trap(&mut vm, Trap::InvalidInstruction(0xFF));
     }
 
     #[test]
@@ -473,6 +485,7 @@ mod tests {
     #[test]
     fn execute_when_stack_overflow_then_trap() {
         // max_stack_depth: 1, but bytecode pushes two values
+        // Cannot use single_function_container because it uses max_stack=16.
         #[rustfmt::skip]
         let bytecode: Vec<u8> = vec![
             0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]
@@ -486,26 +499,16 @@ mod tests {
             .build();
 
         let mut vm = Vm::new().load(container).start();
-        let result = vm.run_round();
-
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().trap, Trap::StackOverflow);
+        assert_trap(&mut vm, Trap::StackOverflow);
     }
 
     #[test]
     fn execute_when_stack_underflow_then_trap() {
         // ADD_I32 tries to pop 2 values from an empty stack
-        let bytecode: Vec<u8> = vec![0x30]; // ADD_I32
-        let container = ContainerBuilder::new()
-            .num_variables(0)
-            .add_function(0, &bytecode, 1, 0)
-            .build();
-
+        let container = single_function_container(&[0x30], 0, &[]);
         let mut vm = Vm::new().load(container).start();
-        let result = vm.run_round();
 
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().trap, Trap::StackUnderflow);
+        assert_trap(&mut vm, Trap::StackUnderflow);
     }
 
     #[test]
@@ -515,16 +518,10 @@ mod tests {
         let bytecode: Vec<u8> = vec![
             0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]
         ];
-        let container = ContainerBuilder::new()
-            .num_variables(0)
-            .add_function(0, &bytecode, 1, 0)
-            .build();
-
+        let container = single_function_container(&bytecode, 0, &[]);
         let mut vm = Vm::new().load(container).start();
-        let result = vm.run_round();
 
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().trap, Trap::InvalidConstantIndex(0));
+        assert_trap(&mut vm, Trap::InvalidConstantIndex(0));
     }
 
     #[test]
@@ -535,17 +532,10 @@ mod tests {
             0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]
             0x18, 0x05, 0x00,  // STORE_VAR_I32 var[5]
         ];
-        let container = ContainerBuilder::new()
-            .num_variables(1)
-            .add_i32_constant(42)
-            .add_function(0, &bytecode, 1, 1)
-            .build();
-
+        let container = single_function_container(&bytecode, 1, &[42]);
         let mut vm = Vm::new().load(container).start();
-        let result = vm.run_round();
 
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().trap, Trap::InvalidVariableIndex(5));
+        assert_trap(&mut vm, Trap::InvalidVariableIndex(5));
     }
 
     #[test]
@@ -555,32 +545,20 @@ mod tests {
         let bytecode: Vec<u8> = vec![
             0x10, 0x05, 0x00,  // LOAD_VAR_I32 var[5]
         ];
-        let container = ContainerBuilder::new()
-            .num_variables(1)
-            .add_function(0, &bytecode, 1, 1)
-            .build();
-
+        let container = single_function_container(&bytecode, 1, &[]);
         let mut vm = Vm::new().load(container).start();
-        let result = vm.run_round();
 
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().trap, Trap::InvalidVariableIndex(5));
+        assert_trap(&mut vm, Trap::InvalidVariableIndex(5));
     }
 
     // Phase 1, Step 1.2: Execute edge-case tests
 
     #[test]
     fn execute_when_empty_bytecode_then_ok() {
-        let bytecode: Vec<u8> = vec![];
-        let container = ContainerBuilder::new()
-            .num_variables(0)
-            .add_function(0, &bytecode, 1, 0)
-            .build();
-
+        let container = single_function_container(&[], 0, &[]);
         let mut vm = Vm::new().load(container).start();
-        let result = vm.run_round();
 
-        assert!(result.is_ok());
+        assert!(vm.run_round().is_ok());
     }
 
     #[test]
@@ -593,13 +571,7 @@ mod tests {
             0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
             0xB5,              // RET_VOID
         ];
-        let container = ContainerBuilder::new()
-            .num_variables(1)
-            .add_i32_constant(i32::MAX)
-            .add_i32_constant(1)
-            .add_function(0, &bytecode, 2, 1)
-            .build();
-
+        let container = single_function_container(&bytecode, 1, &[i32::MAX, 1]);
         let mut vm = Vm::new().load(container).start();
         vm.run_round().unwrap();
 
@@ -616,13 +588,7 @@ mod tests {
             0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
             0xB5,              // RET_VOID
         ];
-        let container = ContainerBuilder::new()
-            .num_variables(1)
-            .add_i32_constant(i32::MIN)
-            .add_i32_constant(-1)
-            .add_function(0, &bytecode, 2, 1)
-            .build();
-
+        let container = single_function_container(&bytecode, 1, &[i32::MIN, -1]);
         let mut vm = Vm::new().load(container).start();
         vm.run_round().unwrap();
 

--- a/compiler/vm/tests/scenarios.rs
+++ b/compiler/vm/tests/scenarios.rs
@@ -58,8 +58,8 @@ fn scenario_when_stop_then_scan_count_reflects_completed_rounds() {
     assert_eq!(stopped.read_variable(0).unwrap(), 5);
 }
 
-/// A program that stores 42 to var[0] then faults. After the fault,
-/// we run two successful scans of a counter first, then fault on scan 3.
+/// One task with two program instances: the counter runs first, then a
+/// fault program traps. The counter's write is visible on the faulted VM.
 ///
 /// Setup: one task with two program instances.
 /// - Program instance 0: counter (increments var[0] each scan)
@@ -84,51 +84,14 @@ fn scenario_when_fault_during_scan_then_prior_writes_visible() {
     // Function 1: always faults
     let fault_bytecode: Vec<u8> = vec![0xFF]; // invalid opcode
 
-    let task = TaskEntry {
-        task_id: 0,
-        priority: 0,
-        task_type: TaskType::Freewheeling,
-        flags: 0x01, // enabled
-        interval_us: 0,
-        single_var_index: 0xFFFF,
-        watchdog_us: 0,
-        input_image_offset: 0,
-        output_image_offset: 0,
-        reserved: [0; 4],
-    };
-
-    // Program instance 0 runs the counter (function 0)
-    let prog0 = ProgramInstanceEntry {
-        instance_id: 0,
-        task_id: 0,
-        entry_function_id: 0,
-        var_table_offset: 0,
-        var_table_count: 1,
-        fb_instance_offset: 0,
-        fb_instance_count: 0,
-        reserved: 0,
-    };
-
-    // Program instance 1 runs the fault program (function 1)
-    let prog1 = ProgramInstanceEntry {
-        instance_id: 1,
-        task_id: 0,
-        entry_function_id: 1,
-        var_table_offset: 0,
-        var_table_count: 1,
-        fb_instance_offset: 0,
-        fb_instance_count: 0,
-        reserved: 0,
-    };
-
     let container = ContainerBuilder::new()
         .num_variables(1)
         .add_i32_constant(1)
         .add_function(0, &counter_bytecode, 2, 1)
         .add_function(1, &fault_bytecode, 1, 0)
-        .add_task(task)
-        .add_program_instance(prog0)
-        .add_program_instance(prog1)
+        .add_task(freewheeling_task(0, 0, 0))
+        .add_program_instance(program_instance(0, 0, 0, 0, 1))
+        .add_program_instance(program_instance(1, 0, 1, 0, 1))
         .build();
 
     let mut vm = Vm::new().load(container).start();


### PR DESCRIPTION
Review test code from Phases 1-4 and extract shared patterns:

vm.rs unit tests:
- Extract single_function_container(bytecode, num_vars, constants) helper used by 8 tests that build a one-function container
- Extract assert_trap(vm, expected) helper used by 6 tests that verify run_round returns a specific trap variant

scenarios.rs integration tests:
- Refactor scenario_when_fault_during_scan_then_prior_writes_visible to use the freewheeling_task() and program_instance() helpers added in Phase 3, replacing 30 lines of manual struct construction

No test behavior changes. All 47 tests pass.

https://claude.ai/code/session_018QW5RMD3Wfnss8Nf2yXgeH