### PR TITLE
Add bit shift/rotate operations (SHL, SHR, ROL, ROR) for bit string t…

### DIFF
--- a/compiler/analyzer/src/function_environment.rs
+++ b/compiler/analyzer/src/function_environment.rs
@@ -316,8 +316,8 @@ mod tests {
         let env = FunctionEnvironmentBuilder::new()
             .with_stdlib_functions()
             .build();
-        // Should have 90 conversion + 6 numeric = 96 stdlib functions
-        assert_eq!(env.len(), 96);
+        // Should have 90 conversion + 6 numeric + 4 bitshift = 100 stdlib functions
+        assert_eq!(env.len(), 100);
         // Should be able to find conversion functions
         assert!(env.contains(&Id::from("INT_TO_REAL")));
         assert!(env.contains(&Id::from("REAL_TO_INT")));

--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -215,6 +215,40 @@ fn get_numeric_functions() -> Vec<FunctionSignature> {
 }
 
 // =============================================================================
+// Bit shift and rotate functions
+// =============================================================================
+
+/// Returns standard bit shift and rotate function definitions.
+///
+/// IEC 61131-3 defines SHL, SHR, ROL, ROR as standard functions operating
+/// on ANY_BIT types with an ANY_INT shift count. The return type matches
+/// the input type.
+fn get_bitshift_functions() -> Vec<FunctionSignature> {
+    vec![
+        FunctionSignature::stdlib(
+            "SHL",
+            TypeName::from("ANY_BIT"),
+            vec![input_param("IN", "ANY_BIT"), input_param("N", "ANY_INT")],
+        ),
+        FunctionSignature::stdlib(
+            "SHR",
+            TypeName::from("ANY_BIT"),
+            vec![input_param("IN", "ANY_BIT"), input_param("N", "ANY_INT")],
+        ),
+        FunctionSignature::stdlib(
+            "ROL",
+            TypeName::from("ANY_BIT"),
+            vec![input_param("IN", "ANY_BIT"), input_param("N", "ANY_INT")],
+        ),
+        FunctionSignature::stdlib(
+            "ROR",
+            TypeName::from("ANY_BIT"),
+            vec![input_param("IN", "ANY_BIT"), input_param("N", "ANY_INT")],
+        ),
+    ]
+}
+
+// =============================================================================
 // Public API
 // =============================================================================
 
@@ -234,6 +268,9 @@ pub fn get_all_stdlib_functions() -> Vec<FunctionSignature> {
     // Numeric functions
     functions.extend(get_numeric_functions());
 
+    // Bit shift and rotate functions
+    functions.extend(get_bitshift_functions());
+
     functions
 }
 
@@ -250,8 +287,9 @@ mod tests {
         // Real-to-int: 2 reals × 4 signed + 2 reals × 4 unsigned = 8 + 8 = 16
         // Real-to-real: 2 × 1 = 2
         // Numeric functions: ABS, SQRT, MIN, MAX, LIMIT, SEL = 6
-        // Total: 56 + 16 + 16 + 2 + 6 = 96
-        assert_eq!(functions.len(), 96);
+        // Bit shift/rotate functions: SHL, SHR, ROL, ROR = 4
+        // Total: 56 + 16 + 16 + 2 + 6 + 4 = 100
+        assert_eq!(functions.len(), 100);
     }
 
     #[test]

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -19,6 +19,7 @@
 //! - Comparison operators (=, <>, <, <=, >, >=)
 //! - Boolean operators (AND, OR, XOR, NOT) with logical semantics
 //! - Bitwise operators (AND, OR, XOR, NOT) for bit string types (BYTE, WORD, DWORD, LWORD)
+//! - Bit shift/rotate functions (SHL, SHR, ROL, ROR) for bit string types
 //! - Variable references (named symbolic variables)
 //! - IF/ELSIF/ELSE statements
 //! - CASE statements (integer and subrange selectors)
@@ -42,8 +43,8 @@ use ironplc_dsl::common::{
 use ironplc_dsl::core::{FileId, Id, Located};
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::textual::{
-    CaseSelectionKind, CompareOp, ExprKind, Operator, ParamAssignmentKind, Statements, StmtKind,
-    SymbolicVariableKind, UnaryOp, Variable,
+    CaseSelectionKind, CompareOp, ExprKind, Function, Operator, ParamAssignmentKind, Statements,
+    StmtKind, SymbolicVariableKind, UnaryOp, Variable,
 };
 use ironplc_problems::Problem;
 
@@ -392,6 +393,21 @@ fn infer_op_type(ctx: &CompileContext, expr: &ExprKind) -> OpType {
             infer_op_type(ctx, &compare.right)
         }
         ExprKind::Expression(inner) => infer_op_type(ctx, inner),
+        ExprKind::Function(func) => func
+            .param_assignment
+            .iter()
+            .find_map(|p| match p {
+                ParamAssignmentKind::PositionalInput(pos) => {
+                    let t = infer_op_type(ctx, &pos.expr);
+                    if t != DEFAULT_OP_TYPE {
+                        Some(t)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .unwrap_or(DEFAULT_OP_TYPE),
         _ => DEFAULT_OP_TYPE,
     }
 }
@@ -419,6 +435,10 @@ fn infer_storage_bits(ctx: &CompileContext, expr: &ExprKind) -> Option<u8> {
         ExprKind::Compare(compare) => infer_storage_bits(ctx, &compare.left)
             .or_else(|| infer_storage_bits(ctx, &compare.right)),
         ExprKind::Expression(inner) => infer_storage_bits(ctx, inner),
+        ExprKind::Function(func) => func.param_assignment.iter().find_map(|p| match p {
+            ParamAssignmentKind::PositionalInput(pos) => infer_storage_bits(ctx, &pos.expr),
+            _ => None,
+        }),
         _ => None,
     }
 }
@@ -1067,37 +1087,139 @@ fn compile_expr(
             file!(),
             line!(),
         )),
-        ExprKind::Function(func) => {
-            let func_id = lookup_builtin(func.name.original())
-                .ok_or_else(|| Diagnostic::todo_with_span(func.name.span(), file!(), line!()))?;
-
-            let expected_args = opcode::builtin::arg_count(func_id) as usize;
-
-            let args: Vec<&ExprKind> = func
-                .param_assignment
-                .iter()
-                .filter_map(|p| match p {
-                    ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-                    _ => None,
-                })
-                .collect();
-
-            if args.len() != expected_args {
-                return Err(Diagnostic::todo_with_span(
-                    func.name.span(),
-                    file!(),
-                    line!(),
-                ));
-            }
-
-            for arg in &args {
-                compile_expr(emitter, ctx, arg, op_type)?;
-            }
-
-            emitter.emit_builtin(func_id);
-            Ok(())
-        }
+        ExprKind::Function(func) => compile_function_call(emitter, ctx, func, op_type),
     }
+}
+
+/// Compiles a standard library function call.
+///
+/// Dispatches shift/rotate functions to a width-aware handler, and other
+/// known builtins to the generic lookup path.
+fn compile_function_call(
+    emitter: &mut Emitter,
+    ctx: &mut CompileContext,
+    func: &Function,
+    op_type: OpType,
+) -> Result<(), Diagnostic> {
+    let name = func.name.lower_case();
+    match name.as_str() {
+        "shl" | "shr" | "rol" | "ror" => {
+            compile_shift_rotate(emitter, ctx, func, op_type, name.as_str())
+        }
+        _ => compile_generic_builtin(emitter, ctx, func, op_type),
+    }
+}
+
+/// Compiles a generic builtin function call via `lookup_builtin`.
+///
+/// All arguments are compiled with the same `op_type` and the function ID
+/// is looked up by name.
+fn compile_generic_builtin(
+    emitter: &mut Emitter,
+    ctx: &mut CompileContext,
+    func: &Function,
+    op_type: OpType,
+) -> Result<(), Diagnostic> {
+    let func_id = lookup_builtin(func.name.original())
+        .ok_or_else(|| Diagnostic::todo_with_span(func.name.span(), file!(), line!()))?;
+
+    let expected_args = opcode::builtin::arg_count(func_id) as usize;
+
+    let args: Vec<&ExprKind> = func
+        .param_assignment
+        .iter()
+        .filter_map(|p| match p {
+            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
+            _ => None,
+        })
+        .collect();
+
+    if args.len() != expected_args {
+        return Err(Diagnostic::todo_with_span(
+            func.name.span(),
+            file!(),
+            line!(),
+        ));
+    }
+
+    for arg in &args {
+        compile_expr(emitter, ctx, arg, op_type)?;
+    }
+
+    emitter.emit_builtin(func_id);
+    Ok(())
+}
+
+/// Compiles a bit shift or rotate function call (SHL, SHR, ROL, ROR).
+///
+/// Expects two positional arguments: IN (value) and N (shift count).
+/// Emits the appropriate BUILTIN opcode based on function name and operand width.
+/// For ROL/ROR on narrow types (BYTE, WORD), emits width-specific builtins
+/// to ensure bits wrap correctly within the narrow type.
+fn compile_shift_rotate(
+    emitter: &mut Emitter,
+    ctx: &mut CompileContext,
+    func: &Function,
+    op_type: OpType,
+    name: &str,
+) -> Result<(), Diagnostic> {
+    let args: Vec<&ExprKind> = func
+        .param_assignment
+        .iter()
+        .filter_map(|p| match p {
+            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
+            _ => None,
+        })
+        .collect();
+
+    if args.len() != 2 {
+        return Err(Diagnostic::todo_with_span(
+            func.name.span(),
+            file!(),
+            line!(),
+        ));
+    }
+
+    // Compile IN (value) with the inferred op_type
+    compile_expr(emitter, ctx, args[0], op_type)?;
+    // Compile N (shift count) — always as i32 for W32, i64 for W64
+    let n_op_type = match op_type.0 {
+        OpWidth::W64 => (OpWidth::W64, Signedness::Signed),
+        _ => DEFAULT_OP_TYPE,
+    };
+    compile_expr(emitter, ctx, args[1], n_op_type)?;
+
+    // Determine storage bits for narrow-type ROL/ROR selection
+    let storage_bits = infer_storage_bits(ctx, args[0]);
+
+    let func_id = match (name, op_type.0) {
+        ("shl", OpWidth::W64) => opcode::builtin::SHL_I64,
+        ("shl", _) => opcode::builtin::SHL_I32,
+        ("shr", OpWidth::W64) => opcode::builtin::SHR_I64,
+        ("shr", _) => opcode::builtin::SHR_I32,
+        ("rol", OpWidth::W64) => opcode::builtin::ROL_I64,
+        ("rol", _) => match storage_bits {
+            Some(8) => opcode::builtin::ROL_U8,
+            Some(16) => opcode::builtin::ROL_U16,
+            _ => opcode::builtin::ROL_I32,
+        },
+        ("ror", OpWidth::W64) => opcode::builtin::ROR_I64,
+        ("ror", _) => match storage_bits {
+            Some(8) => opcode::builtin::ROR_U8,
+            Some(16) => opcode::builtin::ROR_U16,
+            _ => opcode::builtin::ROR_I32,
+        },
+        _ => {
+            return Err(Diagnostic::todo_with_span(
+                func.name.span(),
+                file!(),
+                line!(),
+            ))
+        }
+    };
+
+    emitter.emit_builtin(func_id);
+    Ok(())
 }
 
 /// Compiles a constant literal, pushing it onto the stack.

--- a/compiler/codegen/tests/compile_shift.rs
+++ b/compiler/codegen/tests/compile_shift.rs
@@ -1,0 +1,140 @@
+//! Bytecode-level integration tests for shift/rotate function compilation.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_shl_byte_then_produces_shl_i32_builtin() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#0F;
+  y := SHL(x, 4);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    assert_eq!(container.header.num_variables, 2);
+
+    // x := BYTE#16#0F: LOAD_CONST_I32 pool:0, TRUNC_U8, STORE_VAR_I32 var:0
+    // y := SHL(x, 4):  LOAD_VAR_I32 var:0, LOAD_CONST_I32 pool:1, BUILTIN SHL_I32, TRUNC_U8, STORE_VAR_I32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x0F)
+            0x21, // TRUNC_U8
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (4)
+            0xC4, 0x48, 0x03, // BUILTIN SHL_I32 (0x0348)
+            0x21, // TRUNC_U8
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_rol_byte_then_produces_rol_u8_builtin() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#81;
+  y := ROL(x, 1);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    // Verify the ROL on BYTE emits ROL_U8 (0x0350), not ROL_I32
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x81)
+            0x21, // TRUNC_U8
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
+            0xC4, 0x50, 0x03, // BUILTIN ROL_U8 (0x0350)
+            0x21, // TRUNC_U8
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_ror_word_then_produces_ror_u16_builtin() {
+    let source = "
+PROGRAM main
+  VAR
+    x : WORD;
+    y : WORD;
+  END_VAR
+  x := WORD#16#8001;
+  y := ROR(x, 1);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    // Verify the ROR on WORD emits ROR_U16 (0x0353)
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x8001)
+            0x23, // TRUNC_U16
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
+            0xC4, 0x53, 0x03, // BUILTIN ROR_U16 (0x0353)
+            0x23, // TRUNC_U16
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_shl_dword_then_produces_shl_i32_without_trunc() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DWORD;
+  END_VAR
+  x := DWORD#16#0F;
+  y := SHL(x, 4);
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    // DWORD is 32-bit so no TRUNC needed
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x0F)
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (4)
+            0xC4, 0x48, 0x03, // BUILTIN SHL_I32 (0x0348)
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/end_to_end_shift.rs
+++ b/compiler/codegen/tests/end_to_end_shift.rs
@@ -1,0 +1,222 @@
+//! End-to-end integration tests for bit shift/rotate functions (SHL, SHR, ROL, ROR).
+
+mod common;
+
+use common::parse_and_run;
+
+// --- SHL ---
+
+#[test]
+fn end_to_end_when_shl_byte_then_shifts_left() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#0F;
+  y := SHL(x, 4);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x0F);
+    assert_eq!(bufs.vars[1].as_i32(), 0xF0);
+}
+
+#[test]
+fn end_to_end_when_shl_dword_then_shifts_left() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DWORD;
+  END_VAR
+  x := DWORD#16#0000_000F;
+  y := SHL(x, 16);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x0F);
+    assert_eq!(bufs.vars[1].as_i32(), 0x000F_0000_u32 as i32);
+}
+
+#[test]
+fn end_to_end_when_shl_lword_then_shifts_left_64bit() {
+    let source = "
+PROGRAM main
+  VAR
+    x : LWORD;
+    y : LWORD;
+  END_VAR
+  x := LWORD#16#01;
+  y := SHL(x, 32);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i64(), 0x01);
+    assert_eq!(bufs.vars[1].as_i64(), 0x1_0000_0000);
+}
+
+// --- SHR ---
+
+#[test]
+fn end_to_end_when_shr_word_then_shifts_right() {
+    let source = "
+PROGRAM main
+  VAR
+    x : WORD;
+    y : WORD;
+  END_VAR
+  x := WORD#16#FF00;
+  y := SHR(x, 8);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0xFF00);
+    assert_eq!(bufs.vars[1].as_i32(), 0x00FF);
+}
+
+#[test]
+fn end_to_end_when_shr_byte_then_shifts_right() {
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#F0;
+  y := SHR(x, 4);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0xF0);
+    assert_eq!(bufs.vars[1].as_i32(), 0x0F);
+}
+
+// --- ROL ---
+
+#[test]
+fn end_to_end_when_rol_byte_then_rotates_within_8_bits() {
+    // ROL(BYTE#16#81, 1) should give 0x03 (bit 7 wraps to bit 0 within 8 bits)
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#81;
+  y := ROL(x, 1);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x81);
+    assert_eq!(bufs.vars[1].as_i32(), 0x03);
+}
+
+#[test]
+fn end_to_end_when_rol_word_then_rotates_within_16_bits() {
+    // ROL(WORD#16#8001, 1) = 0x0003
+    let source = "
+PROGRAM main
+  VAR
+    x : WORD;
+    y : WORD;
+  END_VAR
+  x := WORD#16#8001;
+  y := ROL(x, 1);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x8001);
+    assert_eq!(bufs.vars[1].as_i32(), 0x0003);
+}
+
+#[test]
+fn end_to_end_when_rol_dword_then_rotates_left() {
+    // ROL(DWORD#16#80000001, 1) = 0x00000003
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DWORD;
+  END_VAR
+  x := DWORD#16#80000001;
+  y := ROL(x, 1);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x80000001_u32 as i32);
+    assert_eq!(bufs.vars[1].as_i32(), 0x00000003);
+}
+
+// --- ROR ---
+
+#[test]
+fn end_to_end_when_ror_dword_then_rotates_right() {
+    // ROR(DWORD#16#00000001, 1) = 0x80000000 (bit 0 wraps to bit 31)
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DWORD;
+  END_VAR
+  x := DWORD#16#00000001;
+  y := ROR(x, 1);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x01);
+    assert_eq!(bufs.vars[1].as_i32(), 0x80000000_u32 as i32);
+}
+
+#[test]
+fn end_to_end_when_ror_byte_then_rotates_within_8_bits() {
+    // ROR(BYTE#16#01, 1) = 0x80 (bit 0 wraps to bit 7 within 8 bits)
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#01;
+  y := ROR(x, 1);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0x01);
+    assert_eq!(bufs.vars[1].as_i32(), 0x80);
+}
+
+#[test]
+fn end_to_end_when_shl_byte_overflow_then_truncates() {
+    // SHL(BYTE#16#FF, 4) = 0xF0 (shifted to 0xFF0, truncated to u8 = 0xF0)
+    let source = "
+PROGRAM main
+  VAR
+    x : BYTE;
+    y : BYTE;
+  END_VAR
+  x := BYTE#16#FF;
+  y := SHL(x, 4);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[0].as_i32(), 0xFF);
+    assert_eq!(bufs.vars[1].as_i32(), 0xF0);
+}
+
+#[test]
+fn end_to_end_when_shl_with_zero_shift_then_unchanged() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DWORD;
+  END_VAR
+  x := DWORD#16#DEADBEEF;
+  y := SHL(x, 0);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+    assert_eq!(bufs.vars[1].as_i32(), bufs.vars[0].as_i32());
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -423,6 +423,42 @@ pub mod builtin {
     /// SEL for 32-bit integers: pops in1, in0, g, pushes in0 if g==0 else in1.
     pub const SEL_I32: u16 = 0x0347;
 
+    /// SHL for 32-bit: pops shift count (n) and value (a), pushes a << n.
+    pub const SHL_I32: u16 = 0x0348;
+
+    /// SHL for 64-bit: pops shift count (n) and value (a), pushes a << n.
+    pub const SHL_I64: u16 = 0x0349;
+
+    /// SHR for 32-bit: pops shift count (n) and value (a), pushes a >> n (logical).
+    pub const SHR_I32: u16 = 0x034A;
+
+    /// SHR for 64-bit: pops shift count (n) and value (a), pushes a >> n (logical).
+    pub const SHR_I64: u16 = 0x034B;
+
+    /// ROL for 32-bit: pops shift count (n) and value (a), pushes a.rotate_left(n).
+    pub const ROL_I32: u16 = 0x034C;
+
+    /// ROL for 64-bit: pops shift count (n) and value (a), pushes a.rotate_left(n).
+    pub const ROL_I64: u16 = 0x034D;
+
+    /// ROR for 32-bit: pops shift count (n) and value (a), pushes a.rotate_right(n).
+    pub const ROR_I32: u16 = 0x034E;
+
+    /// ROR for 64-bit: pops shift count (n) and value (a), pushes a.rotate_right(n).
+    pub const ROR_I64: u16 = 0x034F;
+
+    /// ROL for 8-bit (BYTE): narrow rotate within 8 bits.
+    pub const ROL_U8: u16 = 0x0350;
+
+    /// ROL for 16-bit (WORD): narrow rotate within 16 bits.
+    pub const ROL_U16: u16 = 0x0351;
+
+    /// ROR for 8-bit (BYTE): narrow rotate within 8 bits.
+    pub const ROR_U8: u16 = 0x0352;
+
+    /// ROR for 16-bit (WORD): narrow rotate within 16 bits.
+    pub const ROR_U16: u16 = 0x0353;
+
     /// Returns the number of arguments a built-in function pops from the stack.
     ///
     /// This is the single source of truth for argument counts, used by both
@@ -435,6 +471,8 @@ pub mod builtin {
             ABS_I32 => 1,
             EXPT_I32 | EXPT_F32 | EXPT_F64 | MIN_I32 | MAX_I32 => 2,
             LIMIT_I32 | SEL_I32 => 3,
+            SHL_I32 | SHL_I64 | SHR_I32 | SHR_I64 | ROL_I32 | ROL_I64 | ROR_I32 | ROR_I64
+            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 => 2,
             _ => panic!("unknown builtin function ID: 0x{:04X}", func_id),
         }
     }

--- a/compiler/plc2x/src/disassemble.rs
+++ b/compiler/plc2x/src/disassemble.rs
@@ -467,6 +467,18 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                     opcode::builtin::MAX_I32 => format!("MAX_I32 (0x{:04X})", func_id),
                     opcode::builtin::LIMIT_I32 => format!("LIMIT_I32 (0x{:04X})", func_id),
                     opcode::builtin::SEL_I32 => format!("SEL_I32 (0x{:04X})", func_id),
+                    opcode::builtin::SHL_I32 => format!("SHL_I32 (0x{:04X})", func_id),
+                    opcode::builtin::SHL_I64 => format!("SHL_I64 (0x{:04X})", func_id),
+                    opcode::builtin::SHR_I32 => format!("SHR_I32 (0x{:04X})", func_id),
+                    opcode::builtin::SHR_I64 => format!("SHR_I64 (0x{:04X})", func_id),
+                    opcode::builtin::ROL_I32 => format!("ROL_I32 (0x{:04X})", func_id),
+                    opcode::builtin::ROL_I64 => format!("ROL_I64 (0x{:04X})", func_id),
+                    opcode::builtin::ROR_I32 => format!("ROR_I32 (0x{:04X})", func_id),
+                    opcode::builtin::ROR_I64 => format!("ROR_I64 (0x{:04X})", func_id),
+                    opcode::builtin::ROL_U8 => format!("ROL_U8 (0x{:04X})", func_id),
+                    opcode::builtin::ROL_U16 => format!("ROL_U16 (0x{:04X})", func_id),
+                    opcode::builtin::ROR_U8 => format!("ROR_U8 (0x{:04X})", func_id),
+                    opcode::builtin::ROR_U16 => format!("ROR_U16 (0x{:04X})", func_id),
                     _ => format!("0x{:04X}", func_id),
                 };
                 instructions.push(json!({

--- a/compiler/vm/src/builtin.rs
+++ b/compiler/vm/src/builtin.rs
@@ -68,6 +68,79 @@ pub fn dispatch(func_id: u16, stack: &mut OperandStack) -> Result<(), Trap> {
             stack.push(Slot::from_i32(if g == 0 { in0 } else { in1 }))?;
             Ok(())
         }
+        opcode::builtin::SHL_I32 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32();
+            stack.push(Slot::from_i32(a.wrapping_shl(n as u32)))?;
+            Ok(())
+        }
+        opcode::builtin::SHL_I64 => {
+            let n = stack.pop()?.as_i64();
+            let a = stack.pop()?.as_i64();
+            stack.push(Slot::from_i64(a.wrapping_shl(n as u32)))?;
+            Ok(())
+        }
+        opcode::builtin::SHR_I32 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32();
+            // Logical shift right: treat as unsigned to fill with zeros.
+            stack.push(Slot::from_i32(((a as u32).wrapping_shr(n as u32)) as i32))?;
+            Ok(())
+        }
+        opcode::builtin::SHR_I64 => {
+            let n = stack.pop()?.as_i64();
+            let a = stack.pop()?.as_i64();
+            stack.push(Slot::from_i64(((a as u64).wrapping_shr(n as u32)) as i64))?;
+            Ok(())
+        }
+        opcode::builtin::ROL_I32 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32();
+            stack.push(Slot::from_i32((a as u32).rotate_left(n as u32) as i32))?;
+            Ok(())
+        }
+        opcode::builtin::ROL_I64 => {
+            let n = stack.pop()?.as_i64();
+            let a = stack.pop()?.as_i64();
+            stack.push(Slot::from_i64((a as u64).rotate_left(n as u32) as i64))?;
+            Ok(())
+        }
+        opcode::builtin::ROR_I32 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32();
+            stack.push(Slot::from_i32((a as u32).rotate_right(n as u32) as i32))?;
+            Ok(())
+        }
+        opcode::builtin::ROR_I64 => {
+            let n = stack.pop()?.as_i64();
+            let a = stack.pop()?.as_i64();
+            stack.push(Slot::from_i64((a as u64).rotate_right(n as u32) as i64))?;
+            Ok(())
+        }
+        opcode::builtin::ROL_U8 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32() as u8;
+            stack.push(Slot::from_i32(a.rotate_left(n as u32) as i32))?;
+            Ok(())
+        }
+        opcode::builtin::ROL_U16 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32() as u16;
+            stack.push(Slot::from_i32(a.rotate_left(n as u32) as i32))?;
+            Ok(())
+        }
+        opcode::builtin::ROR_U8 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32() as u8;
+            stack.push(Slot::from_i32(a.rotate_right(n as u32) as i32))?;
+            Ok(())
+        }
+        opcode::builtin::ROR_U16 => {
+            let n = stack.pop()?.as_i32();
+            let a = stack.pop()?.as_i32() as u16;
+            stack.push(Slot::from_i32(a.rotate_right(n as u32) as i32))?;
+            Ok(())
+        }
         _ => Err(Trap::InvalidBuiltinFunction(func_id)),
     }
 }

--- a/compiler/vm/tests/execute_builtin_shift.rs
+++ b/compiler/vm/tests/execute_builtin_shift.rs
@@ -1,0 +1,420 @@
+//! Integration tests for the BUILTIN shift/rotate opcodes
+//! (SHL, SHR, ROL, ROR) at the VM level.
+
+mod common;
+
+use common::{single_function_container, VmBuffers};
+use ironplc_container::ContainerBuilder;
+use ironplc_vm::Vm;
+
+// --- SHL_I32 ---
+
+#[test]
+fn execute_when_shl_i32_then_shifts_left() {
+    // SHL(0x0F, 4) = 0xF0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x0F)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (4)
+        0xC4, 0x48, 0x03,  // BUILTIN SHL_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x0F, 4]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0xF0);
+}
+
+// --- SHL_I64 ---
+
+#[test]
+fn execute_when_shl_i64_then_shifts_left() {
+    // SHL(0x01_i64, 32) = 0x1_0000_0000
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (1)
+        0x02, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (32)
+        0xC4, 0x49, 0x03,  // BUILTIN SHL_I64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(1)
+        .add_i64_constant(32)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    vm.stop();
+    assert_eq!(b.vars[0].as_i64(), 0x1_0000_0000);
+}
+
+// --- SHR_I32 ---
+
+#[test]
+fn execute_when_shr_i32_then_shifts_right_logical() {
+    // SHR(0xF0, 4) = 0x0F
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0xF0)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (4)
+        0xC4, 0x4A, 0x03,  // BUILTIN SHR_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0xF0, 4]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0x0F);
+}
+
+#[test]
+fn execute_when_shr_i32_high_bit_set_then_logical_shift() {
+    // SHR(0x80000000, 1) = 0x40000000 (logical, not arithmetic)
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x80000000 as i32 = i32::MIN)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (1)
+        0xC4, 0x4A, 0x03,  // BUILTIN SHR_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[i32::MIN, 1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0x40000000);
+}
+
+// --- SHR_I64 ---
+
+#[test]
+fn execute_when_shr_i64_then_shifts_right() {
+    // SHR(0xFF00_i64, 8) = 0xFF
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0xFF00)
+        0x02, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (8)
+        0xC4, 0x4B, 0x03,  // BUILTIN SHR_I64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(0xFF00)
+        .add_i64_constant(8)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    vm.stop();
+    assert_eq!(b.vars[0].as_i64(), 0xFF);
+}
+
+// --- ROL_I32 ---
+
+#[test]
+fn execute_when_rol_i32_then_rotates_left() {
+    // ROL(0x80000001_u32, 1) = 0x00000003
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x80000001 as i32)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (1)
+        0xC4, 0x4C, 0x03,  // BUILTIN ROL_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x80000001_u32 as i32, 1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0x00000003);
+}
+
+// --- ROL_I64 ---
+
+#[test]
+fn execute_when_rol_i64_then_rotates_left() {
+    // ROL(0x8000_0000_0000_0001_u64, 1) = 0x0000_0000_0000_0003
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0]
+        0x02, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (1)
+        0xC4, 0x4D, 0x03,  // BUILTIN ROL_I64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(0x8000_0000_0000_0001_u64 as i64)
+        .add_i64_constant(1)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    vm.stop();
+    assert_eq!(b.vars[0].as_i64(), 0x0000_0000_0000_0003);
+}
+
+// --- ROR_I32 ---
+
+#[test]
+fn execute_when_ror_i32_then_rotates_right() {
+    // ROR(0x80000001_u32, 1) = 0xC0000000
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x80000001 as i32)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (1)
+        0xC4, 0x4E, 0x03,  // BUILTIN ROR_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x80000001_u32 as i32, 1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0xC0000000_u32 as i32);
+}
+
+// --- ROR_I64 ---
+
+#[test]
+fn execute_when_ror_i64_then_rotates_right() {
+    // ROR(0x0000_0000_0000_0001_u64, 1) = 0x8000_0000_0000_0000
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (1)
+        0x02, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (1)
+        0xC4, 0x4F, 0x03,  // BUILTIN ROR_I64
+        0x19, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = ContainerBuilder::new()
+        .num_variables(1)
+        .add_i64_constant(1)
+        .add_i64_constant(1)
+        .add_function(0, &bytecode, 16, 1)
+        .build();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    vm.stop();
+    assert_eq!(b.vars[0].as_i64(), i64::MIN); // 0x8000_0000_0000_0000
+}
+
+// --- ROL_U8 (narrow 8-bit rotate) ---
+
+#[test]
+fn execute_when_rol_u8_then_rotates_within_8_bits() {
+    // ROL(0x81_u8, 1) = 0x03 (bit 7 wraps to bit 0)
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x81)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (1)
+        0xC4, 0x50, 0x03,  // BUILTIN ROL_U8
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x81, 1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0x03);
+}
+
+// --- ROL_U16 (narrow 16-bit rotate) ---
+
+#[test]
+fn execute_when_rol_u16_then_rotates_within_16_bits() {
+    // ROL(0x8001_u16, 1) = 0x0003
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x8001)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (1)
+        0xC4, 0x51, 0x03,  // BUILTIN ROL_U16
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x8001, 1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0x0003);
+}
+
+// --- ROR_U8 (narrow 8-bit rotate) ---
+
+#[test]
+fn execute_when_ror_u8_then_rotates_within_8_bits() {
+    // ROR(0x81_u8, 1) = 0xC0 (bit 0 wraps to bit 7)
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x81)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (1)
+        0xC4, 0x52, 0x03,  // BUILTIN ROR_U8
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x81, 1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0xC0);
+}
+
+// --- ROR_U16 (narrow 16-bit rotate) ---
+
+#[test]
+fn execute_when_ror_u16_then_rotates_within_16_bits() {
+    // ROR(0x8001_u16, 1) = 0xC000
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x8001)
+        0x01, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (1)
+        0xC4, 0x53, 0x03,  // BUILTIN ROR_U16
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0x8001, 1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0xC000);
+}


### PR DESCRIPTION
…ypes

Implement IEC 61131-3 standard library functions SHL, SHR, ROL, and ROR for BYTE, WORD, DWORD, and LWORD types. Uses width-aware builtin opcodes with narrow-type variants (ROL_U8, ROL_U16, ROR_U8, ROR_U16) to ensure correct bit wrapping within 8-bit and 16-bit rotates.