### PR TITLE
Add F32/F64 float variants for standard library builtins and SQRT

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -953,14 +953,45 @@ fn compile_for(
 }
 
 /// Returns the builtin opcode for a named standard library function, if known.
-fn lookup_builtin(name: &str) -> Option<u16> {
+///
+/// The `op_width` selects the correct variant (i32/f32/f64) for the function.
+fn lookup_builtin(name: &str, op_width: OpWidth) -> Option<u16> {
     match name.to_uppercase().as_str() {
-        "EXPT" => Some(opcode::builtin::EXPT_I32),
-        "ABS" => Some(opcode::builtin::ABS_I32),
-        "MIN" => Some(opcode::builtin::MIN_I32),
-        "MAX" => Some(opcode::builtin::MAX_I32),
-        "LIMIT" => Some(opcode::builtin::LIMIT_I32),
-        "SEL" => Some(opcode::builtin::SEL_I32),
+        "EXPT" => Some(match op_width {
+            OpWidth::W32 | OpWidth::W64 => opcode::builtin::EXPT_I32,
+            OpWidth::F32 => opcode::builtin::EXPT_F32,
+            OpWidth::F64 => opcode::builtin::EXPT_F64,
+        }),
+        "ABS" => Some(match op_width {
+            OpWidth::W32 | OpWidth::W64 => opcode::builtin::ABS_I32,
+            OpWidth::F32 => opcode::builtin::ABS_F32,
+            OpWidth::F64 => opcode::builtin::ABS_F64,
+        }),
+        "MIN" => Some(match op_width {
+            OpWidth::W32 | OpWidth::W64 => opcode::builtin::MIN_I32,
+            OpWidth::F32 => opcode::builtin::MIN_F32,
+            OpWidth::F64 => opcode::builtin::MIN_F64,
+        }),
+        "MAX" => Some(match op_width {
+            OpWidth::W32 | OpWidth::W64 => opcode::builtin::MAX_I32,
+            OpWidth::F32 => opcode::builtin::MAX_F32,
+            OpWidth::F64 => opcode::builtin::MAX_F64,
+        }),
+        "LIMIT" => Some(match op_width {
+            OpWidth::W32 | OpWidth::W64 => opcode::builtin::LIMIT_I32,
+            OpWidth::F32 => opcode::builtin::LIMIT_F32,
+            OpWidth::F64 => opcode::builtin::LIMIT_F64,
+        }),
+        "SEL" => Some(match op_width {
+            OpWidth::W32 | OpWidth::W64 => opcode::builtin::SEL_I32,
+            OpWidth::F32 => opcode::builtin::SEL_F32,
+            OpWidth::F64 => opcode::builtin::SEL_F64,
+        }),
+        "SQRT" => match op_width {
+            OpWidth::F32 => Some(opcode::builtin::SQRT_F32),
+            OpWidth::F64 => Some(opcode::builtin::SQRT_F64),
+            OpWidth::W32 | OpWidth::W64 => None,
+        },
         _ => None,
     }
 }
@@ -1120,7 +1151,8 @@ fn compile_generic_builtin(
     func: &Function,
     op_type: OpType,
 ) -> Result<(), Diagnostic> {
-    let func_id = lookup_builtin(func.name.original())
+    let func_name = func.name.original().to_uppercase();
+    let func_id = lookup_builtin(&func_name, op_type.0)
         .ok_or_else(|| Diagnostic::todo_with_span(func.name.span(), file!(), line!()))?;
 
     let expected_args = opcode::builtin::arg_count(func_id) as usize;
@@ -1142,8 +1174,16 @@ fn compile_generic_builtin(
         ));
     }
 
-    for arg in &args {
-        compile_expr(emitter, ctx, arg, op_type)?;
+    let is_sel = func_name == "SEL";
+    for (i, arg) in args.iter().enumerate() {
+        // SEL's first argument (G) is always a BOOL/integer selector,
+        // even when the remaining arguments are float.
+        let arg_op_type = if is_sel && i == 0 {
+            DEFAULT_OP_TYPE
+        } else {
+            op_type
+        };
+        compile_expr(emitter, ctx, arg, arg_op_type)?;
     }
 
     emitter.emit_builtin(func_id);

--- a/compiler/codegen/tests/compile_abs_float.rs
+++ b/compiler/codegen/tests/compile_abs_float.rs
@@ -1,0 +1,70 @@
+//! Bytecode-level integration tests for the ABS function with float types.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_abs_real_then_produces_abs_f32_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 5.0;
+  y := ABS(x);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // x := 5.0: LOAD_CONST_F32 pool:0, STORE_VAR_F32 var:0
+    // y := ABS(x): LOAD_VAR_F32 var:0, BUILTIN ABS_F32, STORE_VAR_F32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x03, 0x00, 0x00, // LOAD_CONST_F32 pool:0
+            0x1A, 0x00, 0x00, // STORE_VAR_F32 var:0
+            0x12, 0x00, 0x00, // LOAD_VAR_F32 var:0
+            0xC4, 0x54, 0x03, // BUILTIN ABS_F32
+            0x1A, 0x01, 0x00, // STORE_VAR_F32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_abs_lreal_then_produces_abs_f64_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := 5.0;
+  y := ABS(x);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // x := 5.0: LOAD_CONST_F64 pool:0, STORE_VAR_F64 var:0
+    // y := ABS(x): LOAD_VAR_F64 var:0, BUILTIN ABS_F64, STORE_VAR_F64 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0
+            0x1B, 0x00, 0x00, // STORE_VAR_F64 var:0
+            0x13, 0x00, 0x00, // LOAD_VAR_F64 var:0
+            0xC4, 0x55, 0x03, // BUILTIN ABS_F64
+            0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/compile_limit_float.rs
+++ b/compiler/codegen/tests/compile_limit_float.rs
@@ -1,0 +1,72 @@
+//! Bytecode-level integration tests for the LIMIT function with float types.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_limit_real_then_produces_limit_f32_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 5.0;
+  y := LIMIT(0.0, x, 10.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // x := 5.0: LOAD_CONST_F32 pool:0, STORE_VAR_F32 var:0
+    // y := LIMIT(0.0, x, 10.0): LOAD_CONST_F32 pool:1, LOAD_VAR_F32 var:0,
+    //   LOAD_CONST_F32 pool:2, BUILTIN LIMIT_F32, STORE_VAR_F32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x03, 0x00, 0x00, // LOAD_CONST_F32 pool:0 (5.0)
+            0x1A, 0x00, 0x00, // STORE_VAR_F32 var:0
+            0x03, 0x01, 0x00, // LOAD_CONST_F32 pool:1 (0.0)
+            0x12, 0x00, 0x00, // LOAD_VAR_F32 var:0
+            0x03, 0x02, 0x00, // LOAD_CONST_F32 pool:2 (10.0)
+            0xC4, 0x5A, 0x03, // BUILTIN LIMIT_F32
+            0x1A, 0x01, 0x00, // STORE_VAR_F32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_limit_lreal_then_produces_limit_f64_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := 5.0;
+  y := LIMIT(0.0, x, 10.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0 (5.0)
+            0x1B, 0x00, 0x00, // STORE_VAR_F64 var:0
+            0x04, 0x01, 0x00, // LOAD_CONST_F64 pool:1 (0.0)
+            0x13, 0x00, 0x00, // LOAD_VAR_F64 var:0
+            0x04, 0x02, 0x00, // LOAD_CONST_F64 pool:2 (10.0)
+            0xC4, 0x5B, 0x03, // BUILTIN LIMIT_F64
+            0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/compile_max_float.rs
+++ b/compiler/codegen/tests/compile_max_float.rs
@@ -1,0 +1,60 @@
+//! Bytecode-level integration tests for the MAX function with float types.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_max_real_then_produces_max_f32_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  y := MAX(x, 10.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x12, 0x00, 0x00, // LOAD_VAR_F32 var:0
+            0x03, 0x00, 0x00, // LOAD_CONST_F32 pool:0 (10.0)
+            0xC4, 0x58, 0x03, // BUILTIN MAX_F32
+            0x1A, 0x01, 0x00, // STORE_VAR_F32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_max_lreal_then_produces_max_f64_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  y := MAX(x, 10.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x13, 0x00, 0x00, // LOAD_VAR_F64 var:0
+            0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0 (10.0)
+            0xC4, 0x59, 0x03, // BUILTIN MAX_F64
+            0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/compile_min_float.rs
+++ b/compiler/codegen/tests/compile_min_float.rs
@@ -1,0 +1,61 @@
+//! Bytecode-level integration tests for the MIN function with float types.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_min_real_then_produces_min_f32_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  y := MIN(x, 10.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    // y := MIN(x, 10.0): LOAD_VAR_F32 var:0, LOAD_CONST_F32 pool:0, BUILTIN MIN_F32, STORE_VAR_F32 var:1
+    assert_eq!(
+        bytecode,
+        &[
+            0x12, 0x00, 0x00, // LOAD_VAR_F32 var:0
+            0x03, 0x00, 0x00, // LOAD_CONST_F32 pool:0 (10.0)
+            0xC4, 0x56, 0x03, // BUILTIN MIN_F32
+            0x1A, 0x01, 0x00, // STORE_VAR_F32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_min_lreal_then_produces_min_f64_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  y := MIN(x, 10.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x13, 0x00, 0x00, // LOAD_VAR_F64 var:0
+            0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0 (10.0)
+            0xC4, 0x57, 0x03, // BUILTIN MIN_F64
+            0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/compile_sel_float.rs
+++ b/compiler/codegen/tests/compile_sel_float.rs
@@ -1,0 +1,67 @@
+//! Bytecode-level integration tests for the SEL function with float types.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_sel_real_then_produces_sel_f32_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    y : REAL;
+  END_VAR
+  y := SEL(0, 10.0, 20.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // y := SEL(0, 10.0, 20.0):
+    //   LOAD_CONST_I32 pool:0 (0)    -- G is always i32
+    //   LOAD_CONST_F32 pool:1 (10.0) -- IN0
+    //   LOAD_CONST_F32 pool:2 (20.0) -- IN1
+    //   BUILTIN SEL_F32
+    //   STORE_VAR_F32 var:0
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
+            0x03, 0x01, 0x00, // LOAD_CONST_F32 pool:1 (10.0)
+            0x03, 0x02, 0x00, // LOAD_CONST_F32 pool:2 (20.0)
+            0xC4, 0x5C, 0x03, // BUILTIN SEL_F32
+            0x1A, 0x00, 0x00, // STORE_VAR_F32 var:0
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_sel_lreal_then_produces_sel_f64_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    y : LREAL;
+  END_VAR
+  y := SEL(1, 10.0, 20.0);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
+            0x04, 0x01, 0x00, // LOAD_CONST_F64 pool:1 (10.0)
+            0x04, 0x02, 0x00, // LOAD_CONST_F64 pool:2 (20.0)
+            0xC4, 0x5D, 0x03, // BUILTIN SEL_F64
+            0x1B, 0x00, 0x00, // STORE_VAR_F64 var:0
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/compile_sqrt.rs
+++ b/compiler/codegen/tests/compile_sqrt.rs
@@ -1,0 +1,70 @@
+//! Bytecode-level integration tests for the SQRT function compilation.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_sqrt_real_then_produces_sqrt_f32_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 9.0;
+  y := SQRT(x);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // x := 9.0: LOAD_CONST_F32 pool:0, STORE_VAR_F32 var:0
+    // y := SQRT(x): LOAD_VAR_F32 var:0, BUILTIN SQRT_F32, STORE_VAR_F32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x03, 0x00, 0x00, // LOAD_CONST_F32 pool:0
+            0x1A, 0x00, 0x00, // STORE_VAR_F32 var:0
+            0x12, 0x00, 0x00, // LOAD_VAR_F32 var:0
+            0xC4, 0x5E, 0x03, // BUILTIN SQRT_F32
+            0x1A, 0x01, 0x00, // STORE_VAR_F32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_sqrt_lreal_then_produces_sqrt_f64_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := 9.0;
+  y := SQRT(x);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    // x := 9.0: LOAD_CONST_F64 pool:0, STORE_VAR_F64 var:0
+    // y := SQRT(x): LOAD_VAR_F64 var:0, BUILTIN SQRT_F64, STORE_VAR_F64 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0
+            0x1B, 0x00, 0x00, // STORE_VAR_F64 var:0
+            0x13, 0x00, 0x00, // LOAD_VAR_F64 var:0
+            0xC4, 0x5F, 0x03, // BUILTIN SQRT_F64
+            0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/end_to_end_abs_float.rs
+++ b/compiler/codegen/tests/end_to_end_abs_float.rs
@@ -1,0 +1,62 @@
+//! End-to-end integration tests for the ABS function with float types.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_abs_real_positive_then_unchanged() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 42.5;
+  y := ABS(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 42.5).abs() < 1e-5, "expected 42.5, got {y}");
+}
+
+#[test]
+fn end_to_end_when_abs_real_negative_then_positive() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := -7.25;
+  y := ABS(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 7.25).abs() < 1e-5, "expected 7.25, got {y}");
+}
+
+#[test]
+fn end_to_end_when_abs_lreal_negative_then_positive() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := -3.141592653589793;
+  y := ABS(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f64();
+    assert!(
+        (y - 3.141592653589793).abs() < 1e-12,
+        "expected pi, got {y}"
+    );
+}

--- a/compiler/codegen/tests/end_to_end_limit_float.rs
+++ b/compiler/codegen/tests/end_to_end_limit_float.rs
@@ -1,0 +1,77 @@
+//! End-to-end integration tests for the LIMIT function with float types.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_limit_real_in_range_then_unchanged() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 5.0;
+  y := LIMIT(0.0, x, 10.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 5.0).abs() < 1e-5, "expected 5.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_limit_real_below_min_then_clamped() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := -5.0;
+  y := LIMIT(0.0, x, 10.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 0.0).abs() < 1e-5, "expected 0.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_limit_real_above_max_then_clamped() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 99.0;
+  y := LIMIT(0.0, x, 10.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 10.0).abs() < 1e-5, "expected 10.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_limit_lreal_below_min_then_clamped() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := -5.0;
+  y := LIMIT(0.0, x, 10.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f64();
+    assert!((y - 0.0).abs() < 1e-12, "expected 0.0, got {y}");
+}

--- a/compiler/codegen/tests/end_to_end_max_float.rs
+++ b/compiler/codegen/tests/end_to_end_max_float.rs
@@ -1,0 +1,59 @@
+//! End-to-end integration tests for the MAX function with float types.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_max_real_then_returns_larger() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 3.0;
+  y := MAX(x, 7.5);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 7.5).abs() < 1e-5, "expected 7.5, got {y}");
+}
+
+#[test]
+fn end_to_end_when_max_real_first_larger_then_returns_first() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 8.0;
+  y := MAX(x, 2.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 8.0).abs() < 1e-5, "expected 8.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_max_lreal_then_returns_larger() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := 3.0;
+  y := MAX(x, 7.5);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f64();
+    assert!((y - 7.5).abs() < 1e-12, "expected 7.5, got {y}");
+}

--- a/compiler/codegen/tests/end_to_end_min_float.rs
+++ b/compiler/codegen/tests/end_to_end_min_float.rs
@@ -1,0 +1,59 @@
+//! End-to-end integration tests for the MIN function with float types.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_min_real_then_returns_smaller() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 7.5;
+  y := MIN(x, 3.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 3.0).abs() < 1e-5, "expected 3.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_min_real_first_smaller_then_returns_first() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 2.0;
+  y := MIN(x, 8.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 2.0).abs() < 1e-5, "expected 2.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_min_lreal_then_returns_smaller() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := 7.5;
+  y := MIN(x, 3.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f64();
+    assert!((y - 3.0).abs() < 1e-12, "expected 3.0, got {y}");
+}

--- a/compiler/codegen/tests/end_to_end_sel_float.rs
+++ b/compiler/codegen/tests/end_to_end_sel_float.rs
@@ -1,0 +1,87 @@
+//! End-to-end integration tests for the SEL function with float types.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_sel_real_false_then_returns_in0() {
+    let source = "
+PROGRAM main
+  VAR
+    y : REAL;
+  END_VAR
+  y := SEL(0, 10.5, 20.5);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[0].as_f32();
+    assert!((y - 10.5).abs() < 1e-5, "expected 10.5, got {y}");
+}
+
+#[test]
+fn end_to_end_when_sel_real_true_then_returns_in1() {
+    let source = "
+PROGRAM main
+  VAR
+    y : REAL;
+  END_VAR
+  y := SEL(1, 10.5, 20.5);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[0].as_f32();
+    assert!((y - 20.5).abs() < 1e-5, "expected 20.5, got {y}");
+}
+
+#[test]
+fn end_to_end_when_sel_real_with_variable_then_selects() {
+    let source = "
+PROGRAM main
+  VAR
+    g : DINT;
+    y : REAL;
+  END_VAR
+  g := 1;
+  y := SEL(g, 100.0, 200.0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 200.0).abs() < 1e-5, "expected 200.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_sel_lreal_false_then_returns_in0() {
+    let source = "
+PROGRAM main
+  VAR
+    y : LREAL;
+  END_VAR
+  y := SEL(0, 10.5, 20.5);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[0].as_f64();
+    assert!((y - 10.5).abs() < 1e-12, "expected 10.5, got {y}");
+}
+
+#[test]
+fn end_to_end_when_sel_lreal_true_then_returns_in1() {
+    let source = "
+PROGRAM main
+  VAR
+    y : LREAL;
+  END_VAR
+  y := SEL(1, 10.5, 20.5);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[0].as_f64();
+    assert!((y - 20.5).abs() < 1e-12, "expected 20.5, got {y}");
+}

--- a/compiler/codegen/tests/end_to_end_sqrt.rs
+++ b/compiler/codegen/tests/end_to_end_sqrt.rs
@@ -1,0 +1,98 @@
+//! End-to-end integration tests for the SQRT function.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_sqrt_real_perfect_square_then_correct() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 9.0;
+  y := SQRT(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 3.0).abs() < 1e-5, "expected 3.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_sqrt_real_zero_then_zero() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := 0.0;
+  y := SQRT(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!((y - 0.0).abs() < 1e-5, "expected 0.0, got {y}");
+}
+
+#[test]
+fn end_to_end_when_sqrt_real_negative_then_nan() {
+    let source = "
+PROGRAM main
+  VAR
+    x : REAL;
+    y : REAL;
+  END_VAR
+  x := -1.0;
+  y := SQRT(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f32();
+    assert!(y.is_nan(), "expected NaN, got {y}");
+}
+
+#[test]
+fn end_to_end_when_sqrt_lreal_then_correct() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := 2.0;
+  y := SQRT(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f64();
+    assert!(
+        (y - std::f64::consts::SQRT_2).abs() < 1e-12,
+        "expected sqrt(2), got {y}"
+    );
+}
+
+#[test]
+fn end_to_end_when_sqrt_lreal_negative_then_nan() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LREAL;
+    y : LREAL;
+  END_VAR
+  x := -1.0;
+  y := SQRT(x);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    let y = bufs.vars[1].as_f64();
+    assert!(y.is_nan(), "expected NaN, got {y}");
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -459,6 +459,42 @@ pub mod builtin {
     /// ROR for 16-bit (WORD): narrow rotate within 16 bits.
     pub const ROR_U16: u16 = 0x0353;
 
+    /// ABS for 32-bit floats: pops one value, pushes its absolute value.
+    pub const ABS_F32: u16 = 0x0354;
+
+    /// ABS for 64-bit floats: pops one value, pushes its absolute value.
+    pub const ABS_F64: u16 = 0x0355;
+
+    /// MIN for 32-bit floats: pops two values (b then a), pushes min(a, b).
+    pub const MIN_F32: u16 = 0x0356;
+
+    /// MIN for 64-bit floats: pops two values (b then a), pushes min(a, b).
+    pub const MIN_F64: u16 = 0x0357;
+
+    /// MAX for 32-bit floats: pops two values (b then a), pushes max(a, b).
+    pub const MAX_F32: u16 = 0x0358;
+
+    /// MAX for 64-bit floats: pops two values (b then a), pushes max(a, b).
+    pub const MAX_F64: u16 = 0x0359;
+
+    /// LIMIT for 32-bit floats: pops mx, in, mn, pushes clamp(in, mn, mx).
+    pub const LIMIT_F32: u16 = 0x035A;
+
+    /// LIMIT for 64-bit floats: pops mx, in, mn, pushes clamp(in, mn, mx).
+    pub const LIMIT_F64: u16 = 0x035B;
+
+    /// SEL for 32-bit floats: pops in1, in0 (f32), g (i32), pushes in0 if g==0 else in1.
+    pub const SEL_F32: u16 = 0x035C;
+
+    /// SEL for 64-bit floats: pops in1, in0 (f64), g (i32), pushes in0 if g==0 else in1.
+    pub const SEL_F64: u16 = 0x035D;
+
+    /// SQRT for 32-bit floats: pops one value, pushes its square root.
+    pub const SQRT_F32: u16 = 0x035E;
+
+    /// SQRT for 64-bit floats: pops one value, pushes its square root.
+    pub const SQRT_F64: u16 = 0x035F;
+
     /// Returns the number of arguments a built-in function pops from the stack.
     ///
     /// This is the single source of truth for argument counts, used by both
@@ -468,11 +504,11 @@ pub mod builtin {
     /// Panics if `func_id` is not a known built-in function ID.
     pub fn arg_count(func_id: u16) -> u16 {
         match func_id {
-            ABS_I32 => 1,
-            EXPT_I32 | EXPT_F32 | EXPT_F64 | MIN_I32 | MAX_I32 => 2,
-            LIMIT_I32 | SEL_I32 => 3,
-            SHL_I32 | SHL_I64 | SHR_I32 | SHR_I64 | ROL_I32 | ROL_I64 | ROR_I32 | ROR_I64
-            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 => 2,
+            ABS_I32 | ABS_F32 | ABS_F64 | SQRT_F32 | SQRT_F64 => 1,
+            EXPT_I32 | EXPT_F32 | EXPT_F64 | MIN_I32 | MIN_F32 | MIN_F64 | MAX_I32 | MAX_F32
+            | MAX_F64 | SHL_I32 | SHL_I64 | SHR_I32 | SHR_I64 | ROL_I32 | ROL_I64 | ROR_I32
+            | ROR_I64 | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 => 2,
+            LIMIT_I32 | LIMIT_F32 | LIMIT_F64 | SEL_I32 | SEL_F32 | SEL_F64 => 3,
             _ => panic!("unknown builtin function ID: 0x{:04X}", func_id),
         }
     }

--- a/compiler/plc2x/src/disassemble.rs
+++ b/compiler/plc2x/src/disassemble.rs
@@ -462,10 +462,20 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                 let func_id = read_u16(bytecode, pc + 1);
                 let operand = match func_id {
                     opcode::builtin::EXPT_I32 => format!("EXPT_I32 (0x{:04X})", func_id),
+                    opcode::builtin::EXPT_F32 => format!("EXPT_F32 (0x{:04X})", func_id),
+                    opcode::builtin::EXPT_F64 => format!("EXPT_F64 (0x{:04X})", func_id),
                     opcode::builtin::ABS_I32 => format!("ABS_I32 (0x{:04X})", func_id),
+                    opcode::builtin::ABS_F32 => format!("ABS_F32 (0x{:04X})", func_id),
+                    opcode::builtin::ABS_F64 => format!("ABS_F64 (0x{:04X})", func_id),
                     opcode::builtin::MIN_I32 => format!("MIN_I32 (0x{:04X})", func_id),
+                    opcode::builtin::MIN_F32 => format!("MIN_F32 (0x{:04X})", func_id),
+                    opcode::builtin::MIN_F64 => format!("MIN_F64 (0x{:04X})", func_id),
                     opcode::builtin::MAX_I32 => format!("MAX_I32 (0x{:04X})", func_id),
+                    opcode::builtin::MAX_F32 => format!("MAX_F32 (0x{:04X})", func_id),
+                    opcode::builtin::MAX_F64 => format!("MAX_F64 (0x{:04X})", func_id),
                     opcode::builtin::LIMIT_I32 => format!("LIMIT_I32 (0x{:04X})", func_id),
+                    opcode::builtin::LIMIT_F32 => format!("LIMIT_F32 (0x{:04X})", func_id),
+                    opcode::builtin::LIMIT_F64 => format!("LIMIT_F64 (0x{:04X})", func_id),
                     opcode::builtin::SEL_I32 => format!("SEL_I32 (0x{:04X})", func_id),
                     opcode::builtin::SHL_I32 => format!("SHL_I32 (0x{:04X})", func_id),
                     opcode::builtin::SHL_I64 => format!("SHL_I64 (0x{:04X})", func_id),
@@ -479,6 +489,10 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                     opcode::builtin::ROL_U16 => format!("ROL_U16 (0x{:04X})", func_id),
                     opcode::builtin::ROR_U8 => format!("ROR_U8 (0x{:04X})", func_id),
                     opcode::builtin::ROR_U16 => format!("ROR_U16 (0x{:04X})", func_id),
+                    opcode::builtin::SEL_F32 => format!("SEL_F32 (0x{:04X})", func_id),
+                    opcode::builtin::SEL_F64 => format!("SEL_F64 (0x{:04X})", func_id),
+                    opcode::builtin::SQRT_F32 => format!("SQRT_F32 (0x{:04X})", func_id),
+                    opcode::builtin::SQRT_F64 => format!("SQRT_F64 (0x{:04X})", func_id),
                     _ => format!("0x{:04X}", func_id),
                 };
                 instructions.push(json!({

--- a/compiler/vm/src/builtin.rs
+++ b/compiler/vm/src/builtin.rs
@@ -141,6 +141,78 @@ pub fn dispatch(func_id: u16, stack: &mut OperandStack) -> Result<(), Trap> {
             stack.push(Slot::from_i32(a.rotate_right(n as u32) as i32))?;
             Ok(())
         }
+        opcode::builtin::ABS_F32 => {
+            let a = stack.pop()?.as_f32();
+            stack.push(Slot::from_f32(a.abs()))?;
+            Ok(())
+        }
+        opcode::builtin::ABS_F64 => {
+            let a = stack.pop()?.as_f64();
+            stack.push(Slot::from_f64(a.abs()))?;
+            Ok(())
+        }
+        opcode::builtin::MIN_F32 => {
+            let b = stack.pop()?.as_f32();
+            let a = stack.pop()?.as_f32();
+            stack.push(Slot::from_f32(a.min(b)))?;
+            Ok(())
+        }
+        opcode::builtin::MIN_F64 => {
+            let b = stack.pop()?.as_f64();
+            let a = stack.pop()?.as_f64();
+            stack.push(Slot::from_f64(a.min(b)))?;
+            Ok(())
+        }
+        opcode::builtin::MAX_F32 => {
+            let b = stack.pop()?.as_f32();
+            let a = stack.pop()?.as_f32();
+            stack.push(Slot::from_f32(a.max(b)))?;
+            Ok(())
+        }
+        opcode::builtin::MAX_F64 => {
+            let b = stack.pop()?.as_f64();
+            let a = stack.pop()?.as_f64();
+            stack.push(Slot::from_f64(a.max(b)))?;
+            Ok(())
+        }
+        opcode::builtin::LIMIT_F32 => {
+            let mx = stack.pop()?.as_f32();
+            let in_val = stack.pop()?.as_f32();
+            let mn = stack.pop()?.as_f32();
+            stack.push(Slot::from_f32(in_val.clamp(mn, mx)))?;
+            Ok(())
+        }
+        opcode::builtin::LIMIT_F64 => {
+            let mx = stack.pop()?.as_f64();
+            let in_val = stack.pop()?.as_f64();
+            let mn = stack.pop()?.as_f64();
+            stack.push(Slot::from_f64(in_val.clamp(mn, mx)))?;
+            Ok(())
+        }
+        opcode::builtin::SEL_F32 => {
+            let in1 = stack.pop()?.as_f32();
+            let in0 = stack.pop()?.as_f32();
+            let g = stack.pop()?.as_i32();
+            stack.push(Slot::from_f32(if g == 0 { in0 } else { in1 }))?;
+            Ok(())
+        }
+        opcode::builtin::SEL_F64 => {
+            let in1 = stack.pop()?.as_f64();
+            let in0 = stack.pop()?.as_f64();
+            let g = stack.pop()?.as_i32();
+            stack.push(Slot::from_f64(if g == 0 { in0 } else { in1 }))?;
+            Ok(())
+        }
+        opcode::builtin::SQRT_F32 => {
+            let a = stack.pop()?.as_f32();
+            stack.push(Slot::from_f32(a.sqrt()))?;
+            Ok(())
+        }
+        opcode::builtin::SQRT_F64 => {
+            let a = stack.pop()?.as_f64();
+            stack.push(Slot::from_f64(a.sqrt()))?;
+            Ok(())
+        }
         _ => Err(Trap::InvalidBuiltinFunction(func_id)),
     }
 }

--- a/compiler/vm/tests/common/mod.rs
+++ b/compiler/vm/tests/common/mod.rs
@@ -31,10 +31,79 @@ impl VmBuffers {
 /// Builds a container with one function from the given bytecode,
 /// with `num_vars` variables and the given constants.
 /// Uses a generous max_stack_depth (16) suitable for most tests.
+#[allow(dead_code)]
 pub fn single_function_container(bytecode: &[u8], num_vars: u16, constants: &[i32]) -> Container {
     let mut builder = ContainerBuilder::new().num_variables(num_vars);
     for &c in constants {
         builder = builder.add_i32_constant(c);
+    }
+    builder.add_function(0, bytecode, 16, num_vars).build()
+}
+
+/// Builds a container with one function from the given bytecode,
+/// with `num_vars` variables and the given f32 constants.
+#[allow(dead_code)]
+pub fn single_function_container_f32(
+    bytecode: &[u8],
+    num_vars: u16,
+    constants: &[f32],
+) -> Container {
+    let mut builder = ContainerBuilder::new().num_variables(num_vars);
+    for &c in constants {
+        builder = builder.add_f32_constant(c);
+    }
+    builder.add_function(0, bytecode, 16, num_vars).build()
+}
+
+/// Builds a container with one function from the given bytecode,
+/// with `num_vars` variables and the given f64 constants.
+#[allow(dead_code)]
+pub fn single_function_container_f64(
+    bytecode: &[u8],
+    num_vars: u16,
+    constants: &[f64],
+) -> Container {
+    let mut builder = ContainerBuilder::new().num_variables(num_vars);
+    for &c in constants {
+        builder = builder.add_f64_constant(c);
+    }
+    builder.add_function(0, bytecode, 16, num_vars).build()
+}
+
+/// Builds a container with one function from the given bytecode,
+/// with `num_vars` variables and a mix of i32 then f32 constants.
+#[allow(dead_code)]
+pub fn single_function_container_i32_f32(
+    bytecode: &[u8],
+    num_vars: u16,
+    i32_constants: &[i32],
+    f32_constants: &[f32],
+) -> Container {
+    let mut builder = ContainerBuilder::new().num_variables(num_vars);
+    for &c in i32_constants {
+        builder = builder.add_i32_constant(c);
+    }
+    for &c in f32_constants {
+        builder = builder.add_f32_constant(c);
+    }
+    builder.add_function(0, bytecode, 16, num_vars).build()
+}
+
+/// Builds a container with one function from the given bytecode,
+/// with `num_vars` variables and a mix of i32 then f64 constants.
+#[allow(dead_code)]
+pub fn single_function_container_i32_f64(
+    bytecode: &[u8],
+    num_vars: u16,
+    i32_constants: &[i32],
+    f64_constants: &[f64],
+) -> Container {
+    let mut builder = ContainerBuilder::new().num_variables(num_vars);
+    for &c in i32_constants {
+        builder = builder.add_i32_constant(c);
+    }
+    for &c in f64_constants {
+        builder = builder.add_f64_constant(c);
     }
     builder.add_function(0, bytecode, 16, num_vars).build()
 }

--- a/compiler/vm/tests/execute_builtin_abs_f32.rs
+++ b/compiler/vm/tests/execute_builtin_abs_f32.rs
@@ -1,0 +1,93 @@
+//! Integration tests for the BUILTIN ABS_F32 opcode.
+
+mod common;
+
+use common::{single_function_container_f32, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_abs_f32_positive_then_unchanged() {
+    // ABS(3.5) = 3.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (3.5)
+        0xC4, 0x54, 0x03,  // BUILTIN ABS_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[3.5]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 3.5).abs() < 1e-5, "expected 3.5, got {result}");
+}
+
+#[test]
+fn execute_when_abs_f32_negative_then_positive() {
+    // ABS(-7.25) = 7.25
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (-7.25)
+        0xC4, 0x54, 0x03,  // BUILTIN ABS_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[-7.25]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 7.25).abs() < 1e-5, "expected 7.25, got {result}");
+}
+
+#[test]
+fn execute_when_abs_f32_zero_then_zero() {
+    // ABS(0.0) = 0.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (0.0)
+        0xC4, 0x54, 0x03,  // BUILTIN ABS_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[0.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 0.0).abs() < 1e-5, "expected 0.0, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_abs_f64.rs
+++ b/compiler/vm/tests/execute_builtin_abs_f64.rs
@@ -1,0 +1,93 @@
+//! Integration tests for the BUILTIN ABS_F64 opcode.
+
+mod common;
+
+use common::{single_function_container_f64, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_abs_f64_positive_then_unchanged() {
+    // ABS(3.5) = 3.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (3.5)
+        0xC4, 0x55, 0x03,  // BUILTIN ABS_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[3.5]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 3.5).abs() < 1e-12, "expected 3.5, got {result}");
+}
+
+#[test]
+fn execute_when_abs_f64_negative_then_positive() {
+    // ABS(-7.25) = 7.25
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (-7.25)
+        0xC4, 0x55, 0x03,  // BUILTIN ABS_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[-7.25]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 7.25).abs() < 1e-12, "expected 7.25, got {result}");
+}
+
+#[test]
+fn execute_when_abs_f64_zero_then_zero() {
+    // ABS(0.0) = 0.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (0.0)
+        0xC4, 0x55, 0x03,  // BUILTIN ABS_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[0.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 0.0).abs() < 1e-12, "expected 0.0, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_limit_f32.rs
+++ b/compiler/vm/tests/execute_builtin_limit_f32.rs
@@ -1,0 +1,99 @@
+//! Integration tests for the BUILTIN LIMIT_F32 opcode.
+
+mod common;
+
+use common::{single_function_container_f32, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_limit_f32_in_range_then_unchanged() {
+    // LIMIT(MN:=1.0, IN:=5.0, MX:=10.0) = 5.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (1.0)  MN
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (5.0)  IN
+        0x03, 0x02, 0x00,  // LOAD_CONST_F32 pool[2] (10.0) MX
+        0xC4, 0x5A, 0x03,  // BUILTIN LIMIT_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[1.0, 5.0, 10.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 5.0).abs() < 1e-5, "expected 5.0, got {result}");
+}
+
+#[test]
+fn execute_when_limit_f32_below_min_then_clamped() {
+    // LIMIT(MN:=1.0, IN:=-5.0, MX:=10.0) = 1.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (1.0)  MN
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (-5.0) IN
+        0x03, 0x02, 0x00,  // LOAD_CONST_F32 pool[2] (10.0) MX
+        0xC4, 0x5A, 0x03,  // BUILTIN LIMIT_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[1.0, -5.0, 10.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 1.0).abs() < 1e-5, "expected 1.0, got {result}");
+}
+
+#[test]
+fn execute_when_limit_f32_above_max_then_clamped() {
+    // LIMIT(MN:=1.0, IN:=99.0, MX:=10.0) = 10.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (1.0)  MN
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (99.0) IN
+        0x03, 0x02, 0x00,  // LOAD_CONST_F32 pool[2] (10.0) MX
+        0xC4, 0x5A, 0x03,  // BUILTIN LIMIT_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[1.0, 99.0, 10.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 10.0).abs() < 1e-5, "expected 10.0, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_limit_f64.rs
+++ b/compiler/vm/tests/execute_builtin_limit_f64.rs
@@ -1,0 +1,99 @@
+//! Integration tests for the BUILTIN LIMIT_F64 opcode.
+
+mod common;
+
+use common::{single_function_container_f64, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_limit_f64_in_range_then_unchanged() {
+    // LIMIT(MN:=1.0, IN:=5.0, MX:=10.0) = 5.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (1.0)  MN
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (5.0)  IN
+        0x04, 0x02, 0x00,  // LOAD_CONST_F64 pool[2] (10.0) MX
+        0xC4, 0x5B, 0x03,  // BUILTIN LIMIT_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[1.0, 5.0, 10.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 5.0).abs() < 1e-12, "expected 5.0, got {result}");
+}
+
+#[test]
+fn execute_when_limit_f64_below_min_then_clamped() {
+    // LIMIT(MN:=1.0, IN:=-5.0, MX:=10.0) = 1.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (1.0)  MN
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (-5.0) IN
+        0x04, 0x02, 0x00,  // LOAD_CONST_F64 pool[2] (10.0) MX
+        0xC4, 0x5B, 0x03,  // BUILTIN LIMIT_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[1.0, -5.0, 10.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 1.0).abs() < 1e-12, "expected 1.0, got {result}");
+}
+
+#[test]
+fn execute_when_limit_f64_above_max_then_clamped() {
+    // LIMIT(MN:=1.0, IN:=99.0, MX:=10.0) = 10.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (1.0)  MN
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (99.0) IN
+        0x04, 0x02, 0x00,  // LOAD_CONST_F64 pool[2] (10.0) MX
+        0xC4, 0x5B, 0x03,  // BUILTIN LIMIT_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[1.0, 99.0, 10.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 10.0).abs() < 1e-12, "expected 10.0, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_max_f32.rs
+++ b/compiler/vm/tests/execute_builtin_max_f32.rs
@@ -1,0 +1,96 @@
+//! Integration tests for the BUILTIN MAX_F32 opcode.
+
+mod common;
+
+use common::{single_function_container_f32, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_max_f32_then_returns_larger() {
+    // MAX(10.5, 3.0) = 10.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (10.5)
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (3.0)
+        0xC4, 0x58, 0x03,  // BUILTIN MAX_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[10.5, 3.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 10.5).abs() < 1e-5, "expected 10.5, got {result}");
+}
+
+#[test]
+fn execute_when_max_f32_equal_then_returns_value() {
+    // MAX(5.0, 5.0) = 5.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (5.0)
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (5.0)
+        0xC4, 0x58, 0x03,  // BUILTIN MAX_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[5.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 5.0).abs() < 1e-5, "expected 5.0, got {result}");
+}
+
+#[test]
+fn execute_when_max_f32_negative_vs_positive_then_returns_positive() {
+    // MAX(-3.0, 7.0) = 7.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (-3.0)
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (7.0)
+        0xC4, 0x58, 0x03,  // BUILTIN MAX_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[-3.0, 7.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 7.0).abs() < 1e-5, "expected 7.0, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_max_f64.rs
+++ b/compiler/vm/tests/execute_builtin_max_f64.rs
@@ -1,0 +1,96 @@
+//! Integration tests for the BUILTIN MAX_F64 opcode.
+
+mod common;
+
+use common::{single_function_container_f64, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_max_f64_then_returns_larger() {
+    // MAX(10.5, 3.0) = 10.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (10.5)
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (3.0)
+        0xC4, 0x59, 0x03,  // BUILTIN MAX_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[10.5, 3.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 10.5).abs() < 1e-12, "expected 10.5, got {result}");
+}
+
+#[test]
+fn execute_when_max_f64_equal_then_returns_value() {
+    // MAX(5.0, 5.0) = 5.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (5.0)
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (5.0)
+        0xC4, 0x59, 0x03,  // BUILTIN MAX_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[5.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 5.0).abs() < 1e-12, "expected 5.0, got {result}");
+}
+
+#[test]
+fn execute_when_max_f64_negative_vs_positive_then_returns_positive() {
+    // MAX(-3.0, 7.0) = 7.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (-3.0)
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (7.0)
+        0xC4, 0x59, 0x03,  // BUILTIN MAX_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[-3.0, 7.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 7.0).abs() < 1e-12, "expected 7.0, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_min_f32.rs
+++ b/compiler/vm/tests/execute_builtin_min_f32.rs
@@ -1,0 +1,99 @@
+//! Integration tests for the BUILTIN MIN_F32 opcode.
+
+mod common;
+
+use common::{single_function_container_f32, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_min_f32_then_returns_smaller() {
+    // MIN(2.5, 7.0) = 2.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (2.5)
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (7.0)
+        0xC4, 0x56, 0x03,  // BUILTIN MIN_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[2.5, 7.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 2.5).abs() < 1e-5, "expected 2.5, got {result}");
+}
+
+#[test]
+fn execute_when_min_f32_equal_then_returns_value() {
+    // MIN(5.0, 5.0) = 5.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (5.0)
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (5.0)
+        0xC4, 0x56, 0x03,  // BUILTIN MIN_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[5.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 5.0).abs() < 1e-5, "expected 5.0, got {result}");
+}
+
+#[test]
+fn execute_when_min_f32_negative_vs_positive_then_returns_negative() {
+    // MIN(-3.0, 7.0) = -3.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (-3.0)
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (7.0)
+        0xC4, 0x56, 0x03,  // BUILTIN MIN_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[-3.0, 7.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!(
+        (result - (-3.0)).abs() < 1e-5,
+        "expected -3.0, got {result}"
+    );
+}

--- a/compiler/vm/tests/execute_builtin_min_f64.rs
+++ b/compiler/vm/tests/execute_builtin_min_f64.rs
@@ -1,0 +1,99 @@
+//! Integration tests for the BUILTIN MIN_F64 opcode.
+
+mod common;
+
+use common::{single_function_container_f64, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_min_f64_then_returns_smaller() {
+    // MIN(2.5, 7.0) = 2.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (2.5)
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (7.0)
+        0xC4, 0x57, 0x03,  // BUILTIN MIN_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[2.5, 7.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 2.5).abs() < 1e-12, "expected 2.5, got {result}");
+}
+
+#[test]
+fn execute_when_min_f64_equal_then_returns_value() {
+    // MIN(5.0, 5.0) = 5.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (5.0)
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (5.0)
+        0xC4, 0x57, 0x03,  // BUILTIN MIN_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[5.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 5.0).abs() < 1e-12, "expected 5.0, got {result}");
+}
+
+#[test]
+fn execute_when_min_f64_negative_vs_positive_then_returns_negative() {
+    // MIN(-3.0, 7.0) = -3.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (-3.0)
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (7.0)
+        0xC4, 0x57, 0x03,  // BUILTIN MIN_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[-3.0, 7.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!(
+        (result - (-3.0)).abs() < 1e-12,
+        "expected -3.0, got {result}"
+    );
+}

--- a/compiler/vm/tests/execute_builtin_sel_f32.rs
+++ b/compiler/vm/tests/execute_builtin_sel_f32.rs
@@ -1,0 +1,68 @@
+//! Integration tests for the BUILTIN SEL_F32 opcode.
+
+mod common;
+
+use common::{single_function_container_i32_f32, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_sel_f32_g_zero_then_returns_in0() {
+    // SEL(G:=0, IN0:=10.5, IN1:=20.5) = 10.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0)     G
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (10.5)  IN0
+        0x03, 0x02, 0x00,  // LOAD_CONST_F32 pool[2] (20.5)  IN1
+        0xC4, 0x5C, 0x03,  // BUILTIN SEL_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_i32_f32(&bytecode, 1, &[0], &[10.5, 20.5]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 10.5).abs() < 1e-5, "expected 10.5, got {result}");
+}
+
+#[test]
+fn execute_when_sel_f32_g_one_then_returns_in1() {
+    // SEL(G:=1, IN0:=10.5, IN1:=20.5) = 20.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (1)     G
+        0x03, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (10.5)  IN0
+        0x03, 0x02, 0x00,  // LOAD_CONST_F32 pool[2] (20.5)  IN1
+        0xC4, 0x5C, 0x03,  // BUILTIN SEL_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_i32_f32(&bytecode, 1, &[1], &[10.5, 20.5]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 20.5).abs() < 1e-5, "expected 20.5, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_sel_f64.rs
+++ b/compiler/vm/tests/execute_builtin_sel_f64.rs
@@ -1,0 +1,68 @@
+//! Integration tests for the BUILTIN SEL_F64 opcode.
+
+mod common;
+
+use common::{single_function_container_i32_f64, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_sel_f64_g_zero_then_returns_in0() {
+    // SEL(G:=0, IN0:=10.5, IN1:=20.5) = 10.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0)     G
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (10.5)  IN0
+        0x04, 0x02, 0x00,  // LOAD_CONST_F64 pool[2] (20.5)  IN1
+        0xC4, 0x5D, 0x03,  // BUILTIN SEL_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_i32_f64(&bytecode, 1, &[0], &[10.5, 20.5]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 10.5).abs() < 1e-12, "expected 10.5, got {result}");
+}
+
+#[test]
+fn execute_when_sel_f64_g_one_then_returns_in1() {
+    // SEL(G:=1, IN0:=10.5, IN1:=20.5) = 20.5
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (1)     G
+        0x04, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (10.5)  IN0
+        0x04, 0x02, 0x00,  // LOAD_CONST_F64 pool[2] (20.5)  IN1
+        0xC4, 0x5D, 0x03,  // BUILTIN SEL_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_i32_f64(&bytecode, 1, &[1], &[10.5, 20.5]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 20.5).abs() < 1e-12, "expected 20.5, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_sqrt_f32.rs
+++ b/compiler/vm/tests/execute_builtin_sqrt_f32.rs
@@ -1,0 +1,93 @@
+//! Integration tests for the BUILTIN SQRT_F32 opcode.
+
+mod common;
+
+use common::{single_function_container_f32, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_sqrt_f32_perfect_square_then_exact() {
+    // SQRT(9.0) = 3.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (9.0)
+        0xC4, 0x5E, 0x03,  // BUILTIN SQRT_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[9.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 3.0).abs() < 1e-5, "expected 3.0, got {result}");
+}
+
+#[test]
+fn execute_when_sqrt_f32_zero_then_zero() {
+    // SQRT(0.0) = 0.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (0.0)
+        0xC4, 0x5E, 0x03,  // BUILTIN SQRT_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[0.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!((result - 0.0).abs() < 1e-5, "expected 0.0, got {result}");
+}
+
+#[test]
+fn execute_when_sqrt_f32_negative_then_nan() {
+    // SQRT(-1.0) = NaN
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (-1.0)
+        0xC4, 0x5E, 0x03,  // BUILTIN SQRT_F32
+        0x1A, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f32(&bytecode, 1, &[-1.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f32();
+    assert!(result.is_nan(), "expected NaN, got {result}");
+}

--- a/compiler/vm/tests/execute_builtin_sqrt_f64.rs
+++ b/compiler/vm/tests/execute_builtin_sqrt_f64.rs
@@ -1,0 +1,93 @@
+//! Integration tests for the BUILTIN SQRT_F64 opcode.
+
+mod common;
+
+use common::{single_function_container_f64, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_sqrt_f64_perfect_square_then_exact() {
+    // SQRT(9.0) = 3.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (9.0)
+        0xC4, 0x5F, 0x03,  // BUILTIN SQRT_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[9.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 3.0).abs() < 1e-12, "expected 3.0, got {result}");
+}
+
+#[test]
+fn execute_when_sqrt_f64_zero_then_zero() {
+    // SQRT(0.0) = 0.0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (0.0)
+        0xC4, 0x5F, 0x03,  // BUILTIN SQRT_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[0.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!((result - 0.0).abs() < 1e-12, "expected 0.0, got {result}");
+}
+
+#[test]
+fn execute_when_sqrt_f64_negative_then_nan() {
+    // SQRT(-1.0) = NaN
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x04, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (-1.0)
+        0xC4, 0x5F, 0x03,  // BUILTIN SQRT_F64
+        0x1B, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container_f64(&bytecode, 1, &[-1.0]);
+    let mut b = VmBuffers::from_container(&c);
+    {
+        let mut vm = Vm::new()
+            .load(
+                &c,
+                &mut b.stack,
+                &mut b.vars,
+                &mut b.tasks,
+                &mut b.programs,
+                &mut b.ready,
+            )
+            .start();
+        vm.run_round(0).unwrap();
+    }
+    let result = b.vars[0].as_f64();
+    assert!(result.is_nan(), "expected NaN, got {result}");
+}

--- a/docs/reference/standard-library/functions/abs.rst
+++ b/docs/reference/standard-library/functions/abs.rst
@@ -10,7 +10,7 @@ Returns the absolute value of a numeric input.
    * - **IEC 61131-3**
      - Section 2.5.1.5.2
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Signatures
 ----------
@@ -34,7 +34,7 @@ Signatures
    * - 3
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
@@ -42,11 +42,11 @@ Signatures
    * - 5
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 6
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/limit.rst
+++ b/docs/reference/standard-library/functions/limit.rst
@@ -10,7 +10,7 @@ Clamps a value to a specified range.
    * - **IEC 61131-3**
      - Section 2.5.1.5.5
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Signatures
 ----------
@@ -42,7 +42,7 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
@@ -78,13 +78,13 @@ Signatures
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/max.rst
+++ b/docs/reference/standard-library/functions/max.rst
@@ -10,7 +10,7 @@ Returns the larger of two inputs.
    * - **IEC 61131-3**
      - Section 2.5.1.5.5
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Signatures
 ----------
@@ -38,7 +38,7 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
@@ -68,12 +68,12 @@ Signatures
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/min.rst
+++ b/docs/reference/standard-library/functions/min.rst
@@ -10,7 +10,7 @@ Returns the smaller of two inputs.
    * - **IEC 61131-3**
      - Section 2.5.1.5.5
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Signatures
 ----------
@@ -38,7 +38,7 @@ Signatures
      - ``DINT``
      - ``DINT``
      - ``DINT``
-     - Not yet supported
+     - Supported
    * - 4
      - ``LINT``
      - ``LINT``
@@ -68,12 +68,12 @@ Signatures
      - ``REAL``
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 10
      - ``LREAL``
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/sel.rst
+++ b/docs/reference/standard-library/functions/sel.rst
@@ -10,7 +10,7 @@ Binary selection — selects one of two inputs based on a Boolean selector.
    * - **IEC 61131-3**
      - Section 2.5.1.5.5
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Signatures
 ----------
@@ -30,7 +30,7 @@ Signatures
      - *ANY*
      - *ANY*
      - *ANY*
-     - Not yet supported
+     - Supported
 
 Description
 -----------

--- a/docs/reference/standard-library/functions/sqrt.rst
+++ b/docs/reference/standard-library/functions/sqrt.rst
@@ -10,7 +10,7 @@ Returns the square root of a numeric input.
    * - **IEC 61131-3**
      - Section 2.5.1.5.2
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Signatures
 ----------
@@ -26,11 +26,11 @@ Signatures
    * - 1
      - ``REAL``
      - ``REAL``
-     - Not yet supported
+     - Supported
    * - 2
      - ``LREAL``
      - ``LREAL``
-     - Not yet supported
+     - Supported
 
 Description
 -----------


### PR DESCRIPTION
Extend ABS, MIN, MAX, LIMIT, SEL with F32/F64 opcodes and add float-only SQRT. Make codegen width-aware so ExprKind::Function emits the correct opcode based on the target variable's type.