### PR TITLE
Refresh CONTRIBUTING docs for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,21 +10,24 @@ as a single repository that hosts all of components:
 * the [compiler](compiler/CONTRIBUTING.md)
 * the [Visual Studio Code Extension](integrations/vscode/CONTRIBUTING.md)
 * the [documentation website](docs/CONTRIBUTING.md)
-* the [interactive playground](playground/)
+* the [interactive playground](playground/CONTRIBUTING.md)
 
 See below for common recommendations or follow the links above for information
 about how to develop each component.
 
-## Code Standards and AI-Assisted Development
+## Code Standards and Project Conventions
 
-IronPLC uses AI-assisted development with detailed coding standards and architectural patterns defined in steering files. These files guide both human and AI contributors to maintain consistency and quality:
+IronPLC has detailed coding standards and architectural patterns defined in
+steering files under `specs/steering/`. These apply to all contributors:
 
 * **[Development Standards](specs/steering/development-standards.md)** - Core project conventions, testing patterns, and error handling
 * **[Compiler Architecture](specs/steering/compiler-architecture.md)** - Patterns for implementing language features and semantic analysis
 * **[Problem Code Management](specs/steering/problem-code-management.md)** - Guidelines for error handling and diagnostic creation
 * **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules
+* **[Common Tasks](specs/steering/common-tasks.md)** - Full command reference for day-to-day development
 
-When contributing code, these steering files provide the detailed implementation guidance, while this CONTRIBUTING.md focuses on the development workflow and setup process.
+The steering files provide the detailed implementation guidance; this
+CONTRIBUTING.md focuses on the development workflow and setup process.
 
 ## Developing
 
@@ -40,7 +43,6 @@ to install:
 Things are even easier if you also install:
 
 * [Just command runner](https://just.systems/man/en/)
-* [act](https://github.com/nektos/act)
 
 Then follow these steps to check that you have a working environment:
 
@@ -68,68 +70,88 @@ Then follow these steps to check that you have a working environment:
 Follow the steps for each component to continue your development
 environment.
 
-## Claude Code Setup (Optional)
+## Planning Non-Trivial Changes
 
-The devcontainer is configured to support Claude Code, Anthropic's AI coding assistant. To use Claude Code in the development environment:
+**Non-trivial changes must start with a plan committed to `specs/plans/`.**
+This keeps design discussion in the open and makes review easier.
 
-1. **Get an Anthropic API key:**
-   - Sign up at [console.anthropic.com](https://console.anthropic.com)
-   - Create an API key in your account settings
+Workflow:
 
-2. **Set the environment variable on your host machine:**
-   
-   **On macOS/Linux:**
-   ```bash
-   export ANTHROPIC_API_KEY="your-api-key-here"
-   ```
-   
-   **On Windows (PowerShell):**
-   ```powershell
-   $env:ANTHROPIC_API_KEY="your-api-key-here"
-   ```
-   
-   **On Windows (Command Prompt):**
-   ```cmd
-   set ANTHROPIC_API_KEY=your-api-key-here
-   ```
+1. Create a feature branch from `main`. Do not commit directly to `main`.
+1. Write an implementation plan and save it under `specs/plans/` (follow the
+   naming convention used by existing files there).
+1. Commit the plan to the feature branch before the implementation code.
+1. Implement the changes following the plan.
+1. Run the pre-PR checks described below.
+1. Push the branch and open a pull request.
 
-3. **Make the environment variable persistent:**
-   
-   **On macOS/Linux:** Add the export command to your shell profile (`.bashrc`, `.zshrc`, etc.)
-   
-   **On Windows:** Set it as a system environment variable through System Properties > Environment Variables
+You may **skip the plan** for mechanical changes: typo fixes, formatting,
+dependency bumps, single-line bug fixes, or documentation-only edits.
 
-4. **Restart VS Code** after setting the environment variable to ensure it's available to the devcontainer.
+## Before You Open a PR
 
-The devcontainer will automatically map your host `ANTHROPIC_API_KEY` environment variable into the container, making Claude Code available for AI-assisted development.
-
-## Local Integration Testing
-
-As described above, cross-platform development is hard. Unfortunately I don't
-know of a great way to run integration tests across all platforms locally.
-
-The best offer here is to run the "on-commit" tests on a Ubuntu Docker image.
-The on-commit tests are slow to run because they test are extensive.
-You will want to run component-specific tests because they are much faster to
-execute. Nevertheless, if you want to reproduce the GitHub commit checks, this
-is the way.
-
-Execute the following to run what you can locally:
+You must run the full CI pipeline locally and see it pass before opening a
+pull request:
 
 ```sh
-just ci-commit-workflow
+cd compiler && just
 ```
+
+This runs compile, coverage (which includes tests), and lint (clippy + fmt).
+All checks must pass.
+
+Common failures:
+
+* **Clippy warnings** - Fix all clippy issues.
+* **Format issues** - Run `cd compiler && just format` to auto-fix.
+* **Coverage below 85%** - Add tests for uncovered code (`just coverage`
+  enforces `--fail-under-lines 85`).
+
+If you touched the VS Code extension, the docs, or the playground, also run
+the component's own CI recipe (`just ci` from that component's directory).
+
+Full cross-platform integration tests run in GitHub Actions when you push.
 
 ## Code Quality Expectations
 
 ### Testing Standards
-All code must follow BDD-style test naming conventions and include comprehensive test coverage. See the development standards steering file for specific patterns and examples.
+
+All tests use BDD-style naming:
+
+```
+function_when_condition_then_expected_result
+```
+
+Example:
+
+```rust
+#[test]
+fn parse_when_input_is_empty_then_returns_error() {
+    // ...
+}
+```
+
+Coverage is enforced at **85%** by `just coverage` in the compiler. Add tests
+for any new code paths.
 
 ### Error Handling
-Error handling is critical for developer experience. All errors must use the shared problem code system with proper documentation. See the problem code management steering file for the complete lifecycle and requirements.
+
+All compiler errors use the shared problem code system. Every new problem
+code requires documentation at
+`docs/reference/compiler/problems/P####.rst`. See the [Problem Code
+Management](specs/steering/problem-code-management.md) steering file for the
+full lifecycle and requirements.
 
 ### Architecture Compliance
-The compiler follows specific architectural patterns for semantic analysis and type checking. Modules must remain focused and under 1000 lines of code. See the compiler architecture steering file for detailed guidance.
+
+The compiler follows specific architectural patterns for semantic analysis
+and type checking. **Modules must stay under 1000 lines of code.** See the
+[Compiler Architecture](specs/steering/compiler-architecture.md) steering
+file for detailed guidance.
 
 ### IEC 61131-3 Compliance
-All language features must follow IEC 61131-3 standard compliance rules with configurable validation levels. See the compliance steering file for implementation requirements.
+
+All language features must follow IEC 61131-3 standard compliance rules with
+configurable validation levels. See the [IEC 61131-3
+Compliance](specs/steering/iec-61131-3-compliance.md) steering file for
+implementation requirements.

--- a/compiler/CONTRIBUTING.md
+++ b/compiler/CONTRIBUTING.md
@@ -4,11 +4,13 @@ This component is the `ironplcc` compiler.
 
 ## Code Standards
 
-The compiler follows specific architectural patterns and coding standards defined in the project's steering files:
+The compiler follows specific architectural patterns and coding standards defined in the project's steering files under `specs/steering/`:
 
-* **Compiler Architecture** (`.kiro/steering/compiler-architecture.md`) - Module organization, semantic analysis patterns, and type system implementation
-* **Problem Code Management** (`.kiro/steering/problem-code-management.md`) - Error handling patterns and diagnostic creation
-* **IEC 61131-3 Compliance** (`.kiro/steering/iec-61131-3-compliance.md`) - Standard compliance validation and type system rules
+* [Development Standards](../specs/steering/development-standards.md) - Core conventions, testing patterns, and error handling
+* [Compiler Architecture](../specs/steering/compiler-architecture.md) - Module organization, semantic analysis patterns, and type system implementation
+* [Problem Code Management](../specs/steering/problem-code-management.md) - Error handling patterns and diagnostic creation
+* [IEC 61131-3 Compliance](../specs/steering/iec-61131-3-compliance.md) - Standard compliance validation and type system rules
+* [Syntax Support Guide](../specs/steering/syntax-support-guide.md) - Checklist for adding new syntax (relevant for parser, codegen, and plc2plc work)
 
 These steering files provide detailed implementation guidance that complements the development workflow described below.
 
@@ -37,7 +39,7 @@ cargo run check ironplc-cli/resources/test/first_steps.st
 
 ### Making Changes
 
-`ironplcc` has a large set of tests. Use `just` to execute the full build pipeline (compile, test, and lint):
+`ironplcc` has a large set of tests. Use `just` to execute the full build pipeline (compile, coverage, and lint). **This is the pipeline you must run before opening a PR:**
 
 ```sh
 just
@@ -45,8 +47,10 @@ just
 
 You can also run individual tasks:
 - `just compile` - Build the compiler
-- `just test` - Run tests and check coverage
+- `just test` - Run tests
+- `just coverage` - Run tests and enforce the 85% coverage floor
 - `just lint` - Check code formatting and style
+- `just format` - Auto-fix formatting
 
 ### Checking Coverage
 
@@ -96,7 +100,8 @@ When working on the compiler:
 
 * **Keep modules focused**: Each analyzer/transformation module should handle one specific aspect and stay under 1000 lines of code
 * **Follow semantic analysis patterns**: Use the `try_from` pattern for AST transformations and proper error handling
-* **Implement proper diagnostics**: All errors must use the shared problem code system with clear, actionable messages
+* **Implement proper diagnostics**: All errors must use the shared problem code system with clear, actionable messages. Every new problem code requires a doc page at `docs/reference/compiler/problems/P####.rst`
 * **Maintain IEC 61131-3 compliance**: Follow standard compliance rules and support configurable validation levels
+* **Use BDD-style test names**: `function_when_condition_then_expected_result` (for example, `parse_when_input_is_empty_then_returns_error`)
 
 See the steering files referenced above for detailed implementation patterns and examples.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,11 +5,17 @@ This contributing guide tells you how to develop the docs.
 ## Prerequisites
 
 You will need Git, Visual Studio Code and the Dev Containers
-extension.
+extension. If you're building outside the Dev Container you also need
+Python 3 and `pip3` (used by `just setup` to install Sphinx and the
+theme/extensions).
 
 ## Developing
 
 1. Open the directory containing this file in Visual Studio Code.
 1. In the Dev Container terminal, change to the `docs` folder.
-1. Run `just`.
+1. Run `just setup` once to install Sphinx and the required extensions.
+1. Run `just` to build the site.
 1. Open `_build/index.html` in a browser.
+
+`just ci` (which runs `setup` + `compile`) is what continuous integration
+runs, and is useful for validating the full build from a clean state.

--- a/integrations/vscode/CONTRIBUTING.md
+++ b/integrations/vscode/CONTRIBUTING.md
@@ -22,6 +22,9 @@ step, you will to a custom-build version).
 1. Make changes as desired.
 1. Reload the extension by pressing `Ctrl+R` or `Cmd+R` on Mac.
 
+Before opening a PR that touches this component, run `just ci` (see below)
+and make sure it passes.
+
 ## Use Custom IronPLC
 
 You will frequently need to make changes to both this Visual Studio Code
@@ -32,11 +35,21 @@ Extension and IronPLC.
 1. In the **Settings** document, search for **ironplc**.
 1. Set the value of **Ironplc: Path** to the directory containing `ironplcc`.
 
-## Run Tests
+## Run Tests and Checks
 
-1. Open the directory containing this file in Visual Studio Code.
-1. Run `just test` to execute the functional tests (or use the debug viewlet as described below).
+The extension has several recipes; run the right one for what you changed:
+
+* `just test-unit` - unit tests (with coverage enforcement)
+* `just test-grammar` - grammar snapshot tests for syntax highlighting
+* `just test` - functional/integration tests (uses Xvfb on Linux)
+* `just check-invariants` - verifies that declared capabilities have test coverage
+* `just lint` - lint checks
+* `just ci` - full pipeline: compile + check-invariants + lint + test-grammar + test-unit + test. **Run this before opening a PR.**
+
+After intentional grammar changes, run `just update-grammar-snapshots` to
+refresh the snapshot files.
 
 ### Alternative: Debug Tests in VS Code
+
 1. Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick **Extension Tests**.
 1. Press `F5` to run the tests in a new window with your extension loaded.

--- a/playground/CONTRIBUTING.md
+++ b/playground/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+This contributing guide tells you how to develop the IronPLC interactive
+playground. The playground is a browser-based editor and runner built from
+the `compiler/playground` WASM crate plus static assets in this directory.
+
+## Prerequisites
+
+You will need:
+
+* Git
+* Rust and Cargo (stable)
+* Node.js and npm
+* Python 3 (used by `just serve` to host the build locally)
+
+If you are using the Dev Container you already have these.
+
+## Developing
+
+1. In a terminal, change to this `playground` directory.
+1. Run `just setup` once to install `wasm-pack`.
+1. Run `just compile` to build the WASM package and assemble the site into
+   `_build/`. This also runs `npm install` to pull in the JS dependencies.
+1. Run `just serve` to build and serve the site at
+   <http://localhost:8080> via Python's built-in HTTP server.
+
+## Run Tests
+
+End-to-end tests use Playwright:
+
+```sh
+just test
+```
+
+This installs the Playwright Chromium browser and runs the test suite
+against a freshly compiled `_build/`.
+
+## Before You Open a PR
+
+Run the full CI recipe and make sure it passes:
+
+```sh
+just ci
+```
+
+This runs `setup` and then `test` (which depends on `compile`), matching
+what GitHub Actions runs for this component.
+
+## Clean Up
+
+`just clean` removes the `_build/` directory.


### PR DESCRIPTION
## Summary

The four existing `CONTRIBUTING.md` files had drifted from how the project actually works today, which would trip up a new contributor. This refresh brings them back in line with the repo's current state and with `CLAUDE.md`.

- **Root `CONTRIBUTING.md`**: drop the broken `just ci-commit-workflow` recommendation (it targets a no-longer-existent `.github/workflows/commit.yaml`) and the long Claude Code / API key section; point contributors at `cd compiler && just` as the canonical pre-PR check; document the mandatory plan-first workflow (`specs/plans/`), the 85% coverage floor, BDD test naming with an example, the 1000-line module cap, and the correct problem-code doc path (`docs/reference/compiler/problems/`).
- **`compiler/CONTRIBUTING.md`**: replace stale `.kiro/steering/*.md` references (those files are now 1-line redirect stubs) with the real `specs/steering/*.md` paths; add `just coverage` and `just format`; add a BDD test-name bullet.
- **`docs/CONTRIBUTING.md`**: add the missing `just setup` step and Python 3 prerequisite so contributors don't hit Sphinx import errors.
- **`integrations/vscode/CONTRIBUTING.md`**: document the full recipe set (`test-unit`, `test-grammar`, `check-invariants`, `lint`, `ci`) instead of only `just test`.
- **`playground/CONTRIBUTING.md`**: new file — the root link previously pointed at a bare directory with no contributor doc.

## Known follow-ups (out of scope for this PR)

1. `justfile:38–46` — `ci-commit-workflow` still calls `act --workflows ./.github/workflows/commit.yaml`, but that workflow doesn't exist. The doc no longer recommends running it, but the recipe itself is still broken and should be fixed or removed.
2. `CLAUDE.md:87` — says problem codes live in `docs/compiler/problems/`; actual path is `docs/reference/compiler/problems/`. Worth fixing in `CLAUDE.md` itself.
3. `.kiro/steering/*.md` — all 1-line stubs redirecting to `specs/steering/`. Either delete them or document their purpose; they're a trip hazard for anyone (human or tool) that finds them first.

## Test plan

- [ ] Every markdown link in the five updated CONTRIBUTING files resolves (verified with a grep-based link-check during authoring; all targets exist).
- [ ] Every `just` recipe referenced in the docs exists in the corresponding `justfile` (verified with `just --list` in each component directory during authoring).
- [ ] Walk-through as a new contributor: follow root CONTRIBUTING top-to-bottom, then each component CONTRIBUTING, in a clean checkout.
- [ ] `cd compiler && just` passes.
- [ ] `cd integrations/vscode && just ci` passes.
- [ ] `cd docs && just setup && just` produces `docs/_build/index.html`.
- [ ] `cd playground && just setup && just compile && just serve` serves the playground.

Docs-only change; no code paths touched.

https://claude.ai/code/session_016YMzQtP3pDMiGohPxx3C9z

---
_Generated by [Claude Code](https://claude.ai/code/session_016YMzQtP3pDMiGohPxx3C9z)_