### PR TITLE
Rename ironplc-web-app package to ironplc-playground

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
@@ -576,6 +576,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironplc-playground"
+version = "0.163.0"
+dependencies = [
+ "base64",
+ "console_error_panic_hook",
+ "ironplc-codegen",
+ "ironplc-container",
+ "ironplc-dsl",
+ "ironplc-parser",
+ "ironplc-vm",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "ironplc-plc2plc"
 version = "0.163.0"
 dependencies = [
@@ -634,23 +651,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "time",
-]
-
-[[package]]
-name = "ironplc-web-app"
-version = "0.163.0"
-dependencies = [
- "base64",
- "console_error_panic_hook",
- "ironplc-codegen",
- "ironplc-container",
- "ironplc-dsl",
- "ironplc-parser",
- "ironplc-vm",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1052,18 +1052,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1318,9 +1318,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1679,9 +1679,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "wit-bindgen"

--- a/compiler/playground/Cargo.toml
+++ b/compiler/playground/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ironplc-web-app"
+name = "ironplc-playground"
 description = "Browser-based compiler and runtime for IronPLC"
 version = "0.163.0"
 edition.workspace = true


### PR DESCRIPTION
## Summary
Renamed the package from `ironplc-web-app` to `ironplc-playground` to better reflect its purpose as a browser-based playground for the IronPLC compiler and runtime.

## Changes
- Updated package name in `compiler/playground/Cargo.toml` from `ironplc-web-app` to `ironplc-playground`

## Rationale
The new name `ironplc-playground` more accurately describes the package's functionality as an interactive, browser-based environment for experimenting with the IronPLC compiler and runtime, rather than a generic web application.

https://claude.ai/code/session_016jA6JzTqo5mGLWXZ4ckWmF