### PR TITLE
Wrap ExprKind in Expr struct to prepare for expression type resolution

### DIFF
--- a/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
@@ -173,9 +173,10 @@ impl Fold<Diagnostic> for DeclarationResolver<'_> {
             ExprKind::UnaryOp(node) => node
                 .recurse_fold(self)
                 .map(|v| Ok(ExprKind::UnaryOp(Box::new(v))))?,
-            ExprKind::Expression(node) => node
-                .recurse_fold(self)
-                .map(|v| Ok(ExprKind::Expression(Box::new(v))))?,
+            ExprKind::Expression(node) => {
+                let folded = self.fold_expr(*node)?;
+                Ok(ExprKind::Expression(Box::new(folded)))
+            }
             ExprKind::Const(node) => node
                 .recurse_fold(self)
                 .map(|v: ConstantKind| Ok(ExprKind::Const(v)))?,

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -43,8 +43,8 @@ use ironplc_dsl::common::{
 use ironplc_dsl::core::{FileId, Id, Located};
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::textual::{
-    CaseSelectionKind, CompareOp, ExprKind, Function, Operator, ParamAssignmentKind, Statements,
-    StmtKind, SymbolicVariableKind, UnaryOp, Variable,
+    CaseSelectionKind, CompareOp, Expr, ExprKind, Function, Operator, ParamAssignmentKind,
+    Statements, StmtKind, SymbolicVariableKind, UnaryOp, Variable,
 };
 use ironplc_problems::Problem;
 
@@ -368,8 +368,8 @@ fn resolve_type_name(name: &Id) -> Option<VarTypeInfo> {
 /// IEC 61131-3 requires homogeneous operand types, so any variable in the expression
 /// determines the operation type. For expressions without variables (pure constants),
 /// returns the default `(W32, Signed)`.
-fn infer_op_type(ctx: &CompileContext, expr: &ExprKind) -> OpType {
-    match expr {
+fn infer_op_type(ctx: &CompileContext, expr: &Expr) -> OpType {
+    match &expr.kind {
         ExprKind::Variable(variable) => {
             if let Variable::Symbolic(SymbolicVariableKind::Named(named)) = variable {
                 return ctx.var_op_type(&named.name);
@@ -417,8 +417,8 @@ fn infer_op_type(ctx: &CompileContext, expr: &ExprKind) -> OpType {
 /// Used after BIT_NOT to emit the correct truncation opcode for narrow types
 /// (BYTE needs TRUNC_U8, WORD needs TRUNC_U16). Returns `None` if no variable
 /// reference is found.
-fn infer_storage_bits(ctx: &CompileContext, expr: &ExprKind) -> Option<u8> {
-    match expr {
+fn infer_storage_bits(ctx: &CompileContext, expr: &Expr) -> Option<u8> {
+    match &expr.kind {
         ExprKind::Variable(variable) => {
             if let Variable::Symbolic(SymbolicVariableKind::Named(named)) = variable {
                 return ctx.var_type_info(&named.name).map(|ti| ti.storage_bits);
@@ -661,7 +661,7 @@ fn compile_case(
 fn compile_case_selector(
     emitter: &mut Emitter,
     ctx: &mut CompileContext,
-    selector_expr: &ExprKind,
+    selector_expr: &Expr,
     selection: &CaseSelectionKind,
     op_type: OpType,
 ) -> Result<(), Diagnostic> {
@@ -818,8 +818,8 @@ enum StepSign {
 /// Inspects an expression and returns its sign if it is a compile-time constant
 /// integer literal (positive or negative). Returns `None` for non-constant
 /// expressions.
-fn try_constant_sign(expr: &ExprKind) -> Option<StepSign> {
-    match expr {
+fn try_constant_sign(expr: &Expr) -> Option<StepSign> {
+    match &expr.kind {
         ExprKind::Const(ConstantKind::IntegerLiteral(lit)) => {
             if lit.value.is_neg {
                 Some(StepSign::Negative)
@@ -830,7 +830,7 @@ fn try_constant_sign(expr: &ExprKind) -> Option<StepSign> {
         ExprKind::UnaryOp(unary) if unary.op == UnaryOp::Neg => {
             // -<literal> is negative
             if matches!(
-                &unary.term,
+                &unary.term.kind,
                 ExprKind::Const(ConstantKind::IntegerLiteral(_))
             ) {
                 Some(StepSign::Negative)
@@ -1003,10 +1003,10 @@ fn lookup_builtin(name: &str, op_width: OpWidth) -> Option<u16> {
 fn compile_expr(
     emitter: &mut Emitter,
     ctx: &mut CompileContext,
-    expr: &ExprKind,
+    expr: &Expr,
     op_type: OpType,
 ) -> Result<(), Diagnostic> {
-    match expr {
+    match &expr.kind {
         ExprKind::Const(constant) => compile_constant(emitter, ctx, constant, op_type),
         ExprKind::Variable(variable) => {
             let var_index = resolve_variable(ctx, variable)?;
@@ -1030,7 +1030,7 @@ fn compile_expr(
             UnaryOp::Neg => {
                 // Constant folding: if the operand is an integer literal,
                 // emit the negated constant directly.
-                if let ExprKind::Const(ConstantKind::IntegerLiteral(lit)) = &unary.term {
+                if let ExprKind::Const(ConstantKind::IntegerLiteral(lit)) = &unary.term.kind {
                     let unsigned = lit.value.value.value as i128;
                     let signed = -unsigned;
                     match op_type.0 {
@@ -1157,7 +1157,7 @@ fn compile_generic_builtin(
 
     let expected_args = opcode::builtin::arg_count(func_id) as usize;
 
-    let args: Vec<&ExprKind> = func
+    let args: Vec<&Expr> = func
         .param_assignment
         .iter()
         .filter_map(|p| match p {
@@ -1203,7 +1203,7 @@ fn compile_shift_rotate(
     op_type: OpType,
     name: &str,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&ExprKind> = func
+    let args: Vec<&Expr> = func
         .param_assignment
         .iter()
         .filter_map(|p| match p {

--- a/compiler/dsl/src/fold.rs
+++ b/compiler/dsl/src/fold.rs
@@ -318,6 +318,8 @@ pub trait Fold<E> {
 
     dispatch!(LateBound);
 
+    dispatch!(Expr);
+
     dispatch!(ExprKind);
 
     // 3.3.2.1

--- a/compiler/dsl/src/sfc.rs
+++ b/compiler/dsl/src/sfc.rs
@@ -33,6 +33,7 @@ pub struct Network {
 ///
 /// See section 2.6.2.
 #[derive(Debug, PartialEq, Clone, Recurse)]
+#[allow(clippy::large_enum_variant)]
 pub enum ElementKind {
     Step(Step),
     Transition(Transition),
@@ -53,7 +54,7 @@ impl ElementKind {
             priority: None,
             from: vec![Id::from(from)],
             to: vec![Id::from(to)],
-            condition,
+            condition: Expr::new(condition),
         })
     }
 
@@ -84,7 +85,7 @@ pub struct Transition {
     pub priority: Option<u32>,
     pub from: Vec<Id>,
     pub to: Vec<Id>,
-    pub condition: ExprKind,
+    pub condition: Expr,
 }
 
 /// Action item for a SFC.

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -3,6 +3,7 @@
 //! See section 3.
 use crate::common::{
     AddressAssignment, ConstantKind, EnumeratedValue, IntegerLiteral, SignedInteger, Subrange,
+    TypeName,
 };
 use crate::core::{Id, Located, SourceSpan};
 use std::fmt;
@@ -124,7 +125,7 @@ pub struct ArrayVariable {
     pub subscripted_variable: Box<SymbolicVariableKind>,
     /// The ordered set of subscripts. These should be expressions that
     /// evaluate to an index.
-    pub subscripts: Vec<ExprKind>,
+    pub subscripts: Vec<Expr>,
 }
 
 impl fmt::Display for ArrayVariable {
@@ -189,8 +190,8 @@ impl Located for FbCall {
 pub struct CompareExpr {
     #[recurse(ignore)]
     pub op: CompareOp,
-    pub left: ExprKind,
-    pub right: ExprKind,
+    pub left: Expr,
+    pub right: Expr,
 }
 
 /// A binary expression that produces an arithmetic result by operating on
@@ -201,8 +202,8 @@ pub struct CompareExpr {
 pub struct BinaryExpr {
     #[recurse(ignore)]
     pub op: Operator,
-    pub left: ExprKind,
-    pub right: ExprKind,
+    pub left: Expr,
+    pub right: Expr,
 }
 
 /// A unary expression that produces a boolean or arithmetic result by
@@ -213,7 +214,7 @@ pub struct BinaryExpr {
 pub struct UnaryExpr {
     #[recurse(ignore)]
     pub op: UnaryOp,
-    pub term: ExprKind,
+    pub term: Expr,
 }
 
 #[derive(Debug, Clone, PartialEq, Recurse)]
@@ -239,13 +240,48 @@ impl fmt::Display for LateBound {
     }
 }
 
+/// Wrapper around `ExprKind` that carries optional resolved type information.
+///
+/// The `resolved_type` field is populated by a later analysis pass. During
+/// parsing and initial construction, it is always `None`.
+#[derive(Debug, PartialEq, Clone, Recurse)]
+pub struct Expr {
+    pub kind: ExprKind,
+    #[recurse(ignore)]
+    pub resolved_type: Option<TypeName>,
+}
+
+impl Expr {
+    /// Creates a new `Expr` with no resolved type.
+    pub fn new(kind: ExprKind) -> Expr {
+        Expr {
+            kind,
+            resolved_type: None,
+        }
+    }
+
+    /// Creates a new `Expr` with a resolved type.
+    pub fn with_type(kind: ExprKind, type_name: TypeName) -> Expr {
+        Expr {
+            kind,
+            resolved_type: Some(type_name),
+        }
+    }
+}
+
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.kind)
+    }
+}
+
 /// Expression that yields a value derived from the input(s) to the expression.
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub enum ExprKind {
     Compare(Box<CompareExpr>),
     BinaryOp(Box<BinaryExpr>),
     UnaryOp(Box<UnaryExpr>),
-    Expression(Box<ExprKind>),
+    Expression(Box<Expr>),
     Const(ConstantKind),
     EnumeratedValue(EnumeratedValue),
     Variable(Variable),
@@ -255,15 +291,26 @@ pub enum ExprKind {
 
 impl ExprKind {
     pub fn compare(op: CompareOp, left: ExprKind, right: ExprKind) -> ExprKind {
-        ExprKind::Compare(Box::new(CompareExpr { op, left, right }))
+        ExprKind::Compare(Box::new(CompareExpr {
+            op,
+            left: Expr::new(left),
+            right: Expr::new(right),
+        }))
     }
 
     pub fn binary(op: Operator, left: ExprKind, right: ExprKind) -> ExprKind {
-        ExprKind::BinaryOp(Box::new(BinaryExpr { op, left, right }))
+        ExprKind::BinaryOp(Box::new(BinaryExpr {
+            op,
+            left: Expr::new(left),
+            right: Expr::new(right),
+        }))
     }
 
     pub fn unary(op: UnaryOp, term: ExprKind) -> ExprKind {
-        ExprKind::UnaryOp(Box::new(UnaryExpr { op, term }))
+        ExprKind::UnaryOp(Box::new(UnaryExpr {
+            op,
+            term: Expr::new(term),
+        }))
     }
 
     pub fn named_variable(name: &str) -> ExprKind {
@@ -322,7 +369,7 @@ impl fmt::Display for ExprKind {
 /// See section 3.2.3.
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct PositionalInput {
-    pub expr: ExprKind,
+    pub expr: Expr,
 }
 
 /// Input argument to a function or function block invocation.
@@ -333,7 +380,7 @@ pub struct PositionalInput {
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct NamedInput {
     pub name: Id,
-    pub expr: ExprKind,
+    pub expr: Expr,
 }
 
 /// Output argument captured from a function or function block invocation.
@@ -356,13 +403,15 @@ pub enum ParamAssignmentKind {
 
 impl ParamAssignmentKind {
     pub fn positional(expr: ExprKind) -> ParamAssignmentKind {
-        ParamAssignmentKind::PositionalInput(PositionalInput { expr })
+        ParamAssignmentKind::PositionalInput(PositionalInput {
+            expr: Expr::new(expr),
+        })
     }
 
     pub fn named(name: &str, expr: ExprKind) -> ParamAssignmentKind {
         ParamAssignmentKind::NamedInput(NamedInput {
             name: Id::from(name),
-            expr,
+            expr: Expr::new(expr),
         })
     }
 }
@@ -489,7 +538,7 @@ pub enum StmtKind {
 impl StmtKind {
     pub fn if_then(condition: ExprKind, body: Vec<StmtKind>) -> StmtKind {
         StmtKind::If(If {
-            expr: condition,
+            expr: Expr::new(condition),
             body,
             else_ifs: vec![],
             else_body: vec![],
@@ -502,7 +551,7 @@ impl StmtKind {
         else_body: Vec<StmtKind>,
     ) -> StmtKind {
         StmtKind::If(If {
-            expr: condition,
+            expr: Expr::new(condition),
             body,
             else_ifs: vec![],
             else_body,
@@ -544,15 +593,18 @@ impl StmtKind {
     }
 
     pub fn assignment(target: Variable, value: ExprKind) -> StmtKind {
-        StmtKind::Assignment(Assignment { target, value })
+        StmtKind::Assignment(Assignment {
+            target,
+            value: Expr::new(value),
+        })
     }
 
     pub fn simple_assignment(target: &str, src: &str) -> StmtKind {
         StmtKind::Assignment(Assignment {
             target: Variable::named(target),
-            value: ExprKind::LateBound(LateBound {
+            value: Expr::new(ExprKind::LateBound(LateBound {
                 value: Id::from(src),
-            }),
+            })),
         })
     }
 
@@ -565,7 +617,7 @@ impl StmtKind {
         }));
         StmtKind::Assignment(Assignment {
             target: Variable::named(target),
-            value: ExprKind::Variable(variable),
+            value: Expr::new(ExprKind::Variable(variable)),
         })
     }
 }
@@ -576,7 +628,7 @@ impl StmtKind {
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct Assignment {
     pub target: Variable,
-    pub value: ExprKind,
+    pub value: Expr,
 }
 
 /// If selection statement.
@@ -584,7 +636,7 @@ pub struct Assignment {
 /// See section 3.3.2.3.
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct If {
-    pub expr: ExprKind,
+    pub expr: Expr,
     pub body: Vec<StmtKind>,
     pub else_ifs: Vec<ElseIf>,
     pub else_body: Vec<StmtKind>,
@@ -592,7 +644,7 @@ pub struct If {
 
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct ElseIf {
-    pub expr: ExprKind,
+    pub expr: Expr,
     pub body: Vec<StmtKind>,
 }
 
@@ -602,7 +654,7 @@ pub struct ElseIf {
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct Case {
     /// An expression, the result of which is used to select a particular case.
-    pub selector: ExprKind,
+    pub selector: Expr,
     pub statement_groups: Vec<CaseStatementGroup>,
     pub else_body: Vec<StmtKind>,
 }
@@ -633,9 +685,9 @@ pub enum CaseSelectionKind {
 pub struct For {
     /// The variable that is assigned and contains the value for each loop iteration.
     pub control: Id,
-    pub from: ExprKind,
-    pub to: ExprKind,
-    pub step: Option<ExprKind>,
+    pub from: Expr,
+    pub to: Expr,
+    pub step: Option<Expr>,
     pub body: Vec<StmtKind>,
 }
 
@@ -644,7 +696,7 @@ pub struct For {
 /// See section 3.3.2.4.
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct While {
-    pub condition: ExprKind,
+    pub condition: Expr,
     pub body: Vec<StmtKind>,
 }
 
@@ -653,7 +705,7 @@ pub struct While {
 /// See section 3.3.2.4.
 #[derive(Debug, PartialEq, Clone, Recurse)]
 pub struct Repeat {
-    pub until: ExprKind,
+    pub until: Expr,
     pub body: Vec<StmtKind>,
 }
 
@@ -667,7 +719,7 @@ mod tests {
             subscripted_variable: Box::new(SymbolicVariableKind::Named(NamedVariable {
                 name: Id::from("data"),
             })),
-            subscripts: vec![ExprKind::integer_literal("0")],
+            subscripts: vec![Expr::new(ExprKind::integer_literal("0"))],
         };
 
         let result = format!("{}", array_var);
@@ -682,8 +734,8 @@ mod tests {
                 name: Id::from("matrix"),
             })),
             subscripts: vec![
-                ExprKind::integer_literal("1"),
-                ExprKind::integer_literal("2"),
+                Expr::new(ExprKind::integer_literal("1")),
+                Expr::new(ExprKind::integer_literal("2")),
             ],
         };
 
@@ -698,7 +750,7 @@ mod tests {
             subscripted_variable: Box::new(SymbolicVariableKind::Named(NamedVariable {
                 name: Id::from("arr"),
             })),
-            subscripts: vec![ExprKind::named_variable("i")],
+            subscripts: vec![Expr::new(ExprKind::named_variable("i"))],
         };
 
         let result = format!("{}", array_var);

--- a/compiler/dsl/src/visitor.rs
+++ b/compiler/dsl/src/visitor.rs
@@ -369,6 +369,8 @@ pub trait Visitor<E> {
 
     dispatch!(LateBound);
 
+    dispatch!(Expr);
+
     dispatch!(ExprKind);
 
     // 3.3.2.1

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -107,7 +107,7 @@ fn flatten_statements(mut items: Vec<StatementsOrEmpty>) -> Vec<StmtKind> {
 
 enum Element {
     StructSelector(Id),
-    ArraySelector(Vec<ExprKind>),
+    ArraySelector(Vec<Expr>),
 }
 
 enum InstanceInitKind {
@@ -749,8 +749,8 @@ parser! {
     //    }
     //  }
     rule subscripted_variable() -> SymbolicVariableKind = symbolic_variable()
-    rule subscript_list() -> Vec<ExprKind> = tok(TokenType::LeftBracket) _ list:subscript()++ (_ tok(TokenType::Comma) _) _ tok(TokenType::RightBracket) { list }
-    rule subscript() -> ExprKind = expression()
+    rule subscript_list() -> Vec<Expr> = tok(TokenType::LeftBracket) _ list:subscript()++ (_ tok(TokenType::Comma) _) _ tok(TokenType::RightBracket) { list }
+    rule subscript() -> Expr = e:expression() { Expr::new(e) }
     rule structured_variable() -> (SymbolicVariableKind, Id) = r:record_variable() tok(TokenType::Period) f:field_selector() { (r, f) }
     rule record_variable() -> SymbolicVariableKind = symbolic_variable()
     rule field_selector() -> Id = identifier()
@@ -1154,7 +1154,7 @@ parser! {
       vec![n1, n2]
     }
     // TODO add simple_instruction_list , fbd_network, rung
-    rule transition_condition() -> ExprKind =  tok(TokenType::Assignment) _ expr:expression() _ tok(TokenType::Semicolon) { expr }
+    rule transition_condition() -> Expr =  tok(TokenType::Assignment) _ expr:expression() _ tok(TokenType::Semicolon) { Expr::new(expr) }
     rule action() -> ElementKind = tok(TokenType::Action) _ name:action_name() _ tok(TokenType::Colon) _ body:function_block_body() _ tok(TokenType::EndAction) {
       ElementKind::Action(Action {
         name,
@@ -1375,7 +1375,7 @@ parser! {
       c:constant() { ExprKind::Const(c) }
       //ev:enumerated_value()
       v:variable() { ExprKind::Variable(v) }
-      tok(TokenType::LeftParen) _ e:expression() _ tok(TokenType::RightParen) { ExprKind::Expression(Box::new(e)) }
+      tok(TokenType::LeftParen) _ e:expression() _ tok(TokenType::RightParen) { ExprKind::Expression(Box::new(Expr::new(e))) }
       f:function_expression() { f }
     }
     rule unary_expression() -> ExprKind = unary:unary_operator()? _ expr:primary_expression() {
@@ -1440,7 +1440,7 @@ parser! {
     } / name:(n:variable_name() _ tok(TokenType::Assignment) { n })? _ expr:expression() {
       match name {
         Some(n) => {
-          ParamAssignmentKind::NamedInput(NamedInput {name: n, expr} )
+          ParamAssignmentKind::NamedInput(NamedInput {name: n, expr: Expr::new(expr)} )
         },
         None => {
           ParamAssignmentKind::positional(expr)
@@ -1450,9 +1450,9 @@ parser! {
 
     // B.3.2.3 Selection statements
     rule selection_statement() -> StmtKind = if_statement() / case_statement()
-    rule if_statement() -> StmtKind = tok(TokenType::If) _ expr:expression() _ tok(TokenType::Then) _ body:statement_list()? _ else_ifs:(tok(TokenType::Elsif) _ expr:expression() _ tok(TokenType::Then) _ body:statement_list() {ElseIf{expr, body}}) ** _ _ else_body:(tok(TokenType::Else) _ e:statement_list() { e })? _ tok(TokenType::EndIf) {
+    rule if_statement() -> StmtKind = tok(TokenType::If) _ expr:expression() _ tok(TokenType::Then) _ body:statement_list()? _ else_ifs:(tok(TokenType::Elsif) _ expr:expression() _ tok(TokenType::Then) _ body:statement_list() {ElseIf{expr: Expr::new(expr), body}}) ** _ _ else_body:(tok(TokenType::Else) _ e:statement_list() { e })? _ tok(TokenType::EndIf) {
       StmtKind::If(If {
-        expr,
+        expr: Expr::new(expr),
         body: body.unwrap_or_default(),
         else_ifs,
         else_body: else_body.unwrap_or_default()
@@ -1460,7 +1460,7 @@ parser! {
     }
     rule case_statement() -> StmtKind = tok(TokenType::Case) _ selector:expression() _ tok(TokenType::Of) _ cases:case_element() ** _ _ else_body:(tok(TokenType::Else) _ e:statement_list() { e })? _ tok(TokenType::EndCase) {
       StmtKind::Case(Case {
-        selector,
+        selector: Expr::new(selector),
         statement_groups: cases,
         else_body: else_body.unwrap_or_default(),
       })
@@ -1486,16 +1486,16 @@ parser! {
       }
     }
     rule control_variable() -> Id = identifier()
-    rule for_list() -> (ExprKind, ExprKind, Option<ExprKind>) = from:expression() _ tok(TokenType::To) _ to:expression() _ step:(tok(TokenType::By) _ s:expression() {s})? { (from, to, step) }
+    rule for_list() -> (Expr, Expr, Option<Expr>) = from:expression() _ tok(TokenType::To) _ to:expression() _ step:(tok(TokenType::By) _ s:expression() {Expr::new(s)})? { (Expr::new(from), Expr::new(to), step) }
     rule while_statement() -> While = tok(TokenType::While) _ condition:expression() _ tok(TokenType::Do) _ body:statement_list() _ tok(TokenType::EndWhile) {
       While {
-        condition,
+        condition: Expr::new(condition),
         body,
       }
     }
     rule repeat_statement() -> Repeat = tok(TokenType::Repeat) _ body:statement_list() _ tok(TokenType::Until) _ until:expression() _ tok(TokenType::EndRepeat) {
       Repeat {
-        until,
+        until: Expr::new(until),
         body,
       }
     }

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -900,7 +900,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
 
         self.indent();
         self.write_ws(":=");
-        self.visit_expr_kind(&node.condition)?;
+        self.visit_expr(&node.condition)?;
         self.write_ws(";");
         self.newline();
         self.outdent();
@@ -1168,7 +1168,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
     ) -> Result<Self::Value, Diagnostic> {
         self.visit_variable(&node.target)?;
         self.write_ws(":=");
-        self.visit_expr_kind(&node.value)?;
+        self.visit_expr(&node.value)?;
 
         self.write_ws(";");
         self.newline();
@@ -1180,7 +1180,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         node: &dsl::textual::CompareExpr,
     ) -> Result<Self::Value, Diagnostic> {
         self.write_ws("(");
-        self.visit_expr_kind(&node.left)?;
+        self.visit_expr(&node.left)?;
 
         let op = match node.op {
             dsl::textual::CompareOp::Or => "OR",
@@ -1195,7 +1195,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         };
         self.write_ws(op);
 
-        self.visit_expr_kind(&node.right)?;
+        self.visit_expr(&node.right)?;
         self.write_ws(")");
         Ok(())
     }
@@ -1205,7 +1205,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         node: &dsl::textual::BinaryExpr,
     ) -> Result<Self::Value, Diagnostic> {
         self.write_ws("(");
-        self.visit_expr_kind(&node.left)?;
+        self.visit_expr(&node.left)?;
 
         let op = match node.op {
             dsl::textual::Operator::Add => "+",
@@ -1217,7 +1217,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         };
         self.write_ws(op);
 
-        self.visit_expr_kind(&node.right)?;
+        self.visit_expr(&node.right)?;
         self.write_ws(")");
 
         Ok(())
@@ -1233,7 +1233,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         };
         self.write_ws(op);
 
-        self.visit_expr_kind(&node.term)
+        self.visit_expr(&node.term)
     }
 
     fn visit_function(&mut self, node: &dsl::textual::Function) -> Result<Self::Value, Diagnostic> {
@@ -1257,7 +1257,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         self.outdent();
 
         self.write_ws("UNTIL");
-        self.visit_expr_kind(&node.until)?;
+        self.visit_expr(&node.until)?;
         self.newline();
 
         self.write_ws("END_REPEAT");
@@ -1270,7 +1270,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
 
     fn visit_if(&mut self, node: &dsl::textual::If) -> Result<Self::Value, Diagnostic> {
         self.write_ws("IF");
-        self.visit_expr_kind(&node.expr)?;
+        self.visit_expr(&node.expr)?;
         self.write_ws("THEN");
         self.newline();
 
@@ -1304,7 +1304,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
 
     fn visit_else_if(&mut self, node: &dsl::textual::ElseIf) -> Result<Self::Value, Diagnostic> {
         self.write_ws("ELSIF");
-        self.visit_expr_kind(&node.expr)?;
+        self.visit_expr(&node.expr)?;
         self.write_ws("THEN");
         self.newline();
 
@@ -1319,7 +1319,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
 
     fn visit_case(&mut self, node: &dsl::textual::Case) -> Result<Self::Value, Diagnostic> {
         self.write_ws("CASE");
-        self.visit_expr_kind(&node.selector)?;
+        self.visit_expr(&node.selector)?;
         self.write_ws("OF");
         self.newline();
 
@@ -1379,13 +1379,13 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         self.write_ws("FOR");
         self.visit_id(&node.control)?;
         self.write_ws(":=");
-        self.visit_expr_kind(&node.from)?;
+        self.visit_expr(&node.from)?;
         self.write_ws("TO");
-        self.visit_expr_kind(&node.to)?;
+        self.visit_expr(&node.to)?;
 
         if let Some(by) = &node.step {
             self.write_ws("BY");
-            self.visit_expr_kind(by)?;
+            self.visit_expr(by)?;
         }
 
         self.write_ws("DO");
@@ -1406,7 +1406,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
 
     fn visit_while(&mut self, node: &dsl::textual::While) -> Result<Self::Value, Diagnostic> {
         self.write_ws("WHILE");
-        self.visit_expr_kind(&node.condition)?;
+        self.visit_expr(&node.condition)?;
         self.write_ws("DO");
         self.newline();
 
@@ -1430,7 +1430,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         self.visit_symbolic_variable_kind(&node.subscripted_variable)?;
 
         self.write_ws("[");
-        visit_comma_separated!(self, node.subscripts.iter(), ExprKind);
+        visit_comma_separated!(self, node.subscripts.iter(), Expr);
         self.write_ws("]");
 
         Ok(())

--- a/compiler/sources/src/xml/transform.rs
+++ b/compiler/sources/src/xml/transform.rs
@@ -23,7 +23,7 @@ use ironplc_dsl::{
         Action as SfcAction, ActionAssociation, ActionQualifier, ElementKind, Network, Sfc, Step,
         Transition,
     },
-    textual::{ExprKind, Statements, StmtKind},
+    textual::{Expr, ExprKind, Statements, StmtKind},
     time::DurationLiteral,
 };
 use ironplc_parser::options::ParseOptions;
@@ -959,18 +959,20 @@ fn transform_sfc_transition(
     // Parse the condition
     let condition = if let Some(ref st_body) = transition.condition_st {
         // Parse inline ST condition as an expression
-        parse_st_condition(
+        Expr::new(parse_st_condition(
             &st_body.text,
             file_id,
             st_body.line_offset,
             st_body.col_offset,
-        )?
+        )?)
     } else if let Some(ref ref_name) = transition.condition_reference {
         // Reference to a named transition - use the name as a variable reference
-        ExprKind::named_variable(ref_name)
+        Expr::new(ExprKind::named_variable(ref_name))
     } else {
         // Default to TRUE if no condition specified
-        ExprKind::Const(ConstantKind::Boolean(BooleanLiteral::new(Boolean::True)))
+        Expr::new(ExprKind::Const(ConstantKind::Boolean(BooleanLiteral::new(
+            Boolean::True,
+        ))))
     };
 
     Ok(Transition {


### PR DESCRIPTION
Introduce an Expr wrapper struct around ExprKind that carries an optional resolved_type field. This is a mechanical migration (PR 2 of 4 for ADR-0013) with zero behavior change — all resolved_type values are None. Later PRs will add a Fold pass to populate types and update codegen to read them.