### PR TITLE
Override serialize-javascript to 7.0.5 to fix vulnerabilities

### DIFF
--- a/integrations/vscode/package-lock.json
+++ b/integrations/vscode/package-lock.json
@@ -6154,16 +6154,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -6456,13 +6446,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -286,5 +286,8 @@
   },
   "dependencies": {
     "vscode-languageclient": "^9"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
Mocha 11.7.5 transitively depends on serialize-javascript ^6.0.2,
which is affected by GHSA-5c6j-r48x-rmvq (RCE via RegExp.flags and
Date.prototype.toISOString) and GHSA-qj8w-gfj5-8c6v (CPU exhaustion
DoS). The 6.x line has no patched version; the fix is only in 7.0.5+.

Add an npm override to force serialize-javascript to ^7.0.5. Unit
tests pass under mocha with the upgraded dependency.