### PR TITLE
Replace Diagnostic::todo with proper diagnostics (P4020, P4021)

### DIFF
--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -483,7 +483,7 @@ pub enum StmtKind {
     Return,
     // Exit statement.
     #[recurse(ignore)]
-    Exit,
+    Exit(SourceSpan),
 }
 
 impl StmtKind {

--- a/compiler/dsl_macro_derive/src/lib.rs
+++ b/compiler/dsl_macro_derive/src/lib.rs
@@ -91,9 +91,16 @@ fn expand_enum_recurse_visit(name: &Ident, data_enum: &DataEnum) -> Result<Token
             // An ignored variant does not recurse, but we need to include is so that all have a
             // defined match.
             if is_ignored(&v.attrs).unwrap() {
-                return Ok(quote! {
-                    #name::#variant_name => Ok(V::Value::default())
-                });
+                let has_fields = !v.fields.is_empty();
+                if has_fields {
+                    return Ok(quote! {
+                        #name::#variant_name(..) => Ok(V::Value::default())
+                    });
+                } else {
+                    return Ok(quote! {
+                        #name::#variant_name => Ok(V::Value::default())
+                    });
+                }
             }
 
             let variant_contained_type = extract_type_ident_from_fields(&v.fields)?;
@@ -236,9 +243,16 @@ fn expand_enum_recurse_fold(name: &Ident, data_enum: &DataEnum) -> Result<TokenS
             // An ignored variant does not recurse, but we need to include is so that all have a
             // defined match.
             if is_ignored(&v.attrs).unwrap() {
-                return Ok(quote! {
-                    #name::#variant_name => Ok(#name::#variant_name)
-                });
+                let has_fields = !v.fields.is_empty();
+                if has_fields {
+                    return Ok(quote! {
+                        #name::#variant_name(inner) => Ok(#name::#variant_name(inner))
+                    });
+                } else {
+                    return Ok(quote! {
+                        #name::#variant_name => Ok(#name::#variant_name)
+                    });
+                }
             }
 
             let variant_contained_type = extract_type_ident_from_fields(&v.fields)?;

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1499,6 +1499,6 @@ parser! {
         body,
       }
     }
-    rule exit_statement() -> StmtKind = tok(TokenType::Exit) { StmtKind::Exit }
+    rule exit_statement() -> StmtKind = t:tok(TokenType::Exit) { StmtKind::Exit(t.span.clone()) }
   }
 }

--- a/compiler/problems/resources/problem-codes.csv
+++ b/compiler/problems/resources/problem-codes.csv
@@ -52,6 +52,8 @@ P4016,FunctionDeclNameDuplicated,Function declaration name is duplicated
 P4017,FunctionCallUndeclared,Function is not declared
 P4018,FunctionCallWrongArgCount,Function call has wrong number of arguments
 P4019,DuplicateTaskName,Task name is duplicated within a resource
+P4020,NoProgramDeclaration,Source does not contain a PROGRAM declaration
+P4021,ExitOutsideLoop,EXIT statement is not inside a loop
 P6001,CannotCanonicalizePath,Unable to canonicalize the path
 P6002,CannotReadMetadata,Unable to read metadata for the path
 P6003,CannotReadDirectory,Unable to read directory

--- a/docs/reference/compiler/problems/P4020.rst
+++ b/docs/reference/compiler/problems/P4020.rst
@@ -1,0 +1,41 @@
+=====
+P4020
+=====
+
+.. problem-summary:: P4020
+
+This error occurs when the compiler cannot find a PROGRAM declaration in the source. At least one PROGRAM is required to compile and run.
+
+Example
+-------
+
+The following code will generate error P4020:
+
+.. code-block::
+
+   FUNCTION_BLOCK my_fb
+   VAR
+       x : INT;
+   END_VAR
+       x := 1;
+   END_FUNCTION_BLOCK
+
+The source defines a function block but does not contain a PROGRAM declaration, so the compiler has no entry point.
+
+To fix this error, add a PROGRAM declaration:
+
+.. code-block::
+
+   FUNCTION_BLOCK my_fb
+   VAR
+       x : INT;
+   END_VAR
+       x := 1;
+   END_FUNCTION_BLOCK
+
+   PROGRAM main
+   VAR
+       fb_inst : my_fb;
+   END_VAR
+       fb_inst();
+   END_PROGRAM

--- a/docs/reference/compiler/problems/P4021.rst
+++ b/docs/reference/compiler/problems/P4021.rst
@@ -1,0 +1,39 @@
+=====
+P4021
+=====
+
+.. problem-summary:: P4021
+
+This error occurs when an EXIT statement appears outside of a loop. EXIT is only valid inside FOR, WHILE, or REPEAT loops, where it terminates the innermost enclosing loop.
+
+Example
+-------
+
+The following code will generate error P4021:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       x : INT;
+   END_VAR
+       x := 1;
+       EXIT;  (* Error: not inside a loop *)
+   END_PROGRAM
+
+The EXIT statement is in the program body but not inside any loop.
+
+To fix this error, move the EXIT statement inside a loop or remove it:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       x : INT;
+   END_VAR
+       FOR x := 1 TO 10 BY 1 DO
+           IF x = 5 THEN
+               EXIT;  (* Valid: inside a FOR loop *)
+           END_IF;
+       END_FOR;
+   END_PROGRAM


### PR DESCRIPTION
Replace three Diagnostic::todo calls in compile.rs with actionable diagnostics: P4020 for missing PROGRAM declaration, P4021 for EXIT outside a loop, and a descriptive P9999 for non-constant FOR step. Add SourceSpan to StmtKind::Exit so the diagnostic can point at the EXIT keyword. Fix the Recurse derive macro to handle ignored tuple enum variants.