### PR TITLE
Fix MCP smoke test: inline variables lost between just recipe lines

### DIFF
--- a/justfile
+++ b/justfile
@@ -196,12 +196,10 @@ endtoend-smoke-test compiler-version extension-version extension-name:
   # Verify ironplcmcp is installed and speaks MCP by performing the required
   # initialize handshake followed by a tools/list request, then checking that
   # the response contains a known tool name.
-  $mcpBin = "{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcmcp.exe"
-  $mcpInput = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0.1"}}}' + "`n" + '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' + "`n" + '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
-  $mcpTmp = "$env:TEMP\mcp-input.txt"
-  Set-Content -Path $mcpTmp -Value $mcpInput
-  $mcpResponse = cmd /c """$mcpBin""" "<" $mcpTmp
-  if ($mcpResponse -notmatch "list_options") { Write-Error "ironplcmcp did not return expected tools/list response. Got: $mcpResponse"; exit 1 }
+  # NOTE: each recipe line runs in a separate PowerShell process, so we cannot
+  # pass variables between lines. Use just template expressions and inline values.
+  Set-Content -Path "{{env_var('TEMP')}}\mcp-input.txt" -Value ('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0.1"}}}' + "`n" + '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' + "`n" + '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')
+  $mcpResponse = cmd /c """{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcmcp.exe""" "<" "{{env_var('TEMP')}}\mcp-input.txt"; if ($mcpResponse -notmatch "list_options") { Write-Error "ironplcmcp did not return expected tools/list response. Got: $mcpResponse"; exit 1 }
 
   IF (Test-Path "C:\\ironplcc.log" -PathType Leaf) { exit 0 } ELSE { exit 1 }
 


### PR DESCRIPTION
In just, each recipe line runs in a separate PowerShell process
(via `set windows-shell`), so variable assignments on one line are
not available on subsequent lines. The MCP smoke test defined
$mcpBin, $mcpInput, $mcpTmp on separate lines and then referenced
them later, causing null values and the Set-Content path error.

Fix by inlining all values using just template expressions
({{env_var('TEMP')}}, {{env_var('LOCALAPPDATA')}}) and combining
the command + assertion on a single line so $mcpResponse is
available for the -notmatch check.

https://claude.ai/code/session_01XsGzX5WBR6bqkxfvFt3yD2