### PR TITLE
Add bitwise operators (AND, OR, XOR, NOT) for bit string types

### DIFF
--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -181,6 +181,58 @@ impl Emitter {
         // Net effect: pop 1, push 1 = no change to stack depth
     }
 
+    // --- Bitwise opcodes (32-bit) ---
+
+    /// Emits BIT_AND_32 (pops two, pushes one).
+    pub fn emit_bit_and_32(&mut self) {
+        self.bytecode.push(opcode::BIT_AND_32);
+        self.pop_stack(1);
+    }
+
+    /// Emits BIT_OR_32 (pops two, pushes one).
+    pub fn emit_bit_or_32(&mut self) {
+        self.bytecode.push(opcode::BIT_OR_32);
+        self.pop_stack(1);
+    }
+
+    /// Emits BIT_XOR_32 (pops two, pushes one).
+    pub fn emit_bit_xor_32(&mut self) {
+        self.bytecode.push(opcode::BIT_XOR_32);
+        self.pop_stack(1);
+    }
+
+    /// Emits BIT_NOT_32 (pops one, pushes one).
+    pub fn emit_bit_not_32(&mut self) {
+        self.bytecode.push(opcode::BIT_NOT_32);
+        // Net effect: pop 1, push 1 = no change to stack depth
+    }
+
+    // --- Bitwise opcodes (64-bit) ---
+
+    /// Emits BIT_AND_64 (pops two, pushes one).
+    pub fn emit_bit_and_64(&mut self) {
+        self.bytecode.push(opcode::BIT_AND_64);
+        self.pop_stack(1);
+    }
+
+    /// Emits BIT_OR_64 (pops two, pushes one).
+    pub fn emit_bit_or_64(&mut self) {
+        self.bytecode.push(opcode::BIT_OR_64);
+        self.pop_stack(1);
+    }
+
+    /// Emits BIT_XOR_64 (pops two, pushes one).
+    pub fn emit_bit_xor_64(&mut self) {
+        self.bytecode.push(opcode::BIT_XOR_64);
+        self.pop_stack(1);
+    }
+
+    /// Emits BIT_NOT_64 (pops one, pushes one).
+    pub fn emit_bit_not_64(&mut self) {
+        self.bytecode.push(opcode::BIT_NOT_64);
+        // Net effect: pop 1, push 1 = no change to stack depth
+    }
+
     // --- Truncation opcodes ---
 
     /// Emits TRUNC_I8 (pops one i32, truncates to i8 range, pushes one i32).

--- a/compiler/codegen/tests/compile_bitwise.rs
+++ b/compiler/codegen/tests/compile_bitwise.rs
@@ -1,0 +1,109 @@
+//! Bytecode-level integration tests for bitwise operator compilation.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_byte_and_then_produces_bit_and_32_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  y := x AND BYTE#16#0F;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // y := x AND BYTE#16#0F:
+    //   LOAD_VAR_I32 var:0
+    //   LOAD_CONST_I32 pool:0 (0x0F)
+    //   BIT_AND_32 (0x58)
+    //   TRUNC_U8 (0x21)
+    //   STORE_VAR_I32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x0F)
+            0x58, // BIT_AND_32
+            0x21, // TRUNC_U8
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_byte_not_then_produces_bit_not_32_with_trunc_u8() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  y := NOT x;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // y := NOT x:
+    //   LOAD_VAR_I32 var:0
+    //   BIT_NOT_32 (0x5B)
+    //   TRUNC_U8 (0x21)  -- inline truncation after NOT
+    //   TRUNC_U8 (0x21)  -- assignment truncation
+    //   STORE_VAR_I32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x5B, // BIT_NOT_32
+            0x21, // TRUNC_U8 (inline NOT truncation)
+            0x21, // TRUNC_U8 (assignment truncation)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_dint_and_in_comparison_then_still_produces_bool_and() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DINT;
+    y : DINT;
+  END_VAR
+  y := x > 0 AND x < 10;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // The AND here is in a comparison context (DINT is signed)
+    // so it should still produce BOOL_AND (0x54), not BIT_AND_32.
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
+            0x6C, // GT_I32
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (10)
+            0x6A, // LT_I32
+            0x54, // BOOL_AND (not BIT_AND_32)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/end_to_end_bitstring.rs
+++ b/compiler/codegen/tests/end_to_end_bitstring.rs
@@ -199,3 +199,214 @@ END_PROGRAM
     let (_c, bufs) = parse_and_run(source);
     assert_eq!(bufs.vars[0].as_i32(), 255);
 }
+
+// --- Bitwise AND ---
+
+#[test]
+fn end_to_end_when_byte_and_then_bitwise() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#FF;
+  y := x AND BYTE#16#0F;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0xFF);
+    assert_eq!(bufs.vars[1].as_i32(), 0x0F);
+}
+
+// --- Bitwise OR ---
+
+#[test]
+fn end_to_end_when_byte_or_then_bitwise() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#F0;
+  y := x OR BYTE#16#0F;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0xF0);
+    assert_eq!(bufs.vars[1].as_i32(), 0xFF);
+}
+
+// --- Bitwise XOR ---
+
+#[test]
+fn end_to_end_when_byte_xor_then_bitwise() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#FF;
+  y := x XOR BYTE#16#0F;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0xFF);
+    assert_eq!(bufs.vars[1].as_i32(), 0xF0);
+}
+
+// --- Bitwise NOT ---
+
+#[test]
+fn end_to_end_when_byte_not_then_truncated() {
+    // NOT BYTE#16#0F should be BYTE#16#F0 (= 240), not 0xFFFFFFF0
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#0F;
+  y := NOT x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x0F);
+    assert_eq!(bufs.vars[1].as_i32(), 0xF0);
+}
+
+// --- DWORD bitwise ops (full 32-bit) ---
+
+#[test]
+fn end_to_end_when_dword_and_then_bitwise() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DWORD;
+  END_VAR
+  x := DWORD#16#FFFF0000;
+  y := x AND DWORD#16#FF00FF00;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    // 0xFFFF0000 AND 0xFF00FF00 = 0xFF000000
+    assert_eq!(bufs.vars[1].as_i32() as u32, 0xFF00_0000);
+}
+
+#[test]
+fn end_to_end_when_dword_not_then_bitwise() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DWORD;
+  END_VAR
+  x := 0;
+  y := NOT x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    // NOT 0 = 0xFFFFFFFF (as i32: -1)
+    assert_eq!(bufs.vars[1].as_i32(), -1);
+}
+
+// --- LWORD bitwise ops (64-bit) ---
+
+#[test]
+fn end_to_end_when_lword_and_then_bitwise() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LWORD;
+    y : LWORD;
+  END_VAR
+  x := LWORD#16#FF;
+  y := x AND LWORD#16#0F;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[1].as_i64(), 0x0F);
+}
+
+#[test]
+fn end_to_end_when_lword_not_then_bitwise() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LWORD;
+    y : LWORD;
+  END_VAR
+  x := 0;
+  y := NOT x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    // NOT 0_i64 = -1_i64
+    assert_eq!(bufs.vars[1].as_i64(), -1);
+}
+
+// --- NOT in IF condition (inline truncation correctness) ---
+
+#[test]
+fn end_to_end_when_byte_not_in_if_then_correct() {
+    // NOT BYTE#16#FF = 0 (after truncation), so IF body should NOT execute
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    result : BYTE;
+  END_VAR
+  x := BYTE#16#FF;
+  result := 0;
+  IF NOT x THEN
+    result := 1;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    // NOT 0xFF → BIT_NOT → 0xFFFFFF00 → TRUNC_U8 → 0x00 → IF sees 0 → skip body
+    assert_eq!(bufs.vars[1].as_i32(), 0);
+}
+
+#[test]
+fn end_to_end_when_byte_not_zero_in_if_then_enters_body() {
+    // NOT BYTE#0 = 0xFF (after truncation), so IF body SHOULD execute
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    result : BYTE;
+  END_VAR
+  x := 0;
+  result := 0;
+  IF NOT x THEN
+    result := 1;
+  END_IF;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    // NOT 0x00 → BIT_NOT → 0xFFFFFFFF → TRUNC_U8 → 0xFF → IF sees non-zero → enter body
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+// --- WORD NOT with truncation ---
+
+#[test]
+fn end_to_end_when_word_not_then_truncated() {
+    let source = "
+PROGRAM main
+  VAR
+    x : WORD;
+    y : WORD;
+  END_VAR
+  x := WORD#16#FF00;
+  y := NOT x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    // NOT 0xFF00 at 32-bit = 0xFFFF00FF, truncated to u16 = 0x00FF
+    assert_eq!(bufs.vars[1].as_i32(), 0x00FF);
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -84,6 +84,42 @@ pub const BOOL_XOR: u8 = 0x56;
 /// Pops one value, pushes 1 if it is zero, else 0.
 pub const BOOL_NOT: u8 = 0x57;
 
+// --- Bitwise opcodes (32-bit) ---
+
+/// Bitwise AND of two 32-bit integers.
+/// Pops two values (b then a), pushes a & b.
+pub const BIT_AND_32: u8 = 0x58;
+
+/// Bitwise OR of two 32-bit integers.
+/// Pops two values (b then a), pushes a | b.
+pub const BIT_OR_32: u8 = 0x59;
+
+/// Bitwise XOR of two 32-bit integers.
+/// Pops two values (b then a), pushes a ^ b.
+pub const BIT_XOR_32: u8 = 0x5A;
+
+/// Bitwise NOT of a 32-bit integer.
+/// Pops one value, pushes !a.
+pub const BIT_NOT_32: u8 = 0x5B;
+
+// --- Bitwise opcodes (64-bit) ---
+
+/// Bitwise AND of two 64-bit integers.
+/// Pops two values (b then a), pushes a & b.
+pub const BIT_AND_64: u8 = 0x60;
+
+/// Bitwise OR of two 64-bit integers.
+/// Pops two values (b then a), pushes a | b.
+pub const BIT_OR_64: u8 = 0x61;
+
+/// Bitwise XOR of two 64-bit integers.
+/// Pops two values (b then a), pushes a ^ b.
+pub const BIT_XOR_64: u8 = 0x62;
+
+/// Bitwise NOT of a 64-bit integer.
+/// Pops one value, pushes !a.
+pub const BIT_NOT_64: u8 = 0x63;
+
 /// Unconditional jump. Operand: i16 offset relative to next instruction.
 pub const JMP: u8 = 0xB0;
 

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -799,6 +799,46 @@ fn execute(
                 let a = stack.pop()?.as_i32();
                 stack.push(Slot::from_i32(if a == 0 { 1 } else { 0 }))?;
             }
+            // --- Bitwise opcodes (32-bit) ---
+            opcode::BIT_AND_32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(a & b))?;
+            }
+            opcode::BIT_OR_32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(a | b))?;
+            }
+            opcode::BIT_XOR_32 => {
+                let b = stack.pop()?.as_i32();
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(a ^ b))?;
+            }
+            opcode::BIT_NOT_32 => {
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(!a))?;
+            }
+            // --- Bitwise opcodes (64-bit) ---
+            opcode::BIT_AND_64 => {
+                let b = stack.pop()?.as_i64();
+                let a = stack.pop()?.as_i64();
+                stack.push(Slot::from_i64(a & b))?;
+            }
+            opcode::BIT_OR_64 => {
+                let b = stack.pop()?.as_i64();
+                let a = stack.pop()?.as_i64();
+                stack.push(Slot::from_i64(a | b))?;
+            }
+            opcode::BIT_XOR_64 => {
+                let b = stack.pop()?.as_i64();
+                let a = stack.pop()?.as_i64();
+                stack.push(Slot::from_i64(a ^ b))?;
+            }
+            opcode::BIT_NOT_64 => {
+                let a = stack.pop()?.as_i64();
+                stack.push(Slot::from_i64(!a))?;
+            }
             opcode::JMP => {
                 let offset = read_i16_le(bytecode, &mut pc);
                 pc = (pc as isize + offset as isize) as usize;

--- a/compiler/vm/tests/execute_bitwise.rs
+++ b/compiler/vm/tests/execute_bitwise.rs
@@ -1,0 +1,292 @@
+//! Integration tests for bitwise opcodes (BIT_AND_32, BIT_OR_32, BIT_XOR_32,
+//! BIT_NOT_32, BIT_AND_64, BIT_OR_64, BIT_XOR_64, BIT_NOT_64).
+
+mod common;
+
+use common::{single_function_container, VmBuffers};
+use ironplc_vm::Vm;
+
+// ---------------------------------------------------------------
+// BIT_AND_32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_and_32_then_bitwise_and() {
+    // 0xFF AND 0x0F → 0x0F
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0xFF = 255)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (0x0F = 15)
+        0x58,              // BIT_AND_32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0xFF, 0x0F]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0x0F);
+}
+
+// ---------------------------------------------------------------
+// BIT_OR_32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_or_32_then_bitwise_or() {
+    // 0xF0 OR 0x0F → 0xFF
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0xF0 = 240)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (0x0F = 15)
+        0x59,              // BIT_OR_32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0xF0, 0x0F]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0xFF);
+}
+
+// ---------------------------------------------------------------
+// BIT_XOR_32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_xor_32_then_bitwise_xor() {
+    // 0xFF XOR 0x0F → 0xF0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0xFF = 255)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (0x0F = 15)
+        0x5A,              // BIT_XOR_32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0xFF, 0x0F]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0xF0);
+}
+
+// ---------------------------------------------------------------
+// BIT_NOT_32
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_not_32_then_bitwise_not() {
+    // NOT 0x0F → 0xFFFFFFF0 (as i32: -16)
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x0F = 15)
+        0x5B,              // BIT_NOT_32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x0F]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), !0x0F_i32);
+}
+
+// ---------------------------------------------------------------
+// BIT_AND_64
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_and_64_then_bitwise_and() {
+    // 0xFF_i64 AND 0x0F_i64 → 0x0F_i64
+    // Use ContainerBuilder directly for i64 constants.
+    use ironplc_container::ContainerBuilder;
+
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0xFF)
+        0x02, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (0x0F)
+        0x60,              // BIT_AND_64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(0xFF)
+        .add_i64_constant(0x0F)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    // read_variable returns i32 (lower 32 bits); 0x0F fits in i32.
+    let stopped = vm.stop();
+    assert_eq!(stopped.read_variable(0).unwrap(), 0x0F);
+}
+
+// ---------------------------------------------------------------
+// BIT_OR_64
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_or_64_then_bitwise_or() {
+    use ironplc_container::ContainerBuilder;
+
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0xF0)
+        0x02, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (0x0F)
+        0x61,              // BIT_OR_64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(0xF0)
+        .add_i64_constant(0x0F)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    let stopped = vm.stop();
+    assert_eq!(stopped.read_variable(0).unwrap(), 0xFF);
+}
+
+// ---------------------------------------------------------------
+// BIT_XOR_64
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_xor_64_then_bitwise_xor() {
+    use ironplc_container::ContainerBuilder;
+
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0xFF)
+        0x02, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (0x0F)
+        0x62,              // BIT_XOR_64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(0xFF)
+        .add_i64_constant(0x0F)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    let stopped = vm.stop();
+    assert_eq!(stopped.read_variable(0).unwrap(), 0xF0);
+}
+
+// ---------------------------------------------------------------
+// BIT_NOT_64
+// ---------------------------------------------------------------
+
+#[test]
+fn execute_when_bit_not_64_then_bitwise_not() {
+    use ironplc_container::ContainerBuilder;
+
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0x0F)
+        0x63,              // BIT_NOT_64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(0x0F)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    // !0x0F_i64 = -16, as i32 (lower 32 bits) = -16
+    let stopped = vm.stop();
+    assert_eq!(stopped.read_variable(0).unwrap(), -16);
+}


### PR DESCRIPTION
IEC 61131-3 requires bitwise (not logical) semantics for AND/OR/XOR/NOT on BYTE, WORD, DWORD, and LWORD types. This adds BIT_AND/OR/XOR/NOT opcodes (32-bit and 64-bit variants) and dispatches to them for unsigned op_types, while signed types continue using BOOL_AND/OR/XOR/NOT.

NOT on narrow types (BYTE, WORD) emits inline truncation to avoid 0xFFFFFFF0-style results leaking into IF conditions.