### PR TITLE
Update derived type docs: fix support status and add playground examples

### DIFF
--- a/docs/reference/language/data-types/derived/array-types.rst
+++ b/docs/reference/language/data-types/derived/array-types.rst
@@ -10,7 +10,7 @@ An array is a fixed-size indexed collection of elements of the same type.
    * - **IEC 61131-3**
      - Section 2.3.3.1
    * - **Support**
-     - Not yet supported
+     - Supported
 
 Syntax
 ------
@@ -24,7 +24,7 @@ Arrays can be declared inline in variable declarations or as named types.
 Example
 -------
 
-.. code-block::
+.. playground::
 
    TYPE
        TenInts : ARRAY [1..10] OF INT;

--- a/docs/reference/language/data-types/derived/enumerated-types.rst
+++ b/docs/reference/language/data-types/derived/enumerated-types.rst
@@ -10,7 +10,7 @@ An enumerated type defines a named set of values.
    * - **IEC 61131-3**
      - Section 2.3.3.1
    * - **Support**
-     - Partial
+     - Supported
 
 Syntax
 ------
@@ -24,7 +24,7 @@ Syntax
 Example
 -------
 
-.. code-block::
+.. playground::
 
    TYPE
        TrafficLight : (Red, Yellow, Green);

--- a/docs/reference/language/data-types/derived/structure-types.rst
+++ b/docs/reference/language/data-types/derived/structure-types.rst
@@ -11,7 +11,7 @@ different types.
    * - **IEC 61131-3**
      - Section 2.3.3.1
    * - **Support**
-     - Partial
+     - Supported
 
 Syntax
 ------
@@ -28,7 +28,7 @@ Syntax
 Example
 -------
 
-.. code-block::
+.. playground::
 
    TYPE
        Point : STRUCT


### PR DESCRIPTION
Structure types, enumerated types, and array types are all fully implemented with end-to-end test coverage but the docs were outdated. Updates status from "Partial"/"Not yet supported" to "Supported" and replaces static code-block examples with interactive playground embeds.

https://claude.ai/code/session_01EJqyf3GAY8VZDjckKA5wWq