### PR TITLE
Make time literal unit suffixes case-insensitive

### DIFF
--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -338,10 +338,11 @@ parser! {
     // Omitted and subsumed into constant.
 
     // B.1.2.3.1 Duration
-    // dt_sep defines case insensitive separators between parts of duration
-    rule dt_sep(val: &str) -> &'input Token = [t if t.token_type == TokenType::Identifier && t.text.as_str() == val]
+    // dt_sep defines case insensitive separators between parts of duration.
+    // See specs/design/time-literals.md — REQ-TL-011.
+    rule dt_sep(val: &str) -> &'input Token = [t if t.token_type == TokenType::Identifier && t.text.eq_ignore_ascii_case(val)]
 
-    pub rule duration() -> DurationLiteral = start:position!() (tok(TokenType::Time) / tok(TokenType::Ltime) / dt_sep("T") / dt_sep("t")) tok(TokenType::Hash) s:(tok(TokenType::Minus))? i:interval() end:position!() {
+    pub rule duration() -> DurationLiteral = start:position!() (tok(TokenType::Time) / tok(TokenType::Ltime) / dt_sep("T")) tok(TokenType::Hash) s:(tok(TokenType::Minus))? i:interval() end:position!() {
       let span = SourceSpan::range(start, end);
       let interval = match s {
         Some(sign) => i.interval * -1,
@@ -379,7 +380,7 @@ parser! {
     rule day_hour() -> Integer = integer()
     rule day_minute() -> Integer = integer()
     rule day_second() -> FixedPoint = fixed_point()
-    rule date() -> DateLiteral = (tok(TokenType::Date) / tok(TokenType::Ldate) / dt_sep("D") / dt_sep("d")) tok(TokenType::Hash) d:date_literal() { DateLiteral::new(d) }
+    rule date() -> DateLiteral = (tok(TokenType::Date) / tok(TokenType::Ldate) / dt_sep("D")) tok(TokenType::Hash) d:date_literal() { DateLiteral::new(d) }
     rule date_literal() -> Date = y:year() tok(TokenType::Minus) m:month() tok(TokenType::Minus) d:day() {?
       let y = y.value;
       let m = Month::try_from(<dsl::common::Integer as TryInto<u8>>::try_into(m).map_err(|e| "month")?).map_err(|e| "month")?;

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -2232,4 +2232,150 @@ END_PROGRAM
             }
         }
     }
+
+    // Duration literal conformance tests — see specs/design/time-literals.md.
+
+    fn duration_program(literal: &str) -> String {
+        format!(
+            "FUNCTION fun:TIME\nVAR\n    tv : TIME := {literal};\nEND_VAR\nfun := tv;\nEND_FUNCTION"
+        )
+    }
+
+    fn extract_duration(library: &Library) -> &DurationLiteral {
+        let func = cast!(
+            &library.elements[0],
+            LibraryElementKind::FunctionDeclaration
+        );
+        let initializer = &func.variables[0].initializer;
+        let simple = cast!(initializer, InitialValueAssignmentKind::Simple);
+        let constant = simple.initial_value.as_ref().expect("initializer");
+        cast!(constant, ConstantKind::Duration)
+    }
+
+    #[rstest]
+    #[case::lower_t_lower("t#5s")]
+    #[case::upper_t_lower("T#5s")]
+    #[case::keyword_upper("TIME#5s")]
+    #[case::keyword_lower("time#5s")]
+    #[case::keyword_mixed("Time#5s")]
+    fn duration_spec_req_tl_002_prefix_case_insensitive(#[case] literal: &str) {
+        // REQ-TL-002: prefix is recognized case-insensitively.
+        let source = duration_program(literal);
+        let result = parse_program(&source, &FileId::default(), &CompilerOptions::default());
+        assert!(
+            result.is_ok(),
+            "parse failed for {literal}: {:?}",
+            result.err()
+        );
+    }
+
+    #[rstest]
+    #[case("T#5us")]
+    #[case("T#5ns")]
+    fn duration_spec_req_tl_010_unsupported_unit_rejected(#[case] literal: &str) {
+        // REQ-TL-010: units outside {d, h, m, s, ms} are parse errors.
+        let source = duration_program(literal);
+        let result = parse_program(&source, &FileId::default(), &CompilerOptions::default());
+        assert!(result.is_err(), "expected parse error for {literal}");
+    }
+
+    #[rstest]
+    #[case::s("T#5S", Duration::seconds(5))]
+    #[case::ms("T#100MS", Duration::milliseconds(100))]
+    #[case::h("T#1H", Duration::hours(1))]
+    #[case::d("T#1D", Duration::days(1))]
+    #[case::m("T#30M", Duration::minutes(30))]
+    fn duration_spec_req_tl_011_unit_suffix_uppercase_accepted(
+        #[case] literal: &str,
+        #[case] expected: Duration,
+    ) {
+        // REQ-TL-011: unit suffixes are case-insensitive.
+        let source = duration_program(literal);
+        let library =
+            parse_program(&source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        assert_eq!(extract_duration(&library).interval, expected);
+    }
+
+    #[rstest]
+    #[case::ms_capital_m("T#500Ms", Duration::milliseconds(500))]
+    #[case::ms_capital_s("T#500mS", Duration::milliseconds(500))]
+    fn duration_spec_req_tl_011_unit_suffix_mixed_case_accepted(
+        #[case] literal: &str,
+        #[case] expected: Duration,
+    ) {
+        // REQ-TL-011: mixed-case unit suffixes parse identically to lowercase.
+        let source = duration_program(literal);
+        let library =
+            parse_program(&source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        assert_eq!(extract_duration(&library).interval, expected);
+    }
+
+    #[test]
+    fn duration_spec_req_tl_012_ms_matched_before_m() {
+        // REQ-TL-012: `T#100ms` is 100 milliseconds, not 100 minutes.
+        let source = duration_program("T#100ms");
+        let library =
+            parse_program(&source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        assert_eq!(
+            extract_duration(&library).interval,
+            Duration::milliseconds(100)
+        );
+    }
+
+    #[test]
+    #[ignore = "compound interval grammar is unreachable; see specs/design/time-literals.md Future Work"]
+    fn duration_spec_req_tl_021_compound_interval() {
+        // REQ-TL-021: compound interval with parts in descending magnitude.
+        let source = duration_program("T#1d2h30m15s500ms");
+        let library =
+            parse_program(&source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let expected = Duration::days(1)
+            + Duration::hours(2)
+            + Duration::minutes(30)
+            + Duration::seconds(15)
+            + Duration::milliseconds(500);
+        assert_eq!(extract_duration(&library).interval, expected);
+    }
+
+    #[rstest]
+    #[case::lower("T#1d_2h_30m_5s_100ms")]
+    #[case::upper("T#1D_2H_30M_5S_100MS")]
+    #[ignore = "compound interval grammar is unreachable; see specs/design/time-literals.md Future Work"]
+    fn duration_spec_req_tl_022_compound_with_underscore(#[case] literal: &str) {
+        // REQ-TL-022: optional `_` separator in compound intervals.
+        let source = duration_program(literal);
+        let library =
+            parse_program(&source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let expected = Duration::days(1)
+            + Duration::hours(2)
+            + Duration::minutes(30)
+            + Duration::seconds(5)
+            + Duration::milliseconds(100);
+        assert_eq!(extract_duration(&library).interval, expected);
+    }
+
+    #[test]
+    fn duration_spec_req_tl_023_negative_duration() {
+        // REQ-TL-023: optional leading `-` negates the interval.
+        let source = duration_program("T#-5s");
+        let library =
+            parse_program(&source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        assert_eq!(extract_duration(&library).interval, Duration::seconds(-5));
+    }
+
+    #[rstest]
+    #[case("D#2026-01-01")]
+    #[case("d#2026-01-01")]
+    fn date_prefix_case_insensitive(#[case] literal: &str) {
+        // Sanity check for the `dt_sep("D")` simplification.
+        let source = format!(
+            "FUNCTION fun:DATE\nVAR\n    dv : DATE := {literal};\nEND_VAR\nfun := dv;\nEND_FUNCTION"
+        );
+        let result = parse_program(&source, &FileId::default(), &CompilerOptions::default());
+        assert!(
+            result.is_ok(),
+            "parse failed for {literal}: {:?}",
+            result.err()
+        );
+    }
 }

--- a/docs/reference/language/data-types/elementary/ltime.rst
+++ b/docs/reference/language/data-types/elementary/ltime.rst
@@ -35,11 +35,13 @@ Literals
 
    LTIME#100ms
    LTIME#5s
-   LTIME#1h30m
-   LTIME#500us
+   LTIME#2h
+   ltime#-500ms
 
-Components can be combined: days (``d``), hours (``h``), minutes (``m``),
-seconds (``s``), milliseconds (``ms``), microseconds (``us``).
+Supported units: days (``d``), hours (``h``), minutes (``m``),
+seconds (``s``), milliseconds (``ms``). Units are case-insensitive,
+so ``LTIME#5S`` and ``LTIME#5s`` are equivalent. The prefix is likewise
+case-insensitive.
 
 See Also
 --------

--- a/docs/reference/language/data-types/elementary/time.rst
+++ b/docs/reference/language/data-types/elementary/time.rst
@@ -31,12 +31,13 @@ Literals
 
    T#100ms
    T#2s
-   T#1h30m
-   T#5d12h30m15s
-   TIME#500us
+   T#-500ms
+   TIME#5S
 
-Components can be combined: days (``d``), hours (``h``), minutes (``m``),
-seconds (``s``), milliseconds (``ms``), microseconds (``us``).
+Supported units: days (``d``), hours (``h``), minutes (``m``),
+seconds (``s``), milliseconds (``ms``). Units are case-insensitive,
+so ``T#5S`` and ``T#5s`` are equivalent. The prefix ``T#`` (or
+``TIME#``) is likewise case-insensitive.
 
 See Also
 --------

--- a/specs/design/time-literals.md
+++ b/specs/design/time-literals.md
@@ -1,0 +1,119 @@
+# Design: Time Literals
+
+## Overview
+
+This design specifies the syntax and parsing semantics of IEC 61131-3 duration literals (time literals) in IronPLC. Duration literals denote intervals of time and may be assigned to `TIME` (Edition 2, 32-bit) or `LTIME` (Edition 3, 64-bit) variables.
+
+The design builds on:
+
+- **[ADR-0021: TIME as 32-bit and LTIME as 64-bit with Millisecond Precision](../adrs/0021-time-32bit-ltime-64bit.md)** — storage width, unit, and sub-millisecond truncation semantics
+- **[ADR-0022: IEC 61131-3:2013 Compiler Flag for LTIME and Future Features](../adrs/0022-edition-3-compiler-flag.md)** — `allow_iec_61131_3_2013` gate for `LTIME`
+
+## Design Goals
+
+1. **Standard conformance** — IEC 61131-3 is a case-insensitive language for keywords and literal markers; time literals must accept every case combination.
+2. **Edition coverage** — a single grammar spans Edition 2 (`T#` / `TIME#`) and Edition 3 (adds `LTIME#`); Edition 3 constructs are gated by the existing compiler flag.
+3. **Testability** — every syntactic claim is a numbered requirement that a parser test can cite by ID.
+4. **Narrow scope for precision** — precision and truncation belong to ADR-0021; this document only requires that the parser preserve the input value without loss.
+
+## Scope
+
+**In scope:** The grammar of duration literals: prefixes (`T`, `TIME`, `LTIME`), unit suffixes (`d`, `h`, `m`, `s`, `ms`), compound forms, the underscore visual separator, and the optional leading sign. Case-insensitive parsing for all tokens in the duration literal.
+
+**Out of scope:**
+
+- Sub-millisecond precision handling (owned by ADR-0021)
+- Timer function blocks (TON, TOF, TP)
+- Date, time-of-day, and date-and-time literals (separate grammar productions)
+- Microsecond (`us`) and nanosecond (`ns`) unit suffixes — not defined by IEC 61131-3 for duration literals
+- Build-time enforcement of the REQ-TL → test link (see Future Work)
+
+---
+
+## 1. Grammar
+
+A duration literal has the form:
+
+```
+duration   = prefix '#' ['-'] interval
+prefix     = 'T' | 'TIME' | 'LTIME'                    (case-insensitive)
+interval   = scalar | compound
+scalar     = fixed_point unit
+compound   = integer unit ['_'] { integer unit ['_'] } [fixed_point trailing_unit]
+unit       = 'd' | 'h' | 'm' | 's' | 'ms'              (case-insensitive)
+```
+
+Units in a compound interval appear in strictly descending magnitude order.
+
+## 2. Prefix
+
+**REQ-TL-001** A duration literal begins with one of the prefixes `T`, `TIME`, or `LTIME`, followed by `#`.
+
+**REQ-TL-002** The prefix is recognized case-insensitively. `T#`, `t#`, `TIME#`, `time#`, `Time#` are equivalent; likewise every case variant of `LTIME#`.
+
+**REQ-TL-003** The `LTIME` prefix is only accepted when `CompilerOptions::allow_iec_61131_3_2013` is `true`. When the flag is `false`, a post-tokenization validation rule rejects the `Ltime` token (per [ADR-0022](../adrs/0022-edition-3-compiler-flag.md)).
+
+## 3. Unit Suffixes
+
+**REQ-TL-010** The complete set of supported unit suffixes is exactly `d` (days), `h` (hours), `m` (minutes), `s` (seconds), and `ms` (milliseconds). Other unit names such as `us` or `ns` are rejected as parse errors.
+
+**REQ-TL-011** Unit suffixes are recognized case-insensitively. Every case variant of a unit is accepted and produces the same `DurationLiteral`. For example, `T#5S`, `T#5s`, `T#500Ms`, `T#500MS`, `T#500mS`, and `T#500ms` are all valid; `T#1H30M30S` equals `T#1h30m30s`.
+
+**REQ-TL-012** When scanning an interval, `ms` is matched before `m` so that a token like `100ms` is not misread as minutes followed by a stray unit.
+
+## 4. Interval Forms
+
+**REQ-TL-020** An interval may be a single scalar: an integer or fixed-point number followed by a unit (e.g., `T#1.5s`, `T#500ms`, `T#2D`).
+
+**REQ-TL-021** An interval may be a compound sequence of parts whose units appear in strictly descending magnitude order (`d` > `h` > `m` > `s` > `ms`). All leading parts are integers; the trailing part may be fixed-point. Example: `T#1d2h30m15s500ms`. *(Specified but not currently implemented — see Future Work.)*
+
+**REQ-TL-022** A compound interval may include `_` between adjacent parts as a visual separator. The separator is optional and has no semantic effect. Example: `T#1d_2h_30m` equals `T#1d2h30m`. *(Specified but not currently implemented — see Future Work.)*
+
+**REQ-TL-023** An optional `-` sign between `#` and the first part negates the interval. Example: `T#-5s` represents negative five seconds.
+
+## 5. Precision and Storage
+
+**REQ-TL-030** The parser preserves the full literal value in a `DurationLiteral` without precision loss. Type-specific truncation — TIME to `i32` milliseconds and LTIME to `i64` milliseconds — happens in codegen as specified by [ADR-0021](../adrs/0021-time-32bit-ltime-64bit.md).
+
+## 6. Edition Coverage
+
+| Edition | Prefixes available | Notes |
+|---------|-------------------|-------|
+| IEC 61131-3 Edition 2 (1993) | `T#`, `TIME#` | REQ-TL-001 through REQ-TL-002 and REQ-TL-010 through REQ-TL-023 apply |
+| IEC 61131-3 Edition 3 (2013) | `T#`, `TIME#`, `LTIME#` | All REQs apply; REQ-TL-003 requires `allow_iec_61131_3_2013` to enable `LTIME#` |
+
+Unit suffix case-insensitivity (REQ-TL-011) applies in both editions.
+
+## 7. Test Mapping
+
+Parser tests link to requirements via the existing `{area}_spec_req_{id}_{description}` naming convention (see [spec-conformance-testing.md](spec-conformance-testing.md)). Tests live in `compiler/parser/src/tests.rs`.
+
+| Requirement | Test function |
+|---|---|
+| REQ-TL-002 | `duration_spec_req_tl_002_prefix_case_insensitive` |
+| REQ-TL-010 | `duration_spec_req_tl_010_unsupported_unit_rejected` |
+| REQ-TL-011 | `duration_spec_req_tl_011_unit_suffix_uppercase_accepted` |
+| REQ-TL-011 | `duration_spec_req_tl_011_unit_suffix_mixed_case_accepted` |
+| REQ-TL-012 | `duration_spec_req_tl_012_ms_matched_before_m` |
+| REQ-TL-021 | `duration_spec_req_tl_021_compound_interval` (ignored — see Future Work) |
+| REQ-TL-022 | `duration_spec_req_tl_022_compound_with_underscore` (ignored — see Future Work) |
+| REQ-TL-023 | `duration_spec_req_tl_023_negative_duration` |
+
+REQ-TL-001 and REQ-TL-020 are covered by existing parser tests for basic duration literals and fixed-point durations (e.g., `parse_program_when_fixed_point_duration_then_ok` in `compiler/parser/src/tests.rs`). REQ-TL-003 is covered by existing LTIME gating tests for [ADR-0022](../adrs/0022-edition-3-compiler-flag.md). REQ-TL-030 is an invariant verified in codegen and DSL tests rather than parser tests.
+
+## 8. Implementation
+
+The duration literal grammar lives in `compiler/parser/src/parser.rs`, section marked `// B.1.2.3.1 Duration`. A single PEG helper rule `dt_sep` matches identifier tokens whose text equals a given unit name (case-insensitively, per REQ-TL-011):
+
+```rust
+rule dt_sep(val: &str) -> &'input Token =
+    [t if t.token_type == TokenType::Identifier && t.text.eq_ignore_ascii_case(val)]
+```
+
+The prefix productions `T` / `t` / `D` / `d` previously listed as explicit alternatives collapse to a single `dt_sep("T")` and `dt_sep("D")` respectively, since `dt_sep` is now case-insensitive.
+
+## 9. Future Work
+
+- **Compound intervals (REQ-TL-021, REQ-TL-022).** The grammar at `compiler/parser/src/parser.rs` defines compound intervals via rules like `days() = fixed_point d | integer d [_] hours()`, but pom's ordered-choice semantics always commit to the first alternative (`fixed_point d`) before reaching the compound branch, making compound intervals unreachable today. Fixing this requires restructuring the grammar (for example, adding a dedicated compound production before the scalar alternatives, or using `pom`'s longest-match combinator). Tests for REQ-TL-021 and REQ-TL-022 exist but are marked `#[ignore]` pending that grammar fix.
+- **Build-time REQ-TL enforcement.** The `#[spec_test(REQ_XX_NNN)]` macro infrastructure in `compiler/container/build.rs` currently scans only `bytecode-container-format.md` and `bytecode-instruction-set.md`. Extending it (or adding analogous machinery to `compiler/parser/`) to scan `time-literals.md` would turn the Test Mapping table into a compile-time check. Today humans verify the mapping by reading this document.
+- **Warning for sub-millisecond literals in TIME.** ADR-0021 notes that sub-millisecond durations truncate to zero for 32-bit TIME; a future analyzer pass could emit a diagnostic.

--- a/specs/plans/2026-04-22-time-literal-case-insensitive.md
+++ b/specs/plans/2026-04-22-time-literal-case-insensitive.md
@@ -1,0 +1,29 @@
+# Time Literal Case-Insensitive Unit Suffixes
+
+## Goal
+
+Make IEC 61131-3 time literal unit suffixes (`d`, `h`, `m`, `s`, `ms`) case-insensitive so that `T#5S`, `T#100MS`, `T#1H30M`, `T#1D_2H` all parse. Today the parser only accepts lowercase unit suffixes, despite a code comment claiming otherwise (`compiler/parser/src/parser.rs:341`) and despite IEC 61131-3 being a case-insensitive language throughout.
+
+## Architecture
+
+Single-line change to the PEG grammar helper `dt_sep` in `compiler/parser/src/parser.rs`: replace the case-sensitive `t.text.as_str() == val` comparison with `t.text.eq_ignore_ascii_case(val)`. This also allows simplifying two existing call sites that listed both cases explicitly (`dt_sep("T") / dt_sep("t")`, `dt_sep("D") / dt_sep("d")`).
+
+A new design document `specs/design/time-literals.md` specifies time literal syntax across IEC 61131-3 Editions 2 and 3, introducing `REQ-TL-NNN` requirement IDs. Tests adopt the existing `{area}_spec_req_{id}_{description}` naming convention from `specs/design/spec-conformance-testing.md`, linking each test to the requirement it verifies. ADR-0021 (TIME/LTIME width) and ADR-0022 (Edition 3 gating) remain unchanged.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `specs/design/time-literals.md` | **New** — design doc with REQ-TL-001 through REQ-TL-030 |
+| `compiler/parser/src/parser.rs` | Make `dt_sep` ASCII case-insensitive; drop redundant `dt_sep("t")` / `dt_sep("d")` alternatives |
+| `compiler/parser/src/tests.rs` | Add REQ-TL-### tests |
+| `docs/reference/language/data-types/elementary/time.rst` | Remove `us` microsecond claim (not supported by parser); add case-insensitivity note |
+
+## Tasks
+
+- [x] Create plan
+- [ ] Create `specs/design/time-literals.md` with REQ-TL-### requirements
+- [ ] Change `dt_sep` rule to `eq_ignore_ascii_case` and simplify redundant alternatives
+- [ ] Add tests for REQ-TL-002, REQ-TL-010, REQ-TL-011, REQ-TL-012, REQ-TL-021, REQ-TL-022, REQ-TL-023
+- [ ] Remove `us` microsecond claim from `time.rst`
+- [ ] Run `cd compiler && just` — all checks pass


### PR DESCRIPTION
The parser compared duration unit identifiers (d, h, m, s, ms) with a
case-sensitive byte comparison, despite the grammar comment stating
"dt_sep defines case insensitive separators between parts of duration"
and despite IEC 61131-3 being a case-insensitive language. Inputs like
T#5S, T#100MS, and T#500Ms failed to parse.

Switch the comparison to eq_ignore_ascii_case and drop the now-redundant
dt_sep("t") / dt_sep("d") alternatives. Add a design document
(specs/design/time-literals.md) with REQ-TL-### requirement IDs spanning
Edition 2 and Edition 3, link parser tests to those IDs via naming
convention, and correct the reference docs that wrongly advertised
microsecond (us) units.

Compound intervals (REQ-TL-021, REQ-TL-022) remain unreachable due to a
pre-existing PEG ordering issue where the scalar branch always wins;
the tests are marked #[ignore] and the design doc documents this as
future work.

https://claude.ai/code/session_01EDuAdtXDAzUYQwJqfzwpuG