### PR TITLE
fix(codegen): support reading function block fields via dot-access

### DIFF
--- a/compiler/codegen/src/compile_expr.rs
+++ b/compiler/codegen/src/compile_expr.rs
@@ -619,6 +619,39 @@ pub(crate) fn compile_variable_read(
             Ok(())
         }
         Variable::Symbolic(SymbolicVariableKind::Structured(structured)) => {
+            // Function block instance field read (e.g. `timer.Q`). FB instances
+            // live in `ctx.fb_instances` rather than `ctx.struct_vars`, and
+            // their fields are stored in the data region addressed via
+            // FB_LOAD_PARAM.
+            if let SymbolicVariableKind::Named(named) = structured.record.as_ref() {
+                if let Some(fb_info) = ctx.fb_instances.get(&named.name) {
+                    let field_name = structured.field.to_string().to_lowercase();
+                    let field_idx =
+                        fb_info
+                            .field_indices
+                            .get(&field_name)
+                            .copied()
+                            .ok_or_else(|| {
+                                Diagnostic::problem(
+                                    Problem::NotImplemented,
+                                    Label::span(
+                                        structured.field.span(),
+                                        format!(
+                                            "Unknown field '{}' on function block '{}'",
+                                            structured.field, named.name
+                                        ),
+                                    ),
+                                )
+                            })?;
+                    let var_index = fb_info.var_index;
+                    emitter.emit_fb_load_instance(var_index);
+                    emitter.emit_fb_load_param(field_idx);
+                    emitter.emit_swap();
+                    emitter.emit_pop();
+                    return Ok(());
+                }
+            }
+
             // STRING fields are composite (multi-slot) and stored in the data
             // region, so we intercept before resolve_struct_field_access which
             // only supports single-slot (primitive/enum) fields.

--- a/compiler/codegen/tests/end_to_end_fb_ton.rs
+++ b/compiler/codegen/tests/end_to_end_fb_ton.rs
@@ -339,3 +339,98 @@ END_PROGRAM
         );
     }
 }
+
+#[test]
+fn end_to_end_when_ton_dot_access_reads_q_after_pt_then_true() {
+    // Reproduces the user's original program that previously failed codegen
+    // with P9999 "Variable 'PulseTimer' is not a structure".
+    let source = "
+PROGRAM main
+  VAR
+    Button : BOOL;
+    Buzzer : BOOL;
+    PulseTimer : TON;
+  END_VAR
+  PulseTimer(IN := NOT Button, PT := T#500ms);
+  Buzzer := PulseTimer.Q;
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs).unwrap();
+
+        // Button stays FALSE → IN is TRUE. Start timing at t=0.
+        vm.run_round(0).unwrap();
+        assert_eq!(
+            vm.read_variable(VarIndex::new(1)).unwrap(),
+            0,
+            "Buzzer should be FALSE before PT elapsed"
+        );
+
+        // At t=600ms, past PT (500ms). Dot-access read should see Q = TRUE.
+        vm.run_round(600_000).unwrap();
+        assert_eq!(
+            vm.read_variable(VarIndex::new(1)).unwrap(),
+            1,
+            "Buzzer should be TRUE via dot-access after PT elapsed"
+        );
+    }
+}
+
+#[test]
+fn end_to_end_when_ton_dot_access_reads_q_before_pt_then_false() {
+    let source = "
+PROGRAM main
+  VAR
+    Button : BOOL;
+    Buzzer : BOOL;
+    PulseTimer : TON;
+  END_VAR
+  PulseTimer(IN := NOT Button, PT := T#500ms);
+  Buzzer := PulseTimer.Q;
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs).unwrap();
+
+        vm.run_round(0).unwrap();
+        // t=100ms: well before PT=500ms, Q must remain FALSE.
+        vm.run_round(100_000).unwrap();
+        assert_eq!(
+            vm.read_variable(VarIndex::new(1)).unwrap(),
+            0,
+            "Buzzer should be FALSE via dot-access before PT elapsed"
+        );
+    }
+}
+
+#[test]
+fn end_to_end_when_ton_dot_access_reads_et_then_elapsed_time_correct() {
+    // Exercises dot-access on a non-BOOL field (ET is TIME/i32 ms).
+    let source = "
+PROGRAM main
+  VAR
+    timer : TON;
+    elapsed : TIME;
+  END_VAR
+  timer(IN := TRUE, PT := T#10s);
+  elapsed := timer.ET;
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs).unwrap();
+
+        vm.run_round(0).unwrap();
+        vm.run_round(3_000_000).unwrap();
+        assert_eq!(
+            vm.read_variable(VarIndex::new(1)).unwrap(),
+            3000,
+            "elapsed should be 3000 ms via dot-access"
+        );
+    }
+}

--- a/compiler/codegen/tests/end_to_end_user_fb.rs
+++ b/compiler/codegen/tests/end_to_end_user_fb.rs
@@ -144,3 +144,74 @@ END_PROGRAM
     let _ = common::try_parse_and_compile(source, &CompilerOptions::default())
         .expect("FB calling user function should compile");
 }
+
+#[test]
+fn end_to_end_when_user_fb_dot_access_read_then_returns_output() {
+    // Mirror of the DOUBLER test using dot-access instead of `Q => result`.
+    let source = "
+FUNCTION_BLOCK DOUBLER
+  VAR_INPUT x : DINT; END_VAR
+  VAR_OUTPUT y : DINT; END_VAR
+  y := x * 2;
+END_FUNCTION_BLOCK
+
+PROGRAM main
+  VAR
+    fb : DOUBLER;
+    result : DINT;
+  END_VAR
+  fb(x := 7);
+  result := fb.y;
+END_PROGRAM
+";
+    let (_container, bufs) = parse_and_run(source, &CompilerOptions::default());
+    assert_eq!(
+        bufs.vars[1].as_i32(),
+        14,
+        "result should be 7 * 2 = 14 via dot-access"
+    );
+}
+
+#[test]
+fn end_to_end_when_user_fb_dot_access_across_rounds_then_stack_stable() {
+    // Proves SWAP+POP cleans the fb_ref between iterations: if the stack
+    // drifted, repeated rounds would either trap or produce wrong values.
+    let source = "
+FUNCTION_BLOCK ACCUMULATOR
+  VAR_INPUT val : DINT; END_VAR
+  VAR total : DINT; END_VAR
+  VAR_OUTPUT sum : DINT; END_VAR
+  total := total + val;
+  sum := total;
+END_FUNCTION_BLOCK
+
+PROGRAM main
+  VAR
+    acc : ACCUMULATOR;
+    result : DINT;
+  END_VAR
+  acc(val := 10);
+  result := acc.sum;
+END_PROGRAM
+";
+    parse_and_run_rounds(source, &CompilerOptions::default(), |vm| {
+        vm.run_round(0).unwrap();
+        assert_eq!(
+            vm.read_variable(VarIndex::new(1)).unwrap(),
+            10,
+            "round 1: result should be 10"
+        );
+        vm.run_round(0).unwrap();
+        assert_eq!(
+            vm.read_variable(VarIndex::new(1)).unwrap(),
+            20,
+            "round 2: result should be 20"
+        );
+        vm.run_round(0).unwrap();
+        assert_eq!(
+            vm.read_variable(VarIndex::new(1)).unwrap(),
+            30,
+            "round 3: result should be 30"
+        );
+    });
+}

--- a/specs/plans/2026-04-21-fb-dot-access-read.md
+++ b/specs/plans/2026-04-21-fb-dot-access-read.md
@@ -1,0 +1,94 @@
+# Plan: Support reading function block instance fields via dot-access
+
+## Summary
+
+Codegen currently rejects reading a function block instance's output via dot-access syntax (e.g. `result := PulseTimer.Q`), emitting `P9999: Variable 'PulseTimer' is not a structure`. The analyzer already accepts the program; the missing capability is in codegen. This plan adds a dedicated emission path for the single-level `fb.field` rvalue case for both standard library FBs (TON, TOF, TP, counters, etc.) and user-defined FBs.
+
+## Problem
+
+This program fails compilation, though it follows IEC 61131-3 semantics:
+
+```iec
+PROGRAM main
+  VAR
+    Button : BOOL;
+    Buzzer : BOOL;
+    PulseTimer : TON;
+  END_VAR
+  PulseTimer(IN := NOT Button, PT := T#500ms);
+  Buzzer := PulseTimer.Q;
+END_PROGRAM
+```
+
+In `compiler/codegen/src/compile_expr.rs`, `compile_variable_read` handles `Variable::Symbolic(SymbolicVariableKind::Structured(..))` by calling `walk_struct_chain`. That helper only looks up `ctx.struct_vars`; FB instances live in the parallel `ctx.fb_instances` map (populated by `compile_setup.rs:109-157` for both stdlib and user FBs). When the root is an FB instance, `walk_struct_chain` produces the misleading "'X' is not a structure" diagnostic. The same defect exists for user-defined FBs (`fb.y` after `fb(x := 7)`).
+
+## Change
+
+### `compiler/codegen/src/compile_expr.rs`
+
+In the `Structured` arm of `compile_variable_read` (around line 621), insert an early branch **before** `walk_struct_chain` is called:
+
+1. If `structured.record` is `SymbolicVariableKind::Named(named)` and `named.name` is a key in `ctx.fb_instances`:
+   - Lookup `field_idx = fb_info.field_indices.get(&lowercase(structured.field))`.
+   - If the field name is unknown: emit an inline diagnostic ("Unknown field 'X' on function block 'Y'"). This is a better message than the current fall-through.
+   - Else emit the read sequence:
+     1. `emitter.emit_fb_load_instance(fb_info.var_index)` — pushes `fb_ref` (stack: `[fb_ref]`)
+     2. `emitter.emit_fb_load_param(field_idx)` — VM peeks `fb_ref`, reads field from data region, pushes value (stack: `[fb_ref, value]`)
+     3. `emitter.emit_swap()` — stack: `[value, fb_ref]`
+     4. `emitter.emit_pop()` — stack: `[value]`
+   - Return `Ok(())`.
+
+Net stack effect: +1 (one value), matching the contract of `compile_variable_read`.
+
+Rationale for not modifying `walk_struct_chain`: its contract is "walk a `struct_vars`-rooted chain." FB fields use a separate storage region (addressed via `FB_LOAD_PARAM`), so a unified walker would contaminate the STRING/array branches that depend on its current return shape.
+
+### Reused, not duplicated
+
+- `ctx.fb_instances: HashMap<Id, FbInstanceInfo>` — `compiler/codegen/src/compile.rs:632`
+- `emit_fb_load_instance` / `emit_fb_load_param` / `emit_swap` / `emit_pop` — `compiler/codegen/src/emit.rs:614, 630, 324, 608`
+- `FbInstanceInfo.field_indices: HashMap<String, u8>` with lowercase keys — matches the lookup idiom used by `compile_fb_call` in `compile_stmt.rs:397, 413`.
+
+## Tests
+
+### `compiler/codegen/tests/end_to_end_fb_ton.rs`
+
+Add:
+
+1. **Regression — user's original program.** `PulseTimer : TON`, call `PulseTimer(IN := NOT Button, PT := T#500ms);` then `Buzzer := PulseTimer.Q;`. Run round at t=0, then t=600ms with `Button = FALSE` (so `IN = TRUE`): expect Buzzer TRUE. Fresh run, round at t=0 then t=100ms: expect Buzzer FALSE.
+2. **Dot-access on ET (non-BOOL field).** `timer(IN := TRUE, PT := T#10s); elapsed := timer.ET;` — at t=3s, expect `elapsed == 3000`.
+
+### `compiler/codegen/tests/end_to_end_user_fb.rs`
+
+Add:
+
+3. **User FB dot-access read.** Mirror of the existing `DOUBLER` test (line 15) using `fb(x := 7); result := fb.y;` — expect `result == 14`.
+4. **User FB dot-access across rounds (stack hygiene).** Reuse the `ACCUMULATOR` pattern: `acc(val := 10); result := acc.sum;` across three rounds. Expect 10, 20, 30. Proves SWAP+POP cleans the fb_ref and the operand stack doesn't drift between rounds.
+
+## Out of scope (tracked separately)
+
+- Writing to FB fields via dot-access (`fb.IN := TRUE`) — [#949](https://github.com/ironplc/ironplc/issues/949).
+- Nested chains (`fb1.fb2.Q`) — [#950](https://github.com/ironplc/ironplc/issues/950).
+- Partial/bit access on FB fields (`fb.state.0`) — [#951](https://github.com/ironplc/ironplc/issues/951).
+
+## Verification
+
+From `compiler/`:
+
+1. `just test` — all new and existing codegen tests pass (in particular `end_to_end_fb_ton` and `end_to_end_user_fb`).
+2. End-to-end reproduction of the user's original program via the CLI:
+   ```bash
+   cargo run --bin ironplcc -- compile --output /tmp/ton.iplc /tmp/ton_test.st
+   ```
+   completes with exit 0 (currently emits P9999 and exits non-zero).
+3. `just` — full CI (build + coverage ≥ 85% + clippy + fmt) green before opening the PR.
+
+## Critical files
+
+- `compiler/codegen/src/compile_expr.rs` — single arm edit.
+- `compiler/codegen/tests/end_to_end_fb_ton.rs` — stdlib regression tests.
+- `compiler/codegen/tests/end_to_end_user_fb.rs` — user FB dot-access tests.
+- Reference-only (no changes):
+  - `compiler/codegen/src/compile_stmt.rs` (emission model, `resolve_fb_field_op_type`).
+  - `compiler/codegen/src/compile.rs` (`FbInstanceInfo`).
+  - `compiler/codegen/src/emit.rs` (opcode helpers).
+  - `compiler/vm/src/vm.rs:1685-1715` (VM semantics for `FB_LOAD_INSTANCE`, `FB_LOAD_PARAM`, `SWAP`).


### PR DESCRIPTION
## Summary

- `result := PulseTimer.Q` (and any `fb.field` rvalue read) now compiles and runs. Previously codegen emitted `P9999: Variable 'PulseTimer' is not a structure`, even though the analyzer accepted the program.
- Fix is a dedicated branch in `compile_variable_read` that checks `ctx.fb_instances` and emits `FB_LOAD_INSTANCE` → `FB_LOAD_PARAM` → `SWAP` → `POP`, leaving just the field value on the stack. Covers stdlib FBs (TON/TOF/TP, counters, bistable, edge) and user-defined FBs — same emission path.
- `walk_struct_chain` is intentionally unchanged: its contract is "walk a `struct_vars`-rooted chain" and FB fields live in a different storage region.

## Context

A user reported `TON isn't recognized` on this program:

```iec
PROGRAM main
  VAR Button : BOOL; Buzzer : BOOL; PulseTimer : TON; END_VAR
  PulseTimer(IN := NOT Button, PT := T#500ms);
  Buzzer := PulseTimer.Q;
END_PROGRAM
```

`TON` was in fact recognized — existing tests all used the `Q => result` output-binding syntax, so the `fb.field` rvalue path had no coverage. See the committed plan at `specs/plans/2026-04-21-fb-dot-access-read.md` for the full design notes.

## Out of scope (tracked)

- #949 — writing to FB fields via dot-access (`fb.IN := TRUE`)
- #950 — nested chains (`fb1.fb2.Q`)
- #951 — partial/bit access on FB fields (`fb.state.0`)

## Test plan

- [x] `compiler/codegen/tests/end_to_end_fb_ton.rs` — three new tests: user's exact program before PT (Buzzer FALSE), after PT (Buzzer TRUE), and ET read (non-BOOL field, `elapsed == 3000`).
- [x] `compiler/codegen/tests/end_to_end_user_fb.rs` — two new tests: DOUBLER `fb(x := 7); result := fb.y;` (expect 14), ACCUMULATOR dot-access across 3 rounds (expect 10, 20, 30 — proves SWAP+POP keeps the operand stack clean).
- [x] `cd compiler && just` — full CI (compile + coverage ≥ 85% + clippy + fmt + dupes) green.
- [x] CLI repro (`cargo run --bin ironplcc -- compile --output /tmp/ton.iplc /tmp/ton_test.st`) with the user's program exits 0; previously exited non-zero with P9999.

https://claude.ai/code/session_01MUPMF2C7ytgxX2pSHpr4Hk