### PR TITLE
issue-resolver: add DRY_RUN mode and fix README webhook invocations

### DIFF
--- a/agents/issue-resolver/.env.example
+++ b/agents/issue-resolver/.env.example
@@ -9,3 +9,9 @@ GITHUB_WEBHOOK_SECRET=
 
 # "owner/repo" — e.g. ironplc/ironplc.
 GITHUB_REPO=ironplc/ironplc
+
+# Optional: when "true", the orchestrator delegates reads to real GitHub
+# but prints comment bodies and label changes instead of POSTing them.
+# Useful for simulating a real issue with a read-only PAT. See
+# `just serve-dryrun`.
+# DRY_RUN=true

--- a/agents/issue-resolver/README.md
+++ b/agents/issue-resolver/README.md
@@ -104,7 +104,7 @@ Drive the orchestrator into the requirements stage (will fail at the
 LLM call without a real Anthropic key, which is fine):
 
 ```bash
-just webhook ACTION=labeled LABEL=status/triage NUMBER=42
+just webhook labeled status/triage 42
 ```
 
 ## Simulate a real issue without writing back (dry run)
@@ -120,7 +120,8 @@ safety net in case the wrapper is bypassed.
 just serve-dryrun
 
 # In another terminal, fabricate the trigger for a real issue number.
-just webhook ACTION=labeled LABEL=status/triage NUMBER=<real issue #>
+# Recipe args are positional: ACTION LABEL NUMBER [EVENT] [port]
+just webhook labeled status/triage <real issue #>
 ```
 
 The would-be comment body and label changes print to the `serve-dryrun`

--- a/agents/issue-resolver/README.md
+++ b/agents/issue-resolver/README.md
@@ -75,6 +75,7 @@ just setup
 | `just setup` | Create `.venv` and install deps (idempotent) |
 | `just test` | Run the unit test suite |
 | `just serve` | Start `uvicorn` on port 8000 with hot-reload |
+| `just serve-dryrun` | Like `serve`, but comment posts and label changes are printed to stdout instead of sent to GitHub |
 | `just health` | `GET /health` against a running `serve` |
 | `just webhook` | Send a properly-signed webhook (default action `opened`, ignored by orchestrator) |
 | `just webhook-bogus` | Send a webhook with an invalid signature; expect 401 |
@@ -105,6 +106,26 @@ LLM call without a real Anthropic key, which is fine):
 ```bash
 just webhook ACTION=labeled LABEL=status/triage NUMBER=42
 ```
+
+## Simulate a real issue without writing back (dry run)
+
+Useful when you want to see how the orchestrator handles a real issue
+that already exists in GitHub, without it actually posting comments or
+moving labels. Reads still hit real GitHub, so use a fine-grained PAT
+with **read-only** access (`metadata: read`, `issues: read`) as a
+safety net in case the wrapper is bypassed.
+
+```bash
+# .env: GITHUB_REPO points at the real repo, GITHUB_TOKEN is read-only.
+just serve-dryrun
+
+# In another terminal, fabricate the trigger for a real issue number.
+just webhook ACTION=labeled LABEL=status/triage NUMBER=<real issue #>
+```
+
+The would-be comment body and label changes print to the `serve-dryrun`
+console, prefixed with `[DRY RUN]`. The ledger still records
+`COMMENT_POSTED` and `LABEL_TRANSITION` events.
 
 ## Full end-to-end (requires real credentials + ngrok + Terraform)
 

--- a/agents/issue-resolver/github_client.py
+++ b/agents/issue-resolver/github_client.py
@@ -18,6 +18,7 @@ Error handling is deliberately small:
 from __future__ import annotations
 
 import hmac
+import sys
 import time
 from dataclasses import dataclass
 from hashlib import sha256
@@ -117,6 +118,54 @@ class GitHubClient:
     def get_authenticated_user_login(self) -> str:
         resp = self._request("GET", "/user")
         return resp.json()["login"]
+
+
+@dataclass(frozen=True)
+class DryRunGitHubClient:
+    """Wrapper that delegates reads but turns writes into stdout logs.
+
+    Lets you point the orchestrator at a real repo with a read-only PAT
+    and watch what it *would* post without touching the issue. Reads
+    (``get_issue``, ``get_issue_comments``, ``get_labels``,
+    ``get_authenticated_user_login``) hit the real API; writes
+    (``post_comment``, ``add_label``, ``remove_label``) print and no-op.
+    """
+
+    inner: GitHubClient
+
+    def get_issue(self, issue_number: int) -> dict:
+        return self.inner.get_issue(issue_number)
+
+    def get_issue_comments(self, issue_number: int) -> list[dict]:
+        return self.inner.get_issue_comments(issue_number)
+
+    def get_labels(self, issue_number: int) -> list[str]:
+        return self.inner.get_labels(issue_number)
+
+    def get_authenticated_user_login(self) -> str:
+        return self.inner.get_authenticated_user_login()
+
+    def post_comment(self, issue_number: int, body: str) -> dict:
+        print(
+            f"\n[DRY RUN] post_comment(#{issue_number}):\n{body}\n",
+            file=sys.stdout,
+            flush=True,
+        )
+        return {"id": 0}
+
+    def add_label(self, issue_number: int, label: str) -> None:
+        print(
+            f"[DRY RUN] add_label(#{issue_number}, {label!r})",
+            file=sys.stdout,
+            flush=True,
+        )
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        print(
+            f"[DRY RUN] remove_label(#{issue_number}, {label!r})",
+            file=sys.stdout,
+            flush=True,
+        )
 
 
 def verify_webhook_signature(

--- a/agents/issue-resolver/justfile
+++ b/agents/issue-resolver/justfile
@@ -14,6 +14,11 @@ test:
 serve port='8000':
     .venv/bin/uvicorn main:app --port {{port}} --reload
 
+# Like `serve`, but the orchestrator delegates reads to real GitHub and
+# only prints what it would post or relabel. Pair with a read-only PAT.
+serve-dryrun port='8000':
+    DRY_RUN=true .venv/bin/uvicorn main:app --port {{port}} --reload
+
 health port='8000':
     curl -s -i localhost:{{port}}/health
 

--- a/agents/issue-resolver/main.py
+++ b/agents/issue-resolver/main.py
@@ -13,13 +13,18 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 import anthropic
 from fastapi import BackgroundTasks, FastAPI, Header, Request, Response
 
 from agents.requirements import RequirementsAgent
 from config import load_config
-from github_client import GitHubClient, verify_webhook_signature
+from github_client import (
+    DryRunGitHubClient,
+    GitHubClient,
+    verify_webhook_signature,
+)
 from ledger import Ledger
 from models import WorkItemEvent
 from orchestrator import Orchestrator, safe_handle_event
@@ -34,7 +39,16 @@ def create_app() -> FastAPI:
 
     config = load_config()
     ledger = Ledger()
-    github = GitHubClient(token=config.github_token, repo=config.github_repo)
+    real_github = GitHubClient(
+        token=config.github_token, repo=config.github_repo
+    )
+    github: GitHubClient | DryRunGitHubClient = real_github
+    if os.environ.get("DRY_RUN") == "true":
+        github = DryRunGitHubClient(real_github)
+        logger.warning(
+            "DRY_RUN=true: comments and label changes will be printed, "
+            "not sent to GitHub"
+        )
     anthropic_client = anthropic.Anthropic(api_key=config.anthropic_api_key)
 
     bot_login: str | None

--- a/agents/issue-resolver/tests/test_github_client.py
+++ b/agents/issue-resolver/tests/test_github_client.py
@@ -8,6 +8,7 @@ from hashlib import sha256
 from unittest.mock import MagicMock, patch
 
 from github_client import (
+    DryRunGitHubClient,
     GitHubAPIError,
     GitHubClient,
     verify_webhook_signature,
@@ -84,6 +85,36 @@ class TestGitHubClient(unittest.TestCase):
         client = GitHubClient(token="tok", repo="o/r")
         # Must not raise.
         client.remove_label(42, "status/triage")
+
+
+class TestDryRunGitHubClient(unittest.TestCase):
+    def test_post_comment_when_dry_run_then_does_not_call_inner(self) -> None:
+        inner = MagicMock(spec=GitHubClient)
+        client = DryRunGitHubClient(inner)
+        result = client.post_comment(7, "hello")
+        inner.post_comment.assert_not_called()
+        self.assertEqual(result, {"id": 0})
+
+    def test_label_writes_when_dry_run_then_does_not_call_inner(self) -> None:
+        inner = MagicMock(spec=GitHubClient)
+        client = DryRunGitHubClient(inner)
+        client.add_label(7, "status/triage")
+        client.remove_label(7, "status/triage")
+        inner.add_label.assert_not_called()
+        inner.remove_label.assert_not_called()
+
+    def test_reads_when_dry_run_then_delegate_to_inner(self) -> None:
+        inner = MagicMock(spec=GitHubClient)
+        inner.get_issue.return_value = {"number": 7}
+        inner.get_issue_comments.return_value = [{"id": 1}]
+        inner.get_labels.return_value = ["status/triage"]
+        inner.get_authenticated_user_login.return_value = "bot"
+        client = DryRunGitHubClient(inner)
+
+        self.assertEqual(client.get_issue(7), {"number": 7})
+        self.assertEqual(client.get_issue_comments(7), [{"id": 1}])
+        self.assertEqual(client.get_labels(7), ["status/triage"])
+        self.assertEqual(client.get_authenticated_user_login(), "bot")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add a `DRY_RUN=true` mode that wraps `GitHubClient` so reads still hit real GitHub but writes (`post_comment`, `add_label`, `remove_label`) print to stdout instead of POSTing. Exposed via a new `just serve-dryrun` recipe. Useful for simulating a real issue (e.g. one already filed in this repo) with a read-only PAT, without risking a comment or label change on the live issue.
- Fix the `just webhook` invocations in the README. just recipe arguments are positional, not `name=value` — the previous form (`ACTION=labeled LABEL=status/triage NUMBER=42`) made just substitute the literal strings into the body, producing invalid JSON and a 400 from the server.

## Test plan

- [x] `cd agents/issue-resolver && just test` — all 36 tests pass, including 3 new ones for `DryRunGitHubClient` (writes don't reach the inner client; reads delegate)
- [x] Manually verified end-to-end: `just serve-dryrun` + `just webhook labeled status/triage <real issue #>` exercises the full pipeline (webhook → orchestrator → real GitHub read → Anthropic → dry-run shim catches the would-be `post_comment` and `add_label`)
- [ ] Reviewer: confirm the README examples now work for you on a fresh checkout

https://claude.ai/code/session_01LS73ZzoMaS9yQfvDZGjiF6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LS73ZzoMaS9yQfvDZGjiF6)_