### PR TITLE
Remove workflow_dispatch triggers from partial workflows

### DIFF
--- a/.github/workflows/partial_compiler.yaml
+++ b/.github/workflows/partial_compiler.yaml
@@ -1,24 +1,5 @@
 name: IronPLC Compiler
 on:
-  # Allow triggering directly
-  workflow_dispatch:
-    inputs:
-      commit-ref:
-        required: false
-        type: string
-        description: 'If not empty, then run for the specified tag'
-      gh-release-tag:
-        required: false
-        type: string
-        default: ""
-        description: 'The Github Release tag to publish to (empty value disables publishing)'
-      version:
-        required: false
-        type: string
-        default: "0.0.0"
-        description: "The version number, such as 1.2.3"
-  
-  # Allow using this workflow from another workflow
   workflow_call:
     inputs:
       commit-ref:

--- a/.github/workflows/partial_integration_test.yaml
+++ b/.github/workflows/partial_integration_test.yaml
@@ -1,37 +1,5 @@
 name: End to End Smoke Test
 on:
-  # Allow triggering directly
-  workflow_dispatch:
-    inputs:
-      extension-version:
-        required: true
-        type: string
-        description: 'The version number to test with (without the "v" prefix)'
-
-      compiler-version:
-        required: true
-        type: string
-        description: 'Usually the version number to test with (without the "v" prefix)'
-
-      ironplcc-installer-x86_64-windows-filename:
-        required: true
-        type: string
-        description: "File name of the IronPLC compiler installer artifact from GitHub releases"
-        default: "ironplcc-x86_64-windows.exe"
-
-      ironplc-vscode-extension-filename:
-        required: true
-        type: string
-        description: "File name of the VS Code Extension artifact from GitHub releases"
-        default: "ironplc-vscode-extension.vsix"
-
-      ironplc-vscode-extension-name:
-        required: true
-        type: string
-        description: "The identifier for the Visual Studio Code extension"
-        default: "garretfick.ironplc"
-
-  # Allow using this workflow from another workflow
   workflow_call:
     inputs:
       extension-version:

--- a/.github/workflows/partial_playground.yaml
+++ b/.github/workflows/partial_playground.yaml
@@ -1,15 +1,6 @@
 name: Playground
 
 on:
-  # Allow triggering directly
-  workflow_dispatch:
-    inputs:
-      commit-ref:
-        required: false
-        type: string
-        description: 'If not empty, then run for the specified branch name or tag'
-
-  # Allow using this workflow from another workflow
   workflow_call:
     inputs:
       commit-ref:

--- a/.github/workflows/partial_playground_e2e.yaml
+++ b/.github/workflows/partial_playground_e2e.yaml
@@ -1,10 +1,6 @@
 name: Playground E2E Tests
 
 on:
-  # Allow triggering directly
-  workflow_dispatch: {}
-
-  # Allow using this workflow from another workflow
   workflow_call: {}
 
 jobs:

--- a/.github/workflows/partial_publish_prerelease.yaml
+++ b/.github/workflows/partial_publish_prerelease.yaml
@@ -1,21 +1,5 @@
 name: Publish Pre-release
 on:
-  # Allow triggering directly
-  workflow_dispatch:
-    inputs:
-      gh-release-id:
-        required: false
-        type: string
-        default: ""
-        description: 'The Github Release ID to set as pre-release'
-      dryrun:
-        required: true
-        type: boolean
-        default: true
-        description: 'If set, run as a dry run and do not create the release artifacts'
-
-
-  # Allow using this workflow from another workflow
   workflow_call:
     inputs:
       gh-release-id:

--- a/.github/workflows/partial_version.yaml
+++ b/.github/workflows/partial_version.yaml
@@ -1,24 +1,5 @@
 name: Version
 on:
-  # Allow triggering directly
-  workflow_dispatch:
-    inputs:
-      commit-tag:
-        required: false
-        type: string
-        description: 'If not empty, then run for the specified tag'
-      gh-release-tag:
-        required: false
-        type: string
-        default: ""
-        description: 'The Github Release tag to publish to (empty value disables publishing)'
-      version:
-        required: false
-        type: string
-        default: "0.0.0"
-        description: "The version number, such as 1.2.3"
-  
-  # Allow using this workflow from another workflow
   workflow_call:
     inputs:
       dryrun:

--- a/.github/workflows/partial_vscode_extension.yaml
+++ b/.github/workflows/partial_vscode_extension.yaml
@@ -1,29 +1,5 @@
 name: VS Code Extension
 on:
-  # Allow triggering directly
-  workflow_dispatch:
-    inputs:
-      commit-ref:
-        required: false
-        type: string
-        description: 'If not empty, then run for the specified branch name or tag'
-      gh-release-tag:
-        required: false
-        type: string
-        default: ""
-        description: 'The Github Release tag to publish to (empty value disables publishing)'
-      artifact-name:
-        required: false
-        type: string
-        default: ""
-        description: 'The name of the VSIX artifact to create (empty value disables publishing)'
-      install-deps:
-        required: false
-        type: boolean
-        default: false
-        description: Set to true running with Act to install extra dependencies
-
-  # Allow using this workflow from another workflow
   workflow_call:
     inputs:
       commit-ref:

--- a/.github/workflows/partial_website.yaml
+++ b/.github/workflows/partial_website.yaml
@@ -1,19 +1,5 @@
 name: Website
 on:
-  # Allow triggering directly
-  workflow_dispatch:
-    inputs:
-      publish:
-        required: true
-        type: boolean
-        default: false
-        description: 'If set true, then publish the website'
-      commit-ref:
-        required: false
-        type: string
-        description: 'If not empty, then run for the specified branch name or tag'
-  
-  # Allow using this workflow from another workflow
   workflow_call:
     inputs:
       publish:


### PR DESCRIPTION
## Summary
Removed `workflow_dispatch` triggers from all partial workflow files, keeping only `workflow_call` as the trigger mechanism. This change enforces that these workflows can only be invoked as reusable workflows from other workflows, not manually triggered directly.

## Key Changes
- **partial_integration_test.yaml**: Removed `workflow_dispatch` with 7 input parameters (extension-version, compiler-version, installer/extension filenames, etc.)
- **partial_vscode_extension.yaml**: Removed `workflow_dispatch` with 5 input parameters (commit-ref, gh-release-tag, artifact-name, install-deps)
- **partial_compiler.yaml**: Removed `workflow_dispatch` with 3 input parameters (commit-ref, gh-release-tag, version)
- **partial_version.yaml**: Removed `workflow_dispatch` with 3 input parameters (commit-tag, gh-release-tag, version)
- **partial_publish_prerelease.yaml**: Removed `workflow_dispatch` with 2 input parameters (gh-release-id, dryrun)
- **partial_website.yaml**: Removed `workflow_dispatch` with 2 input parameters (publish, commit-ref)
- **partial_playground.yaml**: Removed `workflow_dispatch` with 1 input parameter (commit-ref)
- **partial_playground_e2e.yaml**: Removed `workflow_dispatch` with no parameters

## Implementation Details
All partial workflows now exclusively use `workflow_call` as their trigger mechanism, making them true reusable workflows that can only be invoked from other workflows. This prevents accidental direct manual triggers and ensures these workflows are only used as intended within the larger CI/CD orchestration.

https://claude.ai/code/session_017ETJ1XrvJCZop87EtTNBHt