### PR TITLE
Update READMEs to reflect current IronPLC capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 ![](docs/images/banner.svg)
 
-⚠ This project's capabilities are limited to a parser, semantic analyzer, and
-Visual Studio Code Extension that are that are building blocks for a complete
-IEC 61131-3 runtime and development environment.
-
-IronPLC aims to be a SoftPLC written entirely in safe Rust for embedded
+IronPLC is a SoftPLC written entirely in safe Rust for embedded
 devices running programs written in the IEC 61131-3 language.
 
 [![IronPLC Integration](https://github.com/ironplc/ironplc/actions/workflows/integration.yaml/badge.svg)](https://github.com/ironplc/ironplc/actions/workflows/integration.yaml)
@@ -27,24 +23,27 @@ to be written entirely in safe Rust to prevent security issues. The development
 environment aims to be available via Visual Studio Code to provide
 a first class environment.
 
-### Progress
+### What Works Today
 
-The project is progressing towards a minimum loveable product.
-What works today:
+* ✅ **Compiler** (`ironplcc`) — parses and analyzes IEC 61131-3 Structured Text with 60+ diagnostic checks
+* ✅ **Code Generation** — compiles programs to a bytecode container (`.iplc`) format
+* ✅ **Runtime** (`ironplcvm`) — executes compiled bytecode with task scheduling
+* ✅ **Visual Studio Code Extension** — syntax highlighting, real-time diagnostics, build tasks, and bytecode viewer
+* ✅ **Multiple Source Formats** — Structured Text (`.st`, `.iec`), PLCopen XML (`.xml`), and TwinCAT (`.TcPOU`, `.TcGVL`, `.TcDUT`)
+* ✅ **Documentation website**
 
-* ✅ Syntax highlighting
-* ✅ Analysis of structured text files
-* ✅ Visual Studio Code Extension
-* ✅ Documentation website
+### Limitations
 
-What doesn't work:
-* Executing structured text
+Code generation and the runtime currently support a minimal subset of the language:
+`PROGRAM` declarations, `INT` variable declarations, assignment statements,
+integer literal constants, and arithmetic operators (`+`, `-`, `*`, `/`).
+The full IEC 61131-3 language is supported by the parser and semantic analyzer.
 
-IronPLC supports:
+### Platform Support
 
 * ✅ Windows
-* ✅ MacOS
-* ✅ Linux (probably)
+* ✅ macOS
+* ✅ Linux
 
 ## Usage
 
@@ -61,7 +60,7 @@ Contributions are very welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for detai
 
 ## Similar Projects
 
-* [RuSTy](https://github.com/PLC-lang/rusty) - Structured text compiler written in Rust. RuSTy is further along but the LGPL and LGPL licenses are difficult for industrial uses.
+* [RuSTy](https://github.com/PLC-lang/rusty) - Structured text compiler written in Rust. RuSTy is further along but the LGPL and GPL licenses are difficult for industrial uses.
 * [Structured Text language Support](https://github.com/Serhioromano/vscode-st) - Structured text language support for Visual Studio Code.
 * [Beremiz](https://beremiz.org/) - A Python-based PLC programming environment.
 * [RoboPLC](https://github.com/roboplc/roboplc/) - A Rust framework for creating industrial control appliances

--- a/integrations/vscode/README.md
+++ b/integrations/vscode/README.md
@@ -1,10 +1,8 @@
 # IronPLC Visual Studio Code Extension
 
-IronPLC brings IEC 61131-3 support to Visual Studio Code.
-
-⚠ This project's capabilities are limited to a parser, semantic analyzer, and
-Visual Studio Code Extension that are building blocks for a complete
-IEC 61131-3 runtime and development environment.
+IronPLC brings IEC 61131-3 support to Visual Studio Code, providing
+real-time code analysis, syntax highlighting, build tasks, and a bytecode
+viewer for programs written in the IEC 61131-3 Structured Text language.
 
 ## Quick Start
 
@@ -18,6 +16,7 @@ on your system.
 |---------------|----------------|-----------------|
 | Structured Text | `.st`, `.iec` | IEC 61131-3 Structured Text source files |
 | PLCopen XML | Auto-detected | PLCopen TC6 XML project files with embedded Structured Text |
+| TwinCAT | `.TcPOU`, `.TcGVL`, `.TcDUT` | Beckhoff TwinCAT 3 project files with embedded Structured Text |
 
 ## Features
 
@@ -56,6 +55,20 @@ The extension automatically closes:
 ### Bracket Colorization
 
 Matching brackets are colorized to help visualize nesting levels.
+
+### Build Tasks
+
+The extension integrates with the VS Code build system to compile IEC 61131-3
+projects into bytecode container (`.iplc`) files without leaving the editor.
+
+* Press `Ctrl+Shift+B` (or `Cmd+Shift+B` on macOS) and select **ironplc: compile**
+* Output is written to a `.iplc` file in the workspace root
+
+### Bytecode Viewer
+
+Opening an `.iplc` bytecode file displays a human-readable disassembly of
+the compiled program, including the file header, constant pool, task table,
+and function instructions with color-coded opcodes.
 
 ## Commands
 


### PR DESCRIPTION
The main README and VS Code extension README were out of date,
still describing IronPLC as limited to parsing and analysis. Updated
both to reflect the code generator, bytecode runtime, multiple source
format support, build tasks, and bytecode viewer that now exist.

https://claude.ai/code/session_01RFbCptUELYwp4dDyve3k3o