### PR TITLE
Fix flaky sparkline canvas visibility test in e2e suite

### DIFF
--- a/playground/tests/e2e.spec.js
+++ b/playground/tests/e2e.spec.js
@@ -246,9 +246,17 @@ END_PROGRAM
     await page.fill('[data-testid="interval-input"]', "100");
     await page.click('[data-testid="start-btn"]');
 
-    // Wait for sparkline canvases to appear (need at least 2 data points)
+    // Wait for sparkline canvases to appear (need at least 2 data points).
+    // Assert on uPlot's bitmap attributes rather than layout visibility:
+    // uPlot only sets the canvas width/height attributes after commit()
+    // sizes the wrap, so seeing them proves the chart fully rendered. This
+    // avoids a race where renderVariables replaces innerHTML every 500ms
+    // and Playwright's toBeVisible occasionally sees a zero-sized layout box.
     const variablesPanel = page.locator('[data-testid="variables-panel"]');
-    await expect(variablesPanel.locator("canvas").first()).toBeVisible({ timeout: 10000 });
+    const canvas = variablesPanel.locator("canvas").first();
+    await expect(canvas).toBeAttached({ timeout: 10000 });
+    await expect(canvas).toHaveAttribute("width", "120");
+    await expect(canvas).toHaveAttribute("height", "24");
 
     await page.click('[data-testid="stop-btn"]');
   });


### PR DESCRIPTION
## Summary
Updated the e2e test for sparkline rendering to use more reliable assertions that check canvas bitmap attributes instead of layout visibility, eliminating a race condition in the test.

## Key Changes
- Replaced `toBeVisible()` assertion with `toBeAttached()` to verify the canvas element is in the DOM
- Added explicit assertions for canvas `width` and `height` attributes (`120` and `24` respectively)
- Updated test comments to explain why bitmap attribute checks are more reliable than visibility checks

## Implementation Details
The original test used `toBeVisible()` which checks if an element has a non-zero layout box. However, uPlot's rendering process has a timing issue where:
1. The canvas element is attached to the DOM before its width/height attributes are set
2. The `renderVariables` function replaces innerHTML every 500ms, creating a window where Playwright might see a zero-sized layout box
3. This causes intermittent test failures

The fix leverages the fact that uPlot only sets canvas width/height attributes after `commit()` sizes the wrap element, so checking for these attributes provides a more reliable signal that the chart has fully rendered.

https://claude.ai/code/session_01DBQGdai1uTnzzxVyAJgnFE