### PR TITLE
Add line number gutter to playground editor

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -1,6 +1,7 @@
 import uPlot from './uPlot.esm.js';
 
 const editor = document.getElementById("editor");
+const gutter = document.getElementById("editor-gutter");
 const startBtn = document.getElementById("start-btn");
 const stopBtn = document.getElementById("stop-btn");
 const pauseBtn = document.getElementById("pause-btn");
@@ -223,10 +224,27 @@ examplesSelect.addEventListener("change", () => {
   }
 
   editor.value = selected.code;
+  renderLineNumbers();
   trackPageview("/playground/example/" + selected.name, selected.name);
 
   // Reset the dropdown to show "Examples" label
   examplesSelect.selectedIndex = 0;
+});
+
+// --- Line number gutter ---
+
+function renderLineNumbers() {
+  const lineCount = Math.max(1, editor.value.split("\n").length);
+  let text = "1";
+  for (let i = 2; i <= lineCount; i++) {
+    text += "\n" + i;
+  }
+  gutter.textContent = text;
+  gutter.style.minWidth = `${Math.max(2, String(lineCount).length) + 1}ch`;
+}
+
+editor.addEventListener("scroll", () => {
+  gutter.scrollTop = editor.scrollTop;
 });
 
 // Pre-load code from URL parameters
@@ -261,6 +279,8 @@ if (params.has("code")) {
     // Ignore invalid base64
   }
 }
+
+renderLineNumbers();
 
 // --- Web Worker communication ---
 
@@ -518,6 +538,7 @@ pauseBtn.addEventListener("click", () => {
 // --- Source change handling ---
 
 editor.addEventListener("input", () => {
+  renderLineNumbers();
   if (isRunning) {
     stopExecution();
     postCommand("reset");

--- a/playground/index.html
+++ b/playground/index.html
@@ -49,7 +49,9 @@
           </span>
         </div>
       </div>
-      <textarea id="editor" spellcheck="false" data-testid="editor">PROGRAM main
+      <div class="editor-wrapper">
+        <div class="editor-gutter" id="editor-gutter" aria-hidden="true"></div>
+        <textarea id="editor" spellcheck="false" wrap="off" data-testid="editor">PROGRAM main
   VAR
     count : INT;
     doubled : INT;
@@ -63,6 +65,7 @@
   doubled := count * 2;
 END_PROGRAM
 </textarea>
+      </div>
     </section>
 
     <section class="output-section">

--- a/playground/style.css
+++ b/playground/style.css
@@ -167,8 +167,34 @@ main {
   color: var(--border);
 }
 
+.editor-wrapper {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  background: var(--surface);
+}
+
+.editor-gutter {
+  padding: 1rem 0.5rem 1rem 0.75rem;
+  font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas", monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  tab-size: 2;
+  color: var(--text-muted);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  text-align: right;
+  white-space: pre;
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+  min-width: 3ch;
+  flex: 0 0 auto;
+}
+
 #editor {
   flex: 1;
+  min-width: 0;
   background: var(--surface);
   color: var(--text);
   border: none;
@@ -179,6 +205,8 @@ main {
   resize: none;
   outline: none;
   tab-size: 2;
+  overflow: auto;
+  white-space: pre;
 }
 
 .output-section {
@@ -349,6 +377,11 @@ body.embed .toolbar {
 
 body.embed #editor {
   padding: 0.75rem;
+  font-size: 0.8rem;
+}
+
+body.embed .editor-gutter {
+  padding: 0.75rem 0.4rem 0.75rem 0.5rem;
   font-size: 0.8rem;
 }
 

--- a/playground/tests/e2e.spec.js
+++ b/playground/tests/e2e.spec.js
@@ -363,4 +363,27 @@ END_PROGRAM
     await expect(page.locator('[data-testid="duration-display"]')).toBeVisible();
     await expect(page.locator('[data-testid="cycles-display"]')).toBeVisible();
   });
+
+  test("editor_when_loaded_then_shows_line_number_gutter", async ({ page }) => {
+    const gutter = page.locator("#editor-gutter");
+    await expect(gutter).toBeVisible();
+
+    const editor = page.locator('[data-testid="editor"]');
+    const source = await editor.inputValue();
+    const expectedLines = Math.max(1, source.split("\n").length);
+
+    const gutterText = await gutter.textContent();
+    const gutterLines = gutterText.split("\n");
+    expect(gutterLines.length).toBe(expectedLines);
+    expect(gutterLines[0]).toBe("1");
+    expect(gutterLines[gutterLines.length - 1]).toBe(String(expectedLines));
+  });
+
+  test("editor_when_content_changed_then_line_numbers_update", async ({ page }) => {
+    const editor = page.locator('[data-testid="editor"]');
+    await editor.fill("line one\nline two\nline three");
+
+    const gutter = page.locator("#editor-gutter");
+    await expect(gutter).toHaveText("1\n2\n3");
+  });
 });

--- a/specs/plans/2026-04-21-playground-line-numbers.md
+++ b/specs/plans/2026-04-21-playground-line-numbers.md
@@ -1,0 +1,56 @@
+# Playground Line Number Gutter
+
+## Goal
+
+Add an automatic line-number gutter to the left of the playground code editor so users can easily reference lines while writing or reading a program.
+
+## Context
+
+The playground (`/playground/`) uses a plain `<textarea id="editor">` — no CodeMirror, Monaco, or other editor library. Today there is no visible line numbering. Diagnostics surface raw byte offsets (`app.js:649`), which are hard to correlate back to source lines. A visual gutter is the first step toward readable line references.
+
+## Changes
+
+### 1. Wrap the textarea with a gutter
+
+**File:** `playground/index.html`
+
+Wrap `<textarea id="editor">` in `<div class="editor-wrapper">` and add a sibling gutter `<div>` before the textarea:
+
+```html
+<div class="editor-wrapper">
+  <div class="editor-gutter" id="editor-gutter" aria-hidden="true"></div>
+  <textarea id="editor" spellcheck="false" wrap="off" data-testid="editor">...</textarea>
+</div>
+```
+
+`wrap="off"` disables soft-wrap so each `\n` in the source corresponds to exactly one visual line — line numbers always align with their source line.
+
+### 2. Gutter styling
+
+**File:** `playground/style.css`
+
+- `.editor-wrapper`: flex container that fills `.editor-section`.
+- `.editor-gutter`: same font stack, size, and line-height as `#editor` so numbers align; right-aligned muted color; border-right separator; `user-select: none`; `overflow: hidden` (scroll is driven by the textarea).
+- `#editor`: add `overflow: auto` and `white-space: pre` so it scrolls horizontally when `wrap="off"`.
+- `body.embed .editor-gutter`: shrink padding/font to match `body.embed #editor`.
+
+### 3. Render and sync line numbers
+
+**File:** `playground/app.js`
+
+- `renderLineNumbers()` helper: counts `editor.value.split("\n").length`, writes `"1\n2\n…\nN"` into the gutter, and sets `minWidth` in `ch` based on digit count so the gutter widens for 3+ digit line counts.
+- Called once at startup (after URL-param handling), in the `editor` `input` listener, and in the examples-select `change` listener.
+- `editor` `scroll` listener mirrors `scrollTop` to the gutter so numbers stay aligned during vertical scroll.
+
+### 4. Tests
+
+**File:** `playground/tests/e2e.spec.js`
+
+- `editor_when_loaded_then_shows_line_number_gutter`: gutter is visible, first line shows `"1"`, line count matches the default program's `\n` count.
+- `editor_when_content_changed_then_line_numbers_update`: filling the editor with a 3-line program produces gutter text `"1\n2\n3"`.
+
+## Out of scope
+
+- Mapping diagnostic byte offsets to line numbers / clickable "jump to line".
+- Current-line highlighting.
+- Replacing the textarea with CodeMirror/Monaco.


### PR DESCRIPTION
## Summary
Add a visual line number gutter to the left of the playground code editor, allowing users to easily reference lines while writing or reading programs.

## Changes
- **HTML structure**: Wrap the textarea in a flex container with a new gutter div that displays line numbers
- **Styling**: Add `.editor-wrapper` and `.editor-gutter` styles with matching font/line-height to keep numbers aligned; configure textarea for horizontal scrolling with `white-space: pre` and `wrap="off"`
- **Line number rendering**: Implement `renderLineNumbers()` function that:
  - Counts lines by splitting editor content on `\n`
  - Renders line numbers as `"1\n2\n…\nN"` in the gutter
  - Dynamically adjusts gutter width based on digit count
  - Called on startup, after content changes, and when examples are loaded
- **Scroll synchronization**: Mirror textarea `scrollTop` to gutter so line numbers stay aligned during vertical scrolling
- **Responsive design**: Adjust gutter padding/font size in embed mode to match editor scaling
- **Tests**: Add two e2e tests verifying gutter visibility and line number accuracy on load and content change

## Implementation Details
- Gutter uses `aria-hidden="true"` since it's decorative and numbers are implicit in the editor content
- `wrap="off"` ensures each newline in source corresponds to exactly one visual line
- Gutter width uses `ch` units (character width) for precise alignment with monospace font
- Minimum width of 3ch accommodates up to 99 lines; scales to 4ch+ for larger programs

https://claude.ai/code/session_01RVXaNVbjzJWFzUFHakvrQE