### PR TITLE
Add spec-driven development adoption plan

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -731,6 +731,9 @@ dependencies = [
 [[package]]
 name = "ironplc-container"
 version = "0.192.0"
+dependencies = [
+ "spec_test_macro",
+]
 
 [[package]]
 name = "ironplc-dsl"
@@ -1564,6 +1567,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "spec_test_macro"
+version = "0.192.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "strsim"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -16,7 +16,8 @@ members = [
     "test",
     "vm",
     "vm-cli",
-    "playground"
+    "playground",
+    "spec_test_macro"
 ]
 resolver = "2"
 

--- a/compiler/container/Cargo.toml
+++ b/compiler/container/Cargo.toml
@@ -10,3 +10,6 @@ repository.workspace = true
 [features]
 default = ["std"]
 std = []
+
+[dev-dependencies]
+spec_test_macro = { path = "../spec_test_macro" }

--- a/compiler/container/build.rs
+++ b/compiler/container/build.rs
@@ -1,0 +1,100 @@
+//! Build script that generates `spec_requirements.rs` from requirement markers
+//! in the design spec markdown files.
+//!
+//! Markers are bold inline IDs of the form `**REQ-CF-001**` or `**REQ-IS-001**`.
+//! The generated file contains one constant per requirement and an `ALL` slice
+//! listing every requirement. See `specs/design/spec-conformance-testing.md`.
+
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let specs_dir = Path::new(&manifest_dir).join("../../specs/design");
+
+    let spec_files = [
+        "bytecode-container-format.md",
+        "bytecode-instruction-set.md",
+    ];
+
+    let mut requirements = BTreeSet::new();
+
+    for filename in &spec_files {
+        let path = specs_dir.join(filename);
+        println!("cargo:rerun-if-changed={}", path.display());
+
+        if let Ok(content) = fs::read_to_string(&path) {
+            extract_requirements(&content, &mut requirements);
+        }
+    }
+
+    // Also rebuild when the conformance test source changes, so the
+    // completeness meta-test stays up to date with include_str!.
+    let test_path = Path::new(&manifest_dir).join("src/spec_conformance.rs");
+    println!("cargo:rerun-if-changed={}", test_path.display());
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest = Path::new(&out_dir).join("spec_requirements.rs");
+
+    let mut code = String::from("// Auto-generated from specs/design/*.md — do not edit.\n\n");
+
+    for req in &requirements {
+        let ident = req.replace('-', "_");
+        code.push_str(&format!(
+            "#[allow(dead_code)] pub const {ident}: &str = \"{req}\";\n"
+        ));
+    }
+
+    code.push('\n');
+    code.push_str("pub const ALL: &[&str] = &[\n");
+    for req in &requirements {
+        code.push_str(&format!("    \"{req}\",\n"));
+    }
+    code.push_str("];\n");
+
+    fs::write(&dest, code).unwrap();
+}
+
+/// Extracts all `**REQ-XX-NNN**` bold markers from markdown content.
+fn extract_requirements(content: &str, out: &mut BTreeSet<String>) {
+    let mut rest = content;
+    while let Some(start) = rest.find("**REQ-") {
+        let after_open = &rest[start + 2..]; // skip opening **
+        if let Some(end) = after_open.find("**") {
+            let id = &after_open[..end];
+            // Sanity check: must look like REQ-XX-NNN
+            if id.starts_with("REQ-") && id.len() >= 8 {
+                out.insert(id.to_string());
+            }
+            rest = &after_open[end + 2..];
+        } else {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_requirements() {
+        let md = "The header is 256 bytes. **REQ-CF-001** And magic is **REQ-CF-002** here.";
+        let mut reqs = BTreeSet::new();
+        extract_requirements(md, &mut reqs);
+        assert_eq!(reqs.len(), 2);
+        assert!(reqs.contains("REQ-CF-001"));
+        assert!(reqs.contains("REQ-CF-002"));
+    }
+
+    #[test]
+    fn test_extract_ignores_non_req_bold() {
+        let md = "This is **bold text** and **REQ-CF-010** is a req.";
+        let mut reqs = BTreeSet::new();
+        extract_requirements(md, &mut reqs);
+        assert_eq!(reqs.len(), 1);
+        assert!(reqs.contains("REQ-CF-010"));
+    }
+}

--- a/compiler/container/build.rs
+++ b/compiler/container/build.rs
@@ -2,13 +2,16 @@
 //! in the design spec markdown files.
 //!
 //! Markers are bold inline IDs of the form `**REQ-CF-001**` or `**REQ-IS-001**`.
-//! The generated file contains one constant per requirement and an `ALL` slice
-//! listing every requirement. See `specs/design/spec-conformance-testing.md`.
+//! The generated file contains one constant per requirement, an `ALL` slice
+//! listing every requirement, and an `UNTESTED` slice of requirements that have
+//! no corresponding `#[spec_test]` in any source file.
+//!
+//! See `specs/design/spec-conformance-testing.md`.
 
 use std::collections::BTreeSet;
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -30,10 +33,17 @@ fn main() {
         }
     }
 
-    // Also rebuild when the conformance test source changes, so the
-    // completeness meta-test stays up to date with include_str!.
-    let test_path = Path::new(&manifest_dir).join("src/spec_conformance.rs");
-    println!("cargo:rerun-if-changed={}", test_path.display());
+    // Scan all .rs files under src/ for spec_test(REQ_ patterns to find tested
+    // requirements. This allows tests to live in any file.
+    let src_dir = Path::new(&manifest_dir).join("src");
+    let mut tested = BTreeSet::new();
+    let rs_files = collect_rs_files(&src_dir);
+    for path in &rs_files {
+        println!("cargo:rerun-if-changed={}", path.display());
+        if let Ok(content) = fs::read_to_string(path) {
+            extract_tested_requirements(&content, &mut tested);
+        }
+    }
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("spec_requirements.rs");
@@ -48,13 +58,45 @@ fn main() {
     }
 
     code.push('\n');
-    code.push_str("pub const ALL: &[&str] = &[\n");
+    code.push_str("#[allow(dead_code)]\npub const ALL: &[&str] = &[\n");
     for req in &requirements {
         code.push_str(&format!("    \"{req}\",\n"));
     }
     code.push_str("];\n");
 
+    // UNTESTED: requirements in the spec with no #[spec_test] in any source file
+    let untested: Vec<&String> = requirements
+        .iter()
+        .filter(|r| {
+            let ident = r.replace('-', "_");
+            !tested.contains(&ident)
+        })
+        .collect();
+
+    code.push('\n');
+    code.push_str("#[allow(dead_code)]\npub const UNTESTED: &[&str] = &[\n");
+    for req in &untested {
+        code.push_str(&format!("    \"{req}\",\n"));
+    }
+    code.push_str("];\n");
+
     fs::write(&dest, code).unwrap();
+}
+
+/// Collects all `.rs` files under a directory, recursively.
+fn collect_rs_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                files.extend(collect_rs_files(&path));
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                files.push(path);
+            }
+        }
+    }
+    files
 }
 
 /// Extracts all `**REQ-XX-NNN**` bold markers from markdown content.
@@ -75,13 +117,32 @@ fn extract_requirements(content: &str, out: &mut BTreeSet<String>) {
     }
 }
 
+/// Extracts requirement identifiers from `#[spec_test(REQ_XX_NNN)]` attributes
+/// in Rust source. Collects the underscore-form identifiers (e.g. `REQ_CF_001`).
+fn extract_tested_requirements(content: &str, out: &mut BTreeSet<String>) {
+    let mut rest = content;
+    let needle = "spec_test(REQ_";
+    while let Some(start) = rest.find(needle) {
+        let after = &rest[start + "spec_test(".len()..];
+        if let Some(end) = after.find(')') {
+            let ident = &after[..end];
+            if ident.starts_with("REQ_") && ident.len() >= 8 {
+                out.insert(ident.to_string());
+            }
+            rest = &after[end + 1..];
+        } else {
+            break;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_extract_requirements() {
-        let md = "The header is 256 bytes. **REQ-CF-001** And magic is **REQ-CF-002** here.";
+        let md = "**REQ-CF-001** The header is 256 bytes.\n**REQ-CF-002** Magic.";
         let mut reqs = BTreeSet::new();
         extract_requirements(md, &mut reqs);
         assert_eq!(reqs.len(), 2);
@@ -96,5 +157,22 @@ mod tests {
         extract_requirements(md, &mut reqs);
         assert_eq!(reqs.len(), 1);
         assert!(reqs.contains("REQ-CF-010"));
+    }
+
+    #[test]
+    fn test_extract_tested_requirements() {
+        let rs = r#"
+            #[spec_test(REQ_CF_001)]
+            fn some_test() {}
+
+            #[spec_test(REQ_IS_010)]
+            #[ignore]
+            fn another_test() {}
+        "#;
+        let mut tested = BTreeSet::new();
+        extract_tested_requirements(rs, &mut tested);
+        assert_eq!(tested.len(), 2);
+        assert!(tested.contains("REQ_CF_001"));
+        assert!(tested.contains("REQ_IS_010"));
     }
 }

--- a/compiler/container/src/lib.rs
+++ b/compiler/container/src/lib.rs
@@ -57,3 +57,11 @@ pub use task_table::{ProgramInstanceEntry, TaskEntry, TaskTable};
 pub use type_section::{
     ArrayDescriptor, FbTypeDescriptor, FieldEntry, FieldType, TypeSection, UserFbDescriptor,
 };
+
+// Spec conformance testing infrastructure (test-only)
+#[cfg(test)]
+mod spec_requirements {
+    include!(concat!(env!("OUT_DIR"), "/spec_requirements.rs"));
+}
+#[cfg(test)]
+mod spec_conformance;

--- a/compiler/container/src/spec_conformance.rs
+++ b/compiler/container/src/spec_conformance.rs
@@ -83,19 +83,18 @@ fn container_spec_req_cf_004_header_uses_little_endian() {
 #[spec_test(REQ_CF_005)]
 fn container_spec_req_cf_005_header_field_offsets() {
     // Write a header with distinctive values and verify byte offsets
-    let mut header = FileHeader::default();
-    header.num_variables = 0x1234;
-    header.code_section_offset = 0xAABBCCDD;
+    let header = FileHeader {
+        num_variables: 0x1234,
+        code_section_offset: 0xAABBCCDD,
+        ..Default::default()
+    };
 
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
     assert_eq!(buf.len(), 256);
 
     // num_variables at offset 196 (u16 LE)
-    assert_eq!(
-        u16::from_le_bytes([buf[196], buf[197]]),
-        0x1234
-    );
+    assert_eq!(u16::from_le_bytes([buf[196], buf[197]]), 0x1234);
 
     // code_section_offset at offset 176 (u32 LE)
     assert_eq!(
@@ -125,8 +124,10 @@ fn container_spec_req_cf_007_flags_bit0_is_system_uptime() {
     assert_eq!(FLAG_HAS_SYSTEM_UPTIME, 0x01);
 
     // Verify the flag is at byte offset 7
-    let mut header = FileHeader::default();
-    header.flags = FLAG_HAS_SYSTEM_UPTIME;
+    let header = FileHeader {
+        flags: FLAG_HAS_SYSTEM_UPTIME,
+        ..Default::default()
+    };
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
     assert_eq!(buf[7], 0x01);

--- a/compiler/container/src/spec_conformance.rs
+++ b/compiler/container/src/spec_conformance.rs
@@ -22,18 +22,12 @@ use crate::header::{FileHeader, FLAG_HAS_SYSTEM_UPTIME, FORMAT_VERSION, HEADER_S
 
 #[test]
 fn all_spec_requirements_have_tests() {
-    let source = include_str!("spec_conformance.rs");
-    let mut missing = Vec::new();
-    for req in crate::spec_requirements::ALL {
-        let ident = req.replace('-', "_");
-        if !source.contains(&ident) {
-            missing.push(*req);
-        }
-    }
+    // UNTESTED is computed by build.rs by scanning all .rs files under src/
+    // for #[spec_test(REQ_...)] attributes.
     assert!(
-        missing.is_empty(),
+        crate::spec_requirements::UNTESTED.is_empty(),
         "Requirements in spec with no conformance test: {:?}",
-        missing
+        crate::spec_requirements::UNTESTED
     );
 }
 

--- a/compiler/container/src/spec_conformance.rs
+++ b/compiler/container/src/spec_conformance.rs
@@ -1,0 +1,133 @@
+//! Spec conformance tests for the bytecode container format and instruction set.
+//!
+//! Each test is annotated with `#[spec_test(REQ_XX_NNN)]` which:
+//! 1. Adds `#[test]`
+//! 2. References a build-script-generated constant — compilation fails if the
+//!    requirement was removed from the spec markdown.
+//!
+//! The `all_spec_requirements_have_tests` meta-test ensures every requirement
+//! in the spec has at least one test here.
+//!
+//! See `specs/design/spec-conformance-testing.md` for full design.
+
+use std::vec::Vec;
+
+use spec_test_macro::spec_test;
+
+use crate::header::{FileHeader, FLAG_HAS_SYSTEM_UPTIME, FORMAT_VERSION, HEADER_SIZE, MAGIC};
+
+// ---------------------------------------------------------------------------
+// Meta-test: completeness check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_spec_requirements_have_tests() {
+    let source = include_str!("spec_conformance.rs");
+    let mut missing = Vec::new();
+    for req in crate::spec_requirements::ALL {
+        let ident = req.replace('-', "_");
+        if !source.contains(&ident) {
+            missing.push(*req);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "Requirements in spec with no conformance test: {:?}",
+        missing
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Container Format — File Header (REQ-CF-001 through REQ-CF-007)
+// ---------------------------------------------------------------------------
+
+/// REQ-CF-001: The file header is exactly 256 bytes.
+#[spec_test(REQ_CF_001)]
+fn container_spec_req_cf_001_header_size_is_256_bytes() {
+    assert_eq!(core::mem::size_of::<FileHeader>(), HEADER_SIZE);
+    assert_eq!(HEADER_SIZE, 256);
+}
+
+/// REQ-CF-002: Magic number is 0x49504C43 ("IPLC" in ASCII).
+#[spec_test(REQ_CF_002)]
+fn container_spec_req_cf_002_magic_is_iplc() {
+    assert_eq!(MAGIC, 0x49504C43);
+    // On disk (little-endian): bytes are [0x43, 0x4C, 0x50, 0x49].
+    // The u32 value 0x49504C43 encodes "IPLC" MSB-first.
+    let bytes = MAGIC.to_le_bytes();
+    assert_eq!(bytes, [0x43, 0x4C, 0x50, 0x49]);
+}
+
+/// REQ-CF-003: Format version is 1.
+#[spec_test(REQ_CF_003)]
+fn container_spec_req_cf_003_format_version_is_1() {
+    assert_eq!(FORMAT_VERSION, 1);
+}
+
+/// REQ-CF-004: All multi-byte values in the header are little-endian.
+#[spec_test(REQ_CF_004)]
+fn container_spec_req_cf_004_header_uses_little_endian() {
+    let header = FileHeader::default();
+    let mut buf = Vec::new();
+    header.write_to(&mut buf).unwrap();
+
+    // Magic at offset 0: 0x49504C43 in LE is [0x43, 0x4C, 0x50, 0x49]
+    assert_eq!(&buf[0..4], &0x49504C43u32.to_le_bytes());
+
+    // Format version at offset 4: 1u16 in LE is [0x01, 0x00]
+    assert_eq!(&buf[4..6], &1u16.to_le_bytes());
+}
+
+/// REQ-CF-005: Header field offsets match the spec table layout, totaling
+/// 256 bytes with reserved at 218-255.
+#[spec_test(REQ_CF_005)]
+fn container_spec_req_cf_005_header_field_offsets() {
+    // Write a header with distinctive values and verify byte offsets
+    let mut header = FileHeader::default();
+    header.num_variables = 0x1234;
+    header.code_section_offset = 0xAABBCCDD;
+
+    let mut buf = Vec::new();
+    header.write_to(&mut buf).unwrap();
+    assert_eq!(buf.len(), 256);
+
+    // num_variables at offset 196 (u16 LE)
+    assert_eq!(
+        u16::from_le_bytes([buf[196], buf[197]]),
+        0x1234
+    );
+
+    // code_section_offset at offset 176 (u32 LE)
+    assert_eq!(
+        u32::from_le_bytes([buf[176], buf[177], buf[178], buf[179]]),
+        0xAABBCCDD
+    );
+}
+
+/// REQ-CF-006: Reserved bytes are 38 bytes at offsets 218-255.
+#[spec_test(REQ_CF_006)]
+fn container_spec_req_cf_006_reserved_is_38_bytes_at_offset_218() {
+    let header = FileHeader::default();
+    assert_eq!(header.reserved.len(), 38);
+
+    let mut buf = Vec::new();
+    header.write_to(&mut buf).unwrap();
+
+    // Bytes 218..256 should all be zero (reserved)
+    assert_eq!(&buf[218..256], &[0u8; 38]);
+    // And that's exactly the end of the header
+    assert_eq!(buf.len(), 256);
+}
+
+/// REQ-CF-007: Flags bit 0 is FLAG_HAS_SYSTEM_UPTIME (0x01).
+#[spec_test(REQ_CF_007)]
+fn container_spec_req_cf_007_flags_bit0_is_system_uptime() {
+    assert_eq!(FLAG_HAS_SYSTEM_UPTIME, 0x01);
+
+    // Verify the flag is at byte offset 7
+    let mut header = FileHeader::default();
+    header.flags = FLAG_HAS_SYSTEM_UPTIME;
+    let mut buf = Vec::new();
+    header.write_to(&mut buf).unwrap();
+    assert_eq!(buf[7], 0x01);
+}

--- a/compiler/spec_test_macro/Cargo.toml
+++ b/compiler/spec_test_macro/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "spec_test_macro"
+description = "Proc-macro attribute for spec conformance tests"
+version = "0.192.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/compiler/spec_test_macro/src/lib.rs
+++ b/compiler/spec_test_macro/src/lib.rs
@@ -1,0 +1,40 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Ident, ItemFn};
+
+/// Marks a function as a spec conformance test for a given requirement.
+///
+/// Adds `#[test]` and injects a compile-time reference to the generated
+/// constant in `crate::spec_requirements`. If the requirement does not
+/// exist in the spec markdown, compilation fails.
+///
+/// # Usage
+///
+/// ```ignore
+/// #[spec_test(REQ_CF_001)]
+/// fn container_spec_req_cf_001_header_size() {
+///     assert_eq!(std::mem::size_of::<FileHeader>(), 256);
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn spec_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let req_id = parse_macro_input!(attr as Ident);
+    let mut func = parse_macro_input!(item as ItemFn);
+
+    // Inject a reference to the generated constant at the top of the body.
+    // If the constant does not exist, the test fails to compile.
+    let original_block = &func.block;
+    func.block = syn::parse_quote!({
+        let _ = crate::spec_requirements::#req_id;
+        let __inner = || #original_block;
+        __inner()
+    });
+
+    // Add #[test] if not already present.
+    let has_test = func.attrs.iter().any(|a| a.path().is_ident("test"));
+    if !has_test {
+        func.attrs.insert(0, syn::parse_quote!(#[test]));
+    }
+
+    quote!(#func).into()
+}

--- a/specs/design/bytecode-container-format.md
+++ b/specs/design/bytecode-container-format.md
@@ -20,7 +20,9 @@ The format builds on:
 
 ## File Layout
 
-Sections appear in this fixed order. All multi-byte values are little-endian, matching the instruction set encoding. **REQ-CF-004**
+**REQ-CF-004** All multi-byte values are little-endian, matching the instruction set encoding.
+
+Sections appear in this fixed order.
 
 ```
 ┌─────────────────────────────────────────┐  offset 0
@@ -44,7 +46,9 @@ Sections appear in this fixed order. All multi-byte values are little-endian, ma
 
 ## File Header
 
-The header is exactly 256 bytes. **REQ-CF-001** The VM reads this in a single read and decides whether to proceed.
+**REQ-CF-001** The header is exactly 256 bytes.
+
+The VM reads this in a single read and decides whether to proceed.
 
 The header is organized into four logical regions:
 
@@ -53,44 +57,44 @@ The header is organized into four logical regions:
 3. **Section directory** (bytes 136-191): offset/size pairs for each section, in file-layout order
 4. **Runtime parameters** (bytes 192-231): stack/memory budgets, counts, I/O image sizes
 
-| Offset | Field | Type | Description |
-|--------|-------|------|-------------|
-| 0 | magic | u32 | `0x49504C43` ("IPLC" in ASCII) **REQ-CF-002** |
-| 4 | format_version | u16 | Container format version (initially 1) **REQ-CF-003** |
-| 6 | profile | u8 | Reserved for future VM profile definitions; must be zero |
-| 7 | flags | u8 | Bit 0: has system uptime variables (`FLAG_HAS_SYSTEM_UPTIME`); Bit 1: has debug section; Bit 2: has type section **REQ-CF-007** |
-| 8 | content_hash | [u8; 32] | SHA-256 over `source_hash \|\| type_section \|\| constant_pool \|\| code_section` (see Content Hash Scope) |
-| 40 | source_hash | [u8; 32] | SHA-256 of the source text that produced this bytecode (all zeros if unavailable) |
-| 72 | debug_hash | [u8; 32] | SHA-256 over debug section (all zeros if no debug section) |
-| 104 | layout_hash | [u8; 32] | SHA-256 over the memory layout signature (see Layout Hash and Online Change) |
-| 136 | sig_section_offset | u32 | Offset of content signature section (0 if absent) |
-| 140 | sig_section_size | u32 | Size of content signature section |
-| 144 | debug_sig_offset | u32 | Offset of debug signature section (0 if absent) |
-| 148 | debug_sig_size | u32 | Size of debug signature section |
-| 152 | type_section_offset | u32 | Offset of type section (0 if stripped) |
-| 156 | type_section_size | u32 | Size of type section |
-| 160 | task_section_offset | u32 | Offset of task table section (0 if absent; see [Task Support Design](61131-task-support.md)) |
-| 164 | task_section_size | u32 | Size of task table section |
-| 168 | const_section_offset | u32 | Offset of constant pool section |
-| 172 | const_section_size | u32 | Size of constant pool section |
-| 176 | code_section_offset | u32 | Offset of code section |
-| 180 | code_section_size | u32 | Size of code section |
-| 184 | debug_section_offset | u32 | Offset of debug section (0 if absent) |
-| 188 | debug_section_size | u32 | Size of debug section |
-| 192 | max_stack_depth | u16 | Maximum operand stack depth across all functions |
-| 194 | max_call_depth | u16 | Maximum call nesting depth |
-| 196 | num_variables | u16 | Total variable table entries (including compiler-generated hidden variables) |
-| 198 | data_region_bytes | u32 | Total size of the mutable data region in bytes (compiler-summed across all variable-length variables: strings, arrays, FB instances) — see [ADR-0017](../adrs/0017-unified-data-region.md) |
-| 202 | num_temp_bufs | u16 | Number of temporary buffers for string operations |
-| 204 | max_temp_buf_bytes | u32 | Size of the largest temporary buffer in bytes |
-| 208 | num_functions | u16 | Number of function entries in the code section |
-| 210 | num_fb_types | u16 | Number of FB type descriptors in the type section |
-| 212 | input_image_bytes | u16 | Total input process image size in bytes (%I) |
-| 214 | output_image_bytes | u16 | Total output process image size in bytes (%Q) |
-| 216 | memory_image_bytes | u16 | Total memory region size in bytes (%M) |
-| 218 | reserved | [u8; 38] | Reserved for future use; must be zero **REQ-CF-006** |
+**REQ-CF-005** The header field layout is as follows, totaling 256 bytes.
 
-Total header size: 256 bytes. **REQ-CF-005**
+| Requirement | Offset | Field | Type | Description |
+|-------------|--------|-------|------|-------------|
+| **REQ-CF-002** | 0 | magic | u32 | `0x49504C43` ("IPLC" in ASCII) |
+| **REQ-CF-003** | 4 | format_version | u16 | Container format version (initially 1) |
+| | 6 | profile | u8 | Reserved for future VM profile definitions; must be zero |
+| **REQ-CF-007** | 7 | flags | u8 | Bit 0: has system uptime variables (`FLAG_HAS_SYSTEM_UPTIME`); Bit 1: has debug section; Bit 2: has type section |
+| | 8 | content_hash | [u8; 32] | SHA-256 over `source_hash \|\| type_section \|\| constant_pool \|\| code_section` (see Content Hash Scope) |
+| | 40 | source_hash | [u8; 32] | SHA-256 of the source text that produced this bytecode (all zeros if unavailable) |
+| | 72 | debug_hash | [u8; 32] | SHA-256 over debug section (all zeros if no debug section) |
+| | 104 | layout_hash | [u8; 32] | SHA-256 over the memory layout signature (see Layout Hash and Online Change) |
+| | 136 | sig_section_offset | u32 | Offset of content signature section (0 if absent) |
+| | 140 | sig_section_size | u32 | Size of content signature section |
+| | 144 | debug_sig_offset | u32 | Offset of debug signature section (0 if absent) |
+| | 148 | debug_sig_size | u32 | Size of debug signature section |
+| | 152 | type_section_offset | u32 | Offset of type section (0 if stripped) |
+| | 156 | type_section_size | u32 | Size of type section |
+| | 160 | task_section_offset | u32 | Offset of task table section (0 if absent; see [Task Support Design](61131-task-support.md)) |
+| | 164 | task_section_size | u32 | Size of task table section |
+| | 168 | const_section_offset | u32 | Offset of constant pool section |
+| | 172 | const_section_size | u32 | Size of constant pool section |
+| | 176 | code_section_offset | u32 | Offset of code section |
+| | 180 | code_section_size | u32 | Size of code section |
+| | 184 | debug_section_offset | u32 | Offset of debug section (0 if absent) |
+| | 188 | debug_section_size | u32 | Size of debug section |
+| | 192 | max_stack_depth | u16 | Maximum operand stack depth across all functions |
+| | 194 | max_call_depth | u16 | Maximum call nesting depth |
+| | 196 | num_variables | u16 | Total variable table entries (including compiler-generated hidden variables) |
+| | 198 | data_region_bytes | u32 | Total size of the mutable data region in bytes (compiler-summed across all variable-length variables: strings, arrays, FB instances) — see [ADR-0017](../adrs/0017-unified-data-region.md) |
+| | 202 | num_temp_bufs | u16 | Number of temporary buffers for string operations |
+| | 204 | max_temp_buf_bytes | u32 | Size of the largest temporary buffer in bytes |
+| | 208 | num_functions | u16 | Number of function entries in the code section |
+| | 210 | num_fb_types | u16 | Number of FB type descriptors in the type section |
+| | 212 | input_image_bytes | u16 | Total input process image size in bytes (%I) |
+| | 214 | output_image_bytes | u16 | Total output process image size in bytes (%Q) |
+| | 216 | memory_image_bytes | u16 | Total memory region size in bytes (%M) |
+| **REQ-CF-006** | 218 | reserved | [u8; 38] | Reserved for future use; must be zero |
 
 ### Resource Budget Calculation
 

--- a/specs/design/bytecode-container-format.md
+++ b/specs/design/bytecode-container-format.md
@@ -20,7 +20,7 @@ The format builds on:
 
 ## File Layout
 
-Sections appear in this fixed order. All multi-byte values are little-endian, matching the instruction set encoding.
+Sections appear in this fixed order. All multi-byte values are little-endian, matching the instruction set encoding. **REQ-CF-004**
 
 ```
 ┌─────────────────────────────────────────┐  offset 0
@@ -44,7 +44,7 @@ Sections appear in this fixed order. All multi-byte values are little-endian, ma
 
 ## File Header
 
-The header is exactly 256 bytes. The VM reads this in a single read and decides whether to proceed.
+The header is exactly 256 bytes. **REQ-CF-001** The VM reads this in a single read and decides whether to proceed.
 
 The header is organized into four logical regions:
 
@@ -55,10 +55,10 @@ The header is organized into four logical regions:
 
 | Offset | Field | Type | Description |
 |--------|-------|------|-------------|
-| 0 | magic | u32 | `0x49504C43` ("IPLC" in ASCII) |
-| 4 | format_version | u16 | Container format version (initially 1) |
+| 0 | magic | u32 | `0x49504C43` ("IPLC" in ASCII) **REQ-CF-002** |
+| 4 | format_version | u16 | Container format version (initially 1) **REQ-CF-003** |
 | 6 | profile | u8 | Reserved for future VM profile definitions; must be zero |
-| 7 | flags | u8 | Bit 0: has content signature; Bit 1: has debug section; Bit 2: has type section |
+| 7 | flags | u8 | Bit 0: has system uptime variables (`FLAG_HAS_SYSTEM_UPTIME`); Bit 1: has debug section; Bit 2: has type section **REQ-CF-007** |
 | 8 | content_hash | [u8; 32] | SHA-256 over `source_hash \|\| type_section \|\| constant_pool \|\| code_section` (see Content Hash Scope) |
 | 40 | source_hash | [u8; 32] | SHA-256 of the source text that produced this bytecode (all zeros if unavailable) |
 | 72 | debug_hash | [u8; 32] | SHA-256 over debug section (all zeros if no debug section) |
@@ -88,9 +88,9 @@ The header is organized into four logical regions:
 | 212 | input_image_bytes | u16 | Total input process image size in bytes (%I) |
 | 214 | output_image_bytes | u16 | Total output process image size in bytes (%Q) |
 | 216 | memory_image_bytes | u16 | Total memory region size in bytes (%M) |
-| 218 | reserved | [u8; 38] | Reserved for future use; must be zero |
+| 218 | reserved | [u8; 38] | Reserved for future use; must be zero **REQ-CF-006** |
 
-Total header size: 256 bytes.
+Total header size: 256 bytes. **REQ-CF-005**
 
 ### Resource Budget Calculation
 

--- a/specs/design/spec-conformance-testing.md
+++ b/specs/design/spec-conformance-testing.md
@@ -1,0 +1,112 @@
+# Design: Spec Conformance Testing
+
+## Overview
+
+This design describes how IronPLC links design specifications to conformance
+tests, ensuring that the code matches the spec and vice versa. It covers the
+bytecode container format and instruction set specifications.
+
+## Problem
+
+Design specs and implementation can drift apart silently. A spec may document
+hex value `0x05` while the code uses `0x03`, or the spec may add a new feature
+without any test verifying it. Without a formal link between spec claims and
+tests, divergence is invisible until it causes a bug.
+
+## Approach
+
+Every testable claim in a design spec gets a **requirement ID** (e.g.,
+`**REQ-CF-001**`). Each requirement has a corresponding conformance test
+annotated with `#[spec_test(REQ_CF_001)]`. Two build-time guarantees enforce
+the link:
+
+1. **Validity (compile-time):** If a requirement is removed from the spec, any
+   test referencing it fails to compile.
+2. **Completeness (test-time):** If a requirement is added to the spec without
+   a corresponding test, the `all_spec_requirements_have_tests` meta-test fails.
+
+## Requirement Numbering
+
+| Prefix   | Spec Document                          | Example      |
+|----------|----------------------------------------|--------------|
+| REQ-CF   | `bytecode-container-format.md`         | REQ-CF-001   |
+| REQ-IS   | `bytecode-instruction-set.md`          | REQ-IS-001   |
+
+IDs use three-digit zero-padded numbers. Gaps are allowed (IDs are never
+reused). Ranges are grouped by spec section with room between groups for
+future additions.
+
+## Spec Annotation
+
+Requirements appear as inline bold markers in the design docs, directly next
+to the testable claim:
+
+```markdown
+The file header is exactly 256 bytes. **REQ-CF-001**
+```
+
+These are visible when reading the spec and searchable with grep.
+
+## Enforcement Mechanism
+
+### build.rs (compile-time constant generation)
+
+`compiler/container/build.rs` parses the spec markdown files, extracts all
+`**REQ-XX-NNN**` bold markers, and generates a Rust module containing one
+constant per requirement and a list of all requirement IDs:
+
+```rust
+// Auto-generated from specs/design/*.md — do not edit
+#[allow(dead_code)] pub const REQ_CF_001: &str = "REQ-CF-001";
+// ...
+pub const ALL: &[&str] = &["REQ-CF-001", ...];
+```
+
+The build script re-runs whenever the spec files or the test source file
+change (`cargo:rerun-if-changed`).
+
+### #[spec_test] proc-macro attribute
+
+The `spec_test_macro` crate provides a `#[spec_test(REQ_CF_001)]` attribute
+that:
+
+1. Adds `#[test]` to the function.
+2. Injects `let _ = crate::spec_requirements::REQ_CF_001;` at the top of the
+   function body. This references the build-script-generated constant — if
+   the constant does not exist (requirement removed from spec), the test fails
+   to compile.
+
+### Completeness meta-test
+
+A hand-written test reads the conformance test source with `include_str!` and
+checks that every requirement ID from `spec_requirements::ALL` appears in the
+source. This catches requirements that exist in the spec but have no test.
+
+## Test Conventions
+
+- **Naming:** `{area}_spec_req_{id}_{brief_description}`
+  (e.g., `container_spec_req_cf_001_header_size_is_256_bytes`)
+- **`#[ignore]`:** Used for features specified but not yet implemented.
+  The requirement marker is still present, satisfying the completeness check.
+- **Code is king:** When spec and code disagree, the spec is updated to match
+  the code, not vice versa. Exception: intentionally unimplemented features
+  get `#[ignore]` tests.
+
+## Example
+
+In `bytecode-container-format.md`:
+```markdown
+The file header occupies exactly 256 bytes. **REQ-CF-001**
+```
+
+In `spec_conformance.rs`:
+```rust
+#[spec_test(REQ_CF_001)]
+fn container_spec_req_cf_001_header_size_is_256_bytes() {
+    assert_eq!(std::mem::size_of::<FileHeader>(), 256);
+}
+```
+
+Removing `**REQ-CF-001**` from the markdown causes a compile error.
+Adding `**REQ-CF-050**` without a test causes `all_spec_requirements_have_tests`
+to fail.

--- a/specs/design/spec-conformance-testing.md
+++ b/specs/design/spec-conformance-testing.md
@@ -38,14 +38,24 @@ future additions.
 
 ## Spec Annotation
 
-Requirements appear as inline bold markers in the design docs, directly next
-to the testable claim:
+Each testable claim gets its own line, with the requirement ID first:
 
 ```markdown
-The file header is exactly 256 bytes. **REQ-CF-001**
+**REQ-CF-001** The file header is exactly 256 bytes.
 ```
 
-These are visible when reading the spec and searchable with grep.
+For tables, the requirement ID goes in a dedicated first column:
+
+```markdown
+| Requirement | Offset | Field | Type | Description |
+|-------------|--------|-------|------|-------------|
+| **REQ-CF-002** | 0 | magic | u32 | `0x49504C43` ("IPLC" in ASCII) |
+```
+
+Rules:
+- At most one requirement per line.
+- ID-first makes the association unambiguous: the ID labels the text to its right.
+- Visible when reading the spec and searchable with grep.
 
 ## Enforcement Mechanism
 
@@ -78,9 +88,10 @@ that:
 
 ### Completeness meta-test
 
-A hand-written test reads the conformance test source with `include_str!` and
-checks that every requirement ID from `spec_requirements::ALL` appears in the
-source. This catches requirements that exist in the spec but have no test.
+The build script also scans all `.rs` files under `src/` for `spec_test(REQ_`
+patterns and generates an `UNTESTED` constant listing any requirements without
+tests. A meta-test asserts that `UNTESTED` is empty. Tests can live in any
+file within the crate — there is no single-file restriction.
 
 ## Test Conventions
 
@@ -96,7 +107,7 @@ source. This catches requirements that exist in the spec but have no test.
 
 In `bytecode-container-format.md`:
 ```markdown
-The file header occupies exactly 256 bytes. **REQ-CF-001**
+**REQ-CF-001** The file header is exactly 256 bytes.
 ```
 
 In `spec_conformance.rs`:

--- a/specs/plans/2026-04-10-spec-driven-adoption.md
+++ b/specs/plans/2026-04-10-spec-driven-adoption.md
@@ -22,8 +22,44 @@ project's workflow already follows a spec-plan-implement cycle.
 
 ### What's Missing
 
-The gap is **enforcement**. The spec and code are two independent sources of
-truth maintained by hand. Concretely:
+There are two gaps: a **requirements layer** and **enforcement**.
+
+#### No Requirements Layer
+
+The project has specs that say *what* to build (design docs) and *why*
+decisions were made (ADRs), but nothing that says *what the system must do*
+from a user or stakeholder perspective. Requirements sit above design docs —
+they capture testable "must" statements that designs satisfy.
+
+For example, the container format spec describes the header layout in detail,
+but nowhere does the project state:
+
+- "The VM **must** reject bytecode with an invalid content signature"
+- "The compiler **must** produce deterministic output for the same input"
+- "The runtime **must** reject a program at load time if RAM is insufficient"
+
+These claims are implied by the design docs and implemented in code, but they
+aren't captured as first-class, testable requirements. This matters because:
+
+1. **Design docs answer "what does it look like?" not "what must it do?"** — a
+   design doc can describe a header layout without stating that the VM must
+   reject invalid headers. The requirement is the *why* behind the design.
+2. **Requirements are testable contracts** — each "must" statement maps to one
+   or more acceptance tests. Without requirements, you can have passing tests
+   that don't verify the right things.
+3. **Requirements enable traceability** — when a test fails, you can trace it
+   back to a requirement, then to a design doc, then to an ADR. Today the
+   chain starts at the design doc level, missing the top link.
+
+Note: IronPLC's steering files function as the project's **constitution** —
+immutable architectural principles and development standards. A spec-kit-style
+constitution would be redundant. Requirements are the missing layer, not
+principles.
+
+#### Spec-Code Drift
+
+The second gap is **enforcement**. The spec and code are two independent
+sources of truth maintained by hand. Concretely:
 
 1. **Opcode drift** — `specs/design/bytecode-instruction-set.md` defines
    opcodes in markdown tables. `compiler/container/src/opcode.rs` defines them
@@ -101,10 +137,100 @@ The approach below works naturally with Claude Code on any platform: specs are
 markdown files that Claude reads before implementing, and spec tests are Rust
 tests that run with `cargo test`.
 
-## Adoption Strategy: Machine-Readable Spec Layer
+## Known Spec Gaps to Address
 
-The key insight: **keep the human-readable markdown specs but add a
-machine-readable layer that both humans and tools can validate against.**
+Beyond the drift issues already identified, several areas lack any spec at all
+— the code is the only source of truth:
+
+1. **Builtin function registry** — 100+ builtin functions in
+   `compiler/vm/src/builtin.rs` with no spec document listing their IDs,
+   signatures, or semantics. A new builtin can be added to code without any
+   spec update.
+
+2. **Standard library function signatures** — 200+ stdlib functions defined
+   across `intermediates/stdlib_function.rs` (51KB) and
+   `stdlib_function_block.rs` (25KB). The user-facing docs in
+   `docs/reference/stdlib/` describe behavior, but there's no internal spec
+   tying function IDs to implementations.
+
+3. **Type coercion rules** — spread across ADR-0001, ADR-0029, ADR-0031, plus
+   `xform_resolve_expr_types.rs` (42KB). No single document consolidates all
+   coercion rules (implicit widening, explicit narrowing, cross-type
+   conversions). A developer must read multiple ADRs and implementation code to
+   understand the full picture.
+
+4. **DSL / AST node reference** — the AST types in `dsl/src/` (core.rs,
+   textual.rs, common.rs — 150KB+ combined) have no design doc. The code is
+   the spec. Onboarding requires reading code.
+
+5. **Intermediate representations** — `intermediate_type.rs` (74KB) plus the
+   `intermediates/` subdirectory define the compiler's internal type system.
+   No design doc explains the representation choices or evolution path.
+
+These gaps should be addressed **opportunistically** — when touching related
+code, write the spec first, then make the change. Do not attempt a big-bang
+spec-writing effort.
+
+## Adoption Strategy
+
+Two parallel tracks: (A) add a requirements layer above design docs, and (B)
+add a machine-readable spec layer alongside design docs for enforcement.
+
+### Phase 0: Requirements for New Features (immediate)
+
+For every new feature or subsystem going forward, write **requirements** before
+writing the design doc. Requirements capture testable "must" statements:
+
+```markdown
+# Requirements: Bytecode Verifier
+
+## REQ-VER-001: Reject invalid signatures
+The VM MUST reject bytecode where the content signature does not verify
+against the content hash.
+
+## REQ-VER-002: Reject insufficient resources
+The VM MUST reject a program at load time if the computed RAM requirement
+exceeds available RAM, before allocating any runtime resources.
+
+## REQ-VER-003: Deterministic compilation
+The compiler MUST produce identical bytecode (byte-for-byte) for identical
+source input, regardless of compilation environment.
+```
+
+**Location:** `specs/requirements/` (new directory).
+
+**Format:** Markdown with `REQ-{AREA}-{NNN}` identifiers. Each requirement
+uses RFC 2119 language (MUST, SHOULD, MAY). Each requirement maps to one or
+more acceptance tests.
+
+**Relationship to existing artifacts:**
+
+```
+Requirements (specs/requirements/)    — what the system MUST do
+    ↓ satisfied by
+Design docs (specs/design/)           — what the system looks like
+    ↓ justified by
+ADRs (specs/adrs/)                    — why this design was chosen
+    ↓ implemented via
+Plans (specs/plans/)                  — how to build it step by step
+```
+
+**Traceability:** Spec conformance tests (Phase 1) reference requirements:
+
+```rust
+/// REQ-VER-001: Reject invalid signatures
+/// Spec: bytecode-container-format.md § Loading Sequence, step 6
+#[test]
+fn vm_when_invalid_signature_then_rejects() { ... }
+```
+
+**When requirements may be skipped:** Same as plans — mechanical changes,
+bug fixes, formatting, dependency bumps.
+
+**Why this works for velocity:** Requirements are short (1-3 sentences each).
+Writing them before the design doc takes minutes and saves hours of ambiguity.
+Claude Code can draft requirements from a brief description and then implement
+against them.
 
 ### Phase 1: Spec Tests for New Development (immediate)
 
@@ -243,13 +369,18 @@ The closed standard requires a different approach:
 | Recommendation | Priority | Effort |
 |----------------|----------|--------|
 | Do NOT adopt spec-kit | — | — |
+| Steering files = constitution (don't write a separate one) | — | — |
+| Add `specs/requirements/` with REQ-AREA-NNN format | Immediate | Low |
 | Add spec conformance tests for new specs | Immediate | Low |
 | Add `{area}_spec_{claim}` test naming convention | Immediate | Low |
 | Update steering files with spec-first rule | Immediate | Low |
 | Add machine-readable CSV for opcode table | Near-term | Medium |
+| Add machine-readable CSV for builtin function registry | Near-term | Medium |
 | Add CI check for opcode spec-code consistency | Near-term | Medium |
+| Consolidate type coercion rules into single design doc | Near-term | Medium |
 | Treat language reference as the IEC 61131-3 spec | Ongoing | Low |
 | Backfill spec conformance tests for existing specs | Later | High |
+| Write specs for stdlib functions, DSL/AST, IRs | Later | High |
 
 ## What NOT To Do
 

--- a/specs/plans/2026-04-10-spec-driven-adoption.md
+++ b/specs/plans/2026-04-10-spec-driven-adoption.md
@@ -1,0 +1,280 @@
+# Spec-Driven Adoption Plan
+
+## Goal
+
+Pivot IronPLC to spec-driven development (SDD) where specifications are the
+source of truth and implementation is verified against specs, not the other way
+around.
+
+## Current State Assessment
+
+IronPLC already has strong spec culture:
+
+- **35 ADRs** capturing architectural decisions (why)
+- **31 design docs** specifying systems and formats (what)
+- **64 implementation plans** with task breakdowns (how)
+- **9 steering files** guiding AI-assisted development
+- **118 documented problem codes** with examples and fixes
+
+The design docs for the IPLC binary format and instruction set are genuinely
+detailed specifications — byte offsets, field types, opcode tables. The
+project's workflow already follows a spec-plan-implement cycle.
+
+### What's Missing
+
+The gap is **enforcement**. The spec and code are two independent sources of
+truth maintained by hand. Concretely:
+
+1. **Opcode drift** — `specs/design/bytecode-instruction-set.md` defines
+   opcodes in markdown tables. `compiler/container/src/opcode.rs` defines them
+   as Rust constants. Nothing verifies they match. A developer can add an
+   opcode to one without the other.
+
+2. **Header drift** — `specs/design/bytecode-container-format.md` specifies
+   the file header layout with byte offsets. `compiler/container/src/header.rs`
+   implements the same structure. Nothing verifies the field order, types, or
+   offsets match.
+
+3. **Flags drift** — the spec defines `flags` as `Bit 0: has content
+   signature; Bit 1: has debug section; Bit 2: has type section`. The code
+   defines `FLAG_HAS_SYSTEM_UPTIME = 0x01`. These already disagree — the spec
+   and implementation have diverged.
+
+4. **No machine-readable spec layer** — the specs are markdown prose. AI and
+   humans read them, but tools cannot validate against them.
+
+5. **IEC 61131-3 is closed** — the foundational spec cannot be distributed,
+   making traditional spec-driven approaches (embed the spec, generate from
+   it) impossible for language features.
+
+## Spec-Kit Assessment
+
+[Spec-kit](https://github.com/github/spec-kit) is a GitHub-created toolkit for
+spec-driven development with AI. After thorough evaluation:
+
+### What spec-kit provides
+
+- `/speckit.specify` — structured spec generation with user stories, acceptance
+  criteria, requirements
+- `/speckit.plan` — technical planning with constitutional compliance
+- `/speckit.tasks` — executable task lists with parallelization markers
+- `/speckit.implement` — AI-driven implementation from specs
+- Constitution — immutable architectural principles
+- 29+ AI agent integrations (including Claude Code)
+- 50+ community extensions
+
+### Fit analysis
+
+| Capability | IronPLC already has | Spec-kit adds |
+|------------|---------------------|---------------|
+| Spec templates | Design docs in `specs/design/` | Standardized templates with user stories, acceptance criteria |
+| Planning | Plans in `specs/plans/` | Plan generation with constitutional gates |
+| Task breakdown | Plans have checkbox task lists | Parallelization markers, dependency ordering |
+| Architectural principles | Steering files + ADRs | Formal "constitution" with compliance checking |
+| AI guidance | CLAUDE.md, CURSOR.md, Kiro steering | Unified agent integration layer |
+| Spec-code consistency | **Nothing** | **Nothing** (spec-kit doesn't solve this either) |
+
+### Verdict
+
+**Spec-kit is a workflow framework, not a consistency framework.** It
+structures how you go from idea to spec to plan to code, which IronPLC already
+does well. Spec-kit does not solve the core problem: verifying that code
+matches the spec.
+
+Adopting spec-kit would:
+- Add a Python dependency to the dev workflow
+- Replace established conventions with spec-kit templates (disruption for
+  marginal gain)
+- Not solve the spec-code divergence problem
+
+**Recommendation: Do not adopt spec-kit.** IronPLC's existing workflow is
+already mature and well-suited to the project. The investment should go toward
+spec-code consistency, which spec-kit does not address.
+
+### Android / Claude Code compatibility
+
+If spec-kit were adopted, it would work on Android via Claude Code — the
+`specify` CLI runs in the terminal that Claude Code has access to. However,
+since the recommendation is to not adopt it, this is moot.
+
+The approach below works naturally with Claude Code on any platform: specs are
+markdown files that Claude reads before implementing, and spec tests are Rust
+tests that run with `cargo test`.
+
+## Adoption Strategy: Machine-Readable Spec Layer
+
+The key insight: **keep the human-readable markdown specs but add a
+machine-readable layer that both humans and tools can validate against.**
+
+### Phase 1: Spec Tests for New Development (immediate)
+
+For every new spec going forward, require **spec conformance tests** — tests
+that verify the implementation matches specific claims in the spec.
+
+This is the lightest-weight approach and works immediately:
+
+```rust
+// In compiler/container/tests/spec_conformance.rs
+
+/// Spec: bytecode-container-format.md § File Header
+/// "The header is exactly 256 bytes."
+#[test]
+fn header_spec_header_size_is_256_bytes() {
+    assert_eq!(std::mem::size_of::<FileHeader>(), 256);
+    // Or if FileHeader uses dynamic serialization:
+    assert_eq!(HEADER_SIZE, 256);
+}
+
+/// Spec: bytecode-container-format.md § File Header
+/// "magic | u32 | 0x49504C43 ("IPLC" in ASCII)"
+#[test]
+fn header_spec_magic_is_iplc_ascii() {
+    assert_eq!(MAGIC, 0x49504C43);
+    assert_eq!(&MAGIC.to_le_bytes(), b"IPLC");
+}
+
+/// Spec: bytecode-instruction-set.md § Constants
+/// "0x01 | LOAD_CONST_I32"
+#[test]
+fn opcode_spec_load_const_i32_is_0x01() {
+    assert_eq!(LOAD_CONST_I32, 0x01);
+}
+```
+
+**Convention for new specs:**
+- Every design doc that specifies concrete values (opcodes, byte offsets, magic
+  numbers, flag bits, encoding tables) must have corresponding spec
+  conformance tests
+- Test names follow: `{area}_spec_{claim}` (e.g., `header_spec_magic_is_iplc_ascii`)
+- Test doc comments reference the spec section they verify
+
+**Why this works for velocity:**
+- Zero new tools required
+- Tests are written alongside the spec (spec-first) or alongside the
+  implementation (same PR)
+- Claude Code can read the spec and write the conformance tests
+- Works identically on Android, desktop, or web
+
+### Phase 2: Machine-Readable Spec Tables (near-term)
+
+For specs with structured data (opcode tables, header layouts, type mappings),
+add a machine-readable companion file alongside the markdown:
+
+```
+specs/design/bytecode-instruction-set.md          # Human-readable spec
+specs/design/bytecode-instruction-set.opcodes.csv  # Machine-readable opcode table
+```
+
+Example `bytecode-instruction-set.opcodes.csv`:
+```csv
+hex,name,operands,stack_before,stack_after,description
+0x01,LOAD_CONST_I32,index:u16,[],[I32],Push 32-bit signed integer from constant pool
+0x02,LOAD_CONST_U32,index:u16,[],[U32],Push 32-bit unsigned integer from constant pool
+...
+```
+
+Then a build-time or test-time check verifies the CSV matches both the
+markdown spec and the Rust code:
+
+```rust
+#[test]
+fn opcode_spec_all_opcodes_match_csv() {
+    let csv = include_str!("../../../specs/design/bytecode-instruction-set.opcodes.csv");
+    for row in csv.lines().skip(1) {
+        let cols: Vec<&str> = row.split(',').collect();
+        let hex = u8::from_str_radix(&cols[0].trim_start_matches("0x"), 16).unwrap();
+        let name = cols[1];
+        // Verify the Rust constant exists and has the right value
+        let rust_value = opcode_by_name(name);
+        assert_eq!(rust_value, hex, "Opcode {name} mismatch: spec says {hex:#04x}");
+    }
+}
+```
+
+**Why CSV and not JSON/TOML/protobuf:**
+- CSV renders nicely in GitHub (and in Claude Code's file viewer)
+- Easy to diff in PRs
+- Trivially parseable in Rust tests without extra dependencies
+- Can be generated from the markdown tables by Claude Code
+
+### Phase 3: Spec-First Workflow Gate (near-term)
+
+Update the steering files and CLAUDE.md to enforce spec-first for new features:
+
+1. **New rule**: Any change that adds or modifies a binary format, opcode,
+   type mapping, or wire protocol MUST update the design doc FIRST, then
+   implement.
+
+2. **CI check**: A test that verifies every opcode constant in `opcode.rs` has
+   a matching row in the CSV (and vice versa). This makes spec drift a CI
+   failure.
+
+3. **Steering file update**: Add to `development-standards.md`:
+   > For features covered by a design specification in `specs/design/`, the
+   > spec MUST be updated before or in the same PR as the implementation.
+   > Spec conformance tests MUST be added for any new concrete values
+   > (opcodes, byte layouts, flag bits, encoding tables).
+
+### Phase 4: IEC 61131-3 Handling (ongoing)
+
+The closed standard requires a different approach:
+
+1. **IronPLC language reference as the spec** — The 64-page language reference
+   in `docs/reference/language/` already documents what IronPLC supports. This
+   IS the distributable spec. Treat it as such: update the reference BEFORE
+   implementing a new language feature.
+
+2. **Compliance matrix** — The `docs/reference/language/edition-support.rst`
+   page already tracks which IEC features are supported. This is the closest
+   to an executable spec for language features. Keep it as the definitive list.
+
+3. **Parser spec tests** — For each documented syntax construct in the
+   language reference, ensure there's a parser test that verifies the syntax is
+   accepted (or rejected, for unsupported features). The test references the
+   doc page.
+
+4. **Don't try to reproduce IEC 61131-3** — The project can't distribute the
+   standard. Instead, IronPLC's own reference is the spec. When someone
+   contributes a feature, they first update the reference to document what
+   behavior IronPLC will support, then implement it.
+
+## Summary of Recommendations
+
+| Recommendation | Priority | Effort |
+|----------------|----------|--------|
+| Do NOT adopt spec-kit | — | — |
+| Add spec conformance tests for new specs | Immediate | Low |
+| Add `{area}_spec_{claim}` test naming convention | Immediate | Low |
+| Update steering files with spec-first rule | Immediate | Low |
+| Add machine-readable CSV for opcode table | Near-term | Medium |
+| Add CI check for opcode spec-code consistency | Near-term | Medium |
+| Treat language reference as the IEC 61131-3 spec | Ongoing | Low |
+| Backfill spec conformance tests for existing specs | Later | High |
+
+## What NOT To Do
+
+- **Don't adopt a formal spec language** (TLA+, Alloy, etc.) — these are
+  powerful but heavyweight. IronPLC's specs are implementation specs, not
+  mathematical models. The spec test approach gets 90% of the value at 10% of
+  the cost.
+
+- **Don't try to generate code from specs** — code generation from markdown is
+  fragile. The CSV companion + test approach is more robust because it
+  validates bidirectionally without coupling the spec format to the code
+  structure.
+
+- **Don't backfill everything at once** — the existing specs may have
+  diverged. Fix divergence opportunistically (when touching related code) rather
+  than in a big-bang audit.
+
+## Impact on Development Velocity
+
+This approach is designed to be **velocity-neutral or positive**:
+
+- No new tools to install or learn
+- Specs are still markdown (readable on any device, including Android)
+- Spec tests catch drift in CI instead of during debugging
+- Claude Code can read the spec and write both implementation and conformance
+  tests in the same session
+- The CSV companion files are optional scaffolding, not a prerequisite for every
+  spec

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -48,6 +48,32 @@ When a document contains both design and plan content, split it into two files w
 
 **Important**: Plan and design documents must **never** be placed in `docs/`. The `docs/` directory is exclusively for the public Sphinx documentation website. All internal technical documents (plans, designs, ADRs, steering files) belong in `specs/`.
 
+### Design Requirement
+
+Compiler design documents in `specs/design/` **must** include **requirement IDs** for every testable claim. Requirements use the ID-first, one-per-line format:
+
+```markdown
+**REQ-CF-001** The file header is exactly 256 bytes.
+```
+
+For tables, add a Requirement column as the first column:
+
+```markdown
+| Requirement | Offset | Field | Type | Description |
+|-------------|--------|-------|------|-------------|
+| **REQ-CF-002** | 0 | magic | u32 | `0x49504C43` ("IPLC" in ASCII) |
+```
+
+Rules:
+- At most one requirement per line
+- ID-first: `**REQ-XX-NNN**` followed by the testable claim
+- IDs use three-digit zero-padded numbers grouped by section with gaps for future additions
+- IDs are never reused; gaps are allowed
+
+Each requirement **must** have a corresponding conformance test annotated with `#[spec_test(REQ_XX_NNN)]`. The build system enforces this bidirectionally: removing a requirement from the spec causes a compile error; adding a requirement without a test causes the completeness meta-test to fail.
+
+See [Spec Conformance Testing](../design/spec-conformance-testing.md) for the full enforcement mechanism.
+
 ### Planning Requirement
 
 All non-trivial features and changes **must** begin with an implementation plan committed to `specs/plans/` before code changes start. The plan is the first deliverable — commit it to the feature branch before writing any implementation code.


### PR DESCRIPTION
Analyzes the current state of IronPLC's specification practices, evaluates
spec-kit as a potential tool, and recommends a phased approach based on
spec conformance tests and machine-readable spec companions rather than
adopting spec-kit.

https://claude.ai/code/session_01TpRFeXg2WaLBxXn1yL9wXM