### PR TITLE
Add 32-bit bitwise NOT (NOT_I32) across codegen and runtime

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -8,6 +8,7 @@
 //! - Assignment statements
 //! - Integer literal constants
 //! - Binary Add, Sub, Mul, Div, and Mod operators
+//! - Unary Not operator (Boolean / bitwise NOT)
 //! - Variable references (named symbolic variables)
 
 use std::collections::HashMap;
@@ -274,11 +275,11 @@ fn compile_expr(
                     ))
                 }
             }
-            _ => Err(Diagnostic::todo_with_span(
-                expr_span(&unary.term),
-                file!(),
-                line!(),
-            )),
+            UnaryOp::Not => {
+                compile_expr(emitter, ctx, &unary.term)?;
+                emitter.emit_not_i32();
+                Ok(())
+            }
         },
         ExprKind::LateBound(late_bound) => {
             // LateBound values are unresolved identifiers from the parser.

--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -76,6 +76,12 @@ impl Emitter {
         self.pop_stack(1);
     }
 
+    /// Emits NOT_I32 (pops one, pushes one).
+    pub fn emit_not_i32(&mut self) {
+        self.bytecode.push(opcode::NOT_I32);
+        // Net effect: pop 1, push 1 = no change
+    }
+
     /// Emits RET_VOID.
     pub fn emit_ret_void(&mut self) {
         self.bytecode.push(opcode::RET_VOID);
@@ -235,6 +241,26 @@ mod tests {
         em.emit_store_var_i32(1); // stack: 0
 
         assert_eq!(em.max_stack_depth(), 2);
+    }
+
+    #[test]
+    fn emitter_when_not_then_correct_bytecode() {
+        let mut em = Emitter::new();
+        em.emit_load_const_i32(0);
+        em.emit_not_i32();
+
+        assert_eq!(em.bytecode(), &[0x01, 0x00, 0x00, 0x40]);
+    }
+
+    #[test]
+    fn emitter_when_not_then_tracks_stack_depth() {
+        let mut em = Emitter::new();
+        // y := NOT x
+        em.emit_load_var_i32(0); // stack: 1
+        em.emit_not_i32(); // stack: 1 (pop 1, push 1)
+        em.emit_store_var_i32(1); // stack: 0
+
+        assert_eq!(em.max_stack_depth(), 1);
     }
 
     #[test]

--- a/compiler/codegen/tests/compile_not.rs
+++ b/compiler/codegen/tests/compile_not.rs
@@ -1,0 +1,70 @@
+//! Bytecode-level integration tests for the NOT operator compilation.
+
+mod common;
+
+use common::parse;
+use ironplc_codegen::compile;
+
+#[test]
+fn compile_when_not_expression_then_produces_not_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 10;
+  y := NOT x;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    assert_eq!(container.header.num_variables, 2);
+    assert_eq!(container.constant_pool.get_i32(0).unwrap(), 10);
+
+    // x := 10: LOAD_CONST_I32 pool:0, STORE_VAR_I32 var:0
+    // y := NOT x: LOAD_VAR_I32 var:0, NOT_I32, STORE_VAR_I32 var:1
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+            0x40, // NOT_I32
+            0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
+            0xB5, // RET_VOID
+        ]
+    );
+}
+
+#[test]
+fn compile_when_not_constant_then_produces_not_bytecode() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+  END_VAR
+  x := NOT 0;
+END_PROGRAM
+";
+    let library = parse(source);
+    let container = compile(&library).unwrap();
+
+    assert_eq!(container.constant_pool.get_i32(0).unwrap(), 0);
+
+    // x := NOT 0: LOAD_CONST_I32 pool:0, NOT_I32, STORE_VAR_I32 var:0
+    // RET_VOID
+    let bytecode = container.code.get_function_bytecode(0).unwrap();
+    assert_eq!(
+        bytecode,
+        &[
+            0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
+            0x40, // NOT_I32
+            0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
+            0xB5, // RET_VOID
+        ]
+    );
+}

--- a/compiler/codegen/tests/end_to_end.rs
+++ b/compiler/codegen/tests/end_to_end.rs
@@ -9,6 +9,7 @@
 //! - end_to_end_mul.rs (MUL operator)
 //! - end_to_end_div.rs (DIV operator)
 //! - end_to_end_mod.rs (MOD operator)
+//! - end_to_end_not.rs (NOT operator)
 
 mod common;
 

--- a/compiler/codegen/tests/end_to_end_not.rs
+++ b/compiler/codegen/tests/end_to_end_not.rs
@@ -1,0 +1,42 @@
+//! End-to-end integration tests for the NOT operator.
+
+mod common;
+
+use common::parse_and_run;
+
+#[test]
+fn end_to_end_when_not_zero_then_all_ones() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 0;
+  y := NOT x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 0);
+    assert_eq!(bufs.vars[1].as_i32(), -1);
+}
+
+#[test]
+fn end_to_end_when_not_positive_then_complement() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT;
+    y : INT;
+  END_VAR
+  x := 1;
+  y := NOT x;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source);
+
+    assert_eq!(bufs.vars[0].as_i32(), 1);
+    // NOT 1 = -2 (bitwise complement)
+    assert_eq!(bufs.vars[1].as_i32(), -2);
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -34,5 +34,9 @@ pub const DIV_I32: u8 = 0x33;
 /// Traps on division by zero.
 pub const MOD_I32: u8 = 0x34;
 
+/// Bitwise NOT of a 32-bit integer.
+/// Pops one value, pushes its bitwise complement.
+pub const NOT_I32: u8 = 0x40;
+
 /// Return from the current function (void return).
 pub const RET_VOID: u8 = 0xB5;

--- a/compiler/plc2x/src/disassemble.rs
+++ b/compiler/plc2x/src/disassemble.rs
@@ -21,6 +21,7 @@ const SUB_I32: u8 = 0x31;
 const MUL_I32: u8 = 0x32;
 const DIV_I32: u8 = 0x33;
 const MOD_I32: u8 = 0x34;
+const NOT_I32: u8 = 0x40;
 const RET_VOID: u8 = 0xB5;
 
 /// Disassembles a bytecode container into a structured JSON value.
@@ -324,6 +325,15 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                 instructions.push(json!({
                     "offset": offset,
                     "opcode": "MOD_I32",
+                    "operands": "",
+                    "comment": "",
+                }));
+                pc += 1;
+            }
+            NOT_I32 => {
+                instructions.push(json!({
+                    "offset": offset,
+                    "opcode": "NOT_I32",
                     "operands": "",
                     "comment": "",
                 }));

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -408,6 +408,10 @@ fn execute(
                 }
                 stack.push(Slot::from_i32(a.wrapping_rem(b)))?;
             }
+            opcode::NOT_I32 => {
+                let a = stack.pop()?.as_i32();
+                stack.push(Slot::from_i32(!a))?;
+            }
             opcode::RET_VOID => {
                 return Ok(());
             }

--- a/compiler/vm/tests/execute_not_i32.rs
+++ b/compiler/vm/tests/execute_not_i32.rs
@@ -1,0 +1,115 @@
+//! Integration tests for the NOT_I32 opcode.
+
+mod common;
+
+use common::{single_function_container, VmBuffers};
+use ironplc_vm::Vm;
+
+#[test]
+fn execute_when_not_i32_zero_then_all_ones() {
+    // NOT 0 = -1 (all bits set)
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0)
+        0x40,              // NOT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[0]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), -1);
+}
+
+#[test]
+fn execute_when_not_i32_all_ones_then_zero() {
+    // NOT -1 = 0
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (-1)
+        0x40,              // NOT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[-1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 0);
+}
+
+#[test]
+fn execute_when_not_i32_positive_then_complement() {
+    // NOT 1 = -2 (bitwise complement)
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (1)
+        0x40,              // NOT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[1]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), -2);
+}
+
+#[test]
+fn execute_when_not_i32_double_then_identity() {
+    // NOT (NOT x) = x
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x01, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (42)
+        0x40,              // NOT_I32
+        0x40,              // NOT_I32
+        0x18, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+        0xB5,              // RET_VOID
+    ];
+    let c = single_function_container(&bytecode, 1, &[42]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = Vm::new()
+        .load(
+            &c,
+            &mut b.stack,
+            &mut b.vars,
+            &mut b.tasks,
+            &mut b.programs,
+            &mut b.ready,
+        )
+        .start();
+
+    vm.run_round(0).unwrap();
+    assert_eq!(vm.read_variable(0).unwrap(), 42);
+}


### PR DESCRIPTION
Implement the NOT opcode as a unary operator that performs bitwise complement on 32-bit integers. This follows the same pattern as the existing arithmetic opcodes (ADD, SUB, MUL, DIV, MOD).

Changes span the full pipeline:
- container: define NOT_I32 opcode constant (0x40)
- codegen/emit: emit NOT_I32 bytecode (pop one, push one)
- codegen/compile: handle UnaryOp::Not in expression compilation
- vm: execute NOT_I32 as bitwise complement (!a)
- disassembler: decode NOT_I32 in bytecode viewer

https://claude.ai/code/session_01MV3mZJaRBHvzT9f5wEKzZA