### PR TITLE
Add IF/ELSIF/ELSE statement compilation with JMP/JMP_IF_NOT opcodes

### DIFF
--- a/compiler/codegen/tests/compile_if.rs
+++ b/compiler/codegen/tests/compile_if.rs
@@ -1,0 +1,156 @@
+//! Bytecode-level integration tests for IF/ELSIF/ELSE compilation.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_simple_if_then_produces_jmp_if_not() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  IF x > 0 THEN
+    y := 1;
+  END_IF;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // x=var:0, y=var:1
+    // Bytecode layout:
+    //   0: LOAD_VAR_I32 var:0
+    //   3: LOAD_CONST_I32 pool:0 (0)
+    //   6: GT_I32
+    //   7: JMP_IF_NOT offset:+6 -> 16
+    //  10: LOAD_CONST_I32 pool:1 (1)
+    //  13: STORE_VAR_I32 var:1
+    //  16: RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
+            0x6C, // GT_I32
+            0xB2, 0x06, 0x00, // JMP_IF_NOT offset:+6
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_if_else_then_produces_jmp_and_jmp_if_not() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  IF x > 0 THEN
+    y := 1;
+  ELSE
+    y := 2;
+  END_IF;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // Bytecode layout:
+    //   0: LOAD_VAR_I32 var:0
+    //   3: LOAD_CONST_I32 pool:0 (0)
+    //   6: GT_I32
+    //   7: JMP_IF_NOT offset:+9 -> 19
+    //  10: LOAD_CONST_I32 pool:1 (1)
+    //  13: STORE_VAR_I32 var:1
+    //  16: JMP offset:+6 -> 25
+    //  19: LOAD_CONST_I32 pool:2 (2)
+    //  22: STORE_VAR_I32 var:1
+    //  25: RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
+            0x6C, // GT_I32
+            0xB2, 0x09, 0x00, // JMP_IF_NOT offset:+9
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB0, 0x06, 0x00, // JMP offset:+6
+            0x01, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (2)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_if_elsif_else_then_produces_chained_jumps() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  IF x > 5 THEN
+    y := 1;
+  ELSIF x > 0 THEN
+    y := 2;
+  ELSE
+    y := 3;
+  END_IF;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // Bytecode layout:
+    //   0: LOAD_VAR_I32 var:0
+    //   3: LOAD_CONST_I32 pool:0 (5)
+    //   6: GT_I32
+    //   7: JMP_IF_NOT offset:+9 -> 19
+    //  10: LOAD_CONST_I32 pool:1 (1)
+    //  13: STORE_VAR_I32 var:1
+    //  16: JMP offset:+25 -> 44
+    //  19: LOAD_VAR_I32 var:0
+    //  22: LOAD_CONST_I32 pool:2 (0)
+    //  25: GT_I32
+    //  26: JMP_IF_NOT offset:+9 -> 38
+    //  29: LOAD_CONST_I32 pool:3 (2)
+    //  32: STORE_VAR_I32 var:1
+    //  35: JMP offset:+6 -> 44
+    //  38: LOAD_CONST_I32 pool:4 (3)
+    //  41: STORE_VAR_I32 var:1
+    //  44: RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0         (0)
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (5)  (3)
+            0x6C, // GT_I32                      (6)
+            0xB2, 0x09, 0x00, // JMP_IF_NOT offset:+9       (7)
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)  (10)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1         (13)
+            0xB0, 0x19, 0x00, // JMP offset:+25              (16)
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0         (19)
+            0x01, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (0)  (22)
+            0x6C, // GT_I32                      (25)
+            0xB2, 0x09, 0x00, // JMP_IF_NOT offset:+9       (26)
+            0x01, 0x03, 0x00, // LOAD_CONST_I32 pool:3 (2)  (29)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1         (32)
+            0xB0, 0x06, 0x00, // JMP offset:+6              (35)
+            0x01, 0x04, 0x00, // LOAD_CONST_I32 pool:4 (3)  (38)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1         (41)
+            0xB5, // RET_VOID                    (44)
+        ]
+    );
+}

--- a/compiler/codegen/tests/end_to_end_if.rs
+++ b/compiler/codegen/tests/end_to_end_if.rs
@@ -1,0 +1,161 @@
+//! End-to-end integration tests for IF/ELSIF/ELSE statements.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_if_true_then_executes_body() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 5;
+  IF x > 0 THEN
+    y := 1;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 5);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_if_false_then_skips_body() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := -5;
+  IF x > 0 THEN
+    y := 1;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), -5);
+    assert_eq!(bufs.vars[1].as_i32(), 0); // untouched
+}
+
+#[test]
+fn end_to_end_when_if_else_true_then_executes_then() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 5;
+  IF x > 0 THEN
+    y := 1;
+  ELSE
+    y := 2;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 5);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_if_else_false_then_executes_else() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := -5;
+  IF x > 0 THEN
+    y := 1;
+  ELSE
+    y := 2;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), -5);
+    assert_eq!(bufs.vars[1].as_i32(), 2);
+}
+
+#[test]
+fn end_to_end_when_if_elsif_else_first_true_then_executes_first() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  IF x > 5 THEN
+    y := 1;
+  ELSIF x > 0 THEN
+    y := 2;
+  ELSE
+    y := 3;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 10);
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_if_elsif_else_second_true_then_executes_second() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 3;
+  IF x > 5 THEN
+    y := 1;
+  ELSIF x > 0 THEN
+    y := 2;
+  ELSE
+    y := 3;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 3);
+    assert_eq!(bufs.vars[1].as_i32(), 2);
+}
+
+#[test]
+fn end_to_end_when_if_elsif_else_none_true_then_executes_else() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := -5;
+  IF x > 5 THEN
+    y := 1;
+  ELSIF x > 0 THEN
+    y := 2;
+  ELSE
+    y := 3;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), -5);
+    assert_eq!(bufs.vars[1].as_i32(), 3);
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -84,6 +84,12 @@ pub const BOOL_XOR: u8 = 0x56;
 /// Pops one value, pushes 1 if it is zero, else 0.
 pub const BOOL_NOT: u8 = 0x57;
 
+/// Unconditional jump. Operand: i16 offset relative to next instruction.
+pub const JMP: u8 = 0xB0;
+
+/// Jump if top of stack is zero (FALSE). Operand: i16 offset. Pops condition.
+pub const JMP_IF_NOT: u8 = 0xB2;
+
 /// Call a built-in standard library function.
 /// Operand: u16 function ID (little-endian).
 /// Stack effect depends on the specific function.

--- a/compiler/plc2x/src/disassemble.rs
+++ b/compiler/plc2x/src/disassemble.rs
@@ -436,6 +436,28 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                 }));
                 pc += 1;
             }
+            opcode::JMP => {
+                let jump_offset = read_i16(bytecode, pc + 1);
+                let target = (pc as isize + 3 + jump_offset as isize) as usize;
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "JMP",
+                    "operands": format!("offset: {:+}", jump_offset),
+                    "comment": format!("-> {}", target),
+                }));
+                pc += 3;
+            }
+            opcode::JMP_IF_NOT => {
+                let jump_offset = read_i16(bytecode, pc + 1);
+                let target = (pc as isize + 3 + jump_offset as isize) as usize;
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "JMP_IF_NOT",
+                    "operands": format!("offset: {:+}", jump_offset),
+                    "comment": format!("-> {}", target),
+                }));
+                pc += 3;
+            }
             opcode::BUILTIN => {
                 let func_id = read_u16(bytecode, pc + 1);
                 let operand = match func_id {
@@ -477,6 +499,11 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
 /// Reads a little-endian u16 from the bytecode at the given position.
 fn read_u16(bytecode: &[u8], pos: usize) -> u16 {
     u16::from_le_bytes([bytecode[pos], bytecode[pos + 1]])
+}
+
+/// Reads a little-endian i16 from the bytecode at the given position.
+fn read_i16(bytecode: &[u8], pos: usize) -> i16 {
+    i16::from_le_bytes([bytecode[pos], bytecode[pos + 1]])
 }
 
 /// Looks up a constant pool entry by index and returns a display comment.

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -468,6 +468,17 @@ fn execute(
                 let a = stack.pop()?.as_i32();
                 stack.push(Slot::from_i32(if a == 0 { 1 } else { 0 }))?;
             }
+            opcode::JMP => {
+                let offset = read_i16_le(bytecode, &mut pc);
+                pc = (pc as isize + offset as isize) as usize;
+            }
+            opcode::JMP_IF_NOT => {
+                let offset = read_i16_le(bytecode, &mut pc);
+                let cond = stack.pop()?.as_i32();
+                if cond == 0 {
+                    pc = (pc as isize + offset as isize) as usize;
+                }
+            }
             opcode::BUILTIN => {
                 let func_id = read_u16_le(bytecode, &mut pc);
                 builtin::dispatch(func_id, stack)?;
@@ -487,6 +498,13 @@ fn execute(
 /// Reads a little-endian u16 from bytecode at pc, advancing pc by 2.
 fn read_u16_le(bytecode: &[u8], pc: &mut usize) -> u16 {
     let value = u16::from_le_bytes([bytecode[*pc], bytecode[*pc + 1]]);
+    *pc += 2;
+    value
+}
+
+/// Reads a little-endian i16 from bytecode at pc, advancing pc by 2.
+fn read_i16_le(bytecode: &[u8], pc: &mut usize) -> i16 {
+    let value = i16::from_le_bytes([bytecode[*pc], bytecode[*pc + 1]]);
     *pc += 2;
     value
 }

--- a/compiler/vm/tests/execute_if.rs
+++ b/compiler/vm/tests/execute_if.rs
@@ -1,0 +1,167 @@
+//! Integration tests for the JMP and JMP_IF_NOT opcodes.
+
+mod common;
+
+use common::{single_function_container, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_jmp_then_skips_instruction() {
+    // JMP skips over a STORE_VAR_I32, so var[0] stays 0.
+    // var[1] gets set to 99 after the jump target.
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0xB0, 0x03, 0x00,       // JMP offset:+3 (skip next instruction)
+        0x01, 0x00, 0x00,       // LOAD_CONST_I32 pool[0] (99) -- skipped
+        // jump target (offset 6):
+        0x01, 0x00, 0x00,       // LOAD_CONST_I32 pool[0] (99)
+        0x18, 0x01, 0x00,       // STORE_VAR_I32 var[1]
+        0xB5,                   // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 2, &[99]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0); // untouched
+    assert_eq!(vm.read_variable(1).unwrap(), 99);
+}
+
+#[test]
+fn execute_when_jmp_if_not_true_then_no_jump() {
+    // Condition is 1 (true), so JMP_IF_NOT does NOT jump.
+    // Falls through to store 42 into var[0].
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,       // LOAD_CONST_I32 pool[0] (1) -- condition
+        0xB2, 0x06, 0x00,       // JMP_IF_NOT offset:+6 (skip to RET_VOID)
+        0x01, 0x01, 0x00,       // LOAD_CONST_I32 pool[1] (42)
+        0x18, 0x00, 0x00,       // STORE_VAR_I32 var[0]
+        0xB5,                   // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[1, 42]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 42);
+}
+
+#[test]
+fn execute_when_jmp_if_not_false_then_jumps() {
+    // Condition is 0 (false), so JMP_IF_NOT jumps past the store.
+    // var[0] stays 0.
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,       // LOAD_CONST_I32 pool[0] (0) -- condition
+        0xB2, 0x06, 0x00,       // JMP_IF_NOT offset:+6 (skip to RET_VOID)
+        0x01, 0x01, 0x00,       // LOAD_CONST_I32 pool[1] (42) -- skipped
+        0x18, 0x00, 0x00,       // STORE_VAR_I32 var[0]       -- skipped
+        0xB5,                   // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0, 42]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_if_else_true_then_takes_then_branch() {
+    // IF (1) THEN var[0] := 10 ELSE var[0] := 20 END_IF
+    // Condition is true, so var[0] = 10.
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        // IF condition:
+        0x01, 0x00, 0x00,       // LOAD_CONST_I32 pool[0] (1)
+        0xB2, 0x09, 0x00,       // JMP_IF_NOT offset:+9 -> else branch (offset 15)
+        // THEN body:
+        0x01, 0x01, 0x00,       // LOAD_CONST_I32 pool[1] (10)
+        0x18, 0x00, 0x00,       // STORE_VAR_I32 var[0]
+        0xB0, 0x06, 0x00,       // JMP offset:+6 -> end (offset 21)
+        // ELSE body (offset 15):
+        0x01, 0x02, 0x00,       // LOAD_CONST_I32 pool[2] (20)
+        0x18, 0x00, 0x00,       // STORE_VAR_I32 var[0]
+        // END (offset 21):
+        0xB5,                   // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[1, 10, 20]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 10);
+}
+
+#[test]
+fn execute_when_if_else_false_then_takes_else_branch() {
+    // IF (0) THEN var[0] := 10 ELSE var[0] := 20 END_IF
+    // Condition is false, so var[0] = 20.
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        // IF condition:
+        0x01, 0x00, 0x00,       // LOAD_CONST_I32 pool[0] (0)
+        0xB2, 0x09, 0x00,       // JMP_IF_NOT offset:+9 -> else branch (offset 15)
+        // THEN body:
+        0x01, 0x01, 0x00,       // LOAD_CONST_I32 pool[1] (10)
+        0x18, 0x00, 0x00,       // STORE_VAR_I32 var[0]
+        0xB0, 0x06, 0x00,       // JMP offset:+6 -> end (offset 21)
+        // ELSE body (offset 15):
+        0x01, 0x02, 0x00,       // LOAD_CONST_I32 pool[2] (20)
+        0x18, 0x00, 0x00,       // STORE_VAR_I32 var[0]
+        // END (offset 21):
+        0xB5,                   // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0, 10, 20]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 20);
+}


### PR DESCRIPTION
Implement control flow for IF statements by adding jump opcodes to the bytecode instruction set and a backpatching mechanism in the emitter for forward jumps. The compiler now generates condition/jump/body sequences for IF/ELSIF/ELSE chains instead of returning a todo diagnostic.