### PR TITLE
Remove author_association gate from integration workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,12 @@
 # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
 .github/workflows/   @garretfick
 
+# Justfiles — privileged workflow jobs in the `production` environment
+# invoke recipes with IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN, VSCE_PAT,
+# and OVSX_PAT in scope. A malicious recipe edit would have the same
+# blast radius as a malicious workflow edit.
+**/justfile          @garretfick
+
 # This file itself.
 .github/CODEOWNERS   @garretfick
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for security-sensitive paths.
+#
+# GitHub auto-requests review from the listed owners when a PR modifies
+# matching files. With "Require review from Code Owners" enabled on the
+# main branch protection rule, merge is blocked until at least one
+# code owner approves.
+#
+# Note: last matching pattern wins, not all of them. Order matters.
+
+# Workflow definitions — gates publish secrets and runner-minute usage.
+# See specs/adrs/0032-ci-gating-and-secret-scoping.md.
+.github/workflows/   @garretfick
+
+# This file itself.
+.github/CODEOWNERS   @garretfick
+
+# The CI/secret-scoping ADR. Future revisions should be reviewed by an
+# owner who understands the threat model.
+specs/adrs/0032-*    @garretfick

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -126,6 +126,7 @@ jobs:
     needs: [release, publish-website]
     runs-on: ubuntu-latest
     # Scopes VS_MARKETPLACE_TOKEN, OVSX_PAT to deployments from main.
+    # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
     environment: production
     defaults:
       run:
@@ -179,6 +180,7 @@ jobs:
     needs: [release, publish-release]
     runs-on: ubuntu-latest
     # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from main.
+    # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
     environment: production
     steps:
       - name: Download playground artifact
@@ -206,6 +208,7 @@ jobs:
     needs: [release, publish-release]
     runs-on: ubuntu-latest
     # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from main.
+    # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
     environment: production
     defaults:
       run:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -125,6 +125,8 @@ jobs:
     name: Publish Release
     needs: [release, publish-website]
     runs-on: ubuntu-latest
+    # Scopes VS_MARKETPLACE_TOKEN, OVSX_PAT to deployments from main.
+    environment: production
     defaults:
       run:
         working-directory: ./integrations/vscode
@@ -176,6 +178,8 @@ jobs:
     name: Publish Playground to playground.ironplc.com
     needs: [release, publish-release]
     runs-on: ubuntu-latest
+    # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from main.
+    environment: production
     steps:
       - name: Download playground artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -201,6 +205,8 @@ jobs:
     name: Publish Homebrew Tap
     needs: [release, publish-release]
     runs-on: ubuntu-latest
+    # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from main.
+    environment: production
     defaults:
       run:
         working-directory: ./compiler

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -10,11 +10,20 @@ permissions:
   contents: read
 
 jobs:
-  # PRs from untrusted authors are gated by the repo's "Require approval for
-  # first-time contributors" setting, which queues the run for maintainer
-  # approval instead of executing automatically.
+  # Per-run approval gate. Every run pauses here until a reviewer of the
+  # `pr-ci` environment clicks Approve, scoped to that exact commit. This
+  # prevents arbitrary fork PRs (and unreviewed pushes) from consuming
+  # runner minutes or executing untrusted code on our behalf.
+  approve:
+    name: Awaiting maintainer approval
+    runs-on: ubuntu-latest
+    environment: pr-ci
+    steps:
+      - run: echo "Approved by ${{ github.actor }}"
+
   ironplcc-tests:
     name: Build IronPLC Compiler
+    needs: approve
     uses: ./.github/workflows/partial_compiler.yaml
     with:
       commit-ref: ""
@@ -23,6 +32,7 @@ jobs:
 
   vscode-extension:
     name: Build Visual Studio Code Extension
+    needs: approve
     uses: ./.github/workflows/partial_vscode_extension.yaml
     with:
       commit-ref: ""
@@ -31,12 +41,14 @@ jobs:
 
   agents:
     name: Test Agents
+    needs: approve
     uses: ./.github/workflows/partial_agents.yaml
     with:
       commit-ref: ""
 
   docs:
     name: Build Website
+    needs: approve
     # The website doesn't depend on these but we don't publish
     # if those are failing so we depend on those.
     uses: ./.github/workflows/partial_website.yaml
@@ -46,6 +58,7 @@ jobs:
 
   install-script-lint:
     name: Lint Install Script
+    needs: approve
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -54,6 +67,7 @@ jobs:
 
   install-script-smoke:
     name: Install Script Smoke Test (Last Release)
+    needs: approve
     # Runs install.sh against the last published release on Linux and macOS.
     # This catches regressions in the script without requiring a new release.
     uses: ./.github/workflows/partial_install_script_test.yaml

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -10,14 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  # Restrict PR builds to organization members and collaborators to prevent
-  # resource abuse from arbitrary external PRs. workflow_dispatch events
-  # are already restricted by permissions.
+  # PRs from untrusted authors are gated by the repo's "Require approval for
+  # first-time contributors" setting, which queues the run for maintainer
+  # approval instead of executing automatically.
   ironplcc-tests:
     name: Build IronPLC Compiler
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: ./.github/workflows/partial_compiler.yaml
     with:
       commit-ref: ""
@@ -26,9 +23,6 @@ jobs:
 
   vscode-extension:
     name: Build Visual Studio Code Extension
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: ./.github/workflows/partial_vscode_extension.yaml
     with:
       commit-ref: ""
@@ -37,18 +31,12 @@ jobs:
 
   agents:
     name: Test Agents
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: ./.github/workflows/partial_agents.yaml
     with:
       commit-ref: ""
 
   docs:
     name: Build Website
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     # The website doesn't depend on these but we don't publish
     # if those are failing so we depend on those.
     uses: ./.github/workflows/partial_website.yaml
@@ -58,9 +46,6 @@ jobs:
 
   install-script-lint:
     name: Lint Install Script
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -71,9 +56,6 @@ jobs:
     name: Install Script Smoke Test (Last Release)
     # Runs install.sh against the last published release on Linux and macOS.
     # This catches regressions in the script without requiring a new release.
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: ./.github/workflows/partial_install_script_test.yaml
     with:
       compiler-version: ""

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,9 +11,9 @@ permissions:
 
 jobs:
   # Per-run approval gate. Every run pauses here until a reviewer of the
-  # `pr-ci` environment clicks Approve, scoped to that exact commit. This
-  # prevents arbitrary fork PRs (and unreviewed pushes) from consuming
-  # runner minutes or executing untrusted code on our behalf.
+  # `pr-ci` environment clicks Approve, scoped to that exact commit.
+  # See specs/adrs/0032-ci-gating-and-secret-scoping.md for the rationale,
+  # threat model, and one-time GitHub setup required.
   approve:
     name: Awaiting maintainer approval
     runs-on: ubuntu-latest

--- a/.github/workflows/partial_update_dependencies.yaml
+++ b/.github/workflows/partial_update_dependencies.yaml
@@ -31,6 +31,7 @@ jobs:
         runs-on: ubuntu-latest
         # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from
         # main; PR-triggered workflows cannot reach this secret.
+        # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
         environment: production
 
         outputs:

--- a/.github/workflows/partial_update_dependencies.yaml
+++ b/.github/workflows/partial_update_dependencies.yaml
@@ -29,6 +29,9 @@ jobs:
         name: Update Dependencies
 
         runs-on: ubuntu-latest
+        # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from
+        # main; PR-triggered workflows cannot reach this secret.
+        environment: production
 
         outputs:
           commit-ref: ${{ inputs.branch-name }}

--- a/.github/workflows/partial_version.yaml
+++ b/.github/workflows/partial_version.yaml
@@ -36,6 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from
         # main; PR-triggered workflows cannot reach this secret.
+        # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
         environment: production
         
         outputs:

--- a/.github/workflows/partial_version.yaml
+++ b/.github/workflows/partial_version.yaml
@@ -34,6 +34,9 @@ jobs:
         # Only needs to run on one platform because this is defining
         # the container for the release rather than building the artifacts
         runs-on: ubuntu-latest
+        # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from
+        # main; PR-triggered workflows cannot reach this secret.
+        environment: production
         
         outputs:
           # The identifier for the Github release - a unique number

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -71,6 +71,8 @@ jobs:
     name: Merge Changes
     needs: [update-dependencies, build-vscode-extension, build-platform-package, build-docs]
     runs-on: ubuntu-latest
+    # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from main.
+    environment: production
     steps:
       - name: Checkout branch ${{ needs.update-dependencies.outputs.branch-name }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -72,6 +72,7 @@ jobs:
     needs: [update-dependencies, build-vscode-extension, build-platform-package, build-docs]
     runs-on: ubuntu-latest
     # Scopes IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN to deployments from main.
+    # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
     environment: production
     steps:
       - name: Checkout branch ${{ needs.update-dependencies.outputs.branch-name }}

--- a/specs/adrs/0032-ci-gating-and-secret-scoping.md
+++ b/specs/adrs/0032-ci-gating-and-secret-scoping.md
@@ -90,7 +90,7 @@ For any PR that modifies `.github/workflows/**`:
 4. Does it add a new workflow that reads `secrets.*`?
    * The reading job must declare an appropriate environment (`production` for publish secrets; none for `GITHUB_TOKEN`-only).
 
-A CODEOWNERS rule on `.github/workflows/**` ensures a security-aware reviewer is automatically routed to every such PR.
+A CODEOWNERS rule on `.github/workflows/**` and `**/justfile` ensures a security-aware reviewer is automatically routed to every such PR. Justfiles are included because privileged jobs (`environment: production`) execute justfile recipes with publish secrets in scope — a malicious recipe edit has the same blast radius as a malicious workflow edit.
 
 ### One-time GitHub setup
 

--- a/specs/adrs/0032-ci-gating-and-secret-scoping.md
+++ b/specs/adrs/0032-ci-gating-and-secret-scoping.md
@@ -1,0 +1,152 @@
+# CI Gating for Untrusted PRs and Secret Scoping via Environments
+
+status: proposed
+date: 2026-04-27
+
+## Context and Problem Statement
+
+GitHub Actions workflows in this repository span three trust contexts:
+
+1. **PR validation** (`integration.yaml`) — runs untrusted code from forks or unreviewed branches on maintainer-paid runners.
+2. **Scheduled dependency updates** (`update.yaml`) — runs trusted code on a Sunday cron, holds a token that bypasses branch protection on `main`.
+3. **Scheduled releases** (`deployment.yaml`) — runs trusted code on a Monday cron, holds tokens that publish to the VS Code Marketplace, Open VSX, GitHub Pages (playground), and the Homebrew tap.
+
+The risks differ:
+
+* A fork PR can run arbitrary code on a runner. With no secrets in scope, the impact is bounded to runner-minute abuse and a read-only `GITHUB_TOKEN`. With publish secrets in scope, the impact is a compromised release artifact reaching every IronPLC user.
+* A release-time secret leak is catastrophic. `IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN` can push to `main` (bypassing branch protection); `VS_MARKETPLACE_TOKEN`/`OVSX_PAT` can ship a tampered extension to thousands of users.
+
+The repository previously gated PR validation with per-job `if:` conditions that skipped jobs whose author was not an `OWNER`/`MEMBER`/`COLLABORATOR`. Two problems surfaced (see PR #979):
+
+* Skipped checks do not satisfy required-status-check rules, so external PRs hung in `blocked` state with no UI affordance for maintainers to opt in to a specific PR.
+* Publish secrets were stored at the repository level, so any workflow — including a fork PR with a tampered workflow file — could in principle reference them.
+
+## Decision Drivers
+
+* **Untrusted contributors must not consume runner minutes or execute code without explicit, per-commit maintainer approval.**
+* **Publish secrets must be unreachable from PR-triggered workflows**, even if the workflow file is tampered with by the PR author.
+* **Scheduled builds must run unattended** — the weekly dependency update and weekly release cannot wait on a human approver each cron tick.
+* **GitHub's repo-level "Require approval for first-time contributors" setting is per-author, not per-PR.** Once a contributor's first run is approved, every subsequent PR from that account runs automatically — turning a single vetting into a permanent whitelist.
+* **The workflow file on `pull_request` events comes from the PR branch.** Any gate expressed only as `if:` or `needs:` inside the YAML can be edited away by the PR author. Repo-level configuration cannot.
+* **`IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN` is a fine-grained PAT with `Contents: write` on three repos** (`ironplc/ironplc`, `ironplc/ironplc-playground`, `ironplc/homebrew-brew`) and is in the `main`-branch-protection bypass list. Its blast radius is the entire org.
+
+## Considered Options
+
+* Per-job author-association `if:` gates (the previous approach)
+* Repo-level "first-time contributor" approval setting
+* Label-gated workflow with a `safe-to-test` label
+* Two GitHub Environments — `pr-ci` (per-run approval, no secrets) and `production` (secret scoping, branch-restricted)
+* `pull_request_target` for everything
+
+## Decision Outcome
+
+Chosen option: **Two GitHub Environments — `pr-ci` and `production`.**
+
+| Environment | Required reviewers | Deployment branches | Secrets |
+|---|---|---|---|
+| `pr-ci` | Yes (maintainers) | Any | None |
+| `production` | No | `main` only | `IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN`, `VS_MARKETPLACE_TOKEN`, `OVSX_PAT` |
+
+The `pr-ci` environment is referenced by a single zero-step `approve` job at the top of `integration.yaml`. Every other job in that workflow declares `needs: approve`. Every PR run pauses with "Awaiting maintainer approval" until a reviewer clicks Approve, scoped to that exact commit. Pushing a new commit invalidates the approval and queues a new pending one.
+
+The `production` environment holds the publish secrets. It has no required reviewers — the weekly cron runs unattended. Its deployment-branch restriction to `main` means that even a `workflow_dispatch` from a feature branch cannot deploy to it.
+
+Jobs that declare `environment: production`:
+
+* `partial_version.yaml::release` — pushes version commits and tags to `main`
+* `partial_update_dependencies.yaml::update-dependencies` — pushes a feature branch
+* `update.yaml::merge-changes` — merges the dependency-update branch to `main`
+* `deployment.yaml::publish-release` — VS Code Marketplace and Open VSX
+* `deployment.yaml::publish-playground` — pushes to `ironplc/ironplc-playground`
+* `deployment.yaml::publish-homebrew` — pushes to `ironplc/homebrew-brew`
+
+The single job that declares `environment: pr-ci`:
+
+* `integration.yaml::approve` — zero-step gate; every other job in the workflow declares `needs: approve`.
+
+The two layers compose: `pr-ci` answers "is this code allowed to run at all?", `production` answers "is this code allowed to publish?" — and the two sets of jobs never overlap.
+
+### Consequences
+
+* Good, because PR runs cannot reach publish secrets even with a fully tampered workflow file — the secrets are not in repo scope at all.
+* Good, because PR runs require explicit per-commit maintainer approval, scoped to that exact SHA.
+* Good, because scheduled releases continue to run unattended on the weekly cron.
+* Good, because `production` can only be deployed to from `main`, so accidental publishing from a feature branch is prevented by GitHub itself, not by workflow logic.
+* Good, because environment configuration lives at the repo level and cannot be modified by editing files in a PR.
+* Bad, because removing an `environment:` key is a one-line edit that a future contributor or agent could make in good faith, unaware of the security implication. Mitigated by the YAML comments referencing this ADR and by a CODEOWNERS rule on `.github/workflows/`.
+* Bad, because the `pr-ci` gate adds a second-level approval on top of branch protection. Maintainers must click Approve on each PR they push, including their own.
+* Neutral, because the workflow file is still read from the PR branch on `pull_request` events. A malicious author can edit `.github/workflows/integration.yaml` to remove `needs: approve`. They still cannot access publish secrets (those live in `production`, which `pr-ci`-context jobs never enter), and they cannot push to the repo. Worst-case impact reduces to "arbitrary code on a runner with a read-only `GITHUB_TOKEN` and no secrets" — the GitHub baseline for any fork PR.
+
+### Confirmation
+
+For any PR that modifies `.github/workflows/**`:
+
+1. Does it remove or weaken `environment: production` on a job that consumes a publish secret?
+   * If yes, the PR must explain why and revise this ADR.
+2. Does it remove `environment: pr-ci` or `needs: approve` from `integration.yaml`?
+   * If yes, the PR must explain how untrusted PRs will instead be gated.
+3. Does it add a new publish secret?
+   * It must be added to the `production` environment, not to repo-level secrets, and the consuming job must declare `environment: production`.
+4. Does it add a new workflow that reads `secrets.*`?
+   * The reading job must declare an appropriate environment (`production` for publish secrets; none for `GITHUB_TOKEN`-only).
+
+A CODEOWNERS rule on `.github/workflows/**` ensures a security-aware reviewer is automatically routed to every such PR.
+
+### One-time GitHub setup
+
+Recorded here so a future maintainer rebuilding the org can recreate the configuration.
+
+1. **Create the `pr-ci` environment** (Settings → Environments → New environment).
+   * Required reviewers: enabled, with all maintainers added.
+   * Deployment branches and tags: any (must accept fork PR refs).
+   * Environment secrets: none.
+2. **Create the `production` environment.**
+   * Required reviewers: disabled.
+   * Deployment branches and tags: selected branches → `main` only.
+   * Environment secrets: move `IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN`, `VS_MARKETPLACE_TOKEN`, `OVSX_PAT` from repository secrets.
+3. **`IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN` PAT scope** (fine-grained):
+   * Resource owner: `ironplc`.
+   * Selected repositories: `ironplc/ironplc`, `ironplc/ironplc-playground`, `ironplc/homebrew-brew`.
+   * Permissions: `Contents: Read and write`; `Workflows: Read and write` on `ironplc/ironplc`; `Metadata: Read` (auto).
+   * The PAT owner must be in the `main`-branch-protection bypass list on `ironplc/ironplc`.
+4. **CODEOWNERS** at `.github/CODEOWNERS` should route `.github/workflows/**` to a security-aware reviewer, and `main`-branch protection must enable "Require review from Code Owners".
+
+## Pros and Cons of the Options
+
+### Per-job author-association `if:` gates
+
+* Good, because they're declarative inside the workflow file
+* Bad, because they skip rather than queue — required checks are never satisfied for external PRs (PR #979)
+* Bad, because they offer no UI affordance for maintainers to opt in to a specific PR
+* Bad, because they evaluate against an ever-growing implicit whitelist (`OWNER`/`MEMBER`/`COLLABORATOR`)
+* Bad, because the workflow file comes from the PR branch, so the `if:` itself is editable by the author
+
+### Repo-level "first-time contributor" approval
+
+* Good, because it's a single setting toggle and requires no workflow changes
+* Bad, because it whitelists per author after the first approval — one innocuous PR earns permanent automatic-run privileges
+* Bad, because it doesn't address secret scoping at all
+
+### Label-gated workflow with `safe-to-test`
+
+* Good, because it's per-PR rather than per-author
+* Good, because it leaves a label-shaped audit trail
+* Bad, because the workflow file is in the PR branch, so the gate itself is editable
+* Bad, because it requires a second workflow running from base via `pull_request_target` to strip the label on each push, adding moving parts
+* Neutral, because secret scoping has to be solved separately
+
+### Two environments (`pr-ci` + `production`) — chosen
+
+* Good, because environment configuration lives at the repo level and is unaffected by edits in a PR
+* Good, because secret scoping is enforced by GitHub itself, not by workflow logic
+* Good, because it cleanly separates "allowed to run?" (pr-ci) from "allowed to publish?" (production)
+* Good, because branch-restriction on `production` makes accidental publishing from a feature branch impossible
+* Bad, because it requires one-time setup outside the codebase (configuring environments in the GitHub UI)
+* Bad, because the `approve` gate adds friction to maintainers' own PRs
+
+### `pull_request_target` for everything
+
+* Good, because the workflow file is read from the base branch — PR authors cannot edit it
+* Bad, because `pull_request_target` jobs run with full secret access by default — easy to accidentally check out and execute PR code, leaking secrets
+* Bad, because it is a known foot-gun (multiple high-profile incidents in the wild)
+* Bad, because it makes simple build-and-test workflows harder to write safely


### PR DESCRIPTION
The custom if: gate caused all CI checks to be silently skipped for external contributors, leaving PRs in a blocked mergeable state with no affordance for maintainers to opt in (see #979). Rely instead on the repo's "Require approval for contributors" setting, which queues fork PR runs for maintainer approval rather than skipping them.

https://claude.ai/code/session_012ZuE9UMUyu7znPE7C6SEQ7