### PR TITLE
Make pause/stop discoverable via reactive code lenses

### DIFF
--- a/integrations/vscode/src/extension.ts
+++ b/integrations/vscode/src/extension.ts
@@ -13,6 +13,46 @@ import { ProblemCode, formatProblem } from './problems';
 import { RunSession, RunState } from './runSession';
 import { findProgramLenses } from './runCodeLensProvider';
 
+/**
+ * Reactive code lens provider for PROGRAM declarations. Shows "Run Program"
+ * when idle and toggles to "Pause"/"Stop" (or "Resume"/"Stop") as the run
+ * session transitions states.
+ */
+class RunProgramCodeLensProvider implements vscode.CodeLensProvider {
+  private _state: RunState = 'idle';
+  private readonly _emitter = new vscode.EventEmitter<void>();
+  readonly onDidChangeCodeLenses = this._emitter.event;
+
+  constructor(private readonly hasCompiler: () => boolean) {}
+
+  setState(state: RunState): void {
+    if (this._state === state) {
+      return;
+    }
+    this._state = state;
+    this._emitter.fire();
+  }
+
+  provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+    const lenses = findProgramLenses(document.getText(), this._state, this.hasCompiler());
+    return lenses.map((lens) => {
+      const range = new vscode.Range(
+        new vscode.Position(lens.range.start.line, lens.range.start.character),
+        new vscode.Position(lens.range.end.line, lens.range.end.character),
+      );
+      return new vscode.CodeLens(range, lens.command ? {
+        title: lens.command.title,
+        command: lens.command.command,
+        arguments: lens.command.arguments as unknown[] | undefined,
+      } : undefined);
+    });
+  }
+
+  dispose(): void {
+    this._emitter.dispose();
+  }
+}
+
 const VERBOSITY = new Map<string, string[]>([
   ['ERROR', []],
   ['WARN', ['-v']],
@@ -99,6 +139,10 @@ function registerRunSupport(context: vscode.ExtensionContext) {
   stopItem.command = 'ironplc.stopProgram';
   context.subscriptions.push(stopItem);
 
+  // CodeLens provider (reactive — refreshes when the run state changes)
+  const runLensProvider = new RunProgramCodeLensProvider(() => !!client);
+  context.subscriptions.push(runLensProvider);
+
   function updateStatusBar(state: RunState) {
     if (state === 'running') {
       pauseItem.text = '$(debug-pause) Pause';
@@ -114,41 +158,19 @@ function registerRunSupport(context: vscode.ExtensionContext) {
       pauseItem.hide();
       stopItem.hide();
     }
+    runLensProvider.setState(state);
   }
 
   // Initially hidden
   updateStatusBar('idle');
 
-  // CodeLens provider
   const stSelector: vscode.DocumentSelector = [
     { scheme: 'file', language: '61131-3-st' },
     { scheme: 'file', language: 'twincat-pou' },
   ];
 
   context.subscriptions.push(
-    vscode.languages.registerCodeLensProvider(stSelector, {
-      provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
-        const lenses = findProgramLenses(document.getText());
-        const hasCompiler = !!client;
-        return lenses.map(lens => {
-          const range = new vscode.Range(
-            new vscode.Position(lens.range.start.line, lens.range.start.character),
-            new vscode.Position(lens.range.end.line, lens.range.end.character),
-          );
-          if (hasCompiler) {
-            return new vscode.CodeLens(range, lens.command ? {
-              title: lens.command.title,
-              command: lens.command.command,
-              arguments: lens.command.arguments,
-            } : undefined);
-          }
-          return new vscode.CodeLens(range, {
-            title: '$(warning) Run Program (no compiler)',
-            command: 'ironplc.runProgram',
-          });
-        });
-      },
-    }),
+    vscode.languages.registerCodeLensProvider(stSelector, runLensProvider),
   );
 
   // Run command

--- a/integrations/vscode/src/runCodeLensProvider.ts
+++ b/integrations/vscode/src/runCodeLensProvider.ts
@@ -1,7 +1,9 @@
 /**
- * CodeLens provider that shows a "Run Program" action above PROGRAM
+ * CodeLens provider that shows run/pause/stop actions above PROGRAM
  * declarations in IEC 61131-3 Structured Text files.
  */
+
+import { RunState } from './runSession';
 
 /** Minimal subset of vscode types needed for code lens, enabling unit tests
  *  without depending on the vscode module. */
@@ -19,21 +21,74 @@ const PROGRAM_RE = /^\s*PROGRAM\s+(\w+)/i;
 
 /**
  * Find PROGRAM declarations in the given source text and return code lens
- * descriptors for each one.
+ * descriptors for each one, reflecting the current run session state.
+ *
+ * When the session is `idle` or `error`, each PROGRAM line gets a single
+ * "Run Program" lens. When `running`, the line gets "Pause" and "Stop"
+ * lenses. When `paused`, the line gets "Resume" and "Stop" lenses. Pause and
+ * stop lenses take no arguments; the run lens carries the program name so
+ * it can be surfaced to the run command.
  */
-export function findProgramLenses(text: string): CodeLensLike[] {
+export function findProgramLenses(
+  text: string,
+  state: RunState = 'idle',
+  hasCompiler: boolean = true,
+): CodeLensLike[] {
   const lines = text.split('\n');
   const lenses: CodeLensLike[] = [];
 
   for (let i = 0; i < lines.length; i++) {
     const match = PROGRAM_RE.exec(lines[i]);
-    if (match) {
-      const programName = match[1];
+    if (!match) {
+      continue;
+    }
+    const programName = match[1];
+    const range = {
+      start: { line: i, character: 0 },
+      end: { line: i, character: lines[i].length },
+    };
+
+    if (state === 'running') {
       lenses.push({
-        range: {
-          start: { line: i, character: 0 },
-          end: { line: i, character: lines[i].length },
+        range,
+        command: {
+          title: '$(debug-pause) Pause',
+          command: 'ironplc.pauseProgram',
         },
+      });
+      lenses.push({
+        range,
+        command: {
+          title: '$(debug-stop) Stop',
+          command: 'ironplc.stopProgram',
+        },
+      });
+    } else if (state === 'paused') {
+      lenses.push({
+        range,
+        command: {
+          title: '$(debug-continue) Resume',
+          command: 'ironplc.pauseProgram',
+        },
+      });
+      lenses.push({
+        range,
+        command: {
+          title: '$(debug-stop) Stop',
+          command: 'ironplc.stopProgram',
+        },
+      });
+    } else if (!hasCompiler) {
+      lenses.push({
+        range,
+        command: {
+          title: '$(warning) Run Program (no compiler)',
+          command: 'ironplc.runProgram',
+        },
+      });
+    } else {
+      lenses.push({
+        range,
         command: {
           title: '$(play) Run Program',
           command: 'ironplc.runProgram',

--- a/integrations/vscode/src/test/unit/runCodeLensProvider.test.ts
+++ b/integrations/vscode/src/test/unit/runCodeLensProvider.test.ts
@@ -75,4 +75,61 @@ suite('RunCodeLensProvider', () => {
 
     assert.ok(lenses[0].command?.title.includes('Run Program'));
   });
+
+  test('findProgramLenses_when_running_state_then_returns_pause_and_stop_lenses', () => {
+    const text = 'PROGRAM main\nEND_PROGRAM';
+    const lenses = findProgramLenses(text, 'running');
+
+    assert.strictEqual(lenses.length, 2);
+    assert.ok(lenses[0].command?.title.includes('Pause'));
+    assert.strictEqual(lenses[0].command?.command, 'ironplc.pauseProgram');
+    assert.ok(lenses[1].command?.title.includes('Stop'));
+    assert.strictEqual(lenses[1].command?.command, 'ironplc.stopProgram');
+    assert.strictEqual(lenses[0].range.start.line, 0);
+    assert.strictEqual(lenses[1].range.start.line, 0);
+  });
+
+  test('findProgramLenses_when_paused_state_then_returns_resume_and_stop_lenses', () => {
+    const text = 'PROGRAM main\nEND_PROGRAM';
+    const lenses = findProgramLenses(text, 'paused');
+
+    assert.strictEqual(lenses.length, 2);
+    assert.ok(lenses[0].command?.title.includes('Resume'));
+    assert.strictEqual(lenses[0].command?.command, 'ironplc.pauseProgram');
+    assert.ok(lenses[1].command?.title.includes('Stop'));
+    assert.strictEqual(lenses[1].command?.command, 'ironplc.stopProgram');
+  });
+
+  test('findProgramLenses_when_error_state_then_returns_run_lens', () => {
+    const text = 'PROGRAM main\nEND_PROGRAM';
+    const lenses = findProgramLenses(text, 'error');
+
+    assert.strictEqual(lenses.length, 1);
+    assert.ok(lenses[0].command?.title.includes('Run Program'));
+    assert.strictEqual(lenses[0].command?.command, 'ironplc.runProgram');
+  });
+
+  test('findProgramLenses_when_no_compiler_and_idle_then_returns_warning_lens', () => {
+    const text = 'PROGRAM main\nEND_PROGRAM';
+    const lenses = findProgramLenses(text, 'idle', false);
+
+    assert.strictEqual(lenses.length, 1);
+    assert.ok(lenses[0].command?.title.includes('no compiler'));
+    assert.strictEqual(lenses[0].command?.command, 'ironplc.runProgram');
+  });
+
+  test('findProgramLenses_when_running_and_multiple_programs_then_each_gets_pause_stop', () => {
+    const text = 'PROGRAM first\nEND_PROGRAM\n\nPROGRAM second\nEND_PROGRAM';
+    const lenses = findProgramLenses(text, 'running');
+
+    assert.strictEqual(lenses.length, 4);
+    assert.strictEqual(lenses[0].range.start.line, 0);
+    assert.strictEqual(lenses[1].range.start.line, 0);
+    assert.strictEqual(lenses[2].range.start.line, 3);
+    assert.strictEqual(lenses[3].range.start.line, 3);
+    assert.strictEqual(lenses[0].command?.command, 'ironplc.pauseProgram');
+    assert.strictEqual(lenses[1].command?.command, 'ironplc.stopProgram');
+    assert.strictEqual(lenses[2].command?.command, 'ironplc.pauseProgram');
+    assert.strictEqual(lenses[3].command?.command, 'ironplc.stopProgram');
+  });
 });

--- a/specs/plans/2026-04-11-reactive-run-code-lens.md
+++ b/specs/plans/2026-04-11-reactive-run-code-lens.md
@@ -1,0 +1,73 @@
+# Surface Pause/Stop as Inline Code Lenses
+
+## Goal
+
+Make pause and stop discoverable in the VS Code extension by replacing the
+"Run Program" code lens with inline "Pause" + "Stop" (or "Resume" + "Stop")
+actions while a program is running. Today those actions exist only in the
+status bar, where users miss them.
+
+## Background
+
+The plan at `specs/plans/2026-04-05-program-run-button.md` was fully
+implemented: `RunSession.pause()`, `resume()`, and `stop()` all work
+(`integrations/vscode/src/runSession.ts:80-106`), the commands
+`ironplc.pauseProgram` and `ironplc.stopProgram` are registered
+(`integrations/vscode/src/extension.ts:207-226`), and status bar items appear
+while running (`extension.ts:92-117`). The user complaint — "once started,
+there is no way to stop or pause" — is a **discoverability** problem, not a
+missing feature. The code lens above the `PROGRAM` declaration is the most
+visible affordance, and today it never changes.
+
+The LSP server already supports `ironplc/run`, `ironplc/step`, and
+`ironplc/stop` (`compiler/ironplc-cli/src/lsp.rs:274-306`). Pause is client
+side: halt the step interval, let the `VmRunner` session persist until the
+user clicks stop. No server-side changes are required.
+
+## Architecture
+
+Make the code lens provider reactive to `RunSession` state. Every state
+transition fires both the existing status bar update and a new
+`onDidChangeCodeLenses` event, so VS Code re-renders the lenses.
+
+Lens mapping:
+
+| State            | Lenses                                              |
+|------------------|-----------------------------------------------------|
+| `idle` / `error` | `$(play) Run Program` → `ironplc.runProgram`        |
+| `idle` + no compiler | `$(warning) Run Program (no compiler)` → `ironplc.runProgram` |
+| `running`        | `$(debug-pause) Pause`, `$(debug-stop) Stop`        |
+| `paused`         | `$(debug-continue) Resume`, `$(debug-stop) Stop`    |
+
+Multiple `vscode.CodeLens` objects at the same range render as " | "-separated
+links, so pause and stop appear side-by-side above the PROGRAM line.
+
+## File Map
+
+### Modified files
+- `integrations/vscode/src/runCodeLensProvider.ts` — add `state` +
+  `hasCompiler` parameters to `findProgramLenses`; add a new
+  `RunProgramCodeLensProvider` class with `onDidChangeCodeLenses` and
+  `setState()`.
+- `integrations/vscode/src/extension.ts` — replace the anonymous inline
+  `CodeLensProvider` with an instance of `RunProgramCodeLensProvider`; call
+  `setState()` from `updateStatusBar` so lens and status bar refresh together.
+- `integrations/vscode/src/test/unit/runCodeLensProvider.test.ts` — add tests
+  for each state variant (running, paused, error, no-compiler, multi-program).
+
+### Unchanged
+- `runSession.ts` — pause/resume/stop logic is already correct.
+- LSP server — the existing run/step/stop primitives are enough.
+- `package.json` — commands already contributed; no new keybindings.
+
+## Tasks
+
+- [ ] Add `state` + `hasCompiler` parameters to `findProgramLenses`
+- [ ] Add `RunProgramCodeLensProvider` class in `runCodeLensProvider.ts`
+- [ ] Wire `RunProgramCodeLensProvider` into `registerRunSupport` and have
+  `updateStatusBar` call `setState()`
+- [ ] Add BDD unit tests for running / paused / error / no-compiler states
+- [ ] Verify `npm run compile` and `npm test` pass in
+  `integrations/vscode/`
+- [ ] Manual smoke test: run → pause → resume → stop cycle through inline
+  lenses


### PR DESCRIPTION
## Summary
Surface pause and stop actions as inline code lenses above PROGRAM declarations, making them discoverable while a program is running. Previously, these actions were only available in the status bar, creating a discoverability problem despite the underlying functionality being complete.

## Changes
- **`runCodeLensProvider.ts`**: Enhanced `findProgramLenses()` to accept `state` and `hasCompiler` parameters and return context-aware lenses:
  - `idle`/`error`: Shows "Run Program" lens
  - `running`: Shows "Pause" and "Stop" lenses
  - `paused`: Shows "Resume" and "Stop" lenses
  - `idle` + no compiler: Shows "Run Program (no compiler)" warning lens

- **`extension.ts`**: Introduced `RunProgramCodeLensProvider` class that:
  - Implements reactive code lens updates via `onDidChangeCodeLenses` event
  - Maintains current run state and fires refresh events on state transitions
  - Replaces the previous inline `CodeLensProvider` implementation
  - Integrates with `updateStatusBar()` to keep lenses and status bar in sync

- **`runCodeLensProvider.test.ts`**: Added comprehensive unit tests covering:
  - Running state (pause + stop lenses)
  - Paused state (resume + stop lenses)
  - Error state (run lens)
  - No compiler state (warning lens)
  - Multiple programs (each gets appropriate lenses)

## Implementation Details
- Multiple `CodeLens` objects at the same range render as pipe-separated links in VS Code, allowing pause and stop to appear side-by-side
- No LSP server changes required; existing `ironplc/run`, `ironplc/step`, and `ironplc/stop` primitives are sufficient
- Pause is client-side only: halts the step interval while keeping the `VmRunner` session alive
- The provider is registered once and reused, with state updates triggering re-renders via the event emitter pattern

https://claude.ai/code/session_01RnmWhFTK6xkAJWETwjEXA7