### PR TITLE
Improve playground scan cycle UX for newcomers

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -10,6 +10,7 @@ const diagnosticsPanel = document.getElementById("diagnostics-panel");
 const dropOverlay = document.getElementById("drop-overlay");
 
 let sourceChanged = true;
+let previousValues = new Map();
 
 // --- URL parameter handling ---
 
@@ -109,9 +110,11 @@ runBtn.addEventListener("click", async () => {
   const scans = parseInt(scansInput.value, 10) || 1;
 
   status.textContent = "Compiling and running\u2026";
+  runBtn.textContent = "\u25A0 Stop";
   runBtn.disabled = true;
 
   const msg = await postCommand("run_source", { source, scans });
+  runBtn.textContent = "\u25B6 Run";
   runBtn.disabled = false;
 
   if (msg.type === "error") {
@@ -133,6 +136,7 @@ editor.addEventListener("input", () => {
 
 stepBtn.addEventListener("click", async () => {
   const scans = parseInt(scansInput.value, 10) || 1;
+  stepBtn.textContent = "\u25A0 Stepping\u2026";
   stepBtn.disabled = true;
   resetBtn.disabled = true;
 
@@ -141,6 +145,7 @@ stepBtn.addEventListener("click", async () => {
     const loadMsg = await postCommand("load_program", { source: editor.value });
     if (loadMsg.type === "error") {
       status.textContent = loadMsg.error;
+      stepBtn.textContent = "\u25B7 Step";
       stepBtn.disabled = false;
       resetBtn.disabled = false;
       return;
@@ -148,6 +153,7 @@ stepBtn.addEventListener("click", async () => {
     const loadResult = JSON.parse(loadMsg.json);
     if (!loadResult.ok) {
       displayStepResult(loadResult);
+      stepBtn.textContent = "\u25B7 Step";
       stepBtn.disabled = false;
       resetBtn.disabled = false;
       return;
@@ -157,6 +163,7 @@ stepBtn.addEventListener("click", async () => {
 
   status.textContent = "Stepping\u2026";
   const msg = await postCommand("step", { scans });
+  stepBtn.textContent = "\u25B7 Step";
   stepBtn.disabled = false;
   resetBtn.disabled = false;
 
@@ -178,6 +185,7 @@ resetBtn.addEventListener("click", async () => {
   await postCommand("reset");
 
   sourceChanged = true;
+  previousValues = new Map();
   variablesPanel.innerHTML = '<p class="placeholder">Run a program to see variable values.</p>';
   diagnosticsPanel.innerHTML = '<p class="placeholder">No diagnostics.</p>';
   status.textContent = "Ready";
@@ -252,9 +260,10 @@ document.addEventListener("drop", (e) => {
 
 function displayResult(result) {
   if (result.ok) {
-    renderVariables(result.variables, result.scans_completed);
+    previousValues = new Map();
+    renderVariables(result.variables, result.scans_completed, "run");
     diagnosticsPanel.innerHTML = '<p class="placeholder">No diagnostics.</p>';
-    status.textContent = `Completed ${result.scans_completed} scan(s)`;
+    status.textContent = `Ran ${result.scans_completed} scan cycle(s)`;
     activateTab("variables");
   } else if (result.diagnostics && result.diagnostics.length > 0) {
     renderDiagnostics(result.diagnostics);
@@ -262,7 +271,8 @@ function displayResult(result) {
     status.textContent = `${result.diagnostics.length} error(s)`;
     activateTab("diagnostics");
   } else if (result.error) {
-    renderVariables(result.variables || [], result.scans_completed);
+    previousValues = new Map();
+    renderVariables(result.variables || [], result.scans_completed, "run");
     diagnosticsPanel.innerHTML = `<p class="error-message">${escapeHtml(result.error)}</p>`;
     status.textContent = "Runtime error";
     activateTab("diagnostics");
@@ -271,12 +281,14 @@ function displayResult(result) {
 
 function displayRunResult(result, filename) {
   if (result.ok) {
-    renderVariables(result.variables, result.scans_completed);
+    previousValues = new Map();
+    renderVariables(result.variables, result.scans_completed, "run");
     diagnosticsPanel.innerHTML = '<p class="placeholder">No diagnostics.</p>';
-    status.textContent = `${filename}: ${result.scans_completed} scan(s)`;
+    status.textContent = `${filename}: ran ${result.scans_completed} scan cycle(s)`;
     activateTab("variables");
   } else {
-    renderVariables(result.variables || [], result.scans_completed);
+    previousValues = new Map();
+    renderVariables(result.variables || [], result.scans_completed, "run");
     diagnosticsPanel.innerHTML = `<p class="error-message">${escapeHtml(result.error || "Unknown error")}</p>`;
     status.textContent = `${filename}: runtime error`;
     activateTab("diagnostics");
@@ -285,9 +297,9 @@ function displayRunResult(result, filename) {
 
 function displayStepResult(result) {
   if (result.ok) {
-    renderVariables(result.variables, result.total_scans);
+    renderVariables(result.variables, result.total_scans, "step");
     diagnosticsPanel.innerHTML = '<p class="placeholder">No diagnostics.</p>';
-    status.textContent = `Total scans: ${result.total_scans}`;
+    status.textContent = `Scan cycle ${result.total_scans} completed`;
     activateTab("variables");
   } else if (result.diagnostics && result.diagnostics.length > 0) {
     renderDiagnostics(result.diagnostics);
@@ -295,26 +307,41 @@ function displayStepResult(result) {
     status.textContent = `${result.diagnostics.length} error(s)`;
     activateTab("diagnostics");
   } else if (result.error) {
-    renderVariables(result.variables || [], result.total_scans);
+    renderVariables(result.variables || [], result.total_scans, "step");
     diagnosticsPanel.innerHTML = `<p class="error-message">${escapeHtml(result.error)}</p>`;
     status.textContent = "Runtime error";
     activateTab("diagnostics");
   }
 }
 
-function renderVariables(variables, scansCompleted) {
+function renderVariables(variables, scansCompleted, mode) {
   if (!variables || variables.length === 0) {
     variablesPanel.innerHTML = '<p class="placeholder">No variables.</p>';
     return;
   }
 
-  let html = `<p class="success-message">Scans completed: ${scansCompleted}</p>`;
+  let html = '<div class="scan-summary">';
+  if (mode === "step") {
+    html += `<span class="scan-count">Scan cycle ${scansCompleted} completed</span>`;
+    html += '<span class="scan-hint">Click Step again to run another cycle and see values change.</span>';
+  } else {
+    html += `<span class="scan-count">Ran ${scansCompleted} scan cycle(s) from initial state</span>`;
+    html += '<span class="scan-hint">Each scan runs the entire program once. Variables persist between scans.</span>';
+  }
+  html += '</div>';
+
   html += '<table class="var-table"><thead><tr><th>Index</th><th>Value</th></tr></thead><tbody>';
   for (const v of variables) {
-    html += `<tr><td>var[${v.index}]</td><td>${v.value}</td></tr>`;
+    const prev = previousValues.get(v.index);
+    const changed = prev !== undefined && prev !== v.value;
+    html += `<tr${changed ? ' class="changed"' : ''}>`;
+    html += `<td>var[${v.index}]</td><td>${v.value}</td>`;
+    html += '</tr>';
   }
   html += "</tbody></table>";
   variablesPanel.innerHTML = html;
+
+  previousValues = new Map(variables.map(v => [v.index, v.value]));
 }
 
 function renderDiagnostics(diagnostics) {

--- a/playground/index.html
+++ b/playground/index.html
@@ -15,10 +15,10 @@
   <main>
     <section class="editor-section">
       <div class="toolbar">
-        <button id="run-btn" disabled>Compile &amp; Run</button>
-        <button id="step-btn" disabled data-testid="step-btn">Step</button>
-        <button id="reset-btn" disabled data-testid="reset-btn">Reset</button>
-        <label>
+        <button id="run-btn" disabled>&#x25B6; Run</button>
+        <button id="step-btn" disabled data-testid="step-btn">&#x25B7; Step</button>
+        <button id="reset-btn" disabled data-testid="reset-btn">&#x21BB; Reset</button>
+        <label title="A scan cycle runs the entire program once, reading inputs, executing logic, and writing outputs. In a real PLC this repeats continuously. Here you control how many cycles to run.">
           Scans:
           <input id="scans-input" type="number" value="1" min="0" max="10000">
         </label>
@@ -29,11 +29,16 @@
       </div>
       <textarea id="editor" spellcheck="false" data-testid="editor">PROGRAM main
   VAR
-    x : INT;
-    y : INT;
+    count : INT;
+    doubled : INT;
   END_VAR
-  x := 10;
-  y := x + 32;
+
+  (* In a PLC, the program runs in a loop called
+     a "scan cycle". Each click of Step runs one
+     cycle. Variables keep their values between
+     cycles, so count increases each time. *)
+  count := count + 1;
+  doubled := count * 2;
 END_PROGRAM
 </textarea>
     </section>

--- a/playground/style.css
+++ b/playground/style.css
@@ -74,6 +74,7 @@ main {
   cursor: pointer;
   font-size: 0.875rem;
   font-weight: 500;
+  white-space: nowrap;
 }
 
 .toolbar button:hover:not(:disabled),
@@ -207,6 +208,32 @@ table.var-table th {
 
 .success-message {
   color: var(--success);
+}
+
+.scan-summary {
+  background: rgba(107, 255, 155, 0.08);
+  border: 1px solid rgba(107, 255, 155, 0.25);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.scan-count {
+  color: var(--success);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.scan-hint {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+table.var-table tr.changed td {
+  background: rgba(107, 255, 155, 0.15);
 }
 
 .drop-overlay {

--- a/playground/tests/e2e.spec.js
+++ b/playground/tests/e2e.spec.js
@@ -91,7 +91,7 @@ END_PROGRAM
     const editor = page.locator('[data-testid="editor"]');
     const content = await editor.inputValue();
     expect(content).toContain("PROGRAM main");
-    expect(content).toContain("x := 10");
+    expect(content).toContain("count := count + 1");
   });
 
   test("step_when_program_loaded_then_shows_variables_and_scan_count", async ({ page }) => {
@@ -111,7 +111,7 @@ END_PROGRAM
     const variablesPanel = page.locator('[data-testid="variables-panel"]');
     await expect(variablesPanel).toContainText("10", { timeout: 10000 });
     await expect(variablesPanel).toContainText("42");
-    await expect(page.locator('[data-testid="status"]')).toContainText("Total scans: 1");
+    await expect(page.locator('[data-testid="status"]')).toContainText("Scan cycle 1 completed");
   });
 
   test("step_when_clicked_twice_then_scan_count_accumulates", async ({ page }) => {
@@ -125,12 +125,12 @@ END_PROGRAM
 `);
 
     await page.click('[data-testid="step-btn"]');
-    await expect(page.locator('[data-testid="status"]')).toContainText("Total scans: 1", {
+    await expect(page.locator('[data-testid="status"]')).toContainText("Scan cycle 1 completed", {
       timeout: 10000,
     });
 
     await page.click('[data-testid="step-btn"]');
-    await expect(page.locator('[data-testid="status"]')).toContainText("Total scans: 2", {
+    await expect(page.locator('[data-testid="status"]')).toContainText("Scan cycle 2 completed", {
       timeout: 10000,
     });
   });
@@ -147,7 +147,7 @@ END_PROGRAM
 
     // Step first to populate output
     await page.click('[data-testid="step-btn"]');
-    await expect(page.locator('[data-testid="status"]')).toContainText("Total scans: 1", {
+    await expect(page.locator('[data-testid="status"]')).toContainText("Scan cycle 1 completed", {
       timeout: 10000,
     });
 
@@ -186,6 +186,6 @@ END_PROGRAM
 
     await page.click('[data-testid="step-btn"]');
     await expect(variablesPanel).toContainText("99", { timeout: 10000 });
-    await expect(page.locator('[data-testid="status"]')).toContainText("Total scans: 1");
+    await expect(page.locator('[data-testid="status"]')).toContainText("Scan cycle 1 completed");
   });
 });


### PR DESCRIPTION
Replace the static default example with a counter program that demonstrates state changing across cycles, add educational comments explaining scan cycles, use monochrome Unicode icons on buttons (▶ Run, ▷ Step, ↻ Reset) with stateful text during execution (■ Stop / ■ Stepping…), add a prominent scan summary box with contextual hints, highlight changed variables when stepping, add tooltip on the Scans input, and prevent button text wrapping on narrow screens.

https://claude.ai/code/session_01TpYcwwVGsYhzFh7Gzeh87W