### PR TITLE
Collapse 14 parser dialect-flag tests into rstest table

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "logos",
  "peg",
  "phf",
+ "rstest",
  "time",
 ]
 

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -22,3 +22,6 @@ ironplc-problems = { path = "../problems", version = "0.201.0" }
 ironplc-test = { path = "../test", version = "0.201.0" }
 logos = "0.14.0"
 peg = "0.8.3"
+
+[dev-dependencies]
+rstest = "0.26"

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -20,6 +20,7 @@ mod test {
     use dsl::time::*;
     use ironplc_test::cast;
     use ironplc_test::read_shared_resource;
+    use rstest::rstest;
     use time::Duration;
 
     use crate::options::CompilerOptions;
@@ -1110,9 +1111,33 @@ END_FUNCTION_BLOCK",
         );
     }
 
-    #[test]
-    fn parse_when_struct_without_trailing_semicolon_and_flag_enabled_then_ok() {
-        let source = "TYPE MY_POINT :
+    /// Returns options with `allow_missing_semicolon` enabled. Used as a
+    /// function-pointer `#[case]` value for the parametrized dialect-flag tests.
+    fn with_missing_semicolon_flag() -> CompilerOptions {
+        CompilerOptions {
+            allow_missing_semicolon: true,
+            ..Default::default()
+        }
+    }
+
+    /// Returns options with `allow_empty_var_blocks` enabled.
+    fn with_empty_var_blocks_flag() -> CompilerOptions {
+        CompilerOptions {
+            allow_empty_var_blocks: true,
+            ..Default::default()
+        }
+    }
+
+    /// Dialect-flag acceptance tests.
+    ///
+    /// Each case: given a program that the default dialect rejects, parsing
+    /// should succeed when the corresponding `--allow-*` flag is enabled.
+    /// Collapses 14 hand-written tests (cargo-dupes group `c3c13bfc`) into
+    /// one table; each row is still run as an individually-named test.
+    #[rstest]
+    // --allow-missing-semicolon: trailing STRUCT/END_IF/END_WHILE/etc. without `;`
+    #[case::struct_without_trailing_semicolon(
+        "TYPE MY_POINT :
 STRUCT
     X : REAL;
     Y : REAL;
@@ -1125,12 +1150,145 @@ VAR
 END_VAR
     pt.X := 1.0;
     pt.Y := 2.0;
-END_PROGRAM";
-
-        let options = CompilerOptions {
-            allow_missing_semicolon: true,
-            ..Default::default()
-        };
+END_PROGRAM",
+        with_missing_semicolon_flag
+    )]
+    #[case::end_if_without_semicolon(
+        "PROGRAM main
+VAR
+    x : BOOL;
+END_VAR
+    IF x THEN
+        x := FALSE;
+    END_IF
+END_PROGRAM",
+        with_missing_semicolon_flag
+    )]
+    #[case::end_while_without_semicolon(
+        "PROGRAM main
+VAR
+    x : BOOL;
+END_VAR
+    WHILE x DO
+        x := FALSE;
+    END_WHILE
+END_PROGRAM",
+        with_missing_semicolon_flag
+    )]
+    #[case::end_for_without_semicolon(
+        "PROGRAM main
+VAR
+    i : INT;
+END_VAR
+    FOR i := 0 TO 10 DO
+        i := i;
+    END_FOR
+END_PROGRAM",
+        with_missing_semicolon_flag
+    )]
+    #[case::end_case_without_semicolon(
+        "PROGRAM main
+VAR
+    x : INT;
+END_VAR
+    CASE x OF
+        1: x := 2;
+    END_CASE
+END_PROGRAM",
+        with_missing_semicolon_flag
+    )]
+    #[case::end_repeat_without_semicolon(
+        "PROGRAM main
+VAR
+    x : BOOL;
+END_VAR
+    REPEAT
+        x := FALSE;
+    UNTIL x
+    END_REPEAT
+END_PROGRAM",
+        with_missing_semicolon_flag
+    )]
+    #[case::function_end_if_without_semicolon(
+        "FUNCTION MY_FUNC : REAL
+VAR_INPUT
+    x : INT;
+END_VAR
+IF x > 0 THEN
+    MY_FUNC := 1.0;
+ELSE
+    MY_FUNC := 0.0;
+END_IF
+END_FUNCTION",
+        with_missing_semicolon_flag
+    )]
+    // --allow-empty-var-blocks: empty VAR / VAR_INPUT / VAR_OUTPUT / etc.
+    #[case::empty_var_in_function(
+        "
+FUNCTION myFunc : INT
+VAR
+END_VAR
+    myFunc := 1;
+END_FUNCTION",
+        with_empty_var_blocks_flag
+    )]
+    #[case::empty_var_input(
+        "
+FUNCTION myFunc : INT
+VAR_INPUT
+END_VAR
+    myFunc := 1;
+END_FUNCTION",
+        with_empty_var_blocks_flag
+    )]
+    #[case::empty_var_output(
+        "
+FUNCTION myFunc : INT
+VAR_OUTPUT
+END_VAR
+    myFunc := 1;
+END_FUNCTION",
+        with_empty_var_blocks_flag
+    )]
+    #[case::empty_var_in_out(
+        "
+FUNCTION myFunc : INT
+VAR_IN_OUT
+END_VAR
+    myFunc := 1;
+END_FUNCTION",
+        with_empty_var_blocks_flag
+    )]
+    #[case::empty_var_constant(
+        "
+FUNCTION myFunc : INT
+VAR CONSTANT
+END_VAR
+    myFunc := 1;
+END_FUNCTION",
+        with_empty_var_blocks_flag
+    )]
+    #[case::empty_var_in_program(
+        "
+PROGRAM main
+VAR
+END_VAR
+END_PROGRAM",
+        with_empty_var_blocks_flag
+    )]
+    #[case::empty_var_in_function_block(
+        "
+FUNCTION_BLOCK myFb
+VAR
+END_VAR
+END_FUNCTION_BLOCK",
+        with_empty_var_blocks_flag
+    )]
+    fn parse_with_dialect_flag_then_ok(
+        #[case] source: &str,
+        #[case] build_options: fn() -> CompilerOptions,
+    ) {
+        let options = build_options();
         let result = parse_program(source, &FileId::default(), &options);
         assert!(result.is_ok());
     }
@@ -1154,123 +1312,6 @@ END_PROGRAM";
 
         let result = parse_program(source, &FileId::default(), &CompilerOptions::default());
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_when_end_if_without_semicolon_and_flag_enabled_then_ok() {
-        let source = "PROGRAM main
-VAR
-    x : BOOL;
-END_VAR
-    IF x THEN
-        x := FALSE;
-    END_IF
-END_PROGRAM";
-
-        let options = CompilerOptions {
-            allow_missing_semicolon: true,
-            ..Default::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_end_while_without_semicolon_and_flag_enabled_then_ok() {
-        let source = "PROGRAM main
-VAR
-    x : BOOL;
-END_VAR
-    WHILE x DO
-        x := FALSE;
-    END_WHILE
-END_PROGRAM";
-
-        let options = CompilerOptions {
-            allow_missing_semicolon: true,
-            ..Default::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_end_for_without_semicolon_and_flag_enabled_then_ok() {
-        let source = "PROGRAM main
-VAR
-    i : INT;
-END_VAR
-    FOR i := 0 TO 10 DO
-        i := i;
-    END_FOR
-END_PROGRAM";
-
-        let options = CompilerOptions {
-            allow_missing_semicolon: true,
-            ..Default::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_end_case_without_semicolon_and_flag_enabled_then_ok() {
-        let source = "PROGRAM main
-VAR
-    x : INT;
-END_VAR
-    CASE x OF
-        1: x := 2;
-    END_CASE
-END_PROGRAM";
-
-        let options = CompilerOptions {
-            allow_missing_semicolon: true,
-            ..Default::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_end_repeat_without_semicolon_and_flag_enabled_then_ok() {
-        let source = "PROGRAM main
-VAR
-    x : BOOL;
-END_VAR
-    REPEAT
-        x := FALSE;
-    UNTIL x
-    END_REPEAT
-END_PROGRAM";
-
-        let options = CompilerOptions {
-            allow_missing_semicolon: true,
-            ..Default::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_function_end_if_without_semicolon_and_flag_enabled_then_ok() {
-        let source = "FUNCTION MY_FUNC : REAL
-VAR_INPUT
-    x : INT;
-END_VAR
-IF x > 0 THEN
-    MY_FUNC := 1.0;
-ELSE
-    MY_FUNC := 0.0;
-END_IF
-END_FUNCTION";
-
-        let options = CompilerOptions {
-            allow_missing_semicolon: true,
-            ..Default::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
     }
 
     fn parse_text_edition3(source: &str) -> Library {
@@ -1770,22 +1811,6 @@ END_PROGRAM",
     }
 
     #[test]
-    fn parse_when_empty_var_in_function_with_flag_then_ok() {
-        let source = "
-FUNCTION myFunc : INT
-VAR
-END_VAR
-    myFunc := 1;
-END_FUNCTION";
-        let options = CompilerOptions {
-            allow_empty_var_blocks: true,
-            ..CompilerOptions::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
     fn parse_when_empty_var_in_function_without_flag_then_error() {
         let source = "
 FUNCTION myFunc : INT
@@ -1795,100 +1820,6 @@ END_VAR
 END_FUNCTION";
         let result = parse_program(source, &FileId::default(), &CompilerOptions::default());
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_when_empty_var_input_with_flag_then_ok() {
-        let source = "
-FUNCTION myFunc : INT
-VAR_INPUT
-END_VAR
-    myFunc := 1;
-END_FUNCTION";
-        let options = CompilerOptions {
-            allow_empty_var_blocks: true,
-            ..CompilerOptions::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_empty_var_output_with_flag_then_ok() {
-        let source = "
-FUNCTION myFunc : INT
-VAR_OUTPUT
-END_VAR
-    myFunc := 1;
-END_FUNCTION";
-        let options = CompilerOptions {
-            allow_empty_var_blocks: true,
-            ..CompilerOptions::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_empty_var_in_out_with_flag_then_ok() {
-        let source = "
-FUNCTION myFunc : INT
-VAR_IN_OUT
-END_VAR
-    myFunc := 1;
-END_FUNCTION";
-        let options = CompilerOptions {
-            allow_empty_var_blocks: true,
-            ..CompilerOptions::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_empty_var_constant_with_flag_then_ok() {
-        let source = "
-FUNCTION myFunc : INT
-VAR CONSTANT
-END_VAR
-    myFunc := 1;
-END_FUNCTION";
-        let options = CompilerOptions {
-            allow_empty_var_blocks: true,
-            ..CompilerOptions::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_empty_var_in_program_with_flag_then_ok() {
-        let source = "
-PROGRAM main
-VAR
-END_VAR
-END_PROGRAM";
-        let options = CompilerOptions {
-            allow_empty_var_blocks: true,
-            ..CompilerOptions::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_when_empty_var_in_function_block_with_flag_then_ok() {
-        let source = "
-FUNCTION_BLOCK myFb
-VAR
-END_VAR
-END_FUNCTION_BLOCK";
-        let options = CompilerOptions {
-            allow_empty_var_blocks: true,
-            ..CompilerOptions::default()
-        };
-        let result = parse_program(source, &FileId::default(), &options);
-        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Eliminates cargo-dupes group `c3c13bfc` — 14 near-identical dialect-flag tests in `parser/src/tests.rs` (322 duplicated lines) collapsed into one parametrized `#[rstest]` function.

All 14 removed tests shared this shape:

```rust
let source = "...";
let options = CompilerOptions { FLAG: true, ..Default::default() };
let result = parse_program(source, &FileId::default(), &options);
assert!(result.is_ok());
```

where FLAG was either:
- `allow_missing_semicolon` (7 tests — trailing `END_STRUCT`/`END_IF`/`END_WHILE`/etc. without `;`)
- `allow_empty_var_blocks` (7 tests — empty `VAR` / `VAR_INPUT` / `VAR_OUTPUT` / ... blocks)

### Approach

- Factor the two option-builders into small helpers:
  - `with_missing_semicolon_flag()`
  - `with_empty_var_blocks_flag()`
- Pass them as **fn-pointer `#[case]` values** so each case declares both the source program and which flag it needs.
- One `#[rstest] fn parse_with_dialect_flag_then_ok` replaces the 14 functions. Each case still runs as an individually-named test (`case_01_struct_without_trailing_semicolon`, etc.) for precise failure reporting.
- Add `rstest = "0.26"` to the parser crate `[dev-dependencies]`.

### Impact

| Metric | Before | After | Δ |
|---|---|---|---|
| `tests.rs` lines | 2304 | 2235 | −69 |
| Tests in module | 212 | 212 | unchanged (14 fns → 14 rstest cases) |
| Repo-wide exact dup lines | 32,026 | 31,814 | −212 |
| Repo-wide duplication % | 37.8% | 37.6% | −0.2pp |
| Dup group `c3c13bfc` | 14 members | gone | eliminated |

## Test plan
- [x] `cargo test -p ironplc-parser --lib parse_with_dialect_flag_then_ok` — all 14 cases pass
- [x] `cargo test -p ironplc-parser` — full parser suite green (212 tests)
- [x] `just lint` — clippy + rustfmt clean
- [x] `just test` — full workspace suite green
- [x] `cargo dupes` — confirms group `c3c13bfc` eliminated

https://claude.ai/code/session_01Xi7RowQg3sv5b3Tpeamycd