### PR TITLE
Add unit tests for uncovered lines in container and codegen crates

### DIFF
--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -1344,4 +1344,31 @@ mod tests {
 
         assert_eq!(em.max_stack_depth(), 2);
     }
+
+    #[test]
+    fn emitter_when_emit_dup_then_emits_dup_opcode_and_increments_stack() {
+        let mut em = Emitter::new();
+        em.emit_dup();
+
+        assert_eq!(em.bytecode(), &[opcode::DUP]);
+        assert_eq!(em.max_stack_depth(), 1);
+    }
+
+    #[test]
+    fn emitter_when_emit_swap_then_emits_swap_opcode_and_preserves_stack() {
+        let mut em = Emitter::new();
+        em.emit_swap();
+
+        assert_eq!(em.bytecode(), &[opcode::SWAP]);
+        assert_eq!(em.max_stack_depth(), 0);
+    }
+
+    #[test]
+    fn emitter_default_when_constructed_then_matches_new() {
+        let mut default_em: Emitter = Default::default();
+        let mut new_em = Emitter::new();
+
+        assert_eq!(default_em.bytecode(), new_em.bytecode());
+        assert_eq!(default_em.max_stack_depth(), new_em.max_stack_depth());
+    }
 }

--- a/compiler/codegen/src/optimize.rs
+++ b/compiler/codegen/src/optimize.rs
@@ -632,4 +632,29 @@ mod tests {
         let result = optimize(&bytecode, &[]);
         assert_eq!(result, bytecode);
     }
+
+    #[test]
+    fn optimize_when_load_const_out_of_bounds_add_i32_then_keeps_instructions() {
+        // Drives is_zero_constant's `_ => false` default arm: the pool index
+        // points past the end of the empty constant pool.
+        let mut bytecode = Vec::new();
+        bytecode.extend_from_slice(&load_const_i32(5));
+        bytecode.push(opcode::ADD_I32);
+        bytecode.push(opcode::RET_VOID);
+
+        let result = optimize(&bytecode, &[]);
+        assert_eq!(result, bytecode);
+    }
+
+    #[test]
+    fn optimize_when_load_const_out_of_bounds_mul_i32_then_keeps_instructions() {
+        // Drives is_one_constant's `_ => false` default arm.
+        let mut bytecode = Vec::new();
+        bytecode.extend_from_slice(&load_const_i32(5));
+        bytecode.push(opcode::MUL_I32);
+        bytecode.push(opcode::RET_VOID);
+
+        let result = optimize(&bytecode, &[]);
+        assert_eq!(result, bytecode);
+    }
 }

--- a/compiler/container/src/builder.rs
+++ b/compiler/container/src/builder.rs
@@ -475,4 +475,68 @@ mod tests {
         let ts = container.type_section.unwrap();
         assert_eq!(ts.array_descriptors.len(), 2);
     }
+
+    #[test]
+    fn builder_when_add_line_map_entry_then_included_in_debug_section() {
+        use crate::debug_section::LineMapEntry;
+
+        let entry = LineMapEntry {
+            function_id: FunctionId::INIT,
+            bytecode_offset: 4,
+            source_line: 12,
+            source_column: 3,
+        };
+
+        let container = ContainerBuilder::new()
+            .num_variables(0)
+            .add_function(FunctionId::INIT, &[0xB5], 0, 0, 0)
+            .add_line_map_entry(entry)
+            .build();
+
+        let debug = container.debug_section.expect("debug section present");
+        assert_eq!(debug.line_map.len(), 1);
+        assert_eq!(debug.line_map[0], entry);
+    }
+
+    #[test]
+    fn builder_when_add_fb_type_then_included_in_type_section() {
+        use crate::id_types::FbTypeId;
+        use crate::type_section::{FbTypeDescriptor, FieldEntry, FieldType};
+
+        let desc = FbTypeDescriptor {
+            type_id: FbTypeId::new(7),
+            fields: vec![FieldEntry {
+                field_type: FieldType::I32,
+                field_extra: 0,
+            }],
+        };
+
+        let container = ContainerBuilder::new()
+            .num_variables(0)
+            .add_fb_type(desc.clone())
+            .build();
+
+        let ts = container.type_section.expect("type section present");
+        assert_eq!(ts.fb_types.len(), 1);
+        assert_eq!(ts.fb_types[0], desc);
+    }
+
+    #[test]
+    fn builder_default_when_constructed_then_matches_new() {
+        let default_container = ContainerBuilder::default().num_variables(0).build();
+        let new_container = ContainerBuilder::new().num_variables(0).build();
+
+        assert_eq!(
+            default_container.header.num_variables,
+            new_container.header.num_variables
+        );
+        assert_eq!(
+            default_container.code.functions.len(),
+            new_container.code.functions.len()
+        );
+        assert_eq!(
+            default_container.constant_pool.len(),
+            new_container.constant_pool.len()
+        );
+    }
 }

--- a/compiler/container/src/const_type.rs
+++ b/compiler/container/src/const_type.rs
@@ -40,3 +40,38 @@ impl ConstType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn const_type_from_u8_when_valid_tags_then_returns_variant() {
+        assert_eq!(ConstType::from_u8(0).unwrap(), ConstType::I32);
+        assert_eq!(ConstType::from_u8(1).unwrap(), ConstType::U32);
+        assert_eq!(ConstType::from_u8(2).unwrap(), ConstType::I64);
+        assert_eq!(ConstType::from_u8(3).unwrap(), ConstType::U64);
+        assert_eq!(ConstType::from_u8(4).unwrap(), ConstType::F32);
+        assert_eq!(ConstType::from_u8(5).unwrap(), ConstType::F64);
+        assert_eq!(ConstType::from_u8(6).unwrap(), ConstType::Str);
+    }
+
+    #[test]
+    fn const_type_from_u8_when_invalid_tag_then_returns_error() {
+        assert!(matches!(
+            ConstType::from_u8(99),
+            Err(ContainerError::InvalidConstantType(99))
+        ));
+    }
+
+    #[test]
+    fn const_type_as_str_when_each_variant_then_returns_name() {
+        assert_eq!(ConstType::I32.as_str(), "I32");
+        assert_eq!(ConstType::U32.as_str(), "U32");
+        assert_eq!(ConstType::I64.as_str(), "I64");
+        assert_eq!(ConstType::U64.as_str(), "U64");
+        assert_eq!(ConstType::F32.as_str(), "F32");
+        assert_eq!(ConstType::F64.as_str(), "F64");
+        assert_eq!(ConstType::Str.as_str(), "Str");
+    }
+}

--- a/compiler/container/src/constant_pool.rs
+++ b/compiler/container/src/constant_pool.rs
@@ -251,4 +251,90 @@ mod tests {
     fn const_type_as_str_when_f64_then_returns_f64_string() {
         assert_eq!(ConstType::F64.as_str(), "F64");
     }
+
+    #[test]
+    fn constant_pool_when_empty_then_is_empty_returns_true() {
+        let pool = ConstantPool::default();
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn constant_pool_when_push_then_is_empty_returns_false() {
+        let mut pool = ConstantPool::default();
+        pool.push(ConstEntry {
+            const_type: ConstType::I32,
+            value: 1i32.to_le_bytes().to_vec(),
+        });
+        assert!(!pool.is_empty());
+    }
+
+    #[test]
+    fn constant_pool_get_i32_when_type_mismatch_then_returns_error() {
+        let mut pool = ConstantPool::default();
+        pool.push(ConstEntry {
+            const_type: ConstType::F32,
+            value: 1.0f32.to_le_bytes().to_vec(),
+        });
+
+        assert!(matches!(
+            pool.get_i32(ConstantIndex::new(0)),
+            Err(ContainerError::InvalidConstantType(_))
+        ));
+    }
+
+    #[test]
+    fn constant_pool_get_f32_when_type_mismatch_then_returns_error() {
+        let mut pool = ConstantPool::default();
+        pool.push(ConstEntry {
+            const_type: ConstType::I32,
+            value: 1i32.to_le_bytes().to_vec(),
+        });
+
+        assert!(matches!(
+            pool.get_f32(ConstantIndex::new(0)),
+            Err(ContainerError::InvalidConstantType(_))
+        ));
+    }
+
+    #[test]
+    fn constant_pool_get_f64_when_type_mismatch_then_returns_error() {
+        let mut pool = ConstantPool::default();
+        pool.push(ConstEntry {
+            const_type: ConstType::I32,
+            value: 1i32.to_le_bytes().to_vec(),
+        });
+
+        assert!(matches!(
+            pool.get_f64(ConstantIndex::new(0)),
+            Err(ContainerError::InvalidConstantType(_))
+        ));
+    }
+
+    #[test]
+    fn constant_pool_get_i64_when_type_mismatch_then_returns_error() {
+        let mut pool = ConstantPool::default();
+        pool.push(ConstEntry {
+            const_type: ConstType::F64,
+            value: 1.0f64.to_le_bytes().to_vec(),
+        });
+
+        assert!(matches!(
+            pool.get_i64(ConstantIndex::new(0)),
+            Err(ContainerError::InvalidConstantType(_))
+        ));
+    }
+
+    #[test]
+    fn constant_pool_get_str_when_type_mismatch_then_returns_error() {
+        let mut pool = ConstantPool::default();
+        pool.push(ConstEntry {
+            const_type: ConstType::I32,
+            value: 1i32.to_le_bytes().to_vec(),
+        });
+
+        assert!(matches!(
+            pool.get_str(ConstantIndex::new(0)),
+            Err(ContainerError::InvalidConstantType(_))
+        ));
+    }
 }

--- a/compiler/container/src/container.rs
+++ b/compiler/container/src/container.rs
@@ -317,4 +317,95 @@ mod tests {
         );
         assert_eq!(decoded.code.functions.len(), 1);
     }
+
+    #[test]
+    fn container_read_from_when_type_section_truncated_then_type_section_is_none() {
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x01, 0x00, 0x00,
+            0x18, 0x00, 0x00,
+            0xB5,
+        ];
+
+        let mut builder = ContainerBuilder::new();
+        builder.add_array_descriptor(0, 4, 0);
+        let container = builder
+            .num_variables(1)
+            .add_i32_constant(1)
+            .add_function(FunctionId::INIT, &bytecode, 1, 1, 0)
+            .build();
+
+        let mut buf = Vec::new();
+        container.write_to(&mut buf).unwrap();
+
+        // Inflate the declared type_section_size so ts_end exceeds available
+        // bytes, forcing the bounds check at container.rs:109 to return None.
+        let mut header = FileHeader::read_from(&mut Cursor::new(&buf[..HEADER_SIZE])).unwrap();
+        header.type_section_size = buf.len() as u32 * 2;
+
+        let mut tampered = Vec::with_capacity(buf.len());
+        header.write_to(&mut tampered).unwrap();
+        tampered.extend_from_slice(&buf[HEADER_SIZE..]);
+
+        let decoded = Container::read_from(&mut Cursor::new(&tampered)).unwrap();
+        assert!(decoded.type_section.is_none());
+    }
+
+    #[test]
+    fn container_read_from_when_debug_section_truncated_then_debug_section_is_none() {
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x01, 0x00, 0x00,
+            0x18, 0x00, 0x00,
+            0xB5,
+        ];
+
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_i32_constant(1)
+            .add_function(FunctionId::INIT, &bytecode, 1, 1, 0)
+            .add_func_name(FuncNameEntry {
+                function_id: FunctionId::INIT,
+                name: "MAIN".into(),
+            })
+            .build();
+
+        let mut buf = Vec::new();
+        container.write_to(&mut buf).unwrap();
+
+        // Inflate the declared debug_section_size past the end of the buffer,
+        // triggering the bounds check that returns None at container.rs:135.
+        let mut header = FileHeader::read_from(&mut Cursor::new(&buf[..HEADER_SIZE])).unwrap();
+        header.debug_section_size = buf.len() as u32 * 2;
+
+        let mut tampered = Vec::with_capacity(buf.len());
+        header.write_to(&mut tampered).unwrap();
+        tampered.extend_from_slice(&buf[HEADER_SIZE..]);
+
+        let decoded = Container::read_from(&mut Cursor::new(&tampered)).unwrap();
+        assert!(decoded.debug_section.is_none());
+    }
+
+    #[test]
+    fn container_read_from_when_no_debug_section_then_debug_section_is_none() {
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x01, 0x00, 0x00,
+            0x18, 0x00, 0x00,
+            0xB5,
+        ];
+
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_i32_constant(1)
+            .add_function(FunctionId::INIT, &bytecode, 1, 1, 0)
+            .build();
+
+        let mut buf = Vec::new();
+        container.write_to(&mut buf).unwrap();
+
+        let decoded = Container::read_from(&mut Cursor::new(&buf)).unwrap();
+        assert_eq!(decoded.header.debug_section_size, 0);
+        assert!(decoded.debug_section.is_none());
+    }
 }

--- a/compiler/container/src/container_ref.rs
+++ b/compiler/container/src/container_ref.rs
@@ -449,4 +449,351 @@ mod tests {
         assert_eq!(prog.task_id, TaskId::DEFAULT);
         assert_eq!(prog.var_table_count, 2);
     }
+
+    fn f32_constant_bytes() -> Vec<u8> {
+        use crate::ContainerBuilder;
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![0xB5];
+        let container = ContainerBuilder::new()
+            .num_variables(0)
+            .add_f32_constant(1.5)
+            .add_function(FunctionId::INIT, &bytecode, 0, 0, 0)
+            .build();
+        let mut buf = Vec::new();
+        container.write_to(&mut buf).unwrap();
+        buf
+    }
+
+    fn empty_pool_bytes() -> Vec<u8> {
+        use crate::ContainerBuilder;
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![0xB5];
+        let container = ContainerBuilder::new()
+            .num_variables(0)
+            .add_function(FunctionId::INIT, &bytecode, 0, 0, 0)
+            .build();
+        let mut buf = Vec::new();
+        container.write_to(&mut buf).unwrap();
+        buf
+    }
+
+    #[test]
+    fn container_ref_const_count_when_header_truncated_then_errors() {
+        let data = vec![0u8; HEADER_SIZE - 1];
+        let result = ContainerRef::const_count(&data);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_const_count_when_const_section_empty_then_returns_zero() {
+        let data = empty_pool_bytes();
+        assert_eq!(ContainerRef::const_count(&data).unwrap(), 0);
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_const_section_empty_then_const_offsets_empty() {
+        let data = empty_pool_bytes();
+        let mut offsets = vec![0u32; 0];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+        assert_eq!(cref.header().num_functions, 1);
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_const_offset_buf_too_small_then_errors() {
+        // steel_thread_bytes has 2 constants; pass a buffer of length 1.
+        let data = steel_thread_bytes();
+        let mut offsets = vec![0u32; 1];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_const_section_offset_past_end_then_errors() {
+        let mut data = steel_thread_bytes();
+
+        // Inflate const_section_size so const_end > data.len().
+        let mut header =
+            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
+        header.const_section_size = data.len() as u32 * 2;
+
+        let mut tampered = Vec::with_capacity(data.len());
+        header.write_to(&mut tampered).unwrap();
+        tampered.extend_from_slice(&data[HEADER_SIZE..]);
+        data = tampered;
+
+        let mut offsets = vec![0u32; 16];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_code_section_offset_past_end_then_errors() {
+        let mut data = steel_thread_bytes();
+
+        let mut header =
+            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
+        header.code_section_size = data.len() as u32 * 2;
+
+        let mut tampered = Vec::with_capacity(data.len());
+        header.write_to(&mut tampered).unwrap();
+        tampered.extend_from_slice(&data[HEADER_SIZE..]);
+        data = tampered;
+
+        let mut offsets = vec![0u32; 16];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_func_dir_larger_than_code_then_errors() {
+        let mut data = steel_thread_bytes();
+
+        let mut header =
+            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
+        // Inflate num_functions so func_dir_size > code_section.len().
+        header.num_functions = 999;
+
+        let mut tampered = Vec::with_capacity(data.len());
+        header.write_to(&mut tampered).unwrap();
+        tampered.extend_from_slice(&data[HEADER_SIZE..]);
+        data = tampered;
+
+        let mut offsets = vec![0u32; 16];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_task_section_offset_past_end_then_errors() {
+        let mut data = steel_thread_bytes();
+
+        let mut header =
+            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
+        header.task_section_size = data.len() as u32 * 2;
+
+        let mut tampered = Vec::with_capacity(data.len());
+        header.write_to(&mut tampered).unwrap();
+        tampered.extend_from_slice(&data[HEADER_SIZE..]);
+        data = tampered;
+
+        let mut offsets = vec![0u32; 16];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_get_i32_constant_when_type_mismatch_then_errors() {
+        let data = f32_constant_bytes();
+        let count = ContainerRef::const_count(&data).unwrap();
+        let mut offsets = vec![0u32; count as usize];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+
+        let result = cref.get_i32_constant(ConstantIndex::new(0));
+        assert!(matches!(
+            result,
+            Err(ContainerError::InvalidConstantType(_))
+        ));
+    }
+
+    #[test]
+    fn container_ref_get_function_bytecode_when_id_out_of_bounds_then_returns_none() {
+        let data = steel_thread_bytes();
+        let count = ContainerRef::const_count(&data).unwrap();
+        let mut offsets = vec![0u32; count as usize];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+
+        assert!(cref.get_function_bytecode(FunctionId::new(99)).is_none());
+    }
+
+    #[test]
+    fn container_ref_get_function_bytecode_when_entry_length_exceeds_code_then_returns_none() {
+        // Tamper the function directory so the entry claims a bytecode_length
+        // that runs past the end of code_bytes. from_slice validates the
+        // outer section boundary but not individual func entries, so the
+        // bounds check inside get_function_bytecode must catch it.
+        let base = steel_thread_bytes();
+        let header =
+            FileHeader::read_from(&mut std::io::Cursor::new(&base[..HEADER_SIZE])).unwrap();
+        let code_start = header.code_section_offset as usize;
+
+        let mut data = base.clone();
+        // Function directory entry layout (16 bytes):
+        //   function_id(2) + bytecode_offset(4, at bytes 2..6)
+        //   + bytecode_length(4, at bytes 6..10) + ...
+        let length_offset = code_start + 6;
+        data[length_offset..length_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+
+        let mut offsets = vec![0u32; 4];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+        assert!(cref.get_function_bytecode(FunctionId::INIT).is_none());
+    }
+
+    #[test]
+    fn container_ref_task_entry_when_index_out_of_bounds_then_errors() {
+        let data = steel_thread_bytes();
+        let count = ContainerRef::const_count(&data).unwrap();
+        let mut offsets = vec![0u32; count as usize];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+
+        assert!(matches!(
+            cref.task_entry(99),
+            Err(ContainerError::SectionSizeMismatch)
+        ));
+    }
+
+    #[test]
+    fn container_ref_program_entry_when_index_out_of_bounds_then_errors() {
+        let data = steel_thread_bytes();
+        let count = ContainerRef::const_count(&data).unwrap();
+        let mut offsets = vec![0u32; count as usize];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+
+        assert!(matches!(
+            cref.program_entry(99),
+            Err(ContainerError::SectionSizeMismatch)
+        ));
+    }
+
+    #[test]
+    fn read_u16_when_offset_past_end_then_errors() {
+        let data = [1u8, 2, 3];
+        assert!(matches!(
+            read_u16(&data, 2),
+            Err(ContainerError::SectionSizeMismatch)
+        ));
+    }
+
+    /// Rewrites the header of `data` with `tamper` applied.
+    fn with_tampered_header(data: &[u8], tamper: impl FnOnce(&mut FileHeader)) -> Vec<u8> {
+        let mut header =
+            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
+        tamper(&mut header);
+        let mut tampered = Vec::with_capacity(data.len());
+        header.write_to(&mut tampered).unwrap();
+        tampered.extend_from_slice(&data[HEADER_SIZE..]);
+        tampered
+    }
+
+    #[test]
+    fn container_ref_const_count_when_const_section_size_is_zero_then_returns_zero() {
+        // Tamper the header to set const_section_size = 0 so the early-exit
+        // branch in const_count is exercised.
+        let data = with_tampered_header(&steel_thread_bytes(), |h| {
+            h.const_section_size = 0;
+        });
+        assert_eq!(ContainerRef::const_count(&data).unwrap(), 0);
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_const_section_size_is_zero_then_succeeds_with_empty_pool() {
+        let data = with_tampered_header(&steel_thread_bytes(), |h| {
+            h.const_section_size = 0;
+        });
+        let mut offsets = vec![0u32; 0];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+        assert_eq!(cref.header().num_functions, 1);
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_const_section_only_one_byte_then_errors() {
+        // Set const_section_size = 1 so const_section.len() < 2 and the
+        // count-read bounds check returns SectionSizeMismatch.
+        let data = with_tampered_header(&steel_thread_bytes(), |h| {
+            h.const_section_size = 1;
+        });
+        let mut offsets = vec![0u32; 4];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_const_section_truncates_entry_header_then_errors() {
+        // Original const section has 2 entries; clip the section_size so the
+        // entry-header bounds check fails during the pre-scan loop.
+        let data = with_tampered_header(&steel_thread_bytes(), |h| {
+            // 2 (count) + 3 bytes = less than one full 4-byte entry header.
+            h.const_section_size = 5;
+        });
+        let mut offsets = vec![0u32; 4];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_const_section_entry_value_truncated_then_errors() {
+        // Header claims an entry larger than the remaining const section,
+        // so the "pos > const_pool_bytes.len()" check after advancing fires.
+        let data = with_tampered_header(&steel_thread_bytes(), |h| {
+            // Just enough for the count and the first entry header, but the
+            // declared value size will overrun the truncated section.
+            h.const_section_size = 6;
+        });
+        let mut offsets = vec![0u32; 4];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_from_slice_when_task_section_smaller_than_header_then_errors() {
+        // A non-zero but tiny task_section_size forces the header-length
+        // bounds check in from_slice to return SectionSizeMismatch.
+        let data = with_tampered_header(&steel_thread_bytes(), |h| {
+            h.task_section_size = 3;
+        });
+        let mut offsets = vec![0u32; 4];
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
+
+    #[test]
+    fn container_ref_num_programs_and_shared_globals_when_valid_then_return_fields() {
+        let data = steel_thread_bytes();
+        let count = ContainerRef::const_count(&data).unwrap();
+        let mut offsets = vec![0u32; count as usize];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+
+        // The builder synthesizes a single default program with shared_globals_size=0.
+        assert_eq!(cref.num_programs(), 1);
+        assert_eq!(cref.shared_globals_size(), 0);
+    }
+
+    #[test]
+    fn container_ref_num_tasks_and_programs_when_task_section_zero_then_return_zero() {
+        // When task_section_size is 0, from_slice accepts the container and
+        // the runtime accessors fall back to zero rather than indexing an
+        // empty slice.
+        let data = with_tampered_header(&steel_thread_bytes(), |h| {
+            h.task_section_size = 0;
+        });
+        let mut offsets = vec![0u32; 4];
+        let cref = ContainerRef::from_slice(&data, &mut offsets).unwrap();
+        assert_eq!(cref.num_tasks(), 0);
+        assert_eq!(cref.num_programs(), 0);
+        assert_eq!(cref.shared_globals_size(), 0);
+    }
+
+    #[test]
+    fn container_ref_get_i32_constant_when_value_bytes_truncated_then_errors() {
+        // Tamper the container so the first constant's declared value length
+        // would run past the end of the const pool bytes. The pre-scan
+        // already validates this, so we need a direct-crafted buffer.
+        let base = steel_thread_bytes();
+        // Locate the const section by rereading the header.
+        let header =
+            FileHeader::read_from(&mut std::io::Cursor::new(&base[..HEADER_SIZE])).unwrap();
+        let const_start = header.const_section_offset as usize;
+
+        let mut data = base.clone();
+        // Set the first entry's declared value size to a huge number.
+        // Const section layout: [count: u16][entry0: type(1) reserved(1) size(2) value(n)]
+        let size_offset = const_start + 2 + 2;
+        data[size_offset] = 0xFF;
+        data[size_offset + 1] = 0xFF;
+
+        let mut offsets = vec![0u32; 4];
+        // from_slice itself will detect the overrun and error, exercising the
+        // same bounds-check code path.
+        let result = ContainerRef::from_slice(&data, &mut offsets);
+        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+    }
 }

--- a/compiler/container/src/debug_section.rs
+++ b/compiler/container/src/debug_section.rs
@@ -761,4 +761,104 @@ mod tests {
         section.write_to(&mut buf).unwrap();
         assert_eq!(section.section_size(), buf.len() as u32);
     }
+
+    #[test]
+    fn debug_section_lookup_source_location_when_multiple_entries_then_returns_greatest_leq() {
+        let section = DebugSection {
+            var_names: vec![],
+            func_names: vec![],
+            line_map: vec![
+                LineMapEntry {
+                    function_id: FunctionId::INIT,
+                    bytecode_offset: 0,
+                    source_line: 10,
+                    source_column: 1,
+                },
+                LineMapEntry {
+                    function_id: FunctionId::INIT,
+                    bytecode_offset: 8,
+                    source_line: 20,
+                    source_column: 1,
+                },
+                LineMapEntry {
+                    function_id: FunctionId::INIT,
+                    bytecode_offset: 12,
+                    source_line: 30,
+                    source_column: 1,
+                },
+                // Entry for a different function that must never be returned.
+                LineMapEntry {
+                    function_id: FunctionId::GLOBAL_SCOPE,
+                    bytecode_offset: 4,
+                    source_line: 99,
+                    source_column: 1,
+                },
+            ],
+            enum_defs: vec![],
+        };
+
+        // Offset 0: matches the first entry exactly.
+        let hit = section.lookup_source_location(FunctionId::INIT, 0).unwrap();
+        assert_eq!(hit.source_line, 10);
+
+        // Offset 5: before the second entry, should return the first.
+        let hit = section.lookup_source_location(FunctionId::INIT, 5).unwrap();
+        assert_eq!(hit.source_line, 10);
+
+        // Offset 10: between second and third entry, should return the second.
+        let hit = section
+            .lookup_source_location(FunctionId::INIT, 10)
+            .unwrap();
+        assert_eq!(hit.source_line, 20);
+
+        // Offset 12: matches the third entry exactly.
+        let hit = section
+            .lookup_source_location(FunctionId::INIT, 12)
+            .unwrap();
+        assert_eq!(hit.source_line, 30);
+
+        // Offset 100: beyond the last entry, should still return the third.
+        let hit = section
+            .lookup_source_location(FunctionId::INIT, 100)
+            .unwrap();
+        assert_eq!(hit.source_line, 30);
+    }
+
+    #[test]
+    fn debug_section_lookup_source_location_when_entries_out_of_order_then_returns_greatest_leq() {
+        // Stored in descending bytecode_offset order so the later iterations
+        // see entries with smaller offsets than the running best; this
+        // exercises the `_ => {}` fall-through arm that leaves `best`
+        // unchanged.
+        let section = DebugSection {
+            var_names: vec![],
+            func_names: vec![],
+            line_map: vec![
+                LineMapEntry {
+                    function_id: FunctionId::INIT,
+                    bytecode_offset: 12,
+                    source_line: 30,
+                    source_column: 1,
+                },
+                LineMapEntry {
+                    function_id: FunctionId::INIT,
+                    bytecode_offset: 0,
+                    source_line: 10,
+                    source_column: 1,
+                },
+                LineMapEntry {
+                    function_id: FunctionId::INIT,
+                    bytecode_offset: 8,
+                    source_line: 20,
+                    source_column: 1,
+                },
+            ],
+            enum_defs: vec![],
+        };
+
+        let hit = section
+            .lookup_source_location(FunctionId::INIT, 100)
+            .unwrap();
+        assert_eq!(hit.source_line, 30);
+    }
 }

--- a/compiler/container/src/error.rs
+++ b/compiler/container/src/error.rs
@@ -69,3 +69,85 @@ impl From<std::io::Error> for ContainerError {
         ContainerError::Io(e)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as _;
+    use std::string::ToString;
+
+    #[test]
+    fn container_error_display_when_invalid_magic_then_mentions_magic() {
+        let msg = ContainerError::InvalidMagic.to_string();
+        assert!(msg.contains("magic"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_unsupported_version_then_mentions_version() {
+        let msg = ContainerError::UnsupportedVersion.to_string();
+        assert!(msg.contains("version"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_invalid_constant_type_then_contains_tag() {
+        let msg = ContainerError::InvalidConstantType(42).to_string();
+        assert!(msg.contains("42"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_invalid_constant_index_then_contains_index() {
+        let msg = ContainerError::InvalidConstantIndex(ConstantIndex::new(999)).to_string();
+        assert!(msg.contains("999"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_section_size_mismatch_then_mentions_section() {
+        let msg = ContainerError::SectionSizeMismatch.to_string();
+        assert!(msg.contains("section"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_invalid_task_type_then_contains_tag() {
+        let msg = ContainerError::InvalidTaskType(7).to_string();
+        assert!(msg.contains('7'), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_invalid_field_type_then_contains_tag() {
+        let msg = ContainerError::InvalidFieldType(5).to_string();
+        assert!(msg.contains('5'), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_io_error_then_mentions_io() {
+        let err = ContainerError::Io(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        let msg = err.to_string();
+        assert!(msg.contains("I/O"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_invalid_debug_section_then_mentions_debug() {
+        let msg = ContainerError::InvalidDebugSection.to_string();
+        assert!(msg.contains("debug"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_source_when_io_then_returns_some() {
+        let err = ContainerError::Io(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn container_error_source_when_non_io_then_returns_none() {
+        assert!(ContainerError::InvalidMagic.source().is_none());
+        assert!(ContainerError::UnsupportedVersion.source().is_none());
+        assert!(ContainerError::SectionSizeMismatch.source().is_none());
+    }
+
+    #[test]
+    fn container_error_from_io_error_when_converted_then_io_variant() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::UnexpectedEof);
+        let err: ContainerError = io_err.into();
+        assert!(matches!(err, ContainerError::Io(_)));
+    }
+}

--- a/compiler/container/src/header.rs
+++ b/compiler/container/src/header.rs
@@ -334,4 +334,13 @@ mod tests {
         let result = FileHeader::from_bytes(&bytes);
         assert!(matches!(result, Err(ContainerError::InvalidMagic)));
     }
+
+    #[test]
+    fn header_from_bytes_when_wrong_format_version_then_unsupported_version() {
+        let mut bytes = [0u8; HEADER_SIZE];
+        bytes[0..4].copy_from_slice(&MAGIC.to_le_bytes());
+        bytes[4..6].copy_from_slice(&(FORMAT_VERSION + 1).to_le_bytes());
+        let result = FileHeader::from_bytes(&bytes);
+        assert!(matches!(result, Err(ContainerError::UnsupportedVersion)));
+    }
 }

--- a/compiler/container/src/id_types.rs
+++ b/compiler/container/src/id_types.rs
@@ -249,3 +249,85 @@ impl core::ops::AddAssign<u32> for SlotIndex {
         self.0 += rhs;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::string::ToString;
+
+    #[test]
+    fn fb_type_id_display_when_formatted_then_writes_number() {
+        assert_eq!(FbTypeId::new(123).to_string(), "123");
+    }
+
+    #[test]
+    fn var_index_display_when_formatted_then_writes_number() {
+        assert_eq!(VarIndex::new(456).to_string(), "456");
+    }
+
+    #[test]
+    fn var_index_when_add_u16_then_sum() {
+        assert_eq!(VarIndex::new(10) + 5, VarIndex::new(15));
+    }
+
+    #[test]
+    fn var_index_when_sub_var_index_then_delta() {
+        assert_eq!(VarIndex::new(20) - VarIndex::new(5), 15);
+    }
+
+    #[test]
+    fn var_index_when_add_assign_u16_then_mutated() {
+        let mut v = VarIndex::new(10);
+        v += 5u16;
+        assert_eq!(v, VarIndex::new(15));
+    }
+
+    #[test]
+    fn constant_index_to_le_bytes_when_called_then_little_endian_bytes() {
+        assert_eq!(ConstantIndex::new(0x1234).to_le_bytes(), [0x34, 0x12]);
+    }
+
+    #[test]
+    fn var_index_into_i64_when_cast_then_value() {
+        let v: i64 = VarIndex::new(999).into();
+        assert_eq!(v, 999i64);
+    }
+
+    #[test]
+    fn constant_index_display_when_formatted_then_writes_number() {
+        assert_eq!(ConstantIndex::new(777).to_string(), "777");
+    }
+
+    #[test]
+    fn slot_index_display_when_formatted_then_writes_number() {
+        assert_eq!(SlotIndex::new(1234).to_string(), "1234");
+    }
+
+    #[test]
+    fn slot_index_to_le_bytes_when_called_then_little_endian_bytes() {
+        assert_eq!(
+            SlotIndex::new(0x12345678).to_le_bytes(),
+            [0x78, 0x56, 0x34, 0x12]
+        );
+    }
+
+    #[test]
+    fn slot_index_when_add_u32_then_sum() {
+        assert_eq!(SlotIndex::new(100) + 50u32, SlotIndex::new(150));
+    }
+
+    #[test]
+    fn slot_index_when_add_slot_index_then_sum() {
+        assert_eq!(
+            SlotIndex::new(100) + SlotIndex::new(50),
+            SlotIndex::new(150)
+        );
+    }
+
+    #[test]
+    fn slot_index_when_add_assign_u32_then_mutated() {
+        let mut s = SlotIndex::new(100);
+        s += 50u32;
+        assert_eq!(s, SlotIndex::new(150));
+    }
+}

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -1032,3 +1032,44 @@ pub mod fb_type {
     /// F_TRIG (falling edge detector).
     pub const F_TRIG: u16 = 0x0041;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instruction_size_when_unknown_opcode_then_returns_one() {
+        // 0xFE is not assigned; the default arm must return 1 so that
+        // disassembly does not get stuck in an infinite loop.
+        assert_eq!(instruction_size(0xFE), 1);
+    }
+
+    #[test]
+    fn mux_info_when_valid_arity_then_returns_some_count() {
+        assert_eq!(builtin::mux_info(builtin::MUX_I32_BASE + 3), Some(3));
+        assert_eq!(builtin::mux_info(builtin::MUX_F64_BASE + 5), Some(5));
+    }
+
+    #[test]
+    fn mux_info_when_arity_below_two_then_returns_none() {
+        assert_eq!(builtin::mux_info(builtin::MUX_I32_BASE), None);
+        assert_eq!(builtin::mux_info(builtin::MUX_I32_BASE + 1), None);
+    }
+
+    #[test]
+    fn mux_info_when_not_a_mux_id_then_returns_none() {
+        assert_eq!(builtin::mux_info(0x0001), None);
+    }
+
+    #[test]
+    fn arg_count_when_mux_id_then_returns_n_plus_one() {
+        // MUX pops n IN values + 1 K selector.
+        assert_eq!(builtin::arg_count(builtin::MUX_I32_BASE + 3), 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown builtin function ID")]
+    fn arg_count_when_unknown_function_id_then_panics() {
+        let _ = builtin::arg_count(0xFFFF);
+    }
+}

--- a/compiler/container/src/task_type.rs
+++ b/compiler/container/src/task_type.rs
@@ -29,3 +29,23 @@ impl TaskType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_type_from_u8_when_valid_tags_then_returns_variant() {
+        assert_eq!(TaskType::from_u8(0).unwrap(), TaskType::Cyclic);
+        assert_eq!(TaskType::from_u8(1).unwrap(), TaskType::Event);
+        assert_eq!(TaskType::from_u8(2).unwrap(), TaskType::Freewheeling);
+    }
+
+    #[test]
+    fn task_type_from_u8_when_invalid_tag_then_returns_error() {
+        assert!(matches!(
+            TaskType::from_u8(99),
+            Err(ContainerError::InvalidTaskType(99))
+        ));
+    }
+}

--- a/compiler/container/src/type_section.rs
+++ b/compiler/container/src/type_section.rs
@@ -481,4 +481,56 @@ mod tests {
             Err(ContainerError::InvalidFieldType(42))
         ));
     }
+
+    #[test]
+    fn type_section_section_size_when_fb_types_with_fields_then_includes_field_bytes() {
+        let section = TypeSection {
+            fb_types: vec![FbTypeDescriptor {
+                type_id: FbTypeId::new(0x20),
+                fields: vec![
+                    FieldEntry {
+                        field_type: FieldType::I32,
+                        field_extra: 0,
+                    },
+                    FieldEntry {
+                        field_type: FieldType::F64,
+                        field_extra: 0,
+                    },
+                    FieldEntry {
+                        field_type: FieldType::String,
+                        field_extra: 80,
+                    },
+                ],
+            }],
+            array_descriptors: vec![],
+            user_fb_types: vec![],
+        };
+
+        // Header: 2 (FB count) + 2 (array count) + 2 (user FB count) = 6
+        // Per descriptor: 4 (header) + 3 fields * 4 = 16
+        // Total: 6 + 16 = 22
+        assert_eq!(section.section_size(), 22);
+
+        let mut buf = Vec::new();
+        section.write_to(&mut buf).unwrap();
+        assert_eq!(buf.len() as u32, section.section_size());
+    }
+
+    #[test]
+    fn type_section_read_from_when_no_user_fb_descriptor_then_empty_user_fb_types() {
+        // Build a type section payload that stops after the array-count
+        // field, simulating a legacy container without the user FB descriptor
+        // sub-table. The reader should treat the missing data as zero
+        // descriptors rather than erroring.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0u16.to_le_bytes()); // FB count = 0
+        buf.extend_from_slice(&0u16.to_le_bytes()); // array count = 0
+
+        let mut cursor = Cursor::new(&buf);
+        let decoded = TypeSection::read_from(&mut cursor).unwrap();
+
+        assert!(decoded.fb_types.is_empty());
+        assert!(decoded.array_descriptors.is_empty());
+        assert!(decoded.user_fb_types.is_empty());
+    }
 }


### PR DESCRIPTION
Covers previously-untested arithmetic, Display impls, from_u8 arms, error
paths, and truncation handling across 14 files in ironplc-container and
ironplc-codegen. Adds new #[cfg(test)] modules to const_type.rs, error.rs,
id_types.rs, opcode.rs, and task_type.rs, and extends the existing test
modules in the remaining files.

https://claude.ai/code/session_019mx4UtpL2BMtuX5ZtZZ1wJ