### PR TITLE
Add source metadata to Diagnostic and include in LSP problem URLs

### DIFF
--- a/compiler/dsl/src/diagnostic.rs
+++ b/compiler/dsl/src/diagnostic.rs
@@ -96,6 +96,12 @@ pub struct Diagnostic {
 
     /// Additional information about the diagnostic.
     pub secondary: Vec<Label>,
+
+    /// Rust source file that produced this diagnostic (from `file!()` macro).
+    pub source_file: Option<String>,
+
+    /// Rust source line that produced this diagnostic (from `line!()` macro).
+    pub source_line: Option<u32>,
 }
 
 impl Diagnostic {
@@ -110,6 +116,8 @@ impl Diagnostic {
             primary,
             described: vec![],
             secondary: vec![],
+            source_file: None,
+            source_line: None,
         }
     }
 
@@ -126,6 +134,7 @@ impl Diagnostic {
                 format!("Not implemented at {file}#L{line}"),
             ),
         )
+        .with_source(file, line)
     }
 
     /// Creates a "todo" diagnostic associated with a file and line in the Rust
@@ -139,6 +148,7 @@ impl Diagnostic {
             Problem::NotImplemented,
             Label::span(id.span(), format!("Not implemented at {file}#L{line}")),
         )
+        .with_source(file, line)
     }
 
     /// Creates a "todo" diagnostic associated with a file and line in the Rust
@@ -152,6 +162,7 @@ impl Diagnostic {
             Problem::NotImplemented,
             Label::span(ty.span(), format!("Not implemented at {file}#L{line}")),
         )
+        .with_source(file, line)
     }
 
     /// Creates a "todo" diagnostic associated with a file and line in the Rust
@@ -165,6 +176,7 @@ impl Diagnostic {
             Problem::NotImplemented,
             Label::span(span, format!("Not implemented at {file}#L{line}")),
         )
+        .with_source(file, line)
     }
 
     /// Creates an "internal error" diagnostic associated with a file and line in the Rust
@@ -180,6 +192,7 @@ impl Diagnostic {
                 format!("Internal error at {file}#L{line} indicates a bug in the compiler"),
             ),
         )
+        .with_source(file, line)
     }
 
     /// Adds to the problem description (primary text) additional context
@@ -220,6 +233,16 @@ impl Diagnostic {
     /// ```
     pub fn with_secondary(mut self, label: Label) -> Self {
         self.secondary.push(label);
+        self
+    }
+
+    /// Sets the Rust source file and line that produced this diagnostic.
+    ///
+    /// This is typically called with `file!()` and `line!()` to record
+    /// where in the compiler the diagnostic was generated.
+    pub fn with_source(mut self, file: &str, line: u32) -> Self {
+        self.source_file = Some(file.to_string());
+        self.source_line = Some(line);
         self
     }
 

--- a/compiler/plc2x/src/lsp_project.rs
+++ b/compiler/plc2x/src/lsp_project.rs
@@ -447,13 +447,18 @@ fn map_diagnostic(
     let description = diagnostic.description();
     let range = map_label(&diagnostic.primary, project);
 
-    let code_description = match Uri::from_str(
-        format!(
-            "https://www.ironplc.com/reference/compiler/problems/{}.html",
-            diagnostic.code
-        )
-        .as_str(),
-    ) {
+    let mut url_string = format!(
+        "https://www.ironplc.com/reference/compiler/problems/{}.html?version={}",
+        diagnostic.code,
+        env!("CARGO_PKG_VERSION")
+    );
+    if let Some(ref file) = diagnostic.source_file {
+        url_string.push_str(&format!("&file={}", file));
+    }
+    if let Some(line) = diagnostic.source_line {
+        url_string.push_str(&format!("&line={}", line));
+    }
+    let code_description = match Uri::from_str(&url_string) {
         Ok(url) => Some(CodeDescription { href: url }),
         Err(_) => None,
     };
@@ -813,6 +818,69 @@ INVALID_SYNTAX"
         let lsp_diag = super::map_diagnostic(diag, proj.wrapped.as_ref());
 
         assert!(lsp_diag.related_information.is_none());
+    }
+
+    #[test]
+    fn map_diagnostic_when_problem_then_url_has_version_only() {
+        use ironplc_dsl::core::FileId;
+        use ironplc_dsl::diagnostic::{
+            Diagnostic as DslDiagnostic, Label as DslLabel, Location as DslLocation,
+        };
+
+        let mut proj = new_empty_project();
+        let url = Uri::from_str(FAKE_PATH).unwrap();
+        let content = "PROGRAM Main\nEND_PROGRAM";
+        proj.change_text_document(&url, content.to_owned());
+
+        let file_id = FileId::from_path(&std::path::PathBuf::from(url.path().as_str()));
+
+        let diag = DslDiagnostic::problem(
+            ironplc_problems::Problem::SyntaxError,
+            DslLabel {
+                location: DslLocation { start: 0, end: 7 },
+                file_id,
+                message: "some error".to_string(),
+            },
+        );
+
+        let lsp_diag = super::map_diagnostic(diag, proj.wrapped.as_ref());
+
+        let href = lsp_diag.code_description.unwrap().href.to_string();
+        assert!(href.contains("?version="));
+        assert!(!href.contains("&file="));
+        assert!(!href.contains("&line="));
+    }
+
+    #[test]
+    fn map_diagnostic_when_todo_then_url_has_version_file_and_line() {
+        use ironplc_dsl::core::FileId;
+        use ironplc_dsl::diagnostic::{
+            Diagnostic as DslDiagnostic, Label as DslLabel, Location as DslLocation,
+        };
+
+        let mut proj = new_empty_project();
+        let url = Uri::from_str(FAKE_PATH).unwrap();
+        let content = "PROGRAM Main\nEND_PROGRAM";
+        proj.change_text_document(&url, content.to_owned());
+
+        let file_id = FileId::from_path(&std::path::PathBuf::from(url.path().as_str()));
+
+        let diag = DslDiagnostic::problem(
+            ironplc_problems::Problem::SyntaxError,
+            DslLabel {
+                location: DslLocation { start: 0, end: 7 },
+                file_id,
+                message: "some error".to_string(),
+            },
+        )
+        .with_source("compiler/analyzer/src/rule_example.rs", 42);
+
+        let lsp_diag = super::map_diagnostic(diag, proj.wrapped.as_ref());
+
+        let href = lsp_diag.code_description.unwrap().href.to_string();
+        assert!(href.contains("?version="));
+        assert!(href.contains("&file=compiler/analyzer/src/rule_example.rs"));
+        assert!(href.contains("&line=42"));
     }
 
     #[test]


### PR DESCRIPTION
Add optional source_file and source_line fields to Diagnostic struct, populated by todo and internal_error constructors. The LSP provider now appends version, file, and line query parameters to problem code URLs so the website can identify the compiler version and exact source location.

https://claude.ai/code/session_015uf64pFMJ2kNxr7fGW339f