### PR TITLE
Refactor constant pool operations to reduce duplication

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -714,70 +714,67 @@ impl CompileContext {
         idx
     }
 
-    /// Adds an i32 constant to the pool and returns its index.
-    pub(crate) fn add_i32_constant(&mut self, value: i32) -> u16 {
-        for (i, existing) in self.constants.iter().enumerate() {
-            if let PoolConstant::I32(v) = existing {
-                if *v == value {
-                    return i as u16;
-                }
-            }
+    /// Returns the index of an existing constant matching `matches`, or
+    /// pushes `new_value` and returns its index.
+    fn intern_constant(
+        &mut self,
+        matches: impl FnMut(&PoolConstant) -> bool,
+        new_value: PoolConstant,
+    ) -> u16 {
+        if let Some(i) = self.constants.iter().position(matches) {
+            return i as u16;
         }
         let index = self.constants.len() as u16;
-        self.constants.push(PoolConstant::I32(value));
+        self.constants.push(new_value);
         index
+    }
+
+    /// Adds an i32 constant to the pool and returns its index.
+    pub(crate) fn add_i32_constant(&mut self, value: i32) -> u16 {
+        self.intern_constant(
+            |c| matches!(c, PoolConstant::I32(v) if *v == value),
+            PoolConstant::I32(value),
+        )
     }
 
     /// Adds an f32 constant to the pool and returns its index.
+    ///
+    /// Equality uses `to_bits()` so that distinct NaN bit patterns are not
+    /// collapsed to the same pool entry.
     pub(crate) fn add_f32_constant(&mut self, value: f32) -> u16 {
-        for (i, existing) in self.constants.iter().enumerate() {
-            if let PoolConstant::F32(v) = existing {
-                if v.to_bits() == value.to_bits() {
-                    return i as u16;
-                }
-            }
-        }
-        let index = self.constants.len() as u16;
-        self.constants.push(PoolConstant::F32(value));
-        index
+        self.intern_constant(
+            |c| matches!(c, PoolConstant::F32(v) if v.to_bits() == value.to_bits()),
+            PoolConstant::F32(value),
+        )
     }
 
     /// Adds an f64 constant to the pool and returns its index.
+    ///
+    /// Equality uses `to_bits()` so that distinct NaN bit patterns are not
+    /// collapsed to the same pool entry.
     pub(crate) fn add_f64_constant(&mut self, value: f64) -> u16 {
-        for (i, existing) in self.constants.iter().enumerate() {
-            if let PoolConstant::F64(v) = existing {
-                if v.to_bits() == value.to_bits() {
-                    return i as u16;
-                }
-            }
-        }
-        let index = self.constants.len() as u16;
-        self.constants.push(PoolConstant::F64(value));
-        index
+        self.intern_constant(
+            |c| matches!(c, PoolConstant::F64(v) if v.to_bits() == value.to_bits()),
+            PoolConstant::F64(value),
+        )
     }
 
     /// Adds an i64 constant to the pool and returns its index.
     pub(crate) fn add_i64_constant(&mut self, value: i64) -> u16 {
-        for (i, existing) in self.constants.iter().enumerate() {
-            if let PoolConstant::I64(v) = existing {
-                if *v == value {
-                    return i as u16;
-                }
-            }
-        }
-        let index = self.constants.len() as u16;
-        self.constants.push(PoolConstant::I64(value));
-        index
+        self.intern_constant(
+            |c| matches!(c, PoolConstant::I64(v) if *v == value),
+            PoolConstant::I64(value),
+        )
     }
 
     /// Adds a string constant (raw bytes) to the pool and returns its index.
     pub(crate) fn add_str_constant(&mut self, value: Vec<u8>) -> u16 {
-        for (i, existing) in self.constants.iter().enumerate() {
-            if let PoolConstant::Str(v) = existing {
-                if *v == value {
-                    return i as u16;
-                }
-            }
+        if let Some(i) = self
+            .constants
+            .iter()
+            .position(|c| matches!(c, PoolConstant::Str(v) if v == &value))
+        {
+            return i as u16;
         }
         let index = self.constants.len() as u16;
         self.constants.push(PoolConstant::Str(value));

--- a/compiler/container/src/constant_pool.rs
+++ b/compiler/container/src/constant_pool.rs
@@ -52,80 +52,47 @@ impl ConstantPool {
         size
     }
 
-    /// Gets an i32 value from the constant pool at the given index.
-    pub fn get_i32(&self, index: ConstantIndex) -> Result<i32, ContainerError> {
+    /// Reads the first `N` bytes of the entry at `index`, after verifying its
+    /// type matches `expected`.
+    fn get_le_bytes<const N: usize>(
+        &self,
+        index: ConstantIndex,
+        expected: ConstType,
+    ) -> Result<[u8; N], ContainerError> {
         let entry = self
             .entries
             .get(index.raw() as usize)
             .ok_or(ContainerError::InvalidConstantIndex(index))?;
-        if entry.const_type != ConstType::I32 {
+        if entry.const_type != expected {
             return Err(ContainerError::InvalidConstantType(entry.const_type as u8));
         }
-        Ok(i32::from_le_bytes([
-            entry.value[0],
-            entry.value[1],
-            entry.value[2],
-            entry.value[3],
-        ]))
+        let mut bytes = [0u8; N];
+        bytes.copy_from_slice(&entry.value[..N]);
+        Ok(bytes)
+    }
+
+    /// Gets an i32 value from the constant pool at the given index.
+    pub fn get_i32(&self, index: ConstantIndex) -> Result<i32, ContainerError> {
+        self.get_le_bytes::<4>(index, ConstType::I32)
+            .map(i32::from_le_bytes)
     }
 
     /// Gets an f32 value from the constant pool at the given index.
     pub fn get_f32(&self, index: ConstantIndex) -> Result<f32, ContainerError> {
-        let entry = self
-            .entries
-            .get(index.raw() as usize)
-            .ok_or(ContainerError::InvalidConstantIndex(index))?;
-        if entry.const_type != ConstType::F32 {
-            return Err(ContainerError::InvalidConstantType(entry.const_type as u8));
-        }
-        Ok(f32::from_le_bytes([
-            entry.value[0],
-            entry.value[1],
-            entry.value[2],
-            entry.value[3],
-        ]))
+        self.get_le_bytes::<4>(index, ConstType::F32)
+            .map(f32::from_le_bytes)
     }
 
     /// Gets an f64 value from the constant pool at the given index.
     pub fn get_f64(&self, index: ConstantIndex) -> Result<f64, ContainerError> {
-        let entry = self
-            .entries
-            .get(index.raw() as usize)
-            .ok_or(ContainerError::InvalidConstantIndex(index))?;
-        if entry.const_type != ConstType::F64 {
-            return Err(ContainerError::InvalidConstantType(entry.const_type as u8));
-        }
-        Ok(f64::from_le_bytes([
-            entry.value[0],
-            entry.value[1],
-            entry.value[2],
-            entry.value[3],
-            entry.value[4],
-            entry.value[5],
-            entry.value[6],
-            entry.value[7],
-        ]))
+        self.get_le_bytes::<8>(index, ConstType::F64)
+            .map(f64::from_le_bytes)
     }
 
     /// Gets an i64 value from the constant pool at the given index.
     pub fn get_i64(&self, index: ConstantIndex) -> Result<i64, ContainerError> {
-        let entry = self
-            .entries
-            .get(index.raw() as usize)
-            .ok_or(ContainerError::InvalidConstantIndex(index))?;
-        if entry.const_type != ConstType::I64 {
-            return Err(ContainerError::InvalidConstantType(entry.const_type as u8));
-        }
-        Ok(i64::from_le_bytes([
-            entry.value[0],
-            entry.value[1],
-            entry.value[2],
-            entry.value[3],
-            entry.value[4],
-            entry.value[5],
-            entry.value[6],
-            entry.value[7],
-        ]))
+        self.get_le_bytes::<8>(index, ConstType::I64)
+            .map(i64::from_le_bytes)
     }
 
     /// Gets a string value (raw bytes) from the constant pool at the given index.


### PR DESCRIPTION
This PR refactors the constant pool implementation to eliminate code duplication across multiple methods.

## Summary
Extracted common patterns in constant pool operations into reusable helper methods, reducing code duplication and improving maintainability.

## Key Changes

**compiler/codegen/src/compile.rs:**
- Introduced `intern_constant()` helper method that handles the common pattern of searching for an existing constant and returning its index, or adding a new one
- Refactored `add_i32_constant()`, `add_f32_constant()`, `add_f64_constant()`, and `add_i64_constant()` to use the new helper
- Kept `add_str_constant()` with inline implementation due to its unique ownership semantics
- Added documentation clarifying that f32 and f64 equality uses `to_bits()` to preserve distinct NaN bit patterns

**compiler/container/src/constant_pool.rs:**
- Introduced `get_le_bytes<const N: usize>()` helper method that handles the common pattern of validating constant type and extracting bytes
- Refactored `get_i32()`, `get_f32()`, `get_f64()`, and `get_i64()` to use the new helper
- Simplified byte extraction logic using generic const parameters

## Implementation Details
- The `intern_constant()` method uses a closure parameter to allow flexible matching logic for different constant types
- The `get_le_bytes()` method uses const generics to handle different byte sizes (4 for i32/f32, 8 for i64/f64)
- Both helpers maintain the same error handling and validation behavior as the original implementations

https://claude.ai/code/session_01TyE6tqt282qV7Pt9QqYfPX