### PR TITLE
spec: reconcile container format type section with implementation

### DIFF
--- a/.claude/commands/reconcile-spec.md
+++ b/.claude/commands/reconcile-spec.md
@@ -1,0 +1,114 @@
+# Reconcile Spec with Implementation
+
+Reconcile one small section of a design spec with its implementation. This adds
+requirement IDs, fixes spec text to match code (code is king), and writes
+spec_test functions. See [spec-conformance-testing.md](../../specs/design/spec-conformance-testing.md)
+for the full design of the enforcement mechanism.
+
+## Procedure
+
+### Step 1: Understand the infrastructure
+
+Read `specs/design/spec-conformance-testing.md` to understand:
+- Requirement ID format (`**REQ-XX-NNN**`)
+- Annotation rules (ID-first, one per line, bold markers)
+- Enforcement mechanism (build.rs generates constants, proc macro references them)
+- Test naming convention
+
+### Step 2: Pick one small section
+
+Read the target spec file. Find a section that describes testable behavior but
+lacks `**REQ-XX-NNN**` markers. Pick **ONE** small, concrete subsection:
+- A single struct/record format (e.g., one 4-byte entry)
+- A single encoding table (e.g., one enum's value assignments)
+- A single behavioral rule
+
+Never pick an entire major section in one pass.
+
+Find the highest existing requirement ID in the spec:
+
+```bash
+grep -oP '\*\*REQ-\w+-\d+\*\*' <spec-file> | sort -u | tail -1
+```
+
+If no IDs exist yet, determine the correct prefix from
+`spec-conformance-testing.md` or propose a new one following the convention.
+
+### Step 3: Find the implementation
+
+Search the codebase for the types, constants, or functions described in the
+chosen spec section. Use grep/glob to locate the source file(s) that implement
+it. Read **only** the relevant source file(s) -- not the entire crate.
+
+### Step 4: Find the spec conformance infrastructure
+
+Search for the `build.rs` that references this spec file:
+
+```bash
+grep -rl '<spec-filename>' compiler/*/build.rs
+```
+
+If found, identify the crate and its conformance test module (look for
+`spec_conformance` in its `lib.rs`). If not found, set up the infrastructure
+by following the pattern in `spec-conformance-testing.md`:
+- Add a `build.rs` that scans the spec markdown for `**REQ-XX-NNN**` markers
+- Add a `spec_test_macro` dependency to `Cargo.toml`
+- Add `spec_requirements` and `spec_conformance` test modules to `lib.rs`
+- Add the `all_spec_requirements_have_tests` completeness meta-test
+
+Use `compiler/container/build.rs` as a working reference implementation.
+
+### Step 5: Compare spec vs code
+
+For each struct/enum/constant in the implementation:
+- Check field names, types, and byte sizes against the spec
+- Check enum variant values against the spec encoding table
+- Note any fields/variants in code but not in spec, or vice versa
+
+**Code is king.** If the code differs from the spec, the spec must be updated
+to match the code. Exception: if a spec feature is intentionally unimplemented,
+use `#[ignore]` on the test.
+
+### Step 6: Update the spec
+
+- Assign the next available `**REQ-XX-NNN**` ID(s)
+- Place each ID on its own line (ID-first) or in a table's Requirement column
+- If code diverges from spec, update the spec text to match the code
+- Keep changes minimal -- only touch the section being reconciled
+
+### Step 7: Write spec_test functions
+
+Add tests to the conformance test file. Follow the naming convention from
+`spec-conformance-testing.md`:
+
+```
+{area}_spec_req_{id}_{brief_description}
+```
+
+Each test should verify the specific claim its requirement makes. Prefer
+compile-time or structural assertions (size_of, constant values, round-trip
+serialization) over behavioral tests when possible.
+
+### Step 8: Run CI and commit
+
+```bash
+cd compiler && just
+```
+
+All checks must pass (compile, coverage, lint). If the
+`all_spec_requirements_have_tests` meta-test fails, ensure every `**REQ-XX-NNN**`
+in the spec has a matching `#[spec_test(REQ_XX_NNN)]`.
+
+Commit message format:
+
+```
+spec: reconcile {section name} with implementation (REQ-XX-NNN through REQ-XX-MMM)
+```
+
+## Token Efficiency
+
+- Find the highest existing ID with grep; do not re-read entire specs
+- Read only the source file(s) for the chosen section
+- Pick one small subsection per invocation
+- Reference `spec-conformance-testing.md` for mechanism details rather than
+  re-discovering them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Use these commands for common development tasks. Each skill includes fallback co
 - `/project:test` - Run tests (with coverage options)
 - `/project:ci` - **Full CI pipeline (REQUIRED before creating any PR)**
 - `/project:format` - Auto-fix formatting and lint issues
+- `/project:reconcile-spec` - Reconcile one spec section with implementation (add REQ IDs and tests)
 
 For full details, see [specs/steering/common-tasks.md](specs/steering/common-tasks.md).
 

--- a/compiler/container/src/spec_conformance.rs
+++ b/compiler/container/src/spec_conformance.rs
@@ -10,11 +10,14 @@
 //!
 //! See `specs/design/spec-conformance-testing.md` for full design.
 
+use std::vec;
 use std::vec::Vec;
 
 use spec_test_macro::spec_test;
 
 use crate::header::{FileHeader, FLAG_HAS_SYSTEM_UPTIME, FORMAT_VERSION, HEADER_SIZE, MAGIC};
+use crate::id_types::FbTypeId;
+use crate::type_section::{FbTypeDescriptor, FieldEntry, FieldType, TypeSection};
 
 // ---------------------------------------------------------------------------
 // Meta-test: completeness check
@@ -125,4 +128,50 @@ fn container_spec_req_cf_007_flags_bit0_is_system_uptime() {
     let mut buf = Vec::new();
     header.write_to(&mut buf).unwrap();
     assert_eq!(buf[7], 0x01);
+}
+
+// ---------------------------------------------------------------------------
+// Container Format — Type Section (REQ-CF-008 through REQ-CF-009)
+// ---------------------------------------------------------------------------
+
+/// REQ-CF-008: Each FieldEntry is 4 bytes.
+#[spec_test(REQ_CF_008)]
+fn container_spec_req_cf_008_field_entry_is_4_bytes() {
+    let section = TypeSection {
+        fb_types: vec![FbTypeDescriptor {
+            type_id: FbTypeId::new(0),
+            fields: vec![FieldEntry {
+                field_type: FieldType::I32,
+                field_extra: 0,
+            }],
+        }],
+        ..Default::default()
+    };
+    let mut buf = Vec::new();
+    section.write_to(&mut buf).unwrap();
+    // fb_count(2) + type_id(2) + num_fields(1) + reserved(1) + field(4)
+    //   + array_count(2) + user_fb_count(2) = 14
+    // The single field entry occupies exactly 4 bytes (bytes 6..10).
+    assert_eq!(buf.len(), 14);
+}
+
+/// REQ-CF-009: FieldType/var_type encoding values 0 through 10.
+#[spec_test(REQ_CF_009)]
+fn container_spec_req_cf_009_field_type_encoding_values() {
+    assert_eq!(FieldType::I32 as u8, 0);
+    assert_eq!(FieldType::U32 as u8, 1);
+    assert_eq!(FieldType::I64 as u8, 2);
+    assert_eq!(FieldType::U64 as u8, 3);
+    assert_eq!(FieldType::F32 as u8, 4);
+    assert_eq!(FieldType::F64 as u8, 5);
+    assert_eq!(FieldType::String as u8, 6);
+    assert_eq!(FieldType::WString as u8, 7);
+    assert_eq!(FieldType::FbInstance as u8, 8);
+    assert_eq!(FieldType::Time as u8, 9);
+    assert_eq!(FieldType::Slot as u8, 10);
+    // Values 0-10 are valid; 11 is invalid
+    for tag in 0..=10u8 {
+        assert!(FieldType::from_u8(tag).is_ok());
+    }
+    assert!(FieldType::from_u8(11).is_err());
 }

--- a/specs/design/bytecode-container-format.md
+++ b/specs/design/bytecode-container-format.md
@@ -152,9 +152,11 @@ Each VarEntry (4 bytes, fixed size):
 
 | Offset | Field | Type | Description |
 |--------|-------|------|-------------|
-| 0 | var_type | u8 | 0=I32, 1=U32, 2=I64, 3=U64, 4=F32, 5=F64, 6=STRING, 7=WSTRING, 8=FB_INSTANCE, 9=TIME |
+| 0 | var_type | u8 | Type encoding (see below) |
 | 1 | flags | u8 | Bit 0: is array (see array descriptors) |
 | 2 | extra | u16 | For STRING/WSTRING: max length. For FB_INSTANCE: fb_type_id. For arrays: array descriptor index. |
+
+**REQ-CF-009** The `var_type` / `field_type` encoding is: 0=I32, 1=U32, 2=I64, 3=U64, 4=F32, 5=F64, 6=STRING, 7=WSTRING, 8=FB_INSTANCE, 9=TIME, 10=SLOT. The SLOT type represents a heterogeneous structure field slot (8-byte slot for flattened struct layouts).
 
 Variable indices are compiler-assigned. The compiler must produce deterministic indices across compilations using the ordering rules in [Deterministic Ordering](#deterministic-ordering) to ensure that the same source program (with only logic changes) produces compatible bytecode.
 
@@ -182,7 +184,7 @@ Each FB type descriptor defines the field layout for a function block type.
 | 3 | reserved | u8 | Reserved; must be zero |
 | 4 | fields | [FieldEntry; num_fields] | Field descriptors |
 
-Each FieldEntry (4 bytes, fixed size):
+**REQ-CF-008** Each FieldEntry is 4 bytes (fixed size):
 
 | Offset | Field | Type | Description |
 |--------|-------|------|-------------|


### PR DESCRIPTION
## Summary
Reconcile the bytecode container format specification with its implementation by adding requirement IDs and conformance tests for the Type Section (FieldEntry and FieldType encoding).

## Changes

- **Specification updates** (`specs/design/bytecode-container-format.md`):
  - Added `**REQ-CF-008**` marker: FieldEntry is 4 bytes (fixed size)
  - Added `**REQ-CF-009**` marker: FieldType/var_type encoding values 0–10, including the new SLOT type (value 10) for heterogeneous structure field slots
  - Simplified the var_type table description to reference the detailed encoding specification

- **Conformance tests** (`compiler/container/src/spec_conformance.rs`):
  - Added `container_spec_req_cf_008_field_entry_is_4_bytes()`: Verifies that a serialized TypeSection with a single FieldEntry produces the expected byte layout (14 bytes total, with the field entry occupying exactly 4 bytes)
  - Added `container_spec_req_cf_009_field_type_encoding_values()`: Validates all 11 FieldType variants (I32–Slot) encode to values 0–10 and that invalid values (11+) are rejected

- **Infrastructure** (`compiler/container/src/spec_conformance.rs`):
  - Added imports for `FbTypeId`, `FbTypeDescriptor`, `FieldEntry`, `FieldType`, and `TypeSection` to support the new tests

- **Documentation** (`.claude/commands/reconcile-spec.md`):
  - Added comprehensive command guide for reconciling design specs with implementation, including step-by-step procedure, token efficiency tips, and reference to the spec-conformance-testing design

## Implementation Notes
- Code is authoritative: the SLOT type (value 10) was already in the implementation and is now documented in the spec
- Tests use structural assertions (size_of, constant values) rather than behavioral tests, following the conformance testing design
- All existing CI checks pass

https://claude.ai/code/session_01Bb8RHQKiRaZcy4YTUmQi2Y