### PR TITLE
Inline the store-load DUP optimization in the Emitter

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -930,7 +930,6 @@ END_PROGRAM
                 0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
                 0xA1, // DUP (store-load optimization)
                 0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-                0xA3, 0xA3, // NOP, NOP (padding)
                 0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
                 0xB5, // RET_VOID
             ]

--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -28,6 +28,8 @@ pub struct Emitter {
     patches: Vec<PendingPatch>,
     /// Tracks the last emitted load for consecutive-load DUP optimization.
     last_load: Option<LastLoad>,
+    /// Tracks the last emitted store for the store-load DUP optimization.
+    last_store: Option<LastStore>,
 }
 
 /// Records the last emitted load instruction for DUP optimization.
@@ -36,6 +38,19 @@ pub struct Emitter {
 #[derive(Clone, PartialEq)]
 struct LastLoad {
     /// The opcode byte (e.g. LOAD_VAR_I32, LOAD_CONST_I32).
+    opcode: u8,
+    /// The 2-byte operand (little-endian).
+    operand: [u8; 2],
+}
+
+/// Records the last emitted store-variable instruction for the store-load
+/// DUP optimization. When the next emission is a matching LOAD_VAR, the
+/// emitter retroactively inserts a DUP before the STORE and skips the LOAD.
+#[derive(Clone)]
+struct LastStore {
+    /// Byte offset of the STORE_VAR opcode in the bytecode buffer.
+    position: usize,
+    /// The STORE_VAR opcode byte (e.g. STORE_VAR_I32).
     opcode: u8,
     /// The 2-byte operand (little-endian).
     operand: [u8; 2],
@@ -72,12 +87,12 @@ macro_rules! emit_load_var_index {
 }
 
 /// Emit a variable store instruction with a VarIndex operand that pops one value.
+/// Records the store in `last_store` so a following matching LOAD_VAR can be
+/// optimized into a DUP inserted before the STORE.
 macro_rules! emit_store_var_index {
     ($name:ident, $opcode:expr) => {
         pub fn $name(&mut self, index: VarIndex) {
-            self.emit_opcode($opcode);
-            self.bytecode.extend_from_slice(&index.to_le_bytes());
-            self.pop_stack(1);
+            self.emit_store_with_tracking($opcode, index.to_le_bytes());
         }
     };
 }
@@ -110,39 +125,106 @@ impl Emitter {
             labels: Vec::new(),
             patches: Vec::new(),
             last_load: None,
+            last_store: None,
         }
     }
 
-    /// Pushes an opcode byte and invalidates the consecutive-load tracker.
+    /// Pushes an opcode byte and invalidates both DUP trackers.
     ///
-    /// Every non-load emission goes through this method, so `last_load` is
-    /// automatically cleared without needing explicit calls at each site.
-    /// The load path (`emit_load_with_dup_check`) bypasses this to manage
-    /// the tracker itself.
+    /// Every non-load, non-store emission goes through this method, so the
+    /// peephole trackers are automatically cleared without needing explicit
+    /// calls at each site. The load path (`emit_load_with_dup_check`) and
+    /// the store path (`emit_store_with_tracking`) bypass this to manage
+    /// the trackers themselves.
     fn emit_opcode(&mut self, op: u8) {
         self.bytecode.push(op);
         self.last_load = None;
+        self.last_store = None;
     }
 
-    /// Checks if the load matches the last emitted load; if so, emits DUP
-    /// instead of the full load instruction. Otherwise emits the load normally
-    /// and records it for future DUP checks.
+    /// Checks peephole opportunities before emitting a load:
+    ///
+    /// 1. **Consecutive identical load:** if the previous instruction was
+    ///    an identical load, emit a 1-byte DUP instead of the 3-byte load.
+    /// 2. **Store-load pair:** if the previous instruction was a matching
+    ///    STORE_VAR (same width, same operand), retroactively insert a DUP
+    ///    before the STORE and skip this load entirely. This eliminates
+    ///    the redundant round-trip through the variable table.
+    ///
+    /// If neither applies, the load is emitted normally and recorded for
+    /// future checks.
     fn emit_load_with_dup_check(&mut self, op: u8, operand: [u8; 2]) {
+        // Case 1: consecutive identical load.
         let candidate = LastLoad {
             opcode: op,
             operand,
         };
         if self.last_load.as_ref() == Some(&candidate) {
-            // Consecutive identical load — emit DUP instead.
             self.emit_opcode(opcode::DUP);
             self.push_stack(1);
             self.last_load = None;
-        } else {
-            self.bytecode.push(op);
-            self.bytecode.extend_from_slice(&operand);
-            self.push_stack(1);
-            self.last_load = Some(candidate);
+            return;
         }
+
+        // Case 2: store-load pair (STORE_VAR N; LOAD_VAR N of same width).
+        if let Some(store) = &self.last_store {
+            if Self::load_matches_store(op, store.opcode) && store.operand == operand {
+                // Retroactively insert DUP before the STORE. This is safe
+                // because `last_store` is cleared by any intervening
+                // emission or label bind, so the STORE is guaranteed to be
+                // the most recently emitted bytes and no patches or labels
+                // reference positions at or after the STORE.
+                let store_pos = store.position;
+                self.bytecode.insert(store_pos, opcode::DUP);
+                // The DUP;STORE sequence has the same net stack effect as
+                // the original LOAD (+1), so advance current_stack_depth
+                // as if the LOAD had been emitted. The runtime peak at the
+                // DUP is one slot above that value.
+                self.push_stack(1);
+                let dup_peak = self.current_stack_depth.saturating_add(1);
+                if dup_peak > self.max_stack_depth {
+                    self.max_stack_depth = dup_peak;
+                }
+                self.last_load = None;
+                self.last_store = None;
+                return;
+            }
+        }
+
+        // Default: emit the load normally.
+        self.bytecode.push(op);
+        self.bytecode.extend_from_slice(&operand);
+        self.push_stack(1);
+        self.last_load = Some(candidate);
+        self.last_store = None;
+    }
+
+    /// Emits a STORE_VAR instruction and records it for the store-load DUP
+    /// optimization. Bypasses `emit_opcode` so `last_store` is set rather
+    /// than cleared.
+    fn emit_store_with_tracking(&mut self, op: u8, operand: [u8; 2]) {
+        let position = self.bytecode.len();
+        self.bytecode.push(op);
+        self.bytecode.extend_from_slice(&operand);
+        self.pop_stack(1);
+        self.last_load = None;
+        self.last_store = Some(LastStore {
+            position,
+            opcode: op,
+            operand,
+        });
+    }
+
+    /// Returns true if `load_op` is the LOAD_VAR counterpart of `store_op`
+    /// (same type width).
+    fn load_matches_store(load_op: u8, store_op: u8) -> bool {
+        matches!(
+            (store_op, load_op),
+            (opcode::STORE_VAR_I32, opcode::LOAD_VAR_I32)
+                | (opcode::STORE_VAR_I64, opcode::LOAD_VAR_I64)
+                | (opcode::STORE_VAR_F32, opcode::LOAD_VAR_F32)
+                | (opcode::STORE_VAR_F64, opcode::LOAD_VAR_F64)
+        )
     }
 
     // --- Push ops (no operand, push 1) ---
@@ -358,10 +440,11 @@ impl Emitter {
 
     /// Binds a label to the current bytecode position.
     /// Binds a label to the current bytecode position.
-    /// Clears the last-load tracker because a jump may land here.
+    /// Clears the peephole trackers because a jump may land here.
     pub fn bind_label(&mut self, label: Label) {
         self.labels[label.0] = Some(self.bytecode.len());
         self.last_load = None;
+        self.last_store = None;
     }
 
     /// Emits JMP with a placeholder offset targeting the given label.
@@ -594,14 +677,13 @@ impl Emitter {
         self.emit_opcode(opcode::RET_VOID);
     }
 
-    /// Returns the accumulated bytecode, resolving all pending jump patches
-    /// and applying peephole optimizations.
+    /// Returns the accumulated bytecode with all pending jump patches resolved.
     ///
-    /// Must be called before `max_stack_depth()` because the peephole pass
-    /// may increase the reported maximum.
+    /// Peephole optimizations (consecutive load → DUP, store-load → insert
+    /// DUP before STORE) are applied inline during emission, so no separate
+    /// pass runs here.
     pub fn bytecode(&mut self) -> &[u8] {
         self.patch_jumps();
-        self.peephole_store_load();
         &self.bytecode
     }
 
@@ -622,95 +704,6 @@ impl Emitter {
             self.bytecode[patch.patch_offset] = bytes[0];
             self.bytecode[patch.patch_offset + 1] = bytes[1];
         }
-    }
-
-    /// Peephole optimization: replace `STORE_VAR_Xx N; LOAD_VAR_Xx N` with
-    /// `DUP; STORE_VAR_Xx N; NOP; NOP`. This avoids a redundant load when a
-    /// value is stored and immediately read back.
-    ///
-    /// Must be called after `patch_jumps` so that jump targets are resolved.
-    /// The rewrite preserves bytecode length (6 bytes → 6 bytes) so all
-    /// jump offsets remain valid.
-    fn peephole_store_load(&mut self) {
-        if self.bytecode.len() < 6 {
-            return;
-        }
-        let jump_targets = self.collect_jump_targets();
-
-        let mut applied = false;
-        let mut i = 0;
-        while i + 5 < self.bytecode.len() {
-            let store_op = self.bytecode[i];
-            if let Some(load_op) = Self::store_to_load(store_op) {
-                let load_start = i + 3;
-                if self.bytecode[load_start] == load_op
-                    && self.bytecode[i + 1] == self.bytecode[load_start + 1]
-                    && self.bytecode[i + 2] == self.bytecode[load_start + 2]
-                    && !Self::range_has_target(&jump_targets, load_start, load_start + 3)
-                {
-                    // Rewrite: [STORE, lo, hi, LOAD, lo, hi]
-                    //       → [DUP, STORE, lo, hi, NOP, NOP]
-                    self.bytecode[i + 5] = opcode::NOP;
-                    self.bytecode[i + 4] = opcode::NOP;
-                    self.bytecode[i + 3] = self.bytecode[i + 2];
-                    self.bytecode[i + 2] = self.bytecode[i + 1];
-                    self.bytecode[i + 1] = store_op;
-                    self.bytecode[i] = opcode::DUP;
-                    applied = true;
-                    i += 6;
-                    continue;
-                }
-            }
-            i += 1;
-        }
-        // DUP temporarily adds one extra value to the stack before the
-        // STORE pops it, so bump the reported max.
-        if applied {
-            self.max_stack_depth += 1;
-        }
-    }
-
-    /// Maps a STORE_VAR opcode to its corresponding LOAD_VAR opcode.
-    fn store_to_load(op: u8) -> Option<u8> {
-        match op {
-            opcode::STORE_VAR_I32 => Some(opcode::LOAD_VAR_I32),
-            opcode::STORE_VAR_I64 => Some(opcode::LOAD_VAR_I64),
-            opcode::STORE_VAR_F32 => Some(opcode::LOAD_VAR_F32),
-            opcode::STORE_VAR_F64 => Some(opcode::LOAD_VAR_F64),
-            _ => None,
-        }
-    }
-
-    /// Returns true if any jump target falls within [start, end).
-    fn range_has_target(targets: &[bool], start: usize, end: usize) -> bool {
-        targets[start..end].iter().any(|&t| t)
-    }
-
-    /// Scans bytecode for JMP and JMP_IF_NOT instructions and returns a
-    /// boolean array marking every address that is a jump target.
-    fn collect_jump_targets(&self) -> Vec<bool> {
-        let bc = &self.bytecode;
-        let mut targets = vec![false; bc.len()];
-        let mut pc = 0;
-        while pc < bc.len() {
-            match bc[pc] {
-                opcode::JMP | opcode::JMP_IF_NOT => {
-                    if pc + 2 < bc.len() {
-                        let offset = i16::from_le_bytes([bc[pc + 1], bc[pc + 2]]);
-                        let next_pc = pc + 3;
-                        let target = (next_pc as isize + offset as isize) as usize;
-                        if target < targets.len() {
-                            targets[target] = true;
-                        }
-                    }
-                    pc += 3;
-                }
-                _ => {
-                    pc += opcode::instruction_size(bc[pc]);
-                }
-            }
-        }
-        targets
     }
 
     fn push_stack(&mut self, count: u16) {

--- a/compiler/codegen/src/optimize.rs
+++ b/compiler/codegen/src/optimize.rs
@@ -5,7 +5,7 @@
 //! removing them. Jump offsets are adjusted to account for removed bytes.
 //!
 //! This pass runs after the emitter's own in-line peephole optimizations
-//! (consecutive load -> DUP, store-load -> DUP+STORE+NOP) and complements
+//! (consecutive load -> DUP, store-load -> DUP+STORE) and complements
 //! them by handling arithmetic identities that are only visible once the
 //! full instruction stream exists.
 //!
@@ -586,15 +586,6 @@ mod tests {
         assert_eq!(result, vec![opcode::RET_VOID]);
     }
 
-    #[test]
-    fn optimize_when_bytecode_contains_nop_then_preserves_nop() {
-        // NOP bytes (inserted by the emitter's store-load peephole) must
-        // be preserved as 1-byte instructions.
-        let bytecode = vec![opcode::NOP, opcode::NOP, opcode::RET_VOID];
-        let result = optimize(&bytecode, &[]);
-        assert_eq!(result, bytecode);
-    }
-
     // --- String opcode regression tests (instruction size correctness) ---
 
     #[test]
@@ -606,7 +597,7 @@ mod tests {
         bytecode.extend_from_slice(&str_load_var(100));
         bytecode.push(opcode::POP);
         bytecode.extend_from_slice(&jmp(1));
-        bytecode.push(opcode::NOP);
+        bytecode.push(opcode::POP);
         bytecode.push(opcode::RET_VOID);
 
         let result = optimize(&bytecode, &[]);
@@ -621,7 +612,7 @@ mod tests {
         bytecode.extend_from_slice(&find_str(100, 200));
         bytecode.push(opcode::POP);
         bytecode.extend_from_slice(&jmp(1));
-        bytecode.push(opcode::NOP);
+        bytecode.push(opcode::POP);
         bytecode.push(opcode::RET_VOID);
 
         let result = optimize(&bytecode, &[]);
@@ -635,7 +626,7 @@ mod tests {
         let mut bytecode = Vec::new();
         bytecode.extend_from_slice(&str_init(100, 80));
         bytecode.extend_from_slice(&jmp(1));
-        bytecode.push(opcode::NOP);
+        bytecode.push(opcode::POP);
         bytecode.push(opcode::RET_VOID);
 
         let result = optimize(&bytecode, &[]);

--- a/compiler/codegen/tests/compile_abs.rs
+++ b/compiler/codegen/tests/compile_abs.rs
@@ -41,7 +41,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0xC4, 0x43, 0x03, // BUILTIN ABS_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
             0xB5, // RET_VOID

--- a/compiler/codegen/tests/compile_abs_float.rs
+++ b/compiler/codegen/tests/compile_abs_float.rs
@@ -32,7 +32,6 @@ END_PROGRAM
             0x03, 0x00, 0x00, // LOAD_CONST_F32 pool:0
             0xA1, // DUP (store-load optimization)
             0x1A, 0x00, 0x00, // STORE_VAR_F32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0xC4, 0x54, 0x03, // BUILTIN ABS_F32
             0x1A, 0x01, 0x00, // STORE_VAR_F32 var:1
             0xB5, // RET_VOID
@@ -67,7 +66,6 @@ END_PROGRAM
             0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0
             0xA1, // DUP (store-load optimization)
             0x1B, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0xC4, 0x55, 0x03, // BUILTIN ABS_F64
             0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1
             0xB5, // RET_VOID

--- a/compiler/codegen/tests/compile_add.rs
+++ b/compiler/codegen/tests/compile_add.rs
@@ -48,7 +48,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x30, // ADD_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_bool.rs
+++ b/compiler/codegen/tests/compile_bool.rs
@@ -38,7 +38,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (0)
             0x6C, // GT_I32
             0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
@@ -75,7 +74,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (0)
             0x6C, // GT_I32
             0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
@@ -112,7 +110,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (0)
             0x6C, // GT_I32
             0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
@@ -152,7 +149,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x57, // BOOL_NOT
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
             0xB5, // RET_VOID

--- a/compiler/codegen/tests/compile_cmp.rs
+++ b/compiler/codegen/tests/compile_cmp.rs
@@ -48,7 +48,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x68, // EQ_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
@@ -81,7 +80,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x69, // NE_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
@@ -114,7 +112,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x6A, // LT_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
@@ -147,7 +144,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x6B, // LE_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
@@ -180,7 +176,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x6C, // GT_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
@@ -213,7 +208,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x6D, // GE_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_dup.rs
+++ b/compiler/codegen/tests/compile_dup.rs
@@ -36,7 +36,7 @@ END_PROGRAM
 }
 
 #[test]
-fn compile_when_store_then_load_same_var_then_emits_dup_store_nop() {
+fn compile_when_store_then_load_same_var_then_emits_dup_before_store() {
     // x := 7; y := x; is the classic store-load pattern
     let source = "
 PROGRAM main
@@ -60,7 +60,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (7)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
             0xB5, // RET_VOID
         ]

--- a/compiler/codegen/tests/compile_float.rs
+++ b/compiler/codegen/tests/compile_float.rs
@@ -63,7 +63,6 @@ END_PROGRAM
             0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0
             0xA1, // DUP (store-load optimization)
             0x1B, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x04, 0x01, 0x00, // LOAD_CONST_F64 pool:1
             0x4E, // ADD_F64
             0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1

--- a/compiler/codegen/tests/compile_func_forms.rs
+++ b/compiler/codegen/tests/compile_func_forms.rs
@@ -46,8 +46,6 @@ fn assert_two_arg_bytecode(source: &str, expected_opcode: u8) {
             0x18,
             0x00,
             0x00, // STORE_VAR_I32 var:0
-            0xA3,
-            0xA3, // NOP, NOP (padding)
             0x01,
             0x01,
             0x00,            // LOAD_CONST_I32 pool:1 (5)
@@ -219,7 +217,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
             0xB5, // RET_VOID
         ]

--- a/compiler/codegen/tests/compile_loops.rs
+++ b/compiler/codegen/tests/compile_loops.rs
@@ -78,24 +78,24 @@ END_PROGRAM
     let container = parse_and_compile(source, &CompilerOptions::default());
 
     // x=var:0, constants: pool:0=1, pool:1=5
-    // Bytecode layout:
+    // Bytecode layout (store-load optimization inserts DUP before STORE x):
     //   0: LOAD_VAR_I32 var:0          (body: x)
     //   3: LOAD_CONST_I32 pool:0 (1)   (body: 1)
     //   6: ADD_I32                      (x + 1)
-    //   7: STORE_VAR_I32 var:0         (x := ...)
-    //  10: LOAD_VAR_I32 var:0          (condition: x)
-    //  13: LOAD_CONST_I32 pool:1 (5)   (condition: 5)
-    //  16: GT_I32                       (x > 5)
-    //  17: JMP_IF_NOT offset:-20 -> 0  (back to LOOP if false)
-    //  20: RET_VOID
+    //   7: DUP                          (store-load optimization)
+    //   8: STORE_VAR_I32 var:0         (x := ...)
+    //  11: LOAD_CONST_I32 pool:1 (5)   (condition: 5)
+    //  14: GT_I32                       (x > 5)
+    //  15: JMP_IF_NOT offset:-18 -> 0  (back to LOOP if false)
+    //  18: RET_VOID
     let bytecode = container
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
 
-    // Verify JMP_IF_NOT at offset 17 with backward offset -20
-    assert_eq!(bytecode[17], 0xB2); // JMP_IF_NOT
-    assert_eq!(i16::from_le_bytes([bytecode[18], bytecode[19]]), -20);
+    // Verify JMP_IF_NOT at offset 15 with backward offset -18
+    assert_eq!(bytecode[15], 0xB2); // JMP_IF_NOT
+    assert_eq!(i16::from_le_bytes([bytecode[16], bytecode[17]]), -18);
 
     assert_eq!(
         bytecode,
@@ -105,10 +105,9 @@ END_PROGRAM
             0x30, // ADD_I32
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (5)
             0x6C, // GT_I32
-            0xB2, 0xEC, 0xFF, // JMP_IF_NOT offset:-20
+            0xB2, 0xEE, 0xFF, // JMP_IF_NOT offset:-18
             0xB5, // RET_VOID
         ]
     );

--- a/compiler/codegen/tests/compile_max.rs
+++ b/compiler/codegen/tests/compile_max.rs
@@ -48,7 +48,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0xC4, 0x45, 0x03, // BUILTIN MAX_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_min.rs
+++ b/compiler/codegen/tests/compile_min.rs
@@ -48,7 +48,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0xC4, 0x44, 0x03, // BUILTIN MIN_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_mod.rs
+++ b/compiler/codegen/tests/compile_mod.rs
@@ -48,7 +48,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x34, // MOD_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_mul.rs
+++ b/compiler/codegen/tests/compile_mul.rs
@@ -45,7 +45,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x32, // MUL_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_neg.rs
+++ b/compiler/codegen/tests/compile_neg.rs
@@ -41,7 +41,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x35, // NEG_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1
             0xB5, // RET_VOID

--- a/compiler/codegen/tests/compile_pow.rs
+++ b/compiler/codegen/tests/compile_pow.rs
@@ -48,7 +48,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0xC4, 0x40, 0x03, // BUILTIN EXPT_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_sel.rs
+++ b/compiler/codegen/tests/compile_sel.rs
@@ -56,7 +56,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (10)
             0x01, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (20)
             0xC4, 0x47, 0x03, // BUILTIN SEL_I32

--- a/compiler/codegen/tests/compile_shift.rs
+++ b/compiler/codegen/tests/compile_shift.rs
@@ -35,7 +35,6 @@ END_PROGRAM
             0x21, // TRUNC_U8
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (4)
             0xC4, 0x48, 0x03, // BUILTIN SHL_I32 (0x0348)
             0x21, // TRUNC_U8
@@ -71,7 +70,6 @@ END_PROGRAM
             0x21, // TRUNC_U8
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
             0xC4, 0x50, 0x03, // BUILTIN ROL_U8 (0x0350)
             0x21, // TRUNC_U8
@@ -107,7 +105,6 @@ END_PROGRAM
             0x23, // TRUNC_U16
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
             0xC4, 0x53, 0x03, // BUILTIN ROR_U16 (0x0353)
             0x23, // TRUNC_U16
@@ -142,7 +139,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x0F)
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (4)
             0xC4, 0x48, 0x03, // BUILTIN SHL_I32 (0x0348)
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_sqrt.rs
+++ b/compiler/codegen/tests/compile_sqrt.rs
@@ -32,7 +32,6 @@ END_PROGRAM
             0x03, 0x00, 0x00, // LOAD_CONST_F32 pool:0
             0xA1, // DUP (store-load optimization)
             0x1A, 0x00, 0x00, // STORE_VAR_F32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0xC4, 0x5E, 0x03, // BUILTIN SQRT_F32
             0x1A, 0x01, 0x00, // STORE_VAR_F32 var:1
             0xB5, // RET_VOID
@@ -67,7 +66,6 @@ END_PROGRAM
             0x04, 0x00, 0x00, // LOAD_CONST_F64 pool:0
             0xA1, // DUP (store-load optimization)
             0x1B, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0xC4, 0x5F, 0x03, // BUILTIN SQRT_F64
             0x1B, 0x01, 0x00, // STORE_VAR_F64 var:1
             0xB5, // RET_VOID

--- a/compiler/codegen/tests/compile_sub.rs
+++ b/compiler/codegen/tests/compile_sub.rs
@@ -48,7 +48,6 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0
             0xA1, // DUP (store-load optimization)
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1
             0x31, // SUB_I32
             0x18, 0x01, 0x00, // STORE_VAR_I32 var:1

--- a/compiler/codegen/tests/compile_types.rs
+++ b/compiler/codegen/tests/compile_types.rs
@@ -91,7 +91,6 @@ END_PROGRAM
             0x02, 0x00, 0x00, // LOAD_CONST_I64 pool:0 (10)
             0xA1, // DUP (store-load optimization)
             0x19, 0x00, 0x00, // STORE_VAR_I64 var:0
-            0xA3, 0xA3, // NOP, NOP (padding)
             0x02, 0x01, 0x00, // LOAD_CONST_I64 pool:1 (1)
             0x38, // ADD_I64
             0x19, 0x01, 0x00, // STORE_VAR_I64 var:1

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -156,9 +156,6 @@ pub const DUP: Opcode = 0xA1;
 /// Stack effect: [..., a, b] -> [..., b, a]
 pub const SWAP: Opcode = 0xA2;
 
-/// No operation. Used as padding by the peephole optimizer.
-pub const NOP: u8 = 0xA3;
-
 // --- Function block opcodes ---
 
 /// Push FB instance reference from variable table.
@@ -580,7 +577,7 @@ pub fn instruction_size(op: Opcode) -> usize {
         | EQ_F64 | NE_F64 | LT_F64 | LE_F64 | GT_F64 | GE_F64 | BOOL_AND | BOOL_OR | BOOL_XOR
         | BOOL_NOT | BIT_AND_32 | BIT_OR_32 | BIT_XOR_32 | BIT_NOT_32 | BIT_AND_64 | BIT_OR_64
         | BIT_XOR_64 | BIT_NOT_64 | TRUNC_I8 | TRUNC_U8 | TRUNC_I16 | TRUNC_U16 | LOAD_INDIRECT
-        | STORE_INDIRECT | LOAD_TRUE | LOAD_FALSE | POP | DUP | SWAP | NOP | RET | RET_VOID => 1,
+        | STORE_INDIRECT | LOAD_TRUE | LOAD_FALSE | POP | DUP | SWAP | RET | RET_VOID => 1,
 
         // 2-byte: opcode + u8 field index.
         FB_STORE_PARAM | FB_LOAD_PARAM => 2,

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -1638,7 +1638,6 @@ fn execute(
             opcode::SWAP => {
                 stack.swap()?;
             }
-            opcode::NOP => {}
             // --- Function block opcodes ---
             opcode::FB_LOAD_INSTANCE => {
                 let var_index = VarIndex::new(read_u16_le(bytecode, &mut pc)?);


### PR DESCRIPTION
Replaces the post-emission peephole pass (which rewrote STORE+LOAD into DUP+STORE+NOP+NOP to preserve bytecode length) with a retroactive DUP insertion that runs during emission.

The Emitter now tracks the position of the most recent STORE_VAR in `last_store`. When emit_load_with_dup_check sees a matching load:
- insert a DUP byte at the STORE's position (shifting the STORE by 1)
- skip emitting the LOAD entirely
- advance current_stack_depth by 1 and bump max_stack_depth for the transient DUP peak

This is safe because `last_store` is cleared by any intervening emission or label bind, so nothing has been emitted past the STORE and no patches or labels reference positions at or after it.

Consequences:
- NOP opcode removed (no longer used anywhere)
- Bytecode is 2 bytes shorter per optimized site
- The VM no longer dispatches through NOPs, saving 2 dispatch cycles per optimized site
- Snapshot tests updated to drop the NOP padding bytes
- REPEAT-loop test's JMP_IF_NOT offset assertion updated for the new layout

https://claude.ai/code/session_01RcnH36onFt33Zj5T188Hj4