### PR TITLE
Add NEG_I32 unary negation opcode (#525)

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -8,6 +8,7 @@
 //! - Assignment statements
 //! - Integer literal constants
 //! - Binary Add, Sub, Mul, Div, Mod, and Pow operators
+//! - Unary Neg operator
 //! - Variable references (named symbolic variables)
 
 use std::collections::HashMap;
@@ -266,11 +267,9 @@ fn compile_expr(
                     emitter.emit_load_const_i32(pool_index);
                     Ok(())
                 } else {
-                    Err(Diagnostic::todo_with_span(
-                        expr_span(&unary.term),
-                        file!(),
-                        line!(),
-                    ))
+                    compile_expr(emitter, ctx, &unary.term)?;
+                    emitter.emit_neg_i32();
+                    Ok(())
                 }
             }
             _ => Err(Diagnostic::todo_with_span(

--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -76,6 +76,12 @@ impl Emitter {
         self.pop_stack(1);
     }
 
+    /// Emits NEG_I32 (pops one, pushes one).
+    pub fn emit_neg_i32(&mut self) {
+        self.bytecode.push(opcode::NEG_I32);
+        // Net effect: pop 1, push 1 = no change to stack depth
+    }
+
     /// Emits BUILTIN with a function ID (pops two, pushes one for 2-arg functions).
     pub fn emit_builtin(&mut self, func_id: u16) {
         self.bytecode.push(opcode::BUILTIN);
@@ -243,6 +249,26 @@ mod tests {
         em.emit_store_var_i32(1); // stack: 0
 
         assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_neg_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_var_i32(0);
+        em.emit_neg_i32();
+
+        assert_eq!(em.bytecode(), &[0x10, 0x00, 0x00, 0x35]);
+    }
+
+    #[test]
+    fn emitter_when_neg_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := -x
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_neg_i32(); // stack: 1 (pop 1, push 1)
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 1);
     }
 
     #[test]

--- a/compiler/codegen/tests/compile_neg.rs
+++ b/compiler/codegen/tests/compile_neg.rs
@@ -1,0 +1,62 @@
+//! Bytecode-level integration tests for the NEG operator compilation.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_neg_variable_then_produces_neg_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := -x;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    assert_eq!(container.header.num_variables, 2);
+    assert_eq!(container.constant_pool.get_i32(0).unwrap(), 10);
+
+    // x := 10: LOAD_CONST_I32 pool:0, STORE_VAR_I32 var:0
+    // y := -x: LOAD_VAR_I32 var:0, NEG_I32, STORE_VAR_I32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x35, // NEG_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_neg_literal_then_constant_folds() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+  END_VAR
+  x := -5;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // Constant folding: -5 is stored directly in the pool, no NEG_I32 opcode
+    assert_eq!(container.constant_pool.get_i32(0).unwrap(), -5);
+
+    // LOAD_CONST_I32 pool:0 (-5), STORE_VAR_I32 var:0, RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(bytecode, &[0x01, 0x00, 0x00, 0x18, 0x00, 0x00, 0xB5]);
+}

--- a/compiler/codegen/tests/end_to_end.rs
+++ b/compiler/codegen/tests/end_to_end.rs
@@ -10,6 +10,7 @@
 //! - end_to_end_div.rs (DIV operator)
 //! - end_to_end_mod.rs (MOD operator)
 //! - end_to_end_pow.rs (POW/EXPT operator)
+//! - end_to_end_neg.rs (NEG unary operator)
 
 mod common;
 

--- a/compiler/codegen/tests/end_to_end_neg.rs
+++ b/compiler/codegen/tests/end_to_end_neg.rs
@@ -1,0 +1,59 @@
+//! End-to-end integration tests for the NEG unary operator.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_neg_variable_then_negated() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 7;
+  y := -x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 7);
+    assert_eq!(bufs.vars[1].as_i32(), -7);
+}
+
+#[test]
+fn end_to_end_when_neg_negative_variable_then_positive() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := -3;
+  y := -x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), -3);
+    assert_eq!(bufs.vars[1].as_i32(), 3);
+}
+
+#[test]
+fn end_to_end_when_double_neg_then_original() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 42;
+  y := -(-x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 42);
+    assert_eq!(bufs.vars[1].as_i32(), 42);
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -34,6 +34,10 @@ pub const DIV_I32: u8 = 0x33;
 /// Traps on division by zero.
 pub const MOD_I32: u8 = 0x34;
 
+/// Negate a 32-bit integer (wrapping).
+/// Pops one value, pushes its negation.
+pub const NEG_I32: u8 = 0x35;
+
 /// Call a built-in standard library function.
 /// Operand: u16 function ID (little-endian).
 /// Stack effect depends on the specific function.

--- a/compiler/plc2x/src/disassemble.rs
+++ b/compiler/plc2x/src/disassemble.rs
@@ -319,6 +319,15 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                 }));
                 pc += 1;
             }
+            opcode::NEG_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "NEG_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
             opcode::BUILTIN => {
                 let func_id = read_u16(bytecode, pc + 1);
                 let operand = match func_id {

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -409,6 +409,10 @@ fn execute(
                 }
                 stack.push(Slot::from_i32(a.wrapping_rem(b)))?;
             }
+            opcode::NEG_I32 => {
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(a.wrapping_neg()))?;
+            }
             opcode::BUILTIN => {
                 let func_id = read_u16_le(bytecode, &mut pc);
                 builtin::dispatch(func_id, stack)?;

--- a/compiler/vm/tests/execute_neg_i32.rs
+++ b/compiler/vm/tests/execute_neg_i32.rs
@@ -1,0 +1,115 @@
+//! Integration tests for the NEG_I32 opcode.
+
+mod common;
+
+use common::{single_function_container, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_neg_i32_then_correct_result() {
+    // neg(5) = -5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x35,              // NEG_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), -5);
+}
+
+#[test]
+fn execute_when_neg_i32_negative_then_positive() {
+    // neg(-3) = 3
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (-3)
+        0x35,              // NEG_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[-3]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 3);
+}
+
+#[test]
+fn execute_when_neg_i32_zero_then_zero() {
+    // neg(0) = 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0)
+        0x35,              // NEG_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_neg_i32_min_then_wraps() {
+    // neg(i32::MIN) = i32::MIN (wrapping)
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (i32::MIN)
+        0x35,              // NEG_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[i32::MIN]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    // wrapping_neg: i32::MIN wraps to i32::MIN
+    assert_eq!(vm.read_variable(0).unwrap(), i32::MIN);
+}


### PR DESCRIPTION
Implement runtime support for negating variables (e.g., `y := -x`), which previously hit a todo diagnostic. Literal negation (`x := -5`) continues to use constant folding.