### PR TITLE
Add I32 comparison opcodes (EQ, NE, LT, LE, GT, GE)

### DIFF
--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -82,6 +82,48 @@ impl Emitter {
         // Net effect: pop 1, push 1 = no change to stack depth
     }
 
+    /// Emits EQ_I32 (pops two, pushes one).
+    pub fn emit_eq_i32(&mut self) {
+        self.bytecode.push(opcode::EQ_I32);
+        // Net effect: pop 2, push 1 = pop 1
+        self.pop_stack(1);
+    }
+
+    /// Emits NE_I32 (pops two, pushes one).
+    pub fn emit_ne_i32(&mut self) {
+        self.bytecode.push(opcode::NE_I32);
+        // Net effect: pop 2, push 1 = pop 1
+        self.pop_stack(1);
+    }
+
+    /// Emits LT_I32 (pops two, pushes one).
+    pub fn emit_lt_i32(&mut self) {
+        self.bytecode.push(opcode::LT_I32);
+        // Net effect: pop 2, push 1 = pop 1
+        self.pop_stack(1);
+    }
+
+    /// Emits LE_I32 (pops two, pushes one).
+    pub fn emit_le_i32(&mut self) {
+        self.bytecode.push(opcode::LE_I32);
+        // Net effect: pop 2, push 1 = pop 1
+        self.pop_stack(1);
+    }
+
+    /// Emits GT_I32 (pops two, pushes one).
+    pub fn emit_gt_i32(&mut self) {
+        self.bytecode.push(opcode::GT_I32);
+        // Net effect: pop 2, push 1 = pop 1
+        self.pop_stack(1);
+    }
+
+    /// Emits GE_I32 (pops two, pushes one).
+    pub fn emit_ge_i32(&mut self) {
+        self.bytecode.push(opcode::GE_I32);
+        // Net effect: pop 2, push 1 = pop 1
+        self.pop_stack(1);
+    }
+
     /// Emits BUILTIN with a function ID (pops two, pushes one for 2-arg functions).
     pub fn emit_builtin(&mut self, func_id: u16) {
         self.bytecode.push(opcode::BUILTIN);
@@ -325,6 +367,138 @@ mod tests {
         em.emit_load_var_i32(0); // stack: 1
         em.emit_load_const_i32(0); // stack: 2
         em.emit_builtin(opcode::builtin::EXPT_I32); // stack: 1
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_eq_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_const_i32(0);
+        em.emit_load_const_i32(1);
+        em.emit_eq_i32();
+
+        assert_eq!(em.bytecode(), &[0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x68]);
+    }
+
+    #[test]
+    fn emitter_when_eq_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := x = 5
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_load_const_i32(0); // stack: 2
+        em.emit_eq_i32(); // stack: 1
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_ne_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_const_i32(0);
+        em.emit_load_const_i32(1);
+        em.emit_ne_i32();
+
+        assert_eq!(em.bytecode(), &[0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x69]);
+    }
+
+    #[test]
+    fn emitter_when_ne_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := x <> 5
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_load_const_i32(0); // stack: 2
+        em.emit_ne_i32(); // stack: 1
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_lt_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_const_i32(0);
+        em.emit_load_const_i32(1);
+        em.emit_lt_i32();
+
+        assert_eq!(em.bytecode(), &[0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x6A]);
+    }
+
+    #[test]
+    fn emitter_when_lt_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := x < 5
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_load_const_i32(0); // stack: 2
+        em.emit_lt_i32(); // stack: 1
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_le_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_const_i32(0);
+        em.emit_load_const_i32(1);
+        em.emit_le_i32();
+
+        assert_eq!(em.bytecode(), &[0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x6B]);
+    }
+
+    #[test]
+    fn emitter_when_le_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := x <= 5
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_load_const_i32(0); // stack: 2
+        em.emit_le_i32(); // stack: 1
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_gt_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_const_i32(0);
+        em.emit_load_const_i32(1);
+        em.emit_gt_i32();
+
+        assert_eq!(em.bytecode(), &[0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x6C]);
+    }
+
+    #[test]
+    fn emitter_when_gt_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := x > 5
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_load_const_i32(0); // stack: 2
+        em.emit_gt_i32(); // stack: 1
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_ge_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_const_i32(0);
+        em.emit_load_const_i32(1);
+        em.emit_ge_i32();
+
+        assert_eq!(em.bytecode(), &[0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x6D]);
+    }
+
+    #[test]
+    fn emitter_when_ge_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := x >= 5
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_load_const_i32(0); // stack: 2
+        em.emit_ge_i32(); // stack: 1
         em.emit_store_var_i32(1); // stack: 0
 
         assert_eq!(em.max_stack_depth(), 2);

--- a/compiler/codegen/tests/compile_cmp.rs
+++ b/compiler/codegen/tests/compile_cmp.rs
@@ -1,0 +1,193 @@
+//! Bytecode-level integration tests for comparison operator compilation.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_eq_expression_then_produces_eq_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := x = 5;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    assert_eq!(container.header.num_variables, 2);
+    assert_eq!(container.constant_pool.get_i32(0).unwrap(), 10);
+    assert_eq!(container.constant_pool.get_i32(1).unwrap(), 5);
+
+    // x := 10: LOAD_CONST_I32 pool:0, STORE_VAR_I32 var:0
+    // y := x = 5: LOAD_VAR_I32 var:0, LOAD_CONST_I32 pool:1, EQ_I32, STORE_VAR_I32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
+            0x68, // EQ_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_ne_expression_then_produces_ne_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := x <> 5;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
+            0x69, // NE_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_lt_expression_then_produces_lt_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := x < 5;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
+            0x6A, // LT_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_le_expression_then_produces_le_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := x <= 5;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
+            0x6B, // LE_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_gt_expression_then_produces_gt_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := x > 5;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
+            0x6C, // GT_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_ge_expression_then_produces_ge_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := x >= 5;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
+            0x6D, // GE_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/end_to_end.rs
+++ b/compiler/codegen/tests/end_to_end.rs
@@ -11,6 +11,7 @@
 //! - end_to_end_mod.rs (MOD operator)
 //! - end_to_end_pow.rs (POW/EXPT operator)
 //! - end_to_end_neg.rs (NEG unary operator)
+//! - end_to_end_cmp.rs (comparison operators)
 
 mod common;
 

--- a/compiler/codegen/tests/end_to_end_cmp.rs
+++ b/compiler/codegen/tests/end_to_end_cmp.rs
@@ -1,0 +1,113 @@
+//! End-to-end integration tests for comparison operators.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_eq_true_then_one() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 5;
+  y := x = 5;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 5);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_ne_true_then_one() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 5;
+  y := x <> 3;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 5);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_lt_true_then_one() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 3;
+  y := x < 5;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 3);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_le_equal_then_one() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 5;
+  y := x <= 5;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 5);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_gt_true_then_one() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 7;
+  y := x > 5;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 7);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_ge_false_then_zero() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 3;
+  y := x >= 5;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 3);
+    assert_eq!(bufs.vars[1].as_i32(), 0);
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -38,6 +38,30 @@ pub const MOD_I32: u8 = 0x34;
 /// Pops one value, pushes its negation.
 pub const NEG_I32: u8 = 0x35;
 
+/// Compare two 32-bit integers for equality.
+/// Pops two values (b then a), pushes 1 if a == b, else 0.
+pub const EQ_I32: u8 = 0x68;
+
+/// Compare two 32-bit integers for inequality.
+/// Pops two values (b then a), pushes 1 if a != b, else 0.
+pub const NE_I32: u8 = 0x69;
+
+/// Compare two signed 32-bit integers (less than).
+/// Pops two values (b then a), pushes 1 if a < b, else 0.
+pub const LT_I32: u8 = 0x6A;
+
+/// Compare two signed 32-bit integers (less than or equal).
+/// Pops two values (b then a), pushes 1 if a <= b, else 0.
+pub const LE_I32: u8 = 0x6B;
+
+/// Compare two signed 32-bit integers (greater than).
+/// Pops two values (b then a), pushes 1 if a > b, else 0.
+pub const GT_I32: u8 = 0x6C;
+
+/// Compare two signed 32-bit integers (greater than or equal).
+/// Pops two values (b then a), pushes 1 if a >= b, else 0.
+pub const GE_I32: u8 = 0x6D;
+
 /// Call a built-in standard library function.
 /// Operand: u16 function ID (little-endian).
 /// Stack effect depends on the specific function.

--- a/compiler/plc2x/src/disassemble.rs
+++ b/compiler/plc2x/src/disassemble.rs
@@ -328,6 +328,60 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                 }));
                 pc += 1;
             }
+            opcode::EQ_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "EQ_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
+            opcode::NE_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "NE_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
+            opcode::LT_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "LT_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
+            opcode::LE_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "LE_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
+            opcode::GT_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "GT_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
+            opcode::GE_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "GE_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
             opcode::BUILTIN => {
                 let func_id = read_u16(bytecode, pc + 1);
                 let operand = match func_id {

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -413,6 +413,36 @@ fn execute(
                 let a = stack.pop()?.as_i32();
                 stack.push(Slot::from_i32(a.wrapping_neg()))?;
             }
+            opcode::EQ_I32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(if a == b { 1 } else { 0 }))?;
+            }
+            opcode::NE_I32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(if a != b { 1 } else { 0 }))?;
+            }
+            opcode::LT_I32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(if a < b { 1 } else { 0 }))?;
+            }
+            opcode::LE_I32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(if a <= b { 1 } else { 0 }))?;
+            }
+            opcode::GT_I32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(if a > b { 1 } else { 0 }))?;
+            }
+            opcode::GE_I32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(if a >= b { 1 } else { 0 }))?;
+            }
             opcode::BUILTIN => {
                 let func_id = read_u16_le(bytecode, &mut pc);
                 builtin::dispatch(func_id, stack)?;

--- a/compiler/vm/tests/execute_cmp_i32.rs
+++ b/compiler/vm/tests/execute_cmp_i32.rs
@@ -1,0 +1,506 @@
+//! Integration tests for comparison opcodes (EQ_I32, NE_I32, LT_I32, LE_I32, GT_I32, GE_I32).
+
+mod common;
+
+use common::{single_function_container, VmBuffers};
+use ironplc_vm::Vm;
+
+// ---------------------------------------------------------------
+// EQ_I32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_eq_i32_equal_then_one() {
+    // 5 == 5 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x68,              // EQ_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_eq_i32_not_equal_then_zero() {
+    // 5 == 3 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (3)
+        0x68,              // EQ_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5, 3]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_eq_i32_negative_equal_then_one() {
+    // -7 == -7 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (-7)
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (-7)
+        0x68,              // EQ_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[-7]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+// ---------------------------------------------------------------
+// NE_I32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_ne_i32_not_equal_then_one() {
+    // 5 != 3 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (3)
+        0x69,              // NE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5, 3]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_ne_i32_equal_then_zero() {
+    // 5 != 5 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x69,              // NE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+// ---------------------------------------------------------------
+// LT_I32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_lt_i32_less_then_one() {
+    // 3 < 5 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (3)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6A,              // LT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[3, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_lt_i32_equal_then_zero() {
+    // 5 < 5 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x6A,              // LT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_lt_i32_greater_then_zero() {
+    // 7 < 5 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (7)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6A,              // LT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[7, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+// ---------------------------------------------------------------
+// LE_I32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_le_i32_less_then_one() {
+    // 3 <= 5 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (3)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6B,              // LE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[3, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_le_i32_equal_then_one() {
+    // 5 <= 5 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x6B,              // LE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_le_i32_greater_then_zero() {
+    // 7 <= 5 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (7)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6B,              // LE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[7, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+// ---------------------------------------------------------------
+// GT_I32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_gt_i32_greater_then_one() {
+    // 7 > 5 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (7)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6C,              // GT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[7, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_gt_i32_equal_then_zero() {
+    // 5 > 5 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x6C,              // GT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_gt_i32_less_then_zero() {
+    // 3 > 5 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (3)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6C,              // GT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[3, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+// ---------------------------------------------------------------
+// GE_I32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_ge_i32_greater_then_one() {
+    // 7 >= 5 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (7)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6D,              // GE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[7, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_ge_i32_equal_then_one() {
+    // 5 >= 5 → 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
+        0x6D,              // GE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_ge_i32_less_then_zero() {
+    // 3 >= 5 → 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (3)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (5)
+        0x6D,              // GE_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[3, 5]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}


### PR DESCRIPTION
Add six relational comparison opcodes (0x68-0x6D) for signed 32-bit integers. Each pops two values, pushes 1 (true) or 0 (false). Boolean results use the I32 representation per the bytecode spec.