### PR TITLE
Update language reference docs to reflect runtime support for REAL, L…

### DIFF
--- a/docs/reference/language/data-types/byte.rst
+++ b/docs/reference/language/data-types/byte.rst
@@ -16,7 +16,7 @@ Bit string of 8 bits.
    * - **IEC 61131-3**
      - Section 2.3.1
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Literals
 --------

--- a/docs/reference/language/data-types/dword.rst
+++ b/docs/reference/language/data-types/dword.rst
@@ -16,7 +16,7 @@ Bit string of 32 bits.
    * - **IEC 61131-3**
      - Section 2.3.1
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Literals
 --------

--- a/docs/reference/language/data-types/index.rst
+++ b/docs/reference/language/data-types/index.rst
@@ -55,27 +55,27 @@ Elementary Types
    * - :doc:`REAL <real>`
      - 32 bits
      - Single-precision floating point
-     - Not yet supported
+     - Supported
    * - :doc:`LREAL <lreal>`
      - 64 bits
      - Double-precision floating point
-     - Not yet supported
+     - Supported
    * - :doc:`BYTE <byte>`
      - 8 bits
      - Bit string of 8 bits
-     - Not yet supported
+     - Supported
    * - :doc:`WORD <word>`
      - 16 bits
      - Bit string of 16 bits
-     - Not yet supported
+     - Supported
    * - :doc:`DWORD <dword>`
      - 32 bits
      - Bit string of 32 bits
-     - Not yet supported
+     - Supported
    * - :doc:`LWORD <lword>`
      - 64 bits
      - Bit string of 64 bits
-     - Not yet supported
+     - Supported
    * - :doc:`STRING <string>`
      - Variable
      - Single-byte character string

--- a/docs/reference/language/data-types/lreal.rst
+++ b/docs/reference/language/data-types/lreal.rst
@@ -18,7 +18,7 @@ LREAL
    * - **IEC 61131-3**
      - Section 2.3.1
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Literals
 --------

--- a/docs/reference/language/data-types/lword.rst
+++ b/docs/reference/language/data-types/lword.rst
@@ -16,7 +16,7 @@ Bit string of 64 bits.
    * - **IEC 61131-3**
      - Section 2.3.1
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Literals
 --------

--- a/docs/reference/language/data-types/real.rst
+++ b/docs/reference/language/data-types/real.rst
@@ -18,7 +18,7 @@ REAL
    * - **IEC 61131-3**
      - Section 2.3.1
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Literals
 --------

--- a/docs/reference/language/data-types/word.rst
+++ b/docs/reference/language/data-types/word.rst
@@ -16,7 +16,7 @@ Bit string of 16 bits.
    * - **IEC 61131-3**
      - Section 2.3.1
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Literals
 --------

--- a/docs/reference/language/structured-text/arithmetic-operators.rst
+++ b/docs/reference/language/structured-text/arithmetic-operators.rst
@@ -10,7 +10,7 @@ Arithmetic operators perform mathematical computations on numeric values.
    * - **IEC 61131-3**
      - Section 3.3.1
    * - **Support**
-     - Supported for integer types
+     - Supported
 
 Syntax
 ------
@@ -48,9 +48,10 @@ Description
 -----------
 
 Arithmetic operators apply to integer types (``SINT``, ``INT``, ``DINT``,
-``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``). For integer division,
-the result is truncated toward zero. The ``MOD`` operator returns the
-remainder of integer division.
+``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``) and floating-point types
+(``REAL``, ``LREAL``). For integer division, the result is truncated toward
+zero. The ``MOD`` operator returns the remainder of integer division and is
+defined only for integer types.
 
 The unary negation operator ``-`` has higher precedence than the binary
 arithmetic operators. Exponentiation ``**`` has higher precedence than

--- a/docs/reference/language/structured-text/comparison-operators.rst
+++ b/docs/reference/language/structured-text/comparison-operators.rst
@@ -10,7 +10,7 @@ Comparison operators compare two values and produce a ``BOOL`` result.
    * - **IEC 61131-3**
      - Section 3.3.1
    * - **Support**
-     - Supported for integer types
+     - Supported
 
 Syntax
 ------
@@ -46,7 +46,8 @@ Description
 
 Comparison operators compare two operands of the same type and return a
 ``BOOL`` value. They apply to integer types (``SINT``, ``INT``, ``DINT``,
-``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``).
+``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``) and floating-point types
+(``REAL``, ``LREAL``).
 
 Equality (``=``, ``<>``) has lower precedence than the relational operators
 (``<``, ``>``, ``<=``, ``>=``). Both groups have lower precedence than

--- a/docs/reference/standard-library/functions/add.rst
+++ b/docs/reference/standard-library/functions/add.rst
@@ -10,7 +10,7 @@ Returns the sum of two or more inputs.
    * - **IEC 61131-3**
      - Section 2.5.1.5.3
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``SINT``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``LINT``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``USINT``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``UINT``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``UDINT``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``ULINT``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
    * - 11
      - ``TIME``
      - ``TIME``

--- a/docs/reference/standard-library/functions/div.rst
+++ b/docs/reference/standard-library/functions/div.rst
@@ -10,7 +10,7 @@ Returns the quotient of two inputs.
    * - **IEC 61131-3**
      - Section 2.5.1.5.3
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``SINT``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``LINT``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``USINT``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``UINT``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``UDINT``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``ULINT``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/eq.rst
+++ b/docs/reference/standard-library/functions/eq.rst
@@ -10,7 +10,7 @@ Returns TRUE if two inputs are equal.
    * - **IEC 61131-3**
      - Section 2.5.1.5.4
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/expt.rst
+++ b/docs/reference/standard-library/functions/expt.rst
@@ -10,7 +10,7 @@ Returns the result of raising a base to an exponent.
    * - **IEC 61131-3**
      - Section 2.5.1.5.2
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``SINT``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,7 +38,7 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
@@ -48,12 +48,12 @@ Signatures
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/ge.rst
+++ b/docs/reference/standard-library/functions/ge.rst
@@ -10,7 +10,7 @@ Returns TRUE if the first input is greater than or equal to the second.
    * - **IEC 61131-3**
      - Section 2.5.1.5.4
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/gt.rst
+++ b/docs/reference/standard-library/functions/gt.rst
@@ -10,7 +10,7 @@ Returns TRUE if the first input is greater than the second.
    * - **IEC 61131-3**
      - Section 2.5.1.5.4
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/index.rst
+++ b/docs/reference/standard-library/functions/index.rst
@@ -33,7 +33,7 @@ Numeric Functions
      - Not yet supported
    * - :doc:`EXPT <expt>`
      - Exponentiation
-     - Supported (INT)
+     - Supported
 
 Trigonometric Functions
 -----------------------
@@ -76,19 +76,19 @@ Arithmetic Functions
      - Status
    * - :doc:`ADD <add>`
      - Addition
-     - Supported (INT)
+     - Supported
    * - :doc:`SUB <sub>`
      - Subtraction
-     - Supported (INT)
+     - Supported
    * - :doc:`MUL <mul>`
      - Multiplication
-     - Supported (INT)
+     - Supported
    * - :doc:`DIV <div>`
      - Division
-     - Supported (INT)
+     - Supported
    * - :doc:`MOD <mod>`
      - Modulo
-     - Supported (INT)
+     - Supported
 
 Comparison Functions
 --------------------
@@ -102,22 +102,22 @@ Comparison Functions
      - Status
    * - :doc:`GT <gt>`
      - Greater than
-     - Supported (INT)
+     - Supported
    * - :doc:`GE <ge>`
      - Greater than or equal
-     - Supported (INT)
+     - Supported
    * - :doc:`EQ <eq>`
      - Equal
-     - Supported (INT)
+     - Supported
    * - :doc:`LE <le>`
      - Less than or equal
-     - Supported (INT)
+     - Supported
    * - :doc:`LT <lt>`
      - Less than
-     - Supported (INT)
+     - Supported
    * - :doc:`NE <ne>`
      - Not equal
-     - Supported (INT)
+     - Supported
 
 Selection Functions
 -------------------

--- a/docs/reference/standard-library/functions/le.rst
+++ b/docs/reference/standard-library/functions/le.rst
@@ -10,7 +10,7 @@ Returns TRUE if the first input is less than or equal to the second.
    * - **IEC 61131-3**
      - Section 2.5.1.5.4
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/lt.rst
+++ b/docs/reference/standard-library/functions/lt.rst
@@ -10,7 +10,7 @@ Returns TRUE if the first input is less than the second.
    * - **IEC 61131-3**
      - Section 2.5.1.5.4
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/mod.rst
+++ b/docs/reference/standard-library/functions/mod.rst
@@ -10,7 +10,7 @@ Returns the remainder after integer division.
    * - **IEC 61131-3**
      - Section 2.5.1.5.3
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``SINT``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,32 +38,32 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``LINT``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``USINT``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``UINT``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``UDINT``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``ULINT``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/mul.rst
+++ b/docs/reference/standard-library/functions/mul.rst
@@ -10,7 +10,7 @@ Returns the product of two or more inputs.
    * - **IEC 61131-3**
      - Section 2.5.1.5.3
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``SINT``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``LINT``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``USINT``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``UINT``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``UDINT``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``ULINT``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/ne.rst
+++ b/docs/reference/standard-library/functions/ne.rst
@@ -10,7 +10,7 @@ Returns TRUE if two inputs are not equal.
    * - **IEC 61131-3**
      - Section 2.5.1.5.4
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``BOOL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/sub.rst
+++ b/docs/reference/standard-library/functions/sub.rst
@@ -10,7 +10,7 @@ Returns the difference of two inputs.
    * - **IEC 61131-3**
      - Section 2.5.1.5.3
    * - **Support**
-     - Supported (INT)
+     - Supported
 
 Signatures
 ----------
@@ -28,7 +28,7 @@ Signatures
      - ``SINT``
      - ``SINT``
      - ``SINT``
-     - Not yet supported
+     - Supported
    * - 2
      - ``INT``
      - ``INT``
@@ -38,42 +38,42 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
      - ``LINT``
-     - Not yet supported
+     - Supported
    * - 5
      - ``USINT``
      - ``USINT``
      - ``USINT``
-     - Not yet supported
+     - Supported
    * - 6
      - ``UINT``
      - ``UINT``
      - ``UINT``
-     - Not yet supported
+     - Supported
    * - 7
      - ``UDINT``
      - ``UDINT``
      - ``UDINT``
-     - Not yet supported
+     - Supported
    * - 8
      - ``ULINT``
      - ``ULINT``
      - ``ULINT``
-     - Not yet supported
+     - Supported
    * - 9
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
    * - 11
      - ``TIME``
      - ``TIME``


### PR DESCRIPTION
…REAL, and bit string types

The docs were written before floating-point and bit string support was added to the compiler/runtime. This updates support statuses across 22 doc pages to match the actual implementation:

- Data types: REAL, LREAL, BYTE, WORD, DWORD, LWORD → Supported
- Arithmetic/comparison operators: now cover float types too
- Standard library functions (ADD, SUB, MUL, DIV, MOD, EXPT, GT, GE, EQ, LE, LT, NE): all integer type signatures + REAL/LREAL → Supported

https://claude.ai/code/session_01MddzGNmn468EssXtqfdPyM