### PR TITLE
issue-resolver: fix README webhook invocations to use positional args

### DIFF
--- a/agents/issue-resolver/README.md
+++ b/agents/issue-resolver/README.md
@@ -104,7 +104,7 @@ Drive the orchestrator into the requirements stage (will fail at the
 LLM call without a real Anthropic key, which is fine):
 
 ```bash
-just webhook ACTION=labeled LABEL=status/triage NUMBER=42
+just webhook labeled status/triage 42
 ```
 
 ## Simulate a real issue without writing back (dry run)
@@ -120,7 +120,8 @@ safety net in case the wrapper is bypassed.
 just serve-dryrun
 
 # In another terminal, fabricate the trigger for a real issue number.
-just webhook ACTION=labeled LABEL=status/triage NUMBER=<real issue #>
+# Recipe args are positional: ACTION LABEL NUMBER [EVENT] [port]
+just webhook labeled status/triage <real issue #>
 ```
 
 The would-be comment body and label changes print to the `serve-dryrun`


### PR DESCRIPTION
## Summary

- just recipe arguments are positional, not `name=value`. The previous README form (`just webhook ACTION=labeled LABEL=status/triage NUMBER=42`) made just substitute the literal strings `ACTION=labeled`, `NUMBER=42`, etc. into the body via `printf '{"action":"%s","issue":{"number":%s,...}'`, producing invalid JSON like `"number":NUMBER=42` and a 400 from the server.
- Updated both example invocations to the correct positional form `just webhook labeled status/triage 42` and added an inline note about the argument order.

## Test plan

- [x] Verified locally: with the buggy form, the recipe builds `{"action":"ACTION=labeled","issue":{"number":NUMBER=972,...}` which fails `json.loads` and returns 400. With the positional form, the body is well-formed JSON and the orchestrator routes the event correctly.
- [ ] Reviewer: copy-paste either example from the README and confirm it returns 200 (or whatever your server expects for the action).

https://claude.ai/code/session_01LS73ZzoMaS9yQfvDZGjiF6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LS73ZzoMaS9yQfvDZGjiF6)_