### PR TITLE
Add LOAD_TRUE/LOAD_FALSE opcodes for boolean literal constants

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -7,6 +7,7 @@
 //! - PROGRAM declarations with INT variables
 //! - Assignment statements
 //! - Integer literal constants
+//! - Boolean literal constants (TRUE, FALSE)
 //! - Binary Add, Sub, Mul, Div, Mod, and Pow operators
 //! - Unary Neg and Not operators
 //! - Comparison operators (=, <>, <, <=, >, >=)
@@ -17,7 +18,8 @@ use std::collections::HashMap;
 
 use ironplc_container::{opcode, Container, ContainerBuilder};
 use ironplc_dsl::common::{
-    ConstantKind, FunctionBlockBodyKind, Library, LibraryElementKind, ProgramDeclaration, VarDecl,
+    Boolean, ConstantKind, FunctionBlockBodyKind, Library, LibraryElementKind, ProgramDeclaration,
+    VarDecl,
 };
 use ironplc_dsl::core::{Id, Located, SourceSpan};
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
@@ -352,7 +354,13 @@ fn compile_constant(
             Ok(())
         }
         ConstantKind::RealLiteral(_) => Err(Diagnostic::todo(file!(), line!())),
-        ConstantKind::Boolean(_) => Err(Diagnostic::todo(file!(), line!())),
+        ConstantKind::Boolean(lit) => {
+            match lit.value {
+                Boolean::True => emitter.emit_load_true(),
+                Boolean::False => emitter.emit_load_false(),
+            }
+            Ok(())
+        }
         ConstantKind::CharacterString(_) => Err(Diagnostic::todo(file!(), line!())),
         ConstantKind::Duration(_) => Err(Diagnostic::todo(file!(), line!())),
         ConstantKind::TimeOfDay(_) => Err(Diagnostic::todo(file!(), line!())),

--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -27,6 +27,18 @@ impl Emitter {
         self.push_stack(1);
     }
 
+    /// Emits LOAD_TRUE (pushes I32 value 1).
+    pub fn emit_load_true(&mut self) {
+        self.bytecode.push(opcode::LOAD_TRUE);
+        self.push_stack(1);
+    }
+
+    /// Emits LOAD_FALSE (pushes I32 value 0).
+    pub fn emit_load_false(&mut self) {
+        self.bytecode.push(opcode::LOAD_FALSE);
+        self.push_stack(1);
+    }
+
     /// Emits LOAD_VAR_I32 with a variable table index.
     pub fn emit_load_var_i32(&mut self, var_index: u16) {
         self.bytecode.push(opcode::LOAD_VAR_I32);
@@ -610,6 +622,40 @@ mod tests {
         em.emit_load_var_i32(0); // stack: 1
         em.emit_bool_not(); // stack: 1 (pop 1, push 1)
         em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 1);
+    }
+
+    #[test]
+    fn emitter_when_load_true_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_true();
+
+        assert_eq!(em.bytecode(), &[0x07]);
+    }
+
+    #[test]
+    fn emitter_when_load_true_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        em.emit_load_true(); // stack: 1
+        em.emit_store_var_i32(0); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 1);
+    }
+
+    #[test]
+    fn emitter_when_load_false_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_false();
+
+        assert_eq!(em.bytecode(), &[0x08]);
+    }
+
+    #[test]
+    fn emitter_when_load_false_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        em.emit_load_false(); // stack: 1
+        em.emit_store_var_i32(0); // stack: 0
 
         assert_eq!(em.max_stack_depth(), 1);
     }

--- a/compiler/codegen/tests/compile_bool.rs
+++ b/compiler/codegen/tests/compile_bool.rs
@@ -147,3 +147,55 @@ END_PROGRAM
         ]
     );
 }
+
+#[test]
+fn compile_when_true_literal_then_produces_load_true() {
+    let source = "
+PROGRAM main
+  VAR
+    y : INT;
+  END_VAR
+  y := TRUE;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // y := TRUE: LOAD_TRUE, STORE_VAR_I32 var:0
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x07, // LOAD_TRUE
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_false_literal_then_produces_load_false() {
+    let source = "
+PROGRAM main
+  VAR
+    y : INT;
+  END_VAR
+  y := FALSE;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // y := FALSE: LOAD_FALSE, STORE_VAR_I32 var:0
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x08, // LOAD_FALSE
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/end_to_end_bool.rs
+++ b/compiler/codegen/tests/end_to_end_bool.rs
@@ -147,3 +147,33 @@ END_PROGRAM
     assert_eq!(bufs.vars[0].as_i32(), 5);
     assert_eq!(bufs.vars[1].as_i32(), 0);
 }
+
+#[test]
+fn end_to_end_when_true_literal_then_one() {
+    let source = "
+PROGRAM main
+  VAR
+    y : INT;
+  END_VAR
+  y := TRUE;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_false_literal_then_zero() {
+    let source = "
+PROGRAM main
+  VAR
+    y : INT;
+  END_VAR
+  y := FALSE;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 0);
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -4,6 +4,12 @@
 /// Operand: u16 constant pool index (little-endian).
 pub const LOAD_CONST_I32: u8 = 0x01;
 
+/// Push I32 value 1 (boolean TRUE).
+pub const LOAD_TRUE: u8 = 0x07;
+
+/// Push I32 value 0 (boolean FALSE).
+pub const LOAD_FALSE: u8 = 0x08;
+
 /// Load a 32-bit integer from the variable table.
 /// Operand: u16 variable index (little-endian).
 pub const LOAD_VAR_I32: u8 = 0x10;

--- a/compiler/plc2x/src/disassemble.rs
+++ b/compiler/plc2x/src/disassemble.rs
@@ -254,6 +254,24 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                 }));
                 pc += 3;
             }
+            opcode::LOAD_TRUE => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "LOAD_TRUE",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
+            opcode::LOAD_FALSE => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "LOAD_FALSE",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
             opcode::LOAD_VAR_I32 => {
                 let var_index = read_u16(bytecode, pc + 1);
                 instructions.push(json!({

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -366,6 +366,12 @@ fn execute(
                     .map_err(|_| Trap::InvalidConstantIndex(index))?;
                 stack.push(Slot::from_i32(value))?;
             }
+            opcode::LOAD_TRUE => {
+                stack.push(Slot::from_i32(1))?;
+            }
+            opcode::LOAD_FALSE => {
+                stack.push(Slot::from_i32(0))?;
+            }
             opcode::LOAD_VAR_I32 => {
                 let index = read_u16_le(bytecode, &mut pc);
                 scope.check_access(index)?;

--- a/compiler/vm/tests/execute_bool_literal.rs
+++ b/compiler/vm/tests/execute_bool_literal.rs
@@ -1,0 +1,112 @@
+//! Integration tests for LOAD_TRUE and LOAD_FALSE opcodes.
+
+mod common;
+
+use common::{single_function_container, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_load_true_then_one() {
+    // LOAD_TRUE → var[0] = 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x07,              // LOAD_TRUE
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}
+
+#[test]
+fn execute_when_load_false_then_zero() {
+    // LOAD_FALSE → var[0] = 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x08,              // LOAD_FALSE
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_load_true_with_bool_not_then_zero() {
+    // LOAD_TRUE + BOOL_NOT → var[0] = 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x07,              // LOAD_TRUE
+        0x57,              // BOOL_NOT
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_load_false_with_bool_not_then_one() {
+    // LOAD_FALSE + BOOL_NOT → var[0] = 1
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x08,              // LOAD_FALSE
+        0x57,              // BOOL_NOT
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 1);
+}


### PR DESCRIPTION
Enable compilation of TRUE/FALSE literals using dedicated opcodes (0x07, 0x08) that push I32 1/0 without the constant pool.