### PR TITLE
Improve docs onboarding with Explanation quadrant and incremental tutorial

### DIFF
--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,0 +1,16 @@
+===========
+Explanation
+===========
+
+These pages explain the concepts behind IEC 61131-3 and IronPLC. Read them
+to build a mental model before diving into the tutorials, or come back to
+them later when you want to understand *why* things work the way they do.
+
+.. toctree::
+   :maxdepth: 1
+
+   What is IEC 61131-3? <what-is-iec-61131-3>
+   IronPLC and the IEC 61131-3 Ecosystem <ironplc-ecosystem>
+   Structured Text Basics <structured-text-basics>
+   Program Organization <program-organization>
+   Variables and I/O <variables-and-io>

--- a/docs/explanation/ironplc-ecosystem.rst
+++ b/docs/explanation/ironplc-ecosystem.rst
@@ -1,0 +1,93 @@
+=====================================
+IronPLC and the IEC 61131-3 Ecosystem
+=====================================
+
+This page explains where IronPLC fits in the broader world of PLC
+development tools.
+
+--------------------------------------
+The Traditional PLC Workflow
+--------------------------------------
+
+Most PLC manufacturers ship an integrated development environment (IDE) tied
+to their hardware. For example:
+
+- **Beckhoff** provides TwinCAT, which runs inside Visual Studio.
+- **Siemens** provides TIA Portal for its S7 family.
+- **Codesys** provides a vendor-neutral IDE that many smaller manufacturers
+  rebrand (including the open-source **Beremiz** project).
+
+These tools handle everything: editing, compiling, downloading to hardware,
+debugging, and visualization. They are powerful, but they are also
+proprietary, expensive, and locked to specific hardware.
+
+--------------------------------------
+What IronPLC Does Today
+--------------------------------------
+
+IronPLC is an open-source toolchain for working with IEC 61131-3 code. Today
+it provides:
+
+- **A compiler** (:program:`ironplcc`) that parses and checks IEC 61131-3
+  programs for correctness. It catches syntax errors, type mismatches, and
+  other problems before you ever download code to a PLC.
+- **A VS Code extension** that provides auto-completion, syntax highlighting
+  and real-time error checking as you type.
+- **A runtime** (:program:`ironplcvm`) that can execute simple compiled
+  programs. The runtime is in early development and supports only a limited
+  subset of the language.
+
+IronPLC reads several source formats:
+
+- **Structured Text** (:file:`.st` files) — the native text format
+- **PLCopen XML** (:file:`.xml`, :file:`plc.xml`) — used by Beremiz and other
+  PLCopen-compatible tools
+- **TwinCAT** (:file:`.TcPOU`, :file:`.TcGVL`, :file:`.plcproj`) — used by
+  Beckhoff TwinCAT 3
+
+This means you can point IronPLC at an existing project from Beremiz or
+TwinCAT and get a second opinion on your code without changing your workflow.
+
+--------------------------------------
+What IronPLC Does Not Do (Yet)
+--------------------------------------
+
+IronPLC is a young project. Some things it cannot do today:
+
+- **Run on real PLC hardware.** The runtime currently targets a virtual
+  machine, not physical I/O.
+- **Support the full IEC 61131-3 language.** Many features are parsed and
+  checked but code generation covers only a small subset.
+- **Replace your existing IDE.** IronPLC is a complement to your existing
+  tools, not a replacement.
+
+The long-term vision is to become a full development environment for building
+IEC 61131-3 based control systems that run on off-the-shelf embedded
+computers (sometimes called SoftPLCs). That goal is ambitious, and
+contributions are welcome.
+
+--------------------------------------
+How IronPLC Relates to Other Tools
+--------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Tool
+     - Relationship to IronPLC
+   * - **Beremiz**
+     - An open-source PLC IDE. IronPLC can read Beremiz project files
+       (:file:`plc.xml`) to provide additional checking. See
+       :doc:`/how-to-guides/beremiz/check-beremiz-projects`.
+   * - **TwinCAT**
+     - Beckhoff's PLC IDE. IronPLC can read TwinCAT project files to provide
+       additional checking. See
+       :doc:`/how-to-guides/twincat/check-twincat-projects`.
+   * - **Codesys**
+     - A widely used commercial PLC IDE. IronPLC does not currently read
+       Codesys project files, but Codesys can export to PLCopen XML.
+   * - **OpenPLC**
+     - An open-source PLC runtime. IronPLC and OpenPLC have different goals:
+       OpenPLC focuses on running programs on hardware, while IronPLC focuses
+       on checking and compiling code.

--- a/docs/explanation/program-organization.rst
+++ b/docs/explanation/program-organization.rst
@@ -1,0 +1,171 @@
+====================
+Program Organization
+====================
+
+IEC 61131-3 programs are organized in layers. This page explains what
+each layer does and why the structure exists. For hands-on practice building
+up these layers step by step, follow the :doc:`/quickstart/index`.
+
+--------------------------------------
+The Big Picture
+--------------------------------------
+
+An IEC 61131-3 application is built from these building blocks, from
+innermost to outermost:
+
+.. code-block:: text
+
+   CONFIGURATION
+   └── RESOURCE
+       └── TASK
+           └── PROGRAM instance
+               └── Your control logic
+
+Each layer has a specific purpose:
+
+- **PROGRAM** contains the control logic (the code you write).
+- **TASK** defines *how often* a program runs.
+- **RESOURCE** represents a processing unit (a CPU or core).
+- **CONFIGURATION** ties everything together for a specific hardware setup.
+
+This layered model separates *what the program does* from *how and where it
+runs*. You can change the scan rate or move a program to different hardware
+without rewriting the logic.
+
+--------------------------------------
+Programs
+--------------------------------------
+
+A :code:`PROGRAM` is the basic unit of control logic. It declares variables
+and contains statements that execute on every scan:
+
+.. code-block::
+
+   PROGRAM main
+      VAR
+         Counter : INT := 0;
+      END_VAR
+
+      Counter := Counter + 1;
+
+   END_PROGRAM
+
+Programs are similar to classes in object-oriented languages: they bundle
+data (variables) with behavior (statements). Unlike classes, programs are
+not instantiated with :code:`new` — they are instantiated by a
+:code:`CONFIGURATION` (see below).
+
+Variables inside a program retain their values between scans. The
+:code:`Counter` variable above will be 1 after the first scan, 2 after the
+second, and so on.
+
+--------------------------------------
+Functions and Function Blocks
+--------------------------------------
+
+In addition to programs, IEC 61131-3 defines two other kinds of
+**Program Organization Units** (POUs):
+
+- **Functions** are stateless: they take inputs, compute a result, and
+  return it. They do not retain values between calls. Think of them like
+  pure functions.
+- **Function Blocks** are stateful: like programs, they have internal
+  variables that persist between calls. Think of them like objects that
+  you can instantiate multiple times.
+
+You use functions and function blocks inside programs to organize your
+logic into reusable pieces.
+
+--------------------------------------
+Tasks
+--------------------------------------
+
+A :code:`TASK` defines a scheduling policy. The most common kind is a
+periodic task that runs at a fixed interval:
+
+.. code-block::
+
+   TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+
+This says: "run every 100 milliseconds, at priority level 1."
+
+Tasks control the scan rate. A fast task (``T#10ms``) reads inputs and
+writes outputs more frequently, which gives tighter control but uses more
+CPU. A slow task (``T#1s``) is gentler on the CPU but less responsive.
+
+You can define multiple tasks with different intervals — for example, a
+fast task for motion control and a slow task for temperature monitoring.
+
+--------------------------------------
+Resources
+--------------------------------------
+
+A :code:`RESOURCE` represents a processing unit — typically a CPU or
+core. It groups tasks and program instances that run on the same hardware:
+
+.. code-block::
+
+   RESOURCE res ON PLC
+      TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+      PROGRAM plc_task_instance WITH plc_task : main;
+   END_RESOURCE
+
+The line ``PROGRAM plc_task_instance WITH plc_task : main`` means: "create
+an instance of the :code:`main` program, name it :code:`plc_task_instance`,
+and run it on :code:`plc_task`."
+
+The ``ON PLC`` part names the hardware target. In practice, the target
+name is defined by the runtime environment.
+
+--------------------------------------
+Configurations
+--------------------------------------
+
+A :code:`CONFIGURATION` is the top-level container. It holds one or more
+resources and represents a complete deployable unit:
+
+.. code-block::
+
+   CONFIGURATION config
+      RESOURCE res ON PLC
+         TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+         PROGRAM plc_task_instance WITH plc_task : main;
+      END_RESOURCE
+   END_CONFIGURATION
+
+Every IEC 61131-3 application needs exactly one configuration.
+
+--------------------------------------
+Putting It All Together
+--------------------------------------
+
+Here is a complete, minimal application showing all the layers:
+
+.. code-block::
+
+   PROGRAM main
+      VAR
+         Button AT %IX1: BOOL;
+         Buzzer AT %QX1: BOOL;
+      END_VAR
+
+      Buzzer := NOT Button;
+
+   END_PROGRAM
+
+   CONFIGURATION config
+      RESOURCE res ON PLC
+         TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+         PROGRAM plc_task_instance WITH plc_task : main;
+      END_RESOURCE
+   END_CONFIGURATION
+
+Reading from the bottom up:
+
+1. The **configuration** named ``config`` defines one resource.
+2. The **resource** named ``res`` defines one task and one program instance.
+3. The **task** named ``plc_task`` runs every 100 ms.
+4. The **program** named ``main`` reads a button input and controls a buzzer.
+
+For a step-by-step guide to building this up from scratch, see the
+:doc:`/quickstart/index`.

--- a/docs/explanation/structured-text-basics.rst
+++ b/docs/explanation/structured-text-basics.rst
@@ -1,0 +1,154 @@
+=======================
+Structured Text Basics
+=======================
+
+Structured Text (ST) is the primary language supported by IronPLC. This page
+gives you a conceptual overview of the language so you know what to expect
+when you start writing code. For hands-on practice, follow the
+:doc:`/quickstart/index`.
+
+--------------------------------------
+What Structured Text Looks Like
+--------------------------------------
+
+If you have used Pascal, Ada, or even a bit of Python, Structured Text will
+feel familiar. Here is a small example:
+
+.. code-block::
+
+   PROGRAM main
+      VAR
+         Counter : INT := 0;
+         Limit : INT := 100;
+         Running : BOOL := TRUE;
+      END_VAR
+
+      IF Running AND (Counter < Limit) THEN
+         Counter := Counter + 1;
+      ELSE
+         Running := FALSE;
+      END_IF;
+
+   END_PROGRAM
+
+Some things to notice:
+
+- Keywords like :code:`PROGRAM`, :code:`VAR`, :code:`IF`, and :code:`THEN`
+  are uppercase by convention.
+- Variable declarations go inside a :code:`VAR` ... :code:`END_VAR` block
+  at the top.
+- Assignment uses ``:=`` (not ``=``).
+- Statements end with a semicolon.
+- Blocks are closed with :code:`END_PROGRAM`, :code:`END_IF`, and so on
+  rather than curly braces.
+
+--------------------------------------
+Data Types
+--------------------------------------
+
+IEC 61131-3 provides a set of elementary data types:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Type
+     - Size
+     - Description
+   * - :code:`BOOL`
+     - 1 bit
+     - Boolean (TRUE or FALSE)
+   * - :code:`INT`
+     - 16 bits
+     - Signed integer (-32768 to 32767)
+   * - :code:`DINT`
+     - 32 bits
+     - Double integer
+   * - :code:`REAL`
+     - 32 bits
+     - Floating-point number
+   * - :code:`STRING`
+     - Variable
+     - Character string
+   * - :code:`TIME`
+     - —
+     - Duration (for example, ``T#100ms``)
+
+You can also define your own types: enumerations, arrays, structures, and
+subranges. These are covered in the :doc:`/reference/compiler/index`.
+
+--------------------------------------
+Control Flow
+--------------------------------------
+
+Structured Text supports the control flow statements you would expect:
+
+**IF / ELSIF / ELSE:**
+
+.. code-block::
+
+   IF Temperature > 100.0 THEN
+      Alarm := TRUE;
+   ELSIF Temperature > 80.0 THEN
+      Warning := TRUE;
+   ELSE
+      Alarm := FALSE;
+      Warning := FALSE;
+   END_IF;
+
+**CASE:**
+
+.. code-block::
+
+   CASE State OF
+      0: Motor := FALSE;
+      1: Motor := TRUE;
+      2: Motor := FALSE;
+         Alarm := TRUE;
+   END_CASE;
+
+**FOR:**
+
+.. code-block::
+
+   FOR i := 0 TO 9 DO
+      Values[i] := 0;
+   END_FOR;
+
+**WHILE:**
+
+.. code-block::
+
+   WHILE Buffer <> 0 DO
+      Count := Count + 1;
+      Buffer := Buffer / 2;
+   END_WHILE;
+
+-----------------------------------------------
+How ST Differs from General-Purpose Languages
+-----------------------------------------------
+
+Structured Text was designed for real-time control, which leads to some
+differences compared to languages like Python or C:
+
+- **No dynamic memory allocation.** All variables are declared at the top
+  of a block and exist for the lifetime of the program. There is no
+  ``malloc``, ``new``, or garbage collector.
+- **No recursion.** Function calls cannot recurse. This keeps execution
+  time predictable.
+- **Cyclic execution.** Your program runs repeatedly as part of the scan
+  cycle (see :doc:`what-is-iec-61131-3`). You do not write a ``main``
+  function that runs once — you write logic that runs every scan.
+- **Time literals.** Durations are first-class values: ``T#100ms``,
+  ``T#2s``, ``T#1h30m``.
+
+These constraints exist because PLCs must respond within strict time
+deadlines. Predictability matters more than flexibility.
+
+--------------------------------------
+Next Steps
+--------------------------------------
+
+Now that you have a feel for the language, try writing your first program
+in the :doc:`/quickstart/index`. When you need precise details about
+syntax and semantics, consult the :doc:`/reference/compiler/index`.

--- a/docs/explanation/variables-and-io.rst
+++ b/docs/explanation/variables-and-io.rst
@@ -1,0 +1,150 @@
+==================
+Variables and I/O
+==================
+
+This page explains how IEC 61131-3 programs declare variables and connect
+them to physical inputs and outputs. For hands-on practice, see the
+:doc:`/quickstart/index`.
+
+--------------------------------------
+Variable Declarations
+--------------------------------------
+
+Variables are declared inside :code:`VAR` ... :code:`END_VAR` blocks at the
+top of a program, function, or function block:
+
+.. code-block::
+
+   VAR
+      Counter : INT := 0;
+      Temperature : REAL;
+      MotorOn : BOOL := FALSE;
+   END_VAR
+
+Each declaration has a name, a type, and an optional initial value. If you
+omit the initial value, the variable starts at the type's default (0 for
+numbers, FALSE for BOOL, empty for STRING).
+
+Variables declared inside a :code:`PROGRAM` or :code:`FUNCTION_BLOCK`
+**retain their values between scans**. This is how you maintain state in a
+cyclic program — you do not need global variables or external storage.
+
+--------------------------------------
+Variable Sections
+--------------------------------------
+
+IEC 61131-3 uses different keywords to indicate how a variable is used:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Section
+     - Meaning
+   * - :code:`VAR`
+     - Local variable, private to this POU.
+   * - :code:`VAR_INPUT`
+     - An input parameter passed into this POU by the caller.
+   * - :code:`VAR_OUTPUT`
+     - An output parameter passed back to the caller.
+   * - :code:`VAR_IN_OUT`
+     - A parameter passed by reference — the POU can read and modify it.
+   * - :code:`VAR_GLOBAL`
+     - A global variable visible across the configuration.
+
+These sections make the data flow between program organization units
+explicit, which is important for understanding and maintaining complex
+control systems.
+
+--------------------------------------
+Directly Represented Variables
+--------------------------------------
+
+The key concept that distinguishes PLC programming from general-purpose
+programming is the ability to map variables directly to hardware I/O
+addresses. These are called **directly represented variables**.
+
+A directly represented variable uses the :code:`AT` keyword followed by
+an address:
+
+.. code-block::
+
+   VAR
+      Button AT %IX1 : BOOL;
+      Buzzer AT %QX1 : BOOL;
+   END_VAR
+
+The address follows a specific format:
+
+.. code-block:: text
+
+   %<direction><size><address>
+
+Where:
+
+- **Direction** indicates whether this is an input, output, or memory
+  location:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 15 85
+
+     * - Prefix
+       - Meaning
+     * - ``I``
+       - **Input** — read from a sensor or external device
+     * - ``Q``
+       - **Output** — write to an actuator or external device
+     * - ``M``
+       - **Memory** — internal storage, not connected to hardware
+
+- **Size** indicates the width of the data:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 15 85
+
+     * - Suffix
+       - Size
+     * - ``X``
+       - Single bit (BOOL)
+     * - ``B``
+       - Byte (8 bits)
+     * - ``W``
+       - Word (16 bits)
+     * - ``D``
+       - Double word (32 bits)
+
+- **Address** is a numeric identifier for the specific I/O point.
+
+For example:
+
+- ``%IX1`` — read a single bit from input address 1
+- ``%QX1`` — write a single bit to output address 1
+- ``%IW3`` — read a 16-bit word from input address 3
+- ``%MD10`` — a 32-bit memory location at address 10
+
+--------------------------------------
+How I/O Works in the Scan Cycle
+--------------------------------------
+
+During each scan cycle (see :doc:`what-is-iec-61131-3`):
+
+1. The runtime reads all physical inputs and copies them into the input
+   variables (``%I``).
+2. Your program executes using those values.
+3. The runtime copies output variables (``%Q``) to the physical outputs.
+
+This means your program never reads a sensor or writes an actuator
+directly. Instead, it works with a snapshot of the I/O state that is
+refreshed on each scan. This approach (sometimes called **process image**)
+ensures that all input values are consistent within a single scan — a
+sensor value does not change halfway through your logic.
+
+--------------------------------------
+Next Steps
+--------------------------------------
+
+To see these concepts in action, work through the :doc:`/quickstart/index`
+which builds up a program step by step. For details on all supported data
+types and variable sections, see the :doc:`/reference/compiler/index`.

--- a/docs/explanation/what-is-iec-61131-3.rst
+++ b/docs/explanation/what-is-iec-61131-3.rst
@@ -1,0 +1,95 @@
+======================
+What is IEC 61131-3?
+======================
+
+If you are new to industrial automation, this page gives you the background
+you need before writing your first program.
+
+-------------------------------
+Programmable Logic Controllers
+-------------------------------
+
+Factories, power plants, water treatment facilities, and countless other
+systems rely on small, dedicated computers called **Programmable Logic
+Controllers** (PLCs). A PLC reads inputs from sensors (buttons, temperature
+probes, limit switches), runs a control program, and writes outputs to
+actuators (motors, valves, indicator lights).
+
+PLCs have been around since the late 1960s. Over time every manufacturer
+developed its own programming language, which made it hard to move programs
+between vendors or train engineers on more than one platform.
+
+--------------------------------------
+The IEC 61131-3 Standard
+--------------------------------------
+
+**IEC 61131-3** is the international standard that defines programming
+languages for PLCs. Published by the International Electrotechnical
+Commission (IEC), it provides a common set of languages and rules so that
+engineers can write programs that are portable across different hardware.
+
+The standard defines five programming languages:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Language
+     - Description
+   * - **Structured Text (ST)**
+     - A high-level textual language that resembles Pascal. This is the
+       primary language supported by IronPLC.
+   * - **Ladder Diagram (LD)**
+     - A graphical language based on electrical relay logic diagrams.
+   * - **Function Block Diagram (FBD)**
+     - A graphical language that wires together reusable function blocks.
+   * - **Instruction List (IL)**
+     - A low-level textual language similar to assembly. Deprecated in the
+       third edition of the standard.
+   * - **Sequential Function Chart (SFC)**
+     - A graphical language for describing sequential processes with steps
+       and transitions. IronPLC has partial support for SFC.
+
+Most working engineers use a mix of these languages. IronPLC focuses on
+Structured Text because it is the most expressive and the easiest to work
+with using standard software development tools like text editors and version
+control.
+
+--------------------------------------
+The Scan Cycle
+--------------------------------------
+
+A PLC does not run a program once and exit the way a desktop application
+does. Instead, it executes a **scan cycle** that repeats continuously:
+
+1. **Read inputs** — sample all sensors and store the values in memory.
+2. **Execute program** — run the control logic using the input values.
+3. **Write outputs** — send the computed results to actuators.
+4. **Repeat** — go back to step 1.
+
+Each pass through the cycle is called a **scan**. A typical scan takes
+between 1 and 100 milliseconds depending on the complexity of the program
+and the speed of the hardware. This is what makes PLC programs
+**real-time**: they guarantee that inputs are read and outputs are
+updated within a predictable time.
+
+This cycle is fundamentally different from event-driven programming (like
+a web server waiting for HTTP requests) or batch processing (like a script
+that runs once). When you write IEC 61131-3 code, you are writing the logic
+for a single scan, and the runtime takes care of calling it repeatedly.
+
+--------------------------------------
+Why Does This Matter for IronPLC?
+--------------------------------------
+
+Understanding the scan cycle helps you make sense of concepts you will
+encounter in the tutorials:
+
+- **Tasks** define *how often* a scan runs (for example, every 100 ms).
+- **Programs** contain the logic that runs on *each scan*.
+- **Variables** hold state that persists *across scans*.
+- **Directly represented variables** map to *physical inputs and outputs*
+  that the scan cycle reads and writes.
+
+These ideas are explored in more detail in :doc:`program-organization`
+and :doc:`variables-and-io`.

--- a/docs/how-to-guides/beremiz/check-beremiz-projects.rst
+++ b/docs/how-to-guides/beremiz/check-beremiz-projects.rst
@@ -4,7 +4,7 @@ Check Beremiz Projects
 
 This guide shows how to use IronPLC to check a Beremiz project for correctness.
 
-.. include:: ../includes/requires-compiler.rst
+.. include:: ../../includes/requires-compiler.rst
 
 -----------------------------------
 Check with the VS Code Extension

--- a/docs/how-to-guides/beremiz/index.rst
+++ b/docs/how-to-guides/beremiz/index.rst
@@ -1,0 +1,14 @@
+====================
+Coming from Beremiz
+====================
+
+These guides are for engineers who already use `Beremiz
+<https://beremiz.org/>`_ and want to use IronPLC alongside it.
+
+IronPLC can read Beremiz project files (:file:`plc.xml`) directly, so you
+can get a second opinion on your code without changing your workflow.
+
+.. toctree::
+   :maxdepth: 1
+
+   Check Beremiz Projects <check-beremiz-projects>

--- a/docs/how-to-guides/getting-started/index.rst
+++ b/docs/how-to-guides/getting-started/index.rst
@@ -1,0 +1,12 @@
+===============
+Getting Started
+===============
+
+These guides help you with common tasks when you are new to IronPLC
+and IEC 61131-3.
+
+.. toctree::
+   :maxdepth: 1
+
+   Structure a Multi-File Project <structure-a-multi-file-project>
+   Read Compiler Error Messages <read-compiler-error-messages>

--- a/docs/how-to-guides/getting-started/read-compiler-error-messages.rst
+++ b/docs/how-to-guides/getting-started/read-compiler-error-messages.rst
@@ -1,0 +1,84 @@
+=============================
+Read Compiler Error Messages
+=============================
+
+When IronPLC finds a problem in your code, it produces a diagnostic message.
+This guide explains how to read those messages and find the fix.
+
+--------------------------------------
+Anatomy of an Error Message
+--------------------------------------
+
+A typical error message from :program:`ironplcc check` looks like this:
+
+.. code-block:: text
+
+   error[P2001]: Variable 'Counter' is declared but type 'IN' is not defined
+     --> main.st:3:7
+      |
+    3 |       Counter : IN := 0;
+      |       ^^^^^^^ type 'IN' is not defined
+
+The message has several parts:
+
+- **error[P2001]** — the severity (error or warning) and the problem code.
+  The code uniquely identifies the kind of problem.
+- **Variable 'Counter' is declared but type 'IN' is not defined** — a
+  human-readable summary of what went wrong.
+- **--> main.st:3:7** — the file name, line number, and column where the
+  problem was found.
+- The **code snippet** shows the relevant line with a marker pointing to the
+  exact location.
+
+--------------------------------------
+Using Problem Codes
+--------------------------------------
+
+Every problem code (like P2001 above) has a documentation page that
+explains:
+
+- When the error occurs
+- An example that triggers it
+- How to fix it
+
+You can find all problem codes in the :doc:`/reference/compiler/problems/index`.
+
+--------------------------------------
+In the VS Code Extension
+--------------------------------------
+
+When you use the VS Code extension, errors and warnings appear as squiggly
+underlines in the editor. To see the full message:
+
+- Hover over the underlined code to see the diagnostic in a tooltip.
+- Open the :guilabel:`Problems` panel (:menuselection:`View --> Problems`)
+  to see all diagnostics for the workspace.
+- Click on a diagnostic in the Problems panel to jump to the source location.
+
+--------------------------------------
+Common Mistakes
+--------------------------------------
+
+**Misspelled type name:**
+
+.. code-block::
+
+   VAR
+      Counter : IN := 0;   (* should be INT *)
+   END_VAR
+
+**Missing semicolons:**
+
+.. code-block::
+
+   Counter := Counter + 1   (* missing ; *)
+
+**Mismatched END keyword:**
+
+.. code-block::
+
+   PROGRAM main
+   END_FUNCTION   (* should be END_PROGRAM *)
+
+In each case, IronPLC points to the location of the problem and provides
+a code you can look up for more detail.

--- a/docs/how-to-guides/getting-started/structure-a-multi-file-project.rst
+++ b/docs/how-to-guides/getting-started/structure-a-multi-file-project.rst
@@ -1,0 +1,74 @@
+================================
+Structure a Multi-File Project
+================================
+
+This guide gives practical advice on organizing an IEC 61131-3 project
+across multiple files. IronPLC does not enforce any particular layout — use
+whatever makes sense for your project.
+
+.. include:: ../../includes/requires-compiler.rst
+
+--------------------------------------
+A Recommended Starting Layout
+--------------------------------------
+
+For small to medium projects, a flat structure works well:
+
+.. code-block:: text
+
+   my-project/
+   ├── config.st        # Configuration, resource, and task definitions
+   ├── main.st          # Main program
+   ├── utilities.st     # Reusable functions and function blocks
+   └── globals.st       # Global variable lists (if needed)
+
+--------------------------------------
+Separating Configuration from Logic
+--------------------------------------
+
+Keep your :code:`CONFIGURATION` block in its own file. This makes it easy to
+create different configurations for testing and production:
+
+.. code-block:: text
+
+   my-project/
+   ├── config-production.st    # Production configuration (100ms cycle)
+   ├── config-test.st          # Test configuration (different timing)
+   ├── main.st
+   └── utilities.st
+
+When checking with IronPLC, pass the appropriate configuration:
+
+.. code-block:: shell
+
+   ironplcc check main.st utilities.st config-production.st
+
+--------------------------------------
+Checking a Directory
+--------------------------------------
+
+If all your :file:`.st` files are in one directory, you can point IronPLC
+at the directory instead of listing every file:
+
+.. code-block:: shell
+
+   ironplcc check my-project/
+
+IronPLC finds all :file:`.st` files in the directory and checks them
+together.
+
+--------------------------------------
+One POU per File
+--------------------------------------
+
+As your project grows, consider putting each program, function, or function
+block in its own file named after the POU:
+
+.. code-block:: text
+
+   my-project/
+   ├── config.st
+   ├── main.st
+   ├── motor_control.st        # FUNCTION_BLOCK MotorControl
+   ├── temperature_monitor.st  # FUNCTION_BLOCK TemperatureMonitor
+   └── clamp.st                # FUNCTION Clamp

--- a/docs/how-to-guides/index.rst
+++ b/docs/how-to-guides/index.rst
@@ -4,12 +4,43 @@
 How-to guides
 =============
 
-These guides presuppose some familiarity with IronPLC.
+Step-by-step guides for specific tasks. Pick the section that matches where
+you are coming from.
+
+.. grid:: 2
+
+   .. grid-item-card:: Getting Started
+      :link: getting-started/index
+      :link-type: doc
+
+      New to IEC 61131-3 or IronPLC? Start here.
+
+   .. grid-item-card:: Coming from Beremiz
+      :link: beremiz/index
+      :link-type: doc
+
+      Use IronPLC alongside your Beremiz workflow.
+
+.. grid:: 2
+
+   .. grid-item-card:: Coming from TwinCAT
+      :link: twincat/index
+      :link-type: doc
+
+      Use IronPLC alongside Beckhoff TwinCAT 3.
+
+   .. grid-item-card:: General
+      :link: update
+      :link-type: doc
+
+      Updating, troubleshooting, and other tasks.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
+   :hidden:
 
-   Check Beremiz Projects <check-beremiz-projects>
-   Check TwinCAT 3 Projects <check-twincat-projects>
+   Getting Started <getting-started/index>
+   Coming from Beremiz <beremiz/index>
+   Coming from TwinCAT <twincat/index>
    Update IronPLC on your computer <update>
    Troubleshoot the Editor Extension <troubleshoot-editor>

--- a/docs/how-to-guides/twincat/check-twincat-projects.rst
+++ b/docs/how-to-guides/twincat/check-twincat-projects.rst
@@ -5,7 +5,7 @@ Check TwinCAT 3 Projects
 This guide shows how to use IronPLC to check a Beckhoff TwinCAT 3 project
 for correctness.
 
-.. include:: ../includes/requires-compiler.rst
+.. include:: ../../includes/requires-compiler.rst
 
 -----------------------------------
 Check with the VS Code Extension

--- a/docs/how-to-guides/twincat/index.rst
+++ b/docs/how-to-guides/twincat/index.rst
@@ -1,0 +1,15 @@
+====================
+Coming from TwinCAT
+====================
+
+These guides are for engineers who already use Beckhoff TwinCAT 3 and want
+to use IronPLC alongside it.
+
+IronPLC can read TwinCAT project files (:file:`.plcproj`, :file:`.TcPOU`,
+:file:`.TcGVL`) directly, so you can get a second opinion on your code
+without changing your workflow.
+
+.. toctree::
+   :maxdepth: 1
+
+   Check TwinCAT 3 Projects <check-twincat-projects>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,42 +1,51 @@
 .. image:: images/banner.svg
    :align: center
 
-IronPLC is a software development environment for building industrial control systems using off-the-shelf computers. More precisely, IronPLC will one day be an integrated development environment for building IEC 61131-3 based control systems that run on off-the-shelf embedded computers. In effect, we want to make it easy to build SoftPLCs.
+IronPLC is an open-source toolchain for checking and compiling IEC 61131-3
+programs. It integrates into Visual Studio Code to provide auto-completion,
+syntax highlighting, and real-time error checking as you type. It also
+includes a command-line compiler and an early-stage runtime.
 
-The goal is ambitious and IronPLC is far from achieving that goal.
-Today, IronPLC
-integrates into Visual Studio Code and provides tools to work with IEC 61131-3 files:
+IronPLC reads Structured Text, PLCopen XML (Beremiz), and TwinCAT 3 source
+files, so you can use it alongside your existing PLC development environment.
 
-* auto-completion
-* syntax and semantic checks
-
-IronPLC has some pretty big limitations and is not going to replace your
-existing development environment any time soon. Even so, we'd love if you give
-it a try, let us know what you think, fix a bug, or even become a regular
-contributor. IronPLC is MIT licensed and we aim to keep it that way.
+The long-term vision is to become a full development environment for
+building IEC 61131-3 based control systems on off-the-shelf embedded
+computers (SoftPLCs). That goal is ambitious and IronPLC is still early in
+that journey — but there is plenty you can do with it today. IronPLC is MIT
+licensed and we'd love for you to give it a try, share feedback, or
+contribute.
 
 .. grid:: 2
 
     .. grid-item-card::  Tutorials
+        :link: quickstart/index
+        :link-type: doc
 
-        Start here as a new developer:
-
-        * :doc:`quickstart/index`
+        New to IEC 61131-3 or IronPLC? Start here with a step-by-step
+        guide that builds up from nothing.
 
     .. grid-item-card::  How-to guides
+        :link: how-to-guides/index
+        :link-type: doc
 
-        Step-by-step guides for using IronPLC.
+        Practical guides for specific tasks — whether you are getting
+        started, coming from Beremiz, or coming from TwinCAT.
 
-        * :ref:`how to guides target`
-   
 .. grid:: 2
 
-   .. grid-item-card::  Reference
+    .. grid-item-card::  Explanation
+        :link: explanation/index
+        :link-type: doc
 
-        Technical reference material, for
-        
-        * :doc:`reference/compiler/index`
-        * :doc:`reference/editor/index`
+        Understand the concepts behind IEC 61131-3: the scan cycle, program
+        organization, Structured Text, and how I/O works.
+
+    .. grid-item-card::  Reference
+        :link: reference/index
+        :link-type: doc
+
+        Technical reference for the compiler, editor extension, and runtime.
 
 .. toctree::
    :maxdepth: 2
@@ -44,4 +53,5 @@ contributor. IronPLC is MIT licensed and we aim to keep it that way.
 
    Quick start <quickstart/index>
    How-to guides <how-to-guides/index>
+   Explanation <explanation/index>
    Reference <reference/index>

--- a/docs/quickstart/compiling-and-running.rst
+++ b/docs/quickstart/compiling-and-running.rst
@@ -1,0 +1,94 @@
+=======================
+Compiling and Running
+=======================
+
+So far you have been writing code and letting the VS Code extension check it
+for correctness. In this chapter, you will use the command line to compile
+your program into a bytecode container and run it.
+
+.. include:: ../includes/requires-compiler.rst
+
+.. warning::
+
+   The compile command currently supports only trivial programs. Supported
+   features include: :code:`PROGRAM` declarations, :code:`INT` variable
+   declarations, assignment statements, integer literal constants, and
+   the ``+`` (add) operator. Programs using other features will produce a
+   code generation error.
+
+--------------------------------------
+Check the Program
+--------------------------------------
+
+Open a terminal in your :file:`helloworld` directory and run:
+
+.. code-block:: shell
+   :caption: Check Syntax
+   :name: qs-check-syntax
+
+   ironplcc check main.st config.st
+
+On success, the command produces no output. If there are errors, IronPLC
+prints diagnostics with the file name, line number, and a description of
+the problem.
+
+--------------------------------------
+Compile to Bytecode
+--------------------------------------
+
+To compile your source files into a bytecode container (:file:`.iplc` file),
+run:
+
+.. code-block:: shell
+   :caption: Compile Program
+   :name: qs-compile-program
+
+   ironplcc compile main.st --output main.iplc
+
+You can also use the short form ``-o`` for the output flag:
+
+.. code-block:: shell
+
+   ironplcc compile main.st -o main.iplc
+
+On success, the command creates the :file:`.iplc` file at the specified path.
+
+--------------------------------------
+Run the Program
+--------------------------------------
+
+Use the IronPLC virtual machine runtime to execute the compiled program:
+
+.. code-block:: shell
+   :caption: Run Program
+   :name: qs-run-program
+
+   ironplcvm run main.iplc
+
+You can inspect variable values after execution by specifying a dump file:
+
+.. code-block:: shell
+
+   ironplcvm run main.iplc --dump-vars output.txt
+
+--------------------------------------
+What You Have Learned
+--------------------------------------
+
+Over the course of this tutorial, you have:
+
+1. **Installed** IronPLC and the VS Code extension.
+2. **Written** a minimal IEC 61131-3 program.
+3. **Connected** it to inputs and outputs with directly represented variables.
+4. **Configured** the application with a task, resource, and configuration.
+5. **Organized** the code across multiple files.
+6. **Compiled** and **run** the program from the command line.
+
+--------------------------------------
+Where to Go from Here
+--------------------------------------
+
+- :doc:`/explanation/index` — deepen your understanding of IEC 61131-3
+  concepts.
+- :doc:`/how-to-guides/index` — practical guides for specific tasks.
+- :doc:`/reference/compiler/index` — full command and language reference.

--- a/docs/quickstart/configuring.rst
+++ b/docs/quickstart/configuring.rst
@@ -1,0 +1,88 @@
+==============================
+Configuring Your Application
+==============================
+
+In the previous chapter, you wrote a program with inputs and outputs. But
+a program alone is not a complete IEC 61131-3 application — you need to
+tell the runtime *how often* to run it and *on what hardware*. That is the
+job of a configuration.
+
+--------------------------------------
+Add a Configuration Block
+--------------------------------------
+
+Open :file:`main.st` and add the following **below** the existing
+:code:`END_PROGRAM`:
+
+.. code-block::
+   :caption: Complete Application
+   :name: complete-app
+
+   PROGRAM main
+      VAR
+         Button AT %IX1: BOOL;
+         Buzzer AT %QX1: BOOL;
+      END_VAR
+
+      Buzzer := NOT Button;
+
+   END_PROGRAM
+
+   CONFIGURATION config
+      RESOURCE res ON PLC
+         TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+         PROGRAM plc_task_instance WITH plc_task : main;
+      END_RESOURCE
+   END_CONFIGURATION
+
+Save the file. The IronPLC extension should show no errors.
+
+--------------------------------------
+What the Configuration Does
+--------------------------------------
+
+The new block introduces three layers:
+
+**CONFIGURATION**
+   The top-level container for your application. Every IEC 61131-3
+   application has exactly one configuration. Here it is named ``config``.
+
+**RESOURCE**
+   Represents a processing unit (a CPU or core). The resource named ``res``
+   runs ``ON PLC``, where ``PLC`` is the name of the hardware target
+   defined by the runtime environment.
+
+**TASK**
+   Defines a scheduling policy. The task named ``plc_task`` runs every
+   100 milliseconds at priority level 1. This means the runtime will
+   execute the sense-control-actuate cycle 10 times per second.
+
+The line:
+
+.. code-block::
+
+   PROGRAM plc_task_instance WITH plc_task : main;
+
+creates an **instance** of the ``main`` program, names it
+``plc_task_instance``, and binds it to ``plc_task``. Every 100 ms, the
+runtime reads the inputs, runs ``main``, and writes the outputs.
+
+.. tip::
+
+   For a deeper look at how these layers fit together, see
+   :doc:`/explanation/program-organization`.
+
+--------------------------------------
+You Now Have a Complete Application
+--------------------------------------
+
+Your :file:`main.st` file now contains everything needed for a deployable
+IEC 61131-3 application:
+
+- A **program** that reads a button and controls a buzzer.
+- A **configuration** that runs the program every 100 ms.
+
+In the next chapter, you will learn how to split this into multiple files
+as your project grows.
+
+Continue to :doc:`multiple-files`.

--- a/docs/quickstart/helloworld.rst
+++ b/docs/quickstart/helloworld.rst
@@ -2,65 +2,37 @@
 Hello, World!
 =============
 
-Now that you've installed IronPLC, it's time to write a first program.
+Now that you've installed IronPLC, it's time to write your first program.
 
-If you've ever learned another programming language, you likely started
-by writing a "Hello, World" program to display that text.
-Don't worry if you haven't learned another programming language
-or haven't written a "Hello, World" program. 
+In most programming languages, "Hello, World" prints text to the screen.
+IEC 61131-3 is designed for real-time automation controllers that often do
+not have a display, so our "Hello, World" will look a little different. In
+this chapter, we write the simplest possible program and use IronPLC to
+check it for correctness.
 
-IEC 61131-3 is designed for real-time automation controllers
-that often do not have a display. In other words, there is
-often no place to show "Hello, World". Other solutions to get feedback,
-such as creating a file are also unusual.
+--------------------------------------
+Create a Project Directory
+--------------------------------------
 
-In short, a "Hello, World" program in IEC 61131-3 is different.
+In a Terminal, create a new folder and open it in Visual Studio Code:
 
--------------------------------
-The Sense-Control-Actuate Cycle
--------------------------------
+.. code-block:: shell
+   :caption: Create Project Directory
+   :name: newhelloworld
 
-Controllers normally operate as part of a sense-control-actuate cycle.
-We'll start with a simple example to illustrate the idea: a door bell system.
-Our door bell system contains a button (the sensor) and a buzzer (the actuator).
+   mkdir helloworld
+   cd helloworld
+   code .
 
-.. figure:: button-buzzer.svg
-   :width: 200
-   
-   Pressing the button triggers the buzzer.
+--------------------------------------
+Write Your First Program
+--------------------------------------
 
-We desire that the buzzer makes noise when the button is pressed.
-To do that, we use a controller to check the button state and if pressed
-then enable the buzzer.
-
-.. note::
-
-   It is possible to design a simpler door bell system. This
-   example designed to illustrate how to use IEC 61131-3.
-
-------------------------------------------
-Create an Application with Structured Text
-------------------------------------------
-
-This section will show you how to create a IEC 61131-3 application.
-
-In a Terminal, enter the commands in :ref:`Create Project Directory <newhelloworld>` to
-create a new folder and start Visual Studio Code.
-
-   .. code-block:: shell
-      :caption: Create Project Directory
-      :name: newhelloworld
-
-      mkdir helloworld
-      cd helloworld
-      code .
-
-
-In Visual Studio Code, follow the steps to create a new Structured Text file.
+In Visual Studio Code:
 
 #. In the main menu, select :menuselection:`File --> New File...`.
 #. In the :guilabel:`New File...` dialog, select the :menuselection:`Structured Text File` option.
-#. Enter the code in :ref:`Hello World <helloworld>` into the :guilabel:`Editor`.
+#. Enter the following code into the :guilabel:`Editor`:
 
    .. code-block::
       :caption: Hello World
@@ -68,119 +40,49 @@ In Visual Studio Code, follow the steps to create a new Structured Text file.
 
       PROGRAM main
          VAR
-            Button AT %IX1: BOOL;
-            Buzzer AT %QX1: BOOL;
+            Counter : INT := 0;
          END_VAR
 
-         Buzzer := NOT Button;
+         Counter := Counter + 1;
 
       END_PROGRAM
 
-      CONFIGURATION config
-         RESOURCE res ON PLC
-            TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
-            PROGRAM plc_task_instance WITH plc_task : main;
-         END_RESOURCE
-      END_CONFIGURATION
-
 #. Save the file with the name :file:`main.st`.
 
----------------------------------------
-Anatomy of the Hello, World Application
----------------------------------------
+That's it — you have written a valid IEC 61131-3 program. If IronPLC's
+VS Code extension is installed, you should see no errors highlighted in
+the editor.
 
-Let's review this application. IEC 61131-3 applications are structured from blocks
-called Program Organization Units (POUs). The :code:`PROGRAM` is a top level block and
-similar to the :code:`main` function in other languages. The section indicated by
+--------------------------------------
+What This Program Does
+--------------------------------------
 
-.. code-block::
-   :name: main
+Let's break it down:
 
-   PROGRAM main
+- :code:`PROGRAM main` ... :code:`END_PROGRAM` defines a **program** named
+  ``main``. A program is the basic unit of control logic in IEC 61131-3,
+  similar to a ``main`` function in other languages.
 
-   END_PROGRAM
+- :code:`VAR` ... :code:`END_VAR` declares a **variable** named ``Counter``
+  of type :code:`INT` (a 16-bit signed integer), initialized to 0.
 
-defines a :code:`PROGRAM` having the name :code:`main`.
+- ``Counter := Counter + 1;`` is an **assignment statement**. The ``:=``
+  operator assigns the value on the right to the variable on the left.
 
-Unlike the :code:`main` function in other languages, a program does not run by default.
-We need to tell the PLC runtime how we want to run the program. The piece indicated by
+This program increments a counter by one each time it runs. On a real PLC,
+this would happen on every scan cycle — but we have not configured that yet.
+We will add that in :doc:`configuring`.
 
-.. code-block::
-   :name: config
+.. tip::
 
-   CONFIGURATION config
-      
-   END_CONFIGURATION
+   For a deeper look at Structured Text syntax, see
+   :doc:`/explanation/structured-text-basics`.
 
-defines how we want the program to run. The configuration declares we want to execute
-the :code:`main` program once every 100 ms and this task is the highest priority task. This task 
-executed on the hardware element named :code:`res`.
+--------------------------------------
+Next Steps
+--------------------------------------
 
-We want our program to enable (or disable) the buzzer based on whether the button is
-pressed. The piece indicated by
+In the next chapter, we will make the program more interesting by connecting
+it to inputs and outputs using a doorbell example.
 
-.. code-block:: 
-   :name: var
-
-   VAR
-
-   END_VAR
-
-defines two variables that will contain the state of the button and buzzer. We can then use
-the variable containing the state of the button to control the variable containing the
-desired state of the buzzer. The statement indicated by
-
-.. code-block:: 
-   :name: statement
-
-   Buzzer := NOT Button;
-
-does just that. In plain English, the statement says "assign the value of
-:code:`Buzzer` to be the boolean inverse of the value of :code:`Button`."
-
-From the perspective of the program, there is no specific meaning to the
-names :code:`Buzzer` and :code:`Button`. We could have called them
-:code:`foo` and :code:`bar`, but we choose names that were indicative of
-their purpose.
-
-Our program needs to associate the variables :code:`Buzzer` and :code:`Button`
-with digital input/output. We do this by declaring these as directly represented
-variables. Directly represented variable have specific physical or logical locations,
-for example, being associated with a digital input pin. The declarations
-
-.. code-block:: 
-   :name: directly-represented
-
-   AT %IX1
-
-associates the variable :code:`Button` with a 1-bit (Boolean) input.
-
-The net result of these elements is to define a program that every 100 ms, reads
-from an input device, evaluates the logical inverse, and assign the result to
-an output device.
-
----------------------------
-Working with Multiple Files
----------------------------
-
-You can define your IEC 61131-3 application in multiple files and IronPLC
-will combine them into a single unit.
-
-In Visual Studio Code, follow the steps to create a new Structured Text file.
-
-#. In the main menu, select :menuselection:`File --> New File...`.
-#. In the :guilabel:`New File...` dialog, select the :menuselection:`Structured Text File` option.
-#. Enter the code in :ref:`Hello World - Configuration <helloworld-config>` into the :guilabel:`Editor`.
-
-   .. code-block::
-      :caption: Hello World - Configuration
-      :name: helloworld-config
-
-      CONFIGURATION config
-         RESOURCE res ON PLC
-            TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
-            PROGRAM plc_task_instance WITH plc_task : main;
-         END_RESOURCE
-      END_CONFIGURATION
-
-#. Save the file with the name :file:`config.st`.
+Continue to :doc:`sense-control-actuate`.

--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -2,11 +2,13 @@
 Quick start tutorial
 ====================
 
-Let's start your IronPLC journey! IronPLC is still expanding
-so you journey will be quick. In this chapter, we'll discuss:
+This tutorial guides you from installation to a working IEC 61131-3
+application, introducing one concept at a time. Each chapter builds on the
+last and leaves you with a program you can check for correctness.
 
-* Installing IronPLC
-* Writing a program and checking syntax
+If you are completely new to PLC programming, you may want to read
+:doc:`/explanation/what-is-iec-61131-3` first for background on the
+concepts.
 
 .. toctree::
    :maxdepth: 1
@@ -14,3 +16,7 @@ so you journey will be quick. In this chapter, we'll discuss:
 
    Installation <installation>
    Hello, World! <helloworld>
+   The Sense-Control-Actuate Cycle <sense-control-actuate>
+   Configuring Your Application <configuring>
+   Working with Multiple Files <multiple-files>
+   Compiling and Running <compiling-and-running>

--- a/docs/quickstart/multiple-files.rst
+++ b/docs/quickstart/multiple-files.rst
@@ -1,0 +1,78 @@
+============================
+Working with Multiple Files
+============================
+
+As your IEC 61131-3 application grows, you will want to organize your code
+across multiple files. IronPLC combines all files into a single unit, so
+you can split your application however you like.
+
+--------------------------------------
+Split the Application
+--------------------------------------
+
+Right now, :file:`main.st` contains both the program and the configuration.
+Let's separate them.
+
+First, edit :file:`main.st` so it contains **only** the program:
+
+.. code-block::
+   :caption: main.st — Program only
+   :name: main-only
+
+   PROGRAM main
+      VAR
+         Button AT %IX1: BOOL;
+         Buzzer AT %QX1: BOOL;
+      END_VAR
+
+      Buzzer := NOT Button;
+
+   END_PROGRAM
+
+Next, create a new file for the configuration:
+
+#. In the main menu, select :menuselection:`File --> New File...`.
+#. In the :guilabel:`New File...` dialog, select the :menuselection:`Structured Text File` option.
+#. Enter the following code:
+
+   .. code-block::
+      :caption: config.st — Configuration only
+      :name: config-only
+
+      CONFIGURATION config
+         RESOURCE res ON PLC
+            TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+            PROGRAM plc_task_instance WITH plc_task : main;
+         END_RESOURCE
+      END_CONFIGURATION
+
+#. Save the file with the name :file:`config.st`.
+
+The IronPLC extension checks all :file:`.st` files in the workspace
+together, so it will still validate that the configuration references a
+valid program.
+
+--------------------------------------
+Why Split Files?
+--------------------------------------
+
+For a small example like this, splitting may seem unnecessary. But in
+real-world projects, separating programs from configuration has clear
+benefits:
+
+- **Reuse** — the same program can be referenced from different
+  configurations (for example, testing vs. production).
+- **Organization** — each file has a single responsibility.
+- **Collaboration** — different team members can work on different files.
+
+IronPLC does not impose any naming conventions on your files. Use whatever
+structure makes sense for your project.
+
+--------------------------------------
+Next Steps
+--------------------------------------
+
+You now have a complete, multi-file IEC 61131-3 application. In the final
+chapter, you will compile it into a bytecode container and run it.
+
+Continue to :doc:`compiling-and-running`.

--- a/docs/quickstart/sense-control-actuate.rst
+++ b/docs/quickstart/sense-control-actuate.rst
@@ -1,0 +1,97 @@
+================================
+The Sense-Control-Actuate Cycle
+================================
+
+In the previous chapter, you wrote a program that increments a counter. That
+program works, but it does not interact with the outside world. In this
+chapter, you will connect your program to inputs and outputs using a doorbell
+example.
+
+--------------------------------------
+The Idea
+--------------------------------------
+
+Controllers normally operate as part of a **sense-control-actuate** cycle:
+
+1. **Sense** — read inputs from sensors.
+2. **Control** — evaluate logic to decide what to do.
+3. **Actuate** — write outputs to actuators.
+
+We'll illustrate this with a simple doorbell system. The system has a button
+(the sensor) and a buzzer (the actuator).
+
+.. figure:: button-buzzer.svg
+   :width: 200
+
+   Pressing the button triggers the buzzer.
+
+We want the buzzer to sound when the button is pressed. To do that, our
+program reads the button state and sets the buzzer accordingly.
+
+.. note::
+
+   A real doorbell does not need a PLC. This example is deliberately simple
+   to illustrate IEC 61131-3 concepts.
+
+--------------------------------------
+Add Variables for I/O
+--------------------------------------
+
+Open the :file:`main.st` file from the previous chapter and replace its
+contents with:
+
+.. code-block::
+   :caption: Doorbell Program
+   :name: doorbell
+
+   PROGRAM main
+      VAR
+         Button AT %IX1: BOOL;
+         Buzzer AT %QX1: BOOL;
+      END_VAR
+
+      Buzzer := NOT Button;
+
+   END_PROGRAM
+
+Save the file. The IronPLC extension checks the file automatically — you
+should see no errors.
+
+--------------------------------------
+What Changed
+--------------------------------------
+
+We replaced the counter with two new variables:
+
+- ``Button AT %IX1 : BOOL`` — a Boolean **input** variable. The :code:`AT`
+  keyword followed by ``%IX1`` maps this variable to a physical input
+  address. The ``I`` means input, ``X`` means single bit, and ``1`` is the
+  address number.
+
+- ``Buzzer AT %QX1 : BOOL`` — a Boolean **output** variable. The ``Q``
+  means output.
+
+These are called **directly represented variables** because they are tied
+to specific hardware I/O points. On a real PLC, ``%IX1`` would correspond
+to a digital input pin (the button) and ``%QX1`` to a digital output pin
+(the buzzer).
+
+The statement ``Buzzer := NOT Button;`` assigns the logical inverse of
+the button state to the buzzer. When the button is pressed (FALSE in this
+wiring), the buzzer turns on (TRUE).
+
+.. tip::
+
+   For a complete explanation of the addressing format (``%IX``, ``%QX``,
+   ``%MW``, etc.), see :doc:`/explanation/variables-and-io`.
+
+--------------------------------------
+Next Steps
+--------------------------------------
+
+You now have a program with inputs and outputs, but it is not yet a
+complete IEC 61131-3 application. We need to tell the runtime *how often*
+to run this program and *where* to run it. That's what configurations,
+resources, and tasks are for.
+
+Continue to :doc:`configuring`.


### PR DESCRIPTION
Add the missing Explanation documentation quadrant with five conceptual
pages (What is IEC 61131-3, IronPLC Ecosystem, Structured Text Basics,
Program Organization, Variables and I/O). Rework the tutorial into six
incremental chapters that each introduce one concept and leave the reader
with a working program. Restructure how-to guides into families
(getting-started, beremiz, twincat) with a URL structure that supports
growth. Refresh the landing page to lead with what IronPLC does today
and present all four documentation quadrants.

https://claude.ai/code/session_01SGDUYhU2Fmv5YxRJjcHCox