### PR TITLE
Restructure debugger spec around instruction-level pausing

### DIFF
--- a/specs/design/debugger-support.md
+++ b/specs/design/debugger-support.md
@@ -23,7 +23,14 @@ This spec builds on:
 
 Goal #2 forces a single design decision that drives the rest of this spec. Today `execute_with_hook` (`compiler/vm/src/vm.rs`) implements PLC `CALL` by recursing into itself, so the Rust call stack *is* the PLC call stack. That architecture cannot pause mid-CALL: a `Paused` return value from the innermost frame leaves the operand-stack contents, locals, pc, and the chain of Rust frames stranded, with no way to resume.
 
-This spec therefore commits to converting the VM to a **non-recursive (iterative) dispatch** with an **explicit, heap-allocated frame stack**. Every PLC `CALL` pushes a frame; every `RET` pops one; the dispatch loop runs until the frame stack is empty or a debug pause is requested. The frame stack is the single piece of state that has to be checkpointed at a pause and restored at a resume — no Rust frames are involved.
+This spec therefore commits to converting the VM to a **non-recursive (iterative) dispatch** with an **explicit, embedder-provided frame stack**. Every PLC `CALL` pushes a frame; every `RET` pops one; the dispatch loop runs until the frame stack is empty or a debug pause is requested. The frame stack is the single piece of state that has to be checkpointed at a pause and restored at a resume — no Rust frames are involved.
+
+**No heap allocation.** The frame stack follows the same pattern the VM already uses for `OperandStack`, `VariableTable`, `data_region`, and `temp_buf` (`compiler/vm/src/stack.rs:5`, `variable_table.rs:42`): a borrowed `&mut [Frame]` slice owned by the embedder. The compiler already computes the worst-case call depth at compile time — IEC 61131-3 forbids recursion, so the call graph is a DAG and its longest path is the bound — and writes it to the container header as `max_call_depth: u16` (`compiler/container/src/header.rs:57`). The embedder reads that field, allocates a buffer of exactly that size, and hands it to the VM:
+
+- **Hosted (LSP, vm-cli, playground):** `Vec<Frame>` of length `header.max_call_depth`.
+- **`no_std` / Arduino-class:** `heapless::Vec<Frame, N>` or a fixed `[MaybeUninit<Frame>; N]` where `N` is a const upper bound chosen at firmware build time. A program whose `header.max_call_depth` exceeds the embedder's `N` is rejected at load with a clear error, the same way the operand stack and variable table already are.
+
+This preserves the no-heap, no-`alloc` execution profile that the existing VM already supports (see `2026-04-XX-no-std-vm-impl.md`). The debugger adds no new allocation requirement.
 
 This is the largest change in the plan. It must land before any breakpoint, step, or pause feature can work; Phase 2 cannot be skipped or reduced. The alternative — a "scan-boundary-only" debugger — is explicitly rejected because it cannot offer breakpoints in the middle of a function body, which is the headline debugger feature.
 
@@ -426,11 +433,13 @@ The fix is the standard interpreter pattern: store frames on a `Vec<Frame>`, pop
 
 ```rust
 /// One PLC call frame on the explicit frame stack.
+/// `Copy` so the frame stack can live in `[MaybeUninit<Frame>; N]` on no_std.
+#[derive(Clone, Copy)]
 pub struct Frame {
     /// The function this frame is executing.
     pub function_id: FunctionId,
     /// Byte offset within `function`'s bytecode of the *next* opcode to execute.
-    pub pc: usize,
+    pub pc: u32,
     /// Variable scope for this frame (locals + globals view).
     pub scope: VariableScope,
     /// Operand-stack height when this frame was pushed; used by RET to
@@ -444,19 +453,61 @@ pub struct Frame {
 }
 ```
 
-The frame stack is bounded by `MAX_CALL_DEPTH` (already a constant in `vm.rs`); attempting to push beyond it returns `Trap::CallStackOverflow` exactly as today.
+`Frame` is plain-old-data so it costs nothing to copy and can be stored in a fixed-size array on `no_std` targets.
+
+#### FrameStack: borrowed slice, no heap
+
+The frame stack is a borrowed slice plus a length, mirroring `OperandStack` and `VariableTable`:
+
+```rust
+pub struct FrameStack<'a> {
+    slots: &'a mut [Frame],
+    len: u16,
+}
+
+impl<'a> FrameStack<'a> {
+    /// `backing` must be at least `header.max_call_depth` Frames long.
+    pub fn new(backing: &'a mut [Frame]) -> Self { ... }
+
+    pub fn push(&mut self, frame: Frame) -> Result<(), Trap> {
+        if (self.len as usize) >= self.slots.len() {
+            return Err(Trap::CallStackOverflow);
+        }
+        self.slots[self.len as usize] = frame;
+        self.len += 1;
+        Ok(())
+    }
+
+    pub fn pop(&mut self) -> Option<Frame> { ... }
+    pub fn top(&self) -> Option<&Frame> { ... }
+    pub fn top_mut(&mut self) -> Option<&mut Frame> { ... }
+    pub fn len(&self) -> u16 { self.len }
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+```
+
+The slice may be backed by `Vec<Frame>`, `[Frame; N]`, `heapless::Vec<Frame, N>`, or any other contiguous storage. `FrameStack::new` does no allocation. The bound is enforced at runtime via `Trap::CallStackOverflow` (the existing trap), which fires both when the firmware-side const `N` is too small *and* when a malicious container under-reports `max_call_depth`. The constant `MAX_CALL_DEPTH = 32` in `vm.rs:31` is removed in favor of the per-program bound.
+
+#### Container-header bound is authoritative
+
+The compiler computes the worst-case call depth via a topological walk of the call graph (already legal because IEC 61131-3 forbids recursion) and writes it to `FileHeader.max_call_depth`. The codegen change in Phase 2 is to ensure this field is populated for every program; today it defaults to 0. The verifier (`compiler/codegen/src/spec_conformance.rs` or equivalent) gains a check that:
+
+- `header.max_call_depth ≥ longest_path(call_graph) + 1` (the +1 accounts for the entry frame).
+- The call graph contains no cycles (already enforced upstream as the recursion ban; this is a defense-in-depth check).
+
+Embedders read `header.max_call_depth` after loading the container and provision the frame slice. On `no_std` targets where the slice is a fixed `[Frame; N]`, the load fails with `LoadError::ProgramExceedsCallDepth { required, available }` if `header.max_call_depth > N`. This is the same policy the VM already uses for `max_stack_depth` against the operand-stack buffer.
 
 #### Restructured execute
 
 ```rust
-pub(crate) fn execute_with_hook<H: DebugHook>(
+pub(crate) fn execute_with_hook<'a, H: DebugHook>(
     container: &Container,
-    stack: &mut OperandStack,
-    variables: &mut VariableTable,
+    stack: &mut OperandStack<'a>,
+    variables: &mut VariableTable<'a>,
     data_region: &mut [u8],
     temp_buf: &mut [u8],
     max_temp_buf_bytes: usize,
-    frames: &mut FrameStack,
+    frames: &mut FrameStack<'a>,   // borrowed; no heap involved
     current_time_us: u64,
     hook: &mut H,
 ) -> Result<ExecuteOutcome, Trap> {
@@ -674,7 +725,7 @@ enum StepMode {
 
 ### Pause/Resume protocol
 
-A pause leaves the VM in a well-defined `PausedAt(PauseReason)` sub-state inside `VmRunning`. The complete checkpoint is:
+A pause leaves the VM in a well-defined `PausedAt(PauseReason)` sub-state inside `VmRunning`. **No allocation happens at pause or resume** — every piece of preserved state already lives in embedder-provided buffers (operand stack, variable table, data region, temp-buf, frame stack). Pause is just a state-flag flip plus a return out of the dispatch loop; resume is just a re-entry into it. The complete checkpoint is:
 
 | State | Owner | Why preserved |
 |-------|-------|---------------|
@@ -702,12 +753,14 @@ For v1, **breakpoints are global** (any instance hitting them pauses); a future 
 
 ### Concurrency model
 
+The concurrency model below applies to the **hosted DAP server only** (`vm-cli` with `--features dap`). `no_std` embedders have no DAP server — they run the VM with `NoopDebugHook` and pay zero overhead. The `vm` crate exposes the same `DebugHook` trait on both targets, but the Arc/Atomic/thread machinery lives in `vm-cli`, not `vm`, so the core VM stays `no_std` clean.
+
 The DAP I/O thread and the VM thread share three pieces of state. Each one has a specific synchronization rule:
 
 | State | Sharing pattern | Mechanism |
 |-------|-----------------|-----------|
-| `BreakpointTable` | I/O writes (setBreakpoints), VM reads (every instruction) | `arc_swap::ArcSwap<BreakpointTable>` — the I/O thread builds a new table off-thread and atomically swaps the `Arc` pointer. The VM does one `Arc` load per instruction (no contention, no locking). |
-| `pause_requested` | I/O writes (DAP `pause`), VM reads (every instruction) | `AtomicBool` with `Acquire` load + `Release` store. |
+| `BreakpointTable` | I/O writes (setBreakpoints), VM reads (every instruction) | `arc_swap::ArcSwap<BreakpointTable>` — the I/O thread builds a new table off-thread and atomically swaps the `Arc` pointer. The VM does one `Arc` load per instruction (no contention, no locking). Hosted-only (requires `alloc`). |
+| `pause_requested` | I/O writes (DAP `pause`), VM reads (every instruction) | `core::sync::atomic::AtomicBool` with `Acquire` load + `Release` store. Available on `no_std` too, though `no_std` builds never construct one. |
 | Frame stack, operand stack, variables, data region | VM mutates while running; I/O reads only when **paused** | Ownership transfer via channels: while RUNNING, the VM owns these; on pause it sends a `Paused` event with a `&mut`-equivalent handle (in practice a re-entrant `Mutex` held only when paused). DAP requests for variables/stackTrace are serviced from the paused state synchronously by the VM thread itself, fed by a request channel; the I/O thread never touches the VM's data structures directly. |
 
 This last point is important: `variables`, `stackTrace`, and `evaluate` requests are dispatched **on the VM thread** while it is paused, not on the I/O thread. The I/O thread only owns the JSON pipe. This eliminates every Send/Sync hazard the original plan glossed over.
@@ -1107,7 +1160,10 @@ The phasing is reorganized so that the iterative-dispatch rewrite (the prerequis
 |-------|-------|---------|
 | `vm` | new `frame_stack.rs` | `Frame`, `FrameStack` (bounded by `MAX_CALL_DEPTH`), `TempAllocMark` |
 | `vm` | `vm.rs` | Replace recursive `CALL` arm (`vm.rs:1044`, `vm.rs:1865`) with `frames.push(...)`; lift the dispatch loop to iterate `frames`; `execute_with_hook` becomes the loop body's wrapper. Remove `depth` parameter — depth is now `frames.len()`. Add `ExecuteOutcome::{Completed, Paused}` (Paused only reachable after Phase 3 extends the hook signature; for now it's unreachable but the type exists). |
-| `vm` | `vm.rs` | `VmRunning` gains `frames: FrameStack`, `phase: Phase`, `current_instance_id`. `Phase::Running` is the only legal phase reached in this phase; `PausedAt` is added but only used in Phase 3. |
+| `vm` | `vm.rs` | `VmRunning<'a>` gains `frames: FrameStack<'a>`, `phase: Phase`, `current_instance_id`. The frame backing slice is supplied to `Vm::new()` alongside the existing operand-stack and variable-table backing slices; no allocation is added. `Phase::Running` is the only legal phase reached in this phase; `PausedAt` is added but only used in Phase 3. |
+| `vm` | `vm.rs` | `Vm::load()` validates `header.max_call_depth ≤ frames.capacity()` and returns `LoadError::ProgramExceedsCallDepth` otherwise (matches the existing operand-stack/variable-table sizing checks). |
+| `codegen` | `compile_fn.rs` / `compile.rs` | Compute worst-case call depth from the call graph (longest path; the recursion ban guarantees acyclicity) and write it to `FileHeader.max_call_depth`. |
+| `codegen` | `spec_conformance.rs` | Verify the call graph is acyclic and that the emitted `max_call_depth` is at least the longest path + 1. |
 | `vm` | `lib.rs` | Re-export `Frame`, `FrameStack`, `Phase`, `ExecuteOutcome` |
 
 **Migration order** (each commit must compile and pass `cd compiler && just`):
@@ -1259,7 +1315,7 @@ This means bytecode debugging works even when the debug section is stripped — 
 
 For reviewers familiar with the prior version of this document:
 
-1. **Iterative dispatch with explicit `FrameStack`** replaces the recursive `execute_with_hook`. This is the prerequisite for instruction-level pausing.
+1. **Iterative dispatch with explicit `FrameStack`** replaces the recursive `execute_with_hook`. The frame stack is a **borrowed slice** sized at load time from `header.max_call_depth` (computed by the compiler from the call graph; recursion is forbidden by IEC 61131-3 so the longest path is well-defined). No heap allocation; matches the existing `OperandStack` / `VariableTable` model and works on Arduino-class targets. This is the prerequisite for instruction-level pausing.
 2. **`DebugHook` trait extension** — `before_instruction` returns `HookAction`; new `before_call`/`after_return` callbacks; `function_id` parameter added. The existing `NoopDebugHook` + monomorphization model is retained, **not** replaced by `Option<&mut DebugState>`.
 3. **`DebuggerHook` is a `DebugHook` impl**, not a fourth-thing-named-`DebugState`. It owns the breakpoint table reference, step controller, and pause flag.
 4. **Concurrency model is explicit**: `ArcSwap<BreakpointTable>` for the breakpoint table, `AtomicBool` for the pause flag, and DAP request servicing happens *on the VM thread* while paused.

--- a/specs/design/debugger-support.md
+++ b/specs/design/debugger-support.md
@@ -13,10 +13,19 @@ This spec builds on:
 ## Design Goals
 
 1. **Source-level debugging** — breakpoints, stepping, and variable inspection use source line numbers and variable names, not bytecode offsets and indices
-2. **Scan-cycle-aware** — the debugger understands PLC scan cycle semantics; users can pause between cycles, step one cycle at a time, or break mid-cycle
-3. **Zero overhead when disabled** — when no debugger is attached, the VM runs at full speed with no breakpoint checks or callback overhead
-4. **Separable debug info** — the debug section can be stripped from production containers without affecting execution; the debugger loads it separately if needed
-5. **Standard protocol** — use the Debug Adapter Protocol (DAP) so any DAP-compatible editor can debug IronPLC programs, not just VS Code
+2. **Instruction-level pausing** — the VM can pause between any two bytecode instructions, including inside nested CALLs and inside multi-statement expressions, and resume exactly where it left off
+3. **Scan-cycle-aware** — the debugger understands PLC scan cycle semantics; users can pause between cycles, step one cycle at a time, or break mid-cycle
+4. **Zero overhead when disabled** — when no debugger is attached, the VM runs at full speed; the debug hook compiles to nothing via monomorphization
+5. **Separable debug info** — the debug section can be stripped from production containers without affecting execution; the debugger loads it separately if needed
+6. **Standard protocol** — use the Debug Adapter Protocol (DAP) so any DAP-compatible editor can debug IronPLC programs, not just VS Code
+
+### Execution-model commitment
+
+Goal #2 forces a single design decision that drives the rest of this spec. Today `execute_with_hook` (`compiler/vm/src/vm.rs`) implements PLC `CALL` by recursing into itself, so the Rust call stack *is* the PLC call stack. That architecture cannot pause mid-CALL: a `Paused` return value from the innermost frame leaves the operand-stack contents, locals, pc, and the chain of Rust frames stranded, with no way to resume.
+
+This spec therefore commits to converting the VM to a **non-recursive (iterative) dispatch** with an **explicit, heap-allocated frame stack**. Every PLC `CALL` pushes a frame; every `RET` pops one; the dispatch loop runs until the frame stack is empty or a debug pause is requested. The frame stack is the single piece of state that has to be checkpointed at a pause and restored at a resume — no Rust frames are involved.
+
+This is the largest change in the plan. It must land before any breakpoint, step, or pause feature can work; Phase 2 cannot be skipped or reduced. The alternative — a "scan-boundary-only" debugger — is explicitly rejected because it cannot offer breakpoints in the middle of a function body, which is the headline debugger feature.
 
 ## Architecture
 
@@ -38,17 +47,19 @@ This spec builds on:
                                      │ Rust API calls
                                      ▼
                             ┌───────────────────┐
-                            │   VM Debug Engine  │   ironplc-vm crate
+                            │   DebuggerHook     │   ironplc-vm crate
+                            │  (impls DebugHook) │
                             │  BreakpointTable   │
                             │  StepController    │
-                            │  DebugState        │
+                            │  pause_requested   │
                             └────────┬──────────┘
-                                     │
+                                     │ DebugHook trait
                                      ▼
                             ┌───────────────────┐
-                            │   VM Execution     │
-                            │  execute() loop    │   existing VM
-                            │  VmRunning state   │
+                            │   Iterative VM     │   restructured VM
+                            │  dispatch loop     │   explicit FrameStack
+                            │  yieldable/        │   pausable between
+                            │  resumable         │   any two opcodes
                             └───────────────────┘
 ```
 
@@ -57,8 +68,9 @@ The debugger is four layers:
 | Layer | Location | Responsibility |
 |-------|----------|----------------|
 | **Debug info** | `codegen` crate + `container` crate | Emit and parse line maps, variable names in the debug section |
-| **VM debug engine** | `vm` crate | Breakpoint matching, step tracking, pause/continue, variable inspection with names |
-| **DAP server** | `vm-cli` crate | Translate DAP protocol messages to VM debug engine API calls |
+| **VM execution model** | `vm` crate | Iterative dispatch with an explicit `FrameStack`; pausable/resumable. Existing recursive `execute_with_hook` is retired. |
+| **VM debug engine** | `vm` crate | A `DebugHook` implementation (`DebuggerHook`) that holds the breakpoint table, step controller, and a pause-request signal; tracks call depth via `before_call`/`after_return` callbacks |
+| **DAP server** | `vm-cli` crate (feature-gated) | Translate DAP protocol messages to VM debug engine API calls |
 | **VS Code integration** | `integrations/vscode` | Launch configuration, debug adapter descriptor, UI contributions |
 
 ### Why not a separate DAP binary?
@@ -130,7 +142,8 @@ payload_offset = 2 + (8 × sub_table_count) + sum(directory[0..i].size)
 | 6 | SOURCE_FILE | reserved | Source file table for multi-file projects |
 | 7 | LD_RUNG_MAP | reserved | Ladder Diagram rung ID → bytecode mappings |
 | 8 | FBD_NETWORK_MAP | reserved | Function Block Diagram network/element mappings |
-| 9–65535 | — | reserved | Future use |
+| 9 | ENUM_DEF | implemented | Enumeration type → ordinal-ordered value names (`compiler/container/src/debug_section.rs`) |
+| 10–65535 | — | reserved | Future use |
 
 **Rules:**
 - Each tag may appear **at most once** in the directory. A reader that encounters a duplicate tag discards the debug section.
@@ -397,189 +410,309 @@ The debug section optionally embeds the source text. This enables debugging even
 
 ### Overview
 
-The VM debug engine adds breakpoint matching, single-stepping, and pause/continue control to the existing `execute()` function. It is designed to have zero overhead when no debugger is attached.
+Layer 2 has two parts. **Part A** restructures the VM dispatch loop from recursion to an iterative loop over an explicit `FrameStack`. This is a prerequisite — without it, no instruction-level pause is possible. **Part B** introduces a `DebuggerHook` that implements the existing `DebugHook` trait (`compiler/vm/src/debug_hook.rs`) extended with the callbacks the debugger needs, and wires it into the iterative loop.
 
-### Debug State
+The existing `NoopDebugHook` plus monomorphization already provides "zero overhead when disabled"; we keep that mechanism rather than replacing it with a runtime `Option<&mut DebugState>` branch. The plan reuses, not retires, the trait.
 
-A new `DebugState` struct holds all debug-related state:
+### Part A — Iterative dispatch with an explicit frame stack
+
+#### Why iterative
+
+`execute_with_hook` recurses on every PLC `CALL` (`vm.rs:1044`, `vm.rs:1865`). To pause execution between any two opcodes — including opcodes inside a callee — the dispatch loop must be able to *return* control to the DAP server while leaving every PLC frame intact and resumable. With Rust-stack recursion this is impossible: returning unwinds frames, and resume cannot push them back.
+
+The fix is the standard interpreter pattern: store frames on a `Vec<Frame>`, pop the topmost frame's `pc` into a local register, dispatch one opcode, write `pc` back, and loop. `CALL` pushes a frame; `RET` pops one; the loop terminates when the frame stack becomes empty (program done) or a pause is requested (suspended; can resume).
+
+#### Frame layout
 
 ```rust
-/// Debug state attached to a running VM.
-/// Only allocated when a debugger is attached.
-pub struct DebugState {
-    /// Active breakpoints, keyed by (function_id, bytecode_offset).
-    breakpoints: BreakpointTable,
-
-    /// Current stepping mode (None when running freely).
-    step_mode: Option<StepMode>,
-
-    /// Call depth at the point where stepping began (for step-over/step-out).
-    step_origin_depth: u16,
-
-    /// Source line at the point where stepping began (for step-over).
-    step_origin_line: u16,
-
-    /// Debug info from the container (line maps, var names, func names, etc.).
-    debug_info: DebugInfo,
+/// One PLC call frame on the explicit frame stack.
+pub struct Frame {
+    /// The function this frame is executing.
+    pub function_id: FunctionId,
+    /// Byte offset within `function`'s bytecode of the *next* opcode to execute.
+    pub pc: usize,
+    /// Variable scope for this frame (locals + globals view).
+    pub scope: VariableScope,
+    /// Operand-stack height when this frame was pushed; used by RET to
+    /// restore the caller's stack and detect stack imbalance bugs.
+    pub stack_floor: u32,
+    /// Temp-buffer allocator checkpoint at frame entry; restored on RET.
+    pub temp_alloc_mark: TempAllocMark,
+    /// The instance this frame belongs to (carried for `current_instance_id`
+    /// during multi-instance execution; see Layer 2 §Multi-instance).
+    pub instance_id: InstanceId,
 }
 ```
 
-The `DebugInfo` struct contains all six sub-tables parsed from the debug section. The `DebugState` uses them as follows:
+The frame stack is bounded by `MAX_CALL_DEPTH` (already a constant in `vm.rs`); attempting to push beyond it returns `Trap::CallStackOverflow` exactly as today.
 
-- **line_maps** — breakpoint resolution, step tracking (current line lookup), source location for `stackTrace`
-- **var_names** — variable inspection with scope filtering, type-aware formatting, name-based `evaluate`
-- **func_names** — stack frame names for `stackTrace`
-- **type_names / field_names** — reserved for Phase 5 FB instance expansion
+#### Restructured execute
+
+```rust
+pub(crate) fn execute_with_hook<H: DebugHook>(
+    container: &Container,
+    stack: &mut OperandStack,
+    variables: &mut VariableTable,
+    data_region: &mut [u8],
+    temp_buf: &mut [u8],
+    max_temp_buf_bytes: usize,
+    frames: &mut FrameStack,
+    current_time_us: u64,
+    hook: &mut H,
+) -> Result<ExecuteOutcome, Trap> {
+    while let Some(top) = frames.top_mut() {
+        let bytecode = container.code.get_function_bytecode(top.function_id)
+            .ok_or(Trap::InvalidFunctionId(top.function_id))?;
+
+        if top.pc >= bytecode.len() {
+            return Err(Trap::PcOutOfBounds);
+        }
+
+        let op = bytecode[top.pc];
+        // Hook fires *before* pc advances so the hook sees the opcode's offset.
+        match hook.before_instruction(top.function_id, top.pc, op) {
+            HookAction::Continue => {}
+            HookAction::Pause(reason) => return Ok(ExecuteOutcome::Paused(reason)),
+        }
+        top.pc += 1;
+
+        match op {
+            opcode::CALL => {
+                let func_id = read_u16_le(bytecode, &mut top.pc)?;
+                let new_frame = build_callee_frame(container, stack, variables, func_id, top)?;
+                hook.before_call(top.function_id, new_frame.function_id);
+                frames.push(new_frame)?;   // Trap::CallStackOverflow if MAX exceeded
+            }
+            opcode::RET | opcode::RET_VOID => {
+                let returning = frames.pop().expect("non-empty by while-let");
+                temp_alloc.rewind_to(returning.temp_alloc_mark);
+                hook.after_return(returning.function_id,
+                                  frames.top().map(|f| f.function_id));
+                // Caller's frame, if any, resumes on the next loop iteration.
+            }
+            // ... all other opcodes operate on the borrowed `top` ...
+        }
+    }
+    Ok(ExecuteOutcome::Completed)
+}
+```
+
+Two properties matter: every observable state transition (pc bump, frame push/pop) is in this loop, never on the Rust stack; and a `HookAction::Pause` return immediately exits the loop with all frames intact. A subsequent call to `execute_with_hook` with the same `frames` resumes exactly where it stopped.
+
+#### `ExecuteOutcome`
+
+```rust
+pub enum ExecuteOutcome {
+    /// Frame stack drained — program reached the entry function's RET.
+    Completed,
+    /// The hook requested a pause. Frames + operand stack + variables are
+    /// preserved verbatim; another execute_with_hook call resumes.
+    Paused(PauseReason),
+}
+```
+
+A trap remains an `Err(Trap)` and is *not* a Paused result. The outer scan-cycle loop converts a trap into either a fault (no debugger) or a "trap pause" (debugger present and trap-breakpoints enabled — see §Trap Breakpoints).
+
+#### Operand-stack invariants under pause
+
+A pause can land mid-expression, with partial values on the operand stack. That is fine: the operand stack lives in `VmRunning` (not on the Rust stack) and is preserved across a Pause/Resume. The DAP server **must not** mutate the operand stack while paused — `variables` and the frame `pc` are the only legal write targets (and `variables` only via the controlled forcing API).
+
+#### Migration path
+
+The conversion is mechanical but large. It is done in three commits to keep each diff reviewable:
+
+1. **Introduce `FrameStack` and route `CALL`/`RET` through it** without changing recursion. `execute_with_hook` still recurses, but the new frame stack is built and maintained in parallel for cross-checking. Add an internal assert that the explicit depth always matches Rust recursion depth.
+2. **Flip the loop to iterative.** Remove the recursive `execute_with_hook(..., depth + 1, ...)` call inside the `CALL` arm; replace with `frames.push(...)`. Remove the `depth` parameter. Top-level callers gain a `frames: &mut FrameStack` argument.
+3. **Delete the old depth bookkeeping** and the `depth` parameter chain.
+
+After step 2 the VM is pausable; before step 2 it is not. Step 2 is the gate for Phase 2.
+
+### Part B — Extending the DebugHook trait
+
+The current trait (`compiler/vm/src/debug_hook.rs:35`):
+
+```rust
+pub trait DebugHook {
+    fn before_instruction(&mut self, pc: usize, op: u8);
+}
+```
+
+is insufficient for breakpoints (no `function_id`), pause-requests (no return value), or step-out (no CALL/RET notification). We extend it:
+
+```rust
+pub trait DebugHook {
+    /// Called immediately before the opcode at `(function_id, pc)` executes.
+    /// The hook may request a pause via the return value.
+    fn before_instruction(
+        &mut self,
+        function_id: FunctionId,
+        pc: usize,
+        op: u8,
+    ) -> HookAction;
+
+    /// Called when a CALL is about to push a new frame for `callee`.
+    /// `caller` is the function that issued the CALL.
+    fn before_call(&mut self, caller: FunctionId, callee: FunctionId) {
+        let _ = (caller, callee);
+    }
+
+    /// Called when a RET has popped `returning`'s frame; `caller` is the
+    /// function the loop will resume into (None when returning from the
+    /// entry function — i.e. ExecuteOutcome::Completed is next).
+    fn after_return(&mut self, returning: FunctionId, caller: Option<FunctionId>) {
+        let _ = (returning, caller);
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum HookAction {
+    Continue,
+    Pause(PauseReason),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum PauseReason {
+    Breakpoint(BreakpointId),
+    Step,
+    UserPause,
+    Trap(Trap),
+}
+```
+
+`before_call` and `after_return` have default empty bodies, so existing `NoopDebugHook` and any test hooks compile unchanged. The new return type on `before_instruction` is a breaking change to the trait — `NoopDebugHook::before_instruction` returns `HookAction::Continue` from a `#[inline(always)]` body, so monomorphization still folds the call away.
+
+#### Why `before_call`/`after_return` instead of inferring from opcodes
+
+The hook *could* infer call depth by counting `CALL` and `RET` opcodes, but that fails for traps (frame popped without RET) and for any future tail-call optimization. Explicit callbacks keep the depth model stable across these cases.
+
+### DebuggerHook (the actual debugger implementation of DebugHook)
+
+```rust
+/// The DAP server's DebugHook. Holds the breakpoint table, step controller,
+/// pause-request flag, and a reference to the debug info needed to resolve
+/// source locations.
+pub struct DebuggerHook<'a> {
+    breakpoints: &'a BreakpointTable,    // shared with DAP I/O thread (see §Concurrency)
+    step: StepController,
+    pause_requested: &'a AtomicBool,     // set by I/O thread to force a pause
+    debug_info: &'a DebugInfo,
+    /// PLC call depth, maintained via before_call/after_return.
+    depth: u16,
+}
+
+impl<'a> DebugHook for DebuggerHook<'a> {
+    fn before_instruction(
+        &mut self,
+        function_id: FunctionId,
+        pc: usize,
+        _op: u8,
+    ) -> HookAction {
+        if self.pause_requested.swap(false, Ordering::Acquire) {
+            return HookAction::Pause(PauseReason::UserPause);
+        }
+        if let Some(bp_id) = self.breakpoints.hit(function_id, pc as u16) {
+            return HookAction::Pause(PauseReason::Breakpoint(bp_id));
+        }
+        if let Some(reason) = self.step.check(function_id, pc as u16, self.depth, self.debug_info) {
+            return HookAction::Pause(reason);
+        }
+        HookAction::Continue
+    }
+    fn before_call(&mut self, _caller: FunctionId, _callee: FunctionId) {
+        self.depth = self.depth.saturating_add(1);
+    }
+    fn after_return(&mut self, _returning: FunctionId, _caller: Option<FunctionId>) {
+        self.depth = self.depth.saturating_sub(1);
+    }
+}
+```
+
+`StepController` keeps the origin line and origin depth and decides when stepping ends. `BreakpointTable.hit()` returns `Option<BreakpointId>` keyed by `(function_id, bytecode_offset)`.
 
 ### Breakpoint Table
 
 ```rust
-/// Fast breakpoint lookup table.
-///
-/// Uses a sorted Vec of (function_id, bytecode_offset) pairs.
-/// At typical breakpoint counts (< 100), linear scan of a sorted
-/// Vec is faster than a HashMap due to cache locality.
+/// Fast breakpoint lookup, keyed by (FunctionId, bytecode_offset).
+/// Backed by a sorted Vec; linear scan beats HashMap at typical breakpoint
+/// counts (<100) due to cache locality. Wrapped for cross-thread access
+/// — see §Concurrency.
 pub struct BreakpointTable {
     entries: Vec<BreakpointEntry>,
 }
 
 struct BreakpointEntry {
-    function_id: u16,
+    function_id: FunctionId,
     bytecode_offset: u16,
-    id: u32,         // DAP breakpoint ID for reporting back
+    id: BreakpointId,
     enabled: bool,
 }
+
+pub type BreakpointId = u32;
 ```
 
-**Breakpoint resolution.** The DAP client sends breakpoints as source line numbers. The DAP server resolves each line to the nearest `LineMapEntry` with `source_line >= requested_line` for the appropriate function. This "snap to next valid line" behavior matches how most debuggers handle breakpoints on non-statement lines (blank lines, comments, closing END_IF, etc.).
+**Breakpoint resolution.** The DAP client sends breakpoints as source line numbers. The DAP server resolves each line to the nearest `LineMapEntry` with `source_line >= requested_line` for the appropriate function, **after** optimization (see §Optimizer Contract). The resolved line is reported back in the DAP `Breakpoint` response so the client highlights the actual stop line, which may differ from the requested line.
 
 ### Step Modes
 
 ```rust
 enum StepMode {
-    /// Step to the next statement on a different source line (regardless of call depth).
-    /// DAP "next" (step over).
+    /// Step to the next statement on a different source line at *equal or
+    /// shallower* call depth (does not descend into callees). DAP "next".
     StepOver,
-
-    /// Step to the next statement on a different source line (allowing deeper call depth).
-    /// DAP "stepIn".
+    /// Step to the next statement on a different source line, allowing
+    /// deeper call depth. DAP "stepIn".
     StepIn,
-
-    /// Run until the call depth is less than the origin depth.
+    /// Run until call depth is strictly less than the origin depth.
     /// DAP "stepOut".
     StepOut,
-
-    /// Run until the next scan cycle boundary (end of EXECUTE phase).
-    /// Custom: step one scan cycle.
+    /// Run until the next scan cycle boundary. Custom DAP request.
     StepScan,
 }
 ```
 
-### Execute Loop Modification
+`StepController::check` consumes the depth maintained by `before_call`/`after_return` — not a depth inferred from the operand stack — so it stays correct across traps that abort frames.
 
-The `execute()` function gains an optional `&mut DebugState` parameter. When `None`, the loop runs unchanged (zero overhead). When `Some`, the loop checks for debug events at each instruction dispatch:
+### Pause/Resume protocol
 
-```rust
-fn execute(
-    bytecode: &[u8],
-    container: &Container,
-    stack: &mut OperandStack,
-    variables: &mut VariableTable,
-    scope: &VariableScope,
-    debug: Option<&mut DebugState>,
-) -> Result<ExecuteResult, Trap> {
-    let mut pc: usize = 0;
+A pause leaves the VM in a well-defined `PausedAt(PauseReason)` sub-state inside `VmRunning`. The complete checkpoint is:
 
-    while pc < bytecode.len() {
-        // --- Debug check (only when debugger attached) ---
-        if let Some(ref mut dbg) = debug {
-            if let Some(action) = dbg.check(function_id, pc as u16) {
-                return Ok(ExecuteResult::Paused(PauseReason::from(action)));
-            }
-        }
+| State | Owner | Why preserved |
+|-------|-------|---------------|
+| Frame stack | `VmRunning.frames` | Resume position |
+| Operand stack | `VmRunning.stack` | Mid-expression values |
+| Variable table | `VmRunning.variables` | All locals, globals, FB instances |
+| Data region | `VmRunning.data_region` | String contents, large composites |
+| Temp-buf allocator state | `VmRunning.temp_alloc` | Per-frame allocations |
+| Scan cycle phase | `VmRunning.phase` | Whether INPUT_FREEZE happened, whether OUTPUT_FLUSH is pending |
+| Step controller | `DebuggerHook.step` | What the user was asking for |
 
-        let op = bytecode[pc];
-        pc += 1;
-        // ... existing dispatch ...
-    }
-}
-```
+Resume calls `execute_with_hook` with the same arguments. No reconstruction; nothing is rebuilt. **Operand-stack and frame-stack invariants** are tested by a property test that pauses at every opcode boundary in a corpus of programs and asserts that resume produces the same final state as an unpaused run.
 
-**Performance note.** The `if let Some(ref mut dbg)` branch is trivially predictable when `debug` is `None` — the branch predictor will learn the pattern after one iteration and never mispredict. The cost is one branch per instruction (~0.5ns on modern hardware), which is negligible compared to the instruction dispatch cost itself. For production builds without a debugger, passing `None` means zero overhead.
+### Multi-instance pause semantics
 
-#### DebugState::check()
+`run_round` iterates `program_instances` and calls `execute_with_hook` for each instance in sequence (`vm.rs:320`). When a pause fires inside instance *k*:
 
-```rust
-impl DebugState {
-    /// Called at each instruction boundary when a debugger is attached.
-    /// Returns Some(action) if execution should pause.
-    fn check(&mut self, function_id: u16, bytecode_offset: u16) -> Option<PauseAction> {
-        // 1. Check breakpoints
-        if self.breakpoints.hit(function_id, bytecode_offset) {
-            return Some(PauseAction::Breakpoint);
-        }
+- Instances `0..k` have run to completion this round; their state changes are committed in `variables`.
+- Instance *k* is paused mid-execution; its `frames`/`stack` are the live checkpoint.
+- Instances `k+1..` have not been executed this round.
 
-        // 2. Check step mode
-        if let Some(ref mode) = self.step_mode {
-            let current_line = self.debug_info.lookup_line(function_id, bytecode_offset);
-            match mode {
-                StepMode::StepOver => {
-                    if current_line != self.step_origin_line
-                        && self.current_call_depth <= self.step_origin_depth
-                    {
-                        self.step_mode = None;
-                        return Some(PauseAction::Step);
-                    }
-                }
-                StepMode::StepIn => {
-                    if current_line != self.step_origin_line {
-                        self.step_mode = None;
-                        return Some(PauseAction::Step);
-                    }
-                }
-                StepMode::StepOut => {
-                    if self.current_call_depth < self.step_origin_depth {
-                        self.step_mode = None;
-                        return Some(PauseAction::Step);
-                    }
-                }
-                StepMode::StepScan => {
-                    // Handled at the scan cycle boundary, not here
-                }
-            }
-        }
+The DAP server records `current_instance_id = k` and exposes it via `stackTrace` (frames belong to instance *k*) and `variables` (locals are those of instance *k*; globals are shared). On resume, instance *k* finishes, then instances `k+1..` execute as usual; the round then completes normally.
 
-        None
-    }
-}
-```
+For v1, **breakpoints are global** (any instance hitting them pauses); a future `instance_filter` field on `BreakpointEntry` can scope them. v1 documents this explicitly in `--help` output for the `Debug` subcommand.
 
-### Execute Result
+### Concurrency model
 
-The `execute()` function returns a richer result type when debugging:
+The DAP I/O thread and the VM thread share three pieces of state. Each one has a specific synchronization rule:
 
-```rust
-enum ExecuteResult {
-    /// Normal completion (RET_VOID from entry function).
-    Completed,
-    /// Execution paused for a debug event.
-    Paused(PauseReason),
-}
+| State | Sharing pattern | Mechanism |
+|-------|-----------------|-----------|
+| `BreakpointTable` | I/O writes (setBreakpoints), VM reads (every instruction) | `arc_swap::ArcSwap<BreakpointTable>` — the I/O thread builds a new table off-thread and atomically swaps the `Arc` pointer. The VM does one `Arc` load per instruction (no contention, no locking). |
+| `pause_requested` | I/O writes (DAP `pause`), VM reads (every instruction) | `AtomicBool` with `Acquire` load + `Release` store. |
+| Frame stack, operand stack, variables, data region | VM mutates while running; I/O reads only when **paused** | Ownership transfer via channels: while RUNNING, the VM owns these; on pause it sends a `Paused` event with a `&mut`-equivalent handle (in practice a re-entrant `Mutex` held only when paused). DAP requests for variables/stackTrace are serviced from the paused state synchronously by the VM thread itself, fed by a request channel; the I/O thread never touches the VM's data structures directly. |
 
-enum PauseReason {
-    /// Hit a breakpoint.
-    Breakpoint(u32),  // breakpoint ID
-    /// Step completed.
-    Step,
-    /// User requested pause.
-    UserPause,
-}
-```
+This last point is important: `variables`, `stackTrace`, and `evaluate` requests are dispatched **on the VM thread** while it is paused, not on the I/O thread. The I/O thread only owns the JSON pipe. This eliminates every Send/Sync hazard the original plan glossed over.
 
-When the execute loop returns `Paused`, the VM stays in the RUNNING state but does not proceed to OUTPUT_FLUSH. The DAP server can then:
-- Read variable values
-- Set/clear breakpoints
-- Issue a continue/step command to resume
+Per-instruction cost of a real debugger session: one `ArcSwap` load (relaxed-ordering atomic pointer read; ~1 ns) + one `AtomicBool::swap` (~1 ns) + a sorted-Vec scan of the breakpoint table (~5 ns at 10 breakpoints). Roughly 5–10 ns per instruction on top of dispatch — measurable but acceptable for an interactive debug session, and zero when no debugger is attached because `NoopDebugHook` is monomorphized.
 
 ### Scan Cycle Control
 
@@ -591,58 +724,70 @@ For PLC-specific debugging, users need scan-level control:
 | **Pause Between Scans** | Always pause after OUTPUT_FLUSH, before the next INPUT_FREEZE |
 | **Run to Scan N** | Continue until `scan_count` reaches a target value |
 
-These are implemented in `VmRunning::run_round()`:
+A new `VmRunning::run_round_debug` method drives a single round under a `DebuggerHook`. It is structured around the iterative `execute_with_hook` so that mid-scan pauses leave instance state intact:
 
 ```rust
-impl VmRunning {
-    pub fn run_round_debug(
+impl<'a> VmRunning<'a> {
+    pub fn run_round_debug<H: DebugHook>(
         &mut self,
         current_time_us: u64,
-        debug: &mut DebugState,
-    ) -> Result<RoundResult, FaultContext> {
-        // ... existing scheduling logic ...
+        hook: &mut H,
+    ) -> Result<RoundOutcome, FaultContext> {
+        // collect_ready_tasks, INPUT_FREEZE, system-uptime injection — unchanged
 
-        // Execute with debug hooks
-        let result = execute(bytecode, ..., Some(debug))?;
-
-        match result {
-            ExecuteResult::Completed => {
-                // Normal completion — check if scan-level pause requested
-                if debug.step_mode == Some(StepMode::StepScan) {
-                    debug.step_mode = None;
-                    return Ok(RoundResult::PausedAfterScan);
+        for ri in 0..ready_count {
+            for pi in instances_for_task(ready[ri]) {
+                // If we are resuming a previously paused instance, frames is
+                // already populated and we just call execute. Otherwise we
+                // push the entry frame for the program's entry function.
+                if self.frames.is_empty() {
+                    self.frames.push(entry_frame_for(pi))?;
+                    self.current_instance_id = pi.instance_id;
                 }
-                // ... OUTPUT_FLUSH, continue to next round ...
-            }
-            ExecuteResult::Paused(reason) => {
-                // Mid-scan pause — outputs are NOT flushed
-                return Ok(RoundResult::PausedMidScan(reason));
+
+                match execute_with_hook(self.container, &mut self.stack,
+                                        &mut self.variables, self.data_region,
+                                        self.temp_buf, self.max_temp_buf_bytes,
+                                        &mut self.frames, current_time_us, hook)? {
+                    ExecuteOutcome::Completed => { /* frames drained: instance done */ }
+                    ExecuteOutcome::Paused(reason) => {
+                        // Mid-instance pause: frames non-empty, current_instance_id
+                        // marks where we will resume. Outputs are NOT flushed.
+                        return Ok(RoundOutcome::Paused(reason));
+                    }
+                }
             }
         }
+
+        // OUTPUT_FLUSH and scan_count++ run only when every instance completed.
+        self.flush_outputs();
+        self.scan_count += 1;
+        if hook.took_step_scan_now() {
+            return Ok(RoundOutcome::PausedAfterScan);
+        }
+        Ok(RoundOutcome::Completed)
     }
 }
 ```
 
+`run_round_debug` is the single re-entry point: a paused VM resumes by calling it again. The non-empty `self.frames` and `self.current_instance_id` are how we know we're resuming.
+
 ### Variable Inspection
 
-When paused, the debugger can inspect variables using the debug info's scope and type metadata:
+When paused, the debugger inspects variables using debug info plus the topmost frame's `function_id`:
 
 ```rust
-impl DebugState {
-    /// Returns variables visible in the given scope, with names, types, and values.
+impl DebuggerHook<'_> {
     pub fn inspect_variables(
         &self,
         variables: &VariableTable,
-        function_id: u16,
+        function_id: FunctionId,
         scope_filter: ScopeFilter,
     ) -> Vec<NamedVariable> {
-        self.debug_info
-            .var_names
-            .iter()
+        self.debug_info.var_names.iter()
             .filter(|entry| {
-                // Show variables owned by this function OR globals
                 let owned = entry.function_id == function_id
-                    || entry.function_id == 0xFFFF;
+                    || entry.function_id == FunctionId::GLOBAL_SCOPE;
                 owned && scope_filter.matches(entry.var_section)
             })
             .filter_map(|entry| {
@@ -658,16 +803,15 @@ impl DebugState {
             .collect()
     }
 
-    /// Resolves a function_id to its source name for stack frames.
-    pub fn function_name(&self, function_id: u16) -> Option<&str> {
-        self.debug_info
-            .func_names
-            .iter()
+    pub fn function_name(&self, function_id: FunctionId) -> Option<&str> {
+        self.debug_info.func_names.iter()
             .find(|f| f.function_id == function_id)
             .map(|f| f.name.as_str())
     }
 }
 ```
+
+The "global" sentinel is `FunctionId::GLOBAL_SCOPE` (defined in `compiler/container/src/id_types.rs`), not a magic `0xFFFF`. Specs and tests must use the constant.
 
 **Type-aware formatting.** The `VarNameEntry.iec_type_tag` field provides the numeric IEC type tag (see [ADR-0019](../adrs/0019-type-encoding-in-debug-variable-names.md)). The `format_value()` function matches on this tag to render slot values correctly — no string parsing needed:
 
@@ -687,24 +831,57 @@ impl DebugState {
 
 ### Variable Forcing (Write)
 
-Variable forcing allows the debugger to override a variable's value:
+Variable forcing is **only** legal while the VM is paused. The DAP request handler runs on the VM thread (see §Concurrency model), so the write happens with no other reader/writer of `VariableTable`. Forcing while RUNNING returns DAP error `requestNotApplicable`.
 
 ```rust
-impl DebugState {
-    /// Forces a variable to a specific value. The value persists until
-    /// unforced or the program writes to it.
+impl<'a> VmRunning<'a> {
+    /// Force a variable to a value. Caller must ensure the VM is in PausedAt.
     pub fn force_variable(
-        &self,
-        variables: &mut VariableTable,
-        var_index: u16,
+        &mut self,
+        var_index: VarIndex,
         value: Slot,
     ) -> Result<(), Trap> {
-        variables.store(var_index, value)
+        debug_assert!(matches!(self.phase, Phase::PausedAt(_)));
+        self.variables.store(var_index, value)
     }
 }
 ```
 
-**Safety considerations.** Variable forcing can cause unexpected program behavior. The DAP server should display forced variables differently in the UI and log all force operations. A future extension could add a "force table" that re-applies forced values at each scan cycle start (matching industrial PLC behavior), but the initial implementation uses simple write-through.
+**Safety considerations.** Variable forcing can cause unexpected program behavior. The DAP server displays forced variables with a marker and logs every force operation. A future extension can add a "force table" that re-applies forced values at each INPUT_FREEZE phase (matching industrial PLC behavior); v1 ships simple write-through with the paused-only restriction.
+
+### State machine
+
+The VM's `Phase` enum gains paused sub-states. All DAP requests are evaluated against this enum and rejected when illegal.
+
+```text
+                    configurationDone
+        READY ───────────────────────────► RUNNING ─────► (round done) ─┐
+          ▲                                  │                          │
+          │ disconnect                       │ pause / breakpoint /     │
+          │                                  │ step / step-scan         │
+          │                                  ▼                          │
+        EXITED                            PausedAt(reason) ◄────────────┘
+                                              │  ▲
+                                              │  │  (variables, scopes,
+                                              │  │   stackTrace, evaluate,
+                                              │  │   forceVariable,
+                                              │  │   setBreakpoints)
+                                              │  │
+                                continue/next/stepIn/stepOut
+                                              │
+                                              ▼ (re-enter run_round_debug)
+                                          RUNNING
+
+   Trap path:
+        RUNNING ── trap ──► (debugger attached + trap-bp) ──► PausedAt(Trap)
+                          ── (otherwise) ─────────────────► FAULTED ──► EXITED
+
+   PausedAt(Trap) is a *terminal pause*: only inspection requests
+   (variables, stackTrace, evaluate) and `disconnect` are legal. Continue
+   and stepping are rejected. Disconnect transitions to EXITED.
+```
+
+The state diagram is the contract for §DAP Request Mapping below — every request lists the states in which it is legal.
 
 ## Layer 3: DAP Server
 
@@ -724,53 +901,54 @@ The `--dap` flag switches to DAP mode (stdin/stdout JSON messages instead of the
 
 ### DAP Request Mapping
 
-| DAP Request | VM Debug Engine Action |
-|-------------|----------------------|
-| `initialize` | Return capabilities (supportsConfigurationDoneRequest, supportsSingleThread) |
-| `launch` | Load container, allocate VM, transition to READY |
-| `setBreakpoints` | Resolve source lines to bytecode offsets via line map; update BreakpointTable |
-| `configurationDone` | Start VM (READY → RUNNING), run until first breakpoint or pause |
-| `threads` | Return single thread (PLC programs are single-threaded within the scan cycle) |
-| `stackTrace` | Return current function name (FuncNameEntry) + source line/column (LineMapEntry) |
-| `scopes` | Return IEC-specific scopes: Locals (VAR, VAR_TEMP), Inputs (VAR_INPUT), Outputs (VAR_OUTPUT), In/Out (VAR_IN_OUT), Globals (VAR_EXTERNAL, VAR_GLOBAL) — filtered by VarNameEntry.var_section |
-| `variables` | Read variable values from VariableTable; display name (VarNameEntry.name), type (VarNameEntry.type_name), formatted value |
-| `continue` | Resume execution (clear step mode, run until next breakpoint) |
-| `next` | Set StepMode::StepOver, resume execution |
-| `stepIn` | Set StepMode::StepIn, resume execution |
-| `stepOut` | Set StepMode::StepOut, resume execution |
-| `pause` | Set a flag that DebugState::check() tests on next instruction |
-| `disconnect` | Stop VM, exit process |
-| `evaluate` | Read a single variable by name (watches) |
+The "Legal in" column lists the VM `Phase` values in which each request is accepted; requests in any other state return DAP error `requestNotApplicable`.
+
+| DAP Request | Legal in | VM Debug Engine Action |
+|-------------|----------|------------------------|
+| `initialize` | (any) | Return capabilities |
+| `launch` | READY | Load container, allocate VM |
+| `setBreakpoints` | READY, RUNNING, PausedAt | Resolve source lines via line map; build a new `BreakpointTable` and `ArcSwap` it in. While RUNNING, the new table takes effect on the next instruction. |
+| `setExceptionBreakpoints` | READY, PausedAt | Toggle `traps` filter for trap pauses |
+| `configurationDone` | READY | Start VM: transition READY → RUNNING, call `run_round_debug` |
+| `threads` | RUNNING, PausedAt | One DAP thread per active program instance (v1 limit: one instance) |
+| `stackTrace` | PausedAt | Walk `frames` top-to-bottom; for each frame produce `name = func_names[function_id]`, `line/column = line_map.lookup(function_id, pc)` |
+| `scopes` | PausedAt | IEC-specific scopes, filtered by `var_section` of the topmost frame's `function_id` |
+| `variables` | PausedAt | Read from `VariableTable` on the VM thread; format per `iec_type_tag` |
+| `continue` | PausedAt (non-terminal) | Clear step mode; re-enter `run_round_debug` |
+| `next` | PausedAt (non-terminal) | Set `StepMode::StepOver` (origin = current line, depth = current depth); re-enter |
+| `stepIn` | PausedAt (non-terminal) | Set `StepMode::StepIn`; re-enter |
+| `stepOut` | PausedAt (non-terminal) | Set `StepMode::StepOut`; re-enter |
+| `pause` | RUNNING | `pause_requested.store(true, Release)` — VM observes and pauses on next instruction |
+| `disconnect` | (any) | Drop VM, exit |
+| `evaluate` | PausedAt | Bare-identifier lookup in v1 (see §Evaluate scope below) |
+
+**Terminal vs non-terminal pause.** `PausedAt(Trap(_))` is terminal: continue/step are rejected. Every other `PausedAt` is non-terminal.
+
+#### Evaluate scope (v1 limit)
+
+DAP `evaluate` is used for hovers, watches, and the debug console. Full expression evaluation is out of scope for v1 because it requires the parser plus a constant-folding evaluator over live VM state. v1 supports:
+
+- Bare identifiers: `myVar`, `motor`
+- Field access on identifiers: `motor.speed`, `state.flags.error`
+- Constant subscripts: `vec[3]`, `motor.history[0]`
+
+It does **not** support arithmetic, function calls, or non-constant subscripts. The DAP server returns DAP error `evaluateUnsupported` for unsupported forms with a message pointing at the unsupported token. A follow-up phase (out of v1) layers in a sandboxed expression evaluator that reuses the AST evaluator from the constant-folder.
 
 ### Custom DAP Requests
-
-For PLC-specific debugging, the DAP server supports custom requests:
 
 | Custom Request | Description |
 |----------------|-------------|
 | `ironplc/stepScan` | Run one complete scan cycle, then pause |
 | `ironplc/scanCount` | Return current scan_count |
-| `ironplc/forceVariable` | Force a variable to a value |
-| `ironplc/unforceVariable` | Remove a variable force |
+| `ironplc/forceVariable` | Force a variable to a value (PausedAt only) |
+| `ironplc/unforceVariable` | Remove a variable force (PausedAt only) |
+| `ironplc/instances` | List running program instances with their `instance_id` and current frame summary |
 
-### Threading Model
+VS Code does not surface custom requests automatically. The extension registers VS Code commands that wrap each custom request and contributes them to the debug toolbar/menus via `package.json` `menus.debug/toolBar`. Without those contributions the requests are unreachable.
 
-The DAP server runs two threads:
+### Threading
 
-1. **DAP I/O thread** — reads DAP requests from stdin, sends responses/events to stdout
-2. **VM execution thread** — runs the VM; pauses when a debug event fires
-
-Communication between threads uses a channel pair:
-- DAP I/O → VM: `DebugCommand` (Continue, StepOver, SetBreakpoints, Pause, etc.)
-- VM → DAP I/O: `DebugEvent` (Stopped, Continued, Exited, Output, etc.)
-
-```
-┌────────────────┐     commands     ┌─────────────────┐
-│  DAP I/O       │────────────────►│  VM Execution    │
-│  thread        │◄────────────────│  thread          │
-│  (stdin/stdout)│     events      │  (run_round)     │
-└────────────────┘                  └─────────────────┘
-```
+(Already specified in Layer 2 §Concurrency model.) Briefly: DAP I/O is one thread, VM execution is another, breakpoints flow via `ArcSwap`, pause flows via `AtomicBool`, all reads of `frames`/`stack`/`variables` are serviced **on the VM thread** while paused.
 
 ### Capabilities
 
@@ -890,101 +1068,145 @@ These are optional enhancements that can be added after the core debugger works.
 
 ## Phased Implementation
 
+The phasing is reorganized so that the iterative-dispatch rewrite (the prerequisite for instruction-level debugging) is its own phase before any debug feature work. The order is: debug info → iterative VM → debug hook → DAP → VS Code.
+
 ### Phase 1: Debug Info Foundation
 
 **Goal:** Compile programs with full debug info (line maps, variable names with scope/type, function names) and verify via the disassembler.
 
+**Status:** Partially in place — `compiler/container/src/debug_section.rs` already defines `LineMapEntry` (with `source_column`), `VarNameEntry` (with `function_id`, `var_section`, `iec_type_tag`, `type_name`), `FuncNameEntry`, and `EnumDefEntry`, plus the directory/tag mechanism. Outstanding work: codegen wiring, optimizer round-trip, disassembler output.
+
 **Changes:**
 
 | Crate | Files | Changes |
 |-------|-------|---------|
-| `container` | `container.rs`, new `debug_info.rs` | Add `DebugInfo`, `LineMapEntry`, `VarNameEntry`, `FuncNameEntry`, `TypeNameEntry`, `FieldNameEntry` types; serialize/deserialize the full debug section; add `debug_info` field to `Container` |
-| `container` | `builder.rs` | Add `debug_info()` method to `ContainerBuilder` |
+| `container` | `debug_section.rs` | Reconcile tag registry with this spec (Tag 9 = ENUM_DEF must be added to the table; Tag 4 = FB_TYPE_NAME). No on-disk format change. |
+| `container` | `builder.rs` | Existing builder API; verify it accepts a fully populated `DebugSection`. |
 | `container` | `header.rs` | Write `debug_section_offset` and `debug_section_size` when debug section present; set flags bit 1 |
-| `codegen` | `emit.rs` | Add `mark_source_position()`, `line_map()` methods to `Emitter`; track line map entries alongside bytecode |
-| `codegen` | `compile.rs` | Accept source text for `LineOffsetTable` construction; call `mark_source_position()` before each statement; collect `VarDebugInfo` (name, function_id, var_section, type_name) during `assign_variables()`; emit `FuncNameEntry` for each compiled POU; build and pass `DebugInfo` to `ContainerBuilder` |
-| `plc2x` | `disassemble.rs` | Display debug section in disassembly output: line maps with function names, variable names with scope/type annotations |
+| `codegen` | `emit.rs` | `set_current_span` per-statement (per `2026-04-07-debug-source-map-and-hook.md`); deduplicate consecutive identical spans |
+| `codegen` | `compile.rs` | Build `LineOffsetTable` from source; collect `VarNameEntry` + `FuncNameEntry` during compilation; pass `DebugSection` to the container builder |
+| `codegen` | `optimize.rs` | `optimize_with_source_map` — remap line-map offsets through the optimizer's old→new offset table; "snap forward" entries for removed instructions; **invariant test** that every line-map offset lands on an instruction boundary in the optimized stream |
+| `plc2x` | `disassemble.rs` | Render line maps and variable names alongside disassembly |
 
-**Tests:**
-- Codegen: compile a program, verify line map entries map to expected source lines and columns
-- Codegen: verify `VarNameEntry` includes correct `function_id`, `var_section`, and `type_name` for each variable
-- Codegen: verify `FuncNameEntry` maps function_id 0 to the program's name
-- Container: roundtrip test — write full debug section (all 6 sub-tables), read it back, verify contents
+**Tests** (in addition to the optimizer property tests in `2026-04-07-debug-source-map-and-hook.md`):
+- Codegen: compile, verify line-map entries map to expected lines and columns
+- Codegen: verify `VarNameEntry` carries the right `function_id`, `var_section`, `iec_type_tag`, and `type_name`
+- Codegen: verify `FuncNameEntry` for the program's entry function
+- Container: roundtrip with all sub-tables (line map, var name, func name, enum def)
 - Container: read container without debug section — `debug_info` is `None`
-- Container: read container with malformed debug section — silently discarded
-- Container: read container with partial debug section (missing new sub-tables) — missing tables treated as empty
+- Container: malformed debug section — silently discarded
+- Container: partial debug section — missing tables treated as empty
 
-### Phase 2: VM Debug Engine
+### Phase 2: Iterative VM dispatch (prerequisite)
 
-**Goal:** The VM can pause at breakpoints, single-step, and inspect variables by name.
+**Goal:** Convert `execute_with_hook` from recursive to iterative. No new debugger features in this phase — the *only* observable change is that `CALL`/`RET` go through an explicit `FrameStack`. Behavior is identical to today.
 
 **Changes:**
 
 | Crate | Files | Changes |
 |-------|-------|---------|
-| `vm` | new `debug.rs` | `DebugState`, `BreakpointTable`, `StepMode`, `PauseReason`, `ExecuteResult` types |
-| `vm` | `vm.rs` | Add `debug: Option<DebugState>` to `VmRunning`; add `run_round_debug()` method; wire debug state into execute |
-| `vm` | `vm.rs` (execute fn) | Add `debug: Option<&mut DebugState>` parameter; add debug check at instruction dispatch; increment/decrement `current_call_depth` on CALL/RET instructions for step-over/step-out support |
-| `vm` | `lib.rs` | Export debug types |
+| `vm` | new `frame_stack.rs` | `Frame`, `FrameStack` (bounded by `MAX_CALL_DEPTH`), `TempAllocMark` |
+| `vm` | `vm.rs` | Replace recursive `CALL` arm (`vm.rs:1044`, `vm.rs:1865`) with `frames.push(...)`; lift the dispatch loop to iterate `frames`; `execute_with_hook` becomes the loop body's wrapper. Remove `depth` parameter — depth is now `frames.len()`. Add `ExecuteOutcome::{Completed, Paused}` (Paused only reachable after Phase 3 extends the hook signature; for now it's unreachable but the type exists). |
+| `vm` | `vm.rs` | `VmRunning` gains `frames: FrameStack`, `phase: Phase`, `current_instance_id`. `Phase::Running` is the only legal phase reached in this phase; `PausedAt` is added but only used in Phase 3. |
+| `vm` | `lib.rs` | Re-export `Frame`, `FrameStack`, `Phase`, `ExecuteOutcome` |
+
+**Migration order** (each commit must compile and pass `cd compiler && just`):
+1. Introduce `FrameStack`; maintain it in parallel with recursion; assert `frames.len() == depth + 1`.
+2. Flip the loop iterative; remove the recursive `execute_with_hook(...)` self-call inside `CALL`.
+3. Delete `depth` parameter and recursion-based bookkeeping.
 
 **Tests:**
-- Breakpoint: set breakpoint on a line, run, verify VM pauses at the correct bytecode offset
-- Step over: pause at line N, step over, verify pause at line N+1 (not inside called function)
-- Step in: pause at a function call line, step in, verify pause inside the function body
-- Step out: pause inside a function, step out, verify pause at the caller's next line
-- Continue: pause at breakpoint, continue, verify VM runs until next breakpoint or completion
-- No debug overhead: run without debug state, verify execute() signature accepts `None`
-- Variable inspection: pause at breakpoint, inspect variables by name, verify correct values
+- All existing VM tests must pass unchanged (this phase is a no-op behavioural change).
+- Frame-stack overflow returns `Trap::CallStackOverflow` exactly as before.
+- New: pause-corpus test scaffolding — for every opcode in `MAX_OPCODE`, a fixture program where the VM can be paused at that opcode boundary by a *test* hook and resumed; the final `variables` and `data_region` are bitwise identical to an unpaused run. (The pause path is exercised by a synthetic hook; it does not yet need the DebuggerHook.)
 
-### Phase 3: DAP Server
+### Phase 3: VM Debug Engine
+
+**Goal:** With iterative dispatch in place, add the debugger-grade `DebugHook` extension and the `DebuggerHook` impl. The VM can pause at breakpoints, single-step (over/in/out/scan), and inspect variables.
+
+**Changes:**
+
+| Crate | Files | Changes |
+|-------|-------|---------|
+| `vm` | `debug_hook.rs` | Extend trait: `before_instruction(function_id, pc, op) -> HookAction`; add `before_call`/`after_return` with default empty bodies; add `HookAction`, `PauseReason`. `NoopDebugHook` returns `HookAction::Continue` from `#[inline(always)]`. |
+| `vm` | `vm.rs` (dispatch loop) | Inspect `HookAction` from `before_instruction`; call `before_call` before pushing a frame; call `after_return` after popping. Surface `ExecuteOutcome::Paused` from the loop. |
+| `vm` | new `debug.rs` | `BreakpointTable` (sorted Vec, `ArcSwap`-able), `BreakpointId`, `StepMode`, `StepController`, `DebuggerHook` (impls `DebugHook`). |
+| `vm` | `vm.rs` | `VmRunning::run_round_debug<H: DebugHook>` — re-entrant; advances all instances of the current scan or returns `RoundOutcome::Paused`. `Phase::PausedAt(reason)` set on pause. `force_variable` allowed only in `PausedAt`. |
+| `vm` | `lib.rs` | Export `DebuggerHook`, `BreakpointTable`, `BreakpointId`, `StepMode`, `PauseReason`, `RoundOutcome`. |
+
+**Tests:**
+- Breakpoint: set bp on a line in the entry function — pauses at the correct `(function_id, bytecode_offset)`.
+- Breakpoint: set bp on a line **inside a callee** — pauses with the callee's frame on top of the frame stack; `stackTrace` walks back to the caller.
+- Step-over across a CALL: at line with a CALL, step-over lands on the next line *after* the CALL with depth equal to origin.
+- Step-in into a CALL: lands on the first statement of the callee with depth = origin + 1.
+- Step-out from inside a callee: lands on the line after the CALL in the caller, depth = origin − 1.
+- Pause/Resume parity: from a corpus of programs, pause at every instruction boundary, resume, assert final `variables` and `data_region` are bitwise identical to an unpaused run.
+- Concurrency: spawn DAP I/O thread analogue, swap the breakpoint table while the VM thread is running, verify the swap is observed within one instruction and no torn reads occur (run under `loom` or `shuttle`).
+- No overhead with `NoopDebugHook`: a `criterion` bench shows < 1% delta vs main on the existing benchmark suite.
+- Trap during debug: with trap-bp enabled, transitions to `PausedAt(Trap)`; only inspection requests are accepted; `continue`/`step` return `requestNotApplicable`; `disconnect` cleanly tears down.
+
+### Phase 4: DAP Server
 
 **Goal:** Launch `ironplcvm debug --dap <file.iplc>` and debug from VS Code using standard DAP.
 
+**Packaging decision.** DAP support is **feature-gated** on the `vm-cli` crate (`--features dap`) so that the production VM binary doesn't pull in `serde_json`, the DAP types, and the I/O loop unless it's a debug build. Distribution ships two binaries: `ironplcvm` (no DAP) and `ironplcvm-debug` (DAP enabled), or one binary with the `dap` feature on by default in the VS Code distribution.
+
 **Changes:**
 
 | Crate | Files | Changes |
 |-------|-------|---------|
-| `vm-cli` | `main.rs` | Add `Debug` subcommand with `--dap` flag |
-| `vm-cli` | new `dap.rs` | DAP message parsing (Content-Length framing, JSON deserialization) |
-| `vm-cli` | new `dap_server.rs` | DAP request handling, maps to VM debug engine API |
-| `vm-cli` | new `dap_types.rs` | DAP protocol types (Request, Response, Event, Capabilities, etc.) |
-
-**Dependency consideration:** The DAP protocol is simpler than LSP and does not require a large framework. The initial implementation can use manual JSON serialization with `serde_json`, similar to how the disassembler produces JSON. If a well-maintained DAP crate exists (e.g., `dap-rs`), prefer it over hand-rolling the protocol.
+| `vm-cli` | `Cargo.toml` | New `dap` feature gating the new modules below |
+| `vm-cli` | `main.rs` | Behind `#[cfg(feature = "dap")]`: add `Debug` subcommand with `--dap` flag |
+| `vm-cli` | new `dap/framing.rs` | Content-Length framing reader/writer |
+| `vm-cli` | new `dap/types.rs` | DAP protocol types (Request, Response, Event, Capabilities). Prefer the `dap-types` crate if it's a fit; otherwise hand-rolled with `serde`. |
+| `vm-cli` | new `dap/server.rs` | Two-thread server: I/O thread + VM thread. I/O thread routes requests through a channel to the VM thread; VM thread services them while paused. |
+| `vm-cli` | new `dap/state.rs` | `Phase` mirror plus per-state legality checks (returns `requestNotApplicable` for illegal requests) |
 
 **Tests:**
-- Unit tests for DAP message parsing (Content-Length framing)
-- Integration test: send `initialize` + `launch` + `setBreakpoints` + `configurationDone` messages to a DAP server process, verify it sends `stopped` event at the breakpoint
-- Integration test: send `continue` after stopped, verify execution completes
-- Integration test: send `variables` request while paused, verify variable names and values
+- Unit: Content-Length framing roundtrip.
+- Unit: state-machine legality table — every (state, request) pair returns the documented response.
+- Integration: spawn `ironplcvm-debug --dap` as a subprocess, send `initialize` + `launch` + `setBreakpoints` + `configurationDone`, expect `stopped` at the breakpoint.
+- Integration: from `stopped`, request `stackTrace`, `scopes`, `variables`; verify entries.
+- Integration: send `pause` while RUNNING, verify `stopped` event with `reason: pause`.
+- Integration: send `setBreakpoints` while RUNNING, verify the new breakpoint takes effect.
+- Integration: trigger a trap with trap-bp enabled, verify `stopped` event with `reason: exception` and `disconnect` returns cleanly.
 
-### Phase 4: VS Code Integration
-
-**Goal:** Click "Debug" in VS Code and get a working debug session with breakpoints, stepping, and variable inspection.
-
-**Changes:**
+### Phase 5: VS Code Integration
 
 | Location | Files | Changes |
 |----------|-------|---------|
-| `integrations/vscode` | `package.json` | Add `debuggers` contribution (see VS Code Integration section above) |
-| `integrations/vscode/src` | new `debugAdapter.ts` | `DebugAdapterDescriptorFactory` implementation; launches `ironplcvm debug --dap` |
-| `integrations/vscode/src` | `extension.ts` | Register debug adapter factory on activation |
+| `integrations/vscode` | `package.json` | Add `debuggers` contribution; **also add `commands` and `menus.debug/toolBar` entries for `ironplc.stepScan` and `ironplc.scanCount`** (otherwise custom DAP requests are unreachable) |
+| `integrations/vscode/src` | new `debugAdapter.ts` | `DebugAdapterDescriptorFactory`; if `program` is `.st`, run the compiler with debug info enabled to emit a temp `.iplc`; launch `ironplcvm-debug --dap <file.iplc>` |
+| `integrations/vscode/src` | new `customRequests.ts` | Wraps `ironplc/stepScan`, `ironplc/forceVariable` etc. as VS Code commands |
+| `integrations/vscode/src` | `extension.ts` | Register debug adapter factory and custom-request commands |
 
 **Tests:**
-- Extension test: verify debug adapter is registered
-- Extension test: verify launch configuration resolves the ironplcvm path
-- Manual test: set breakpoint in .st file, press F5, verify breakpoint hit and variable inspection works
+- Extension: debug adapter registered.
+- Extension: launch configuration resolves the `ironplcvm-debug` path (env var, settings, then bundled).
+- Manual: F5 with a breakpoint hits, variable inspection populates, Step Scan toolbar works.
 
-### Phase 5: PLC-Specific Enhancements (Future)
+### Phase 6: PLC-Specific Enhancements (Future)
 
 These enhancements build on the core debugger but are not required for initial functionality:
 
-1. **Scan cycle toolbar** — custom VS Code toolbar button for Step Scan
-2. **Variable forcing** — write variables through the debug interface with force indicators in the UI
-3. **Process image inspection** — view %I, %Q, %M regions with bit/byte/word addressing
-4. **Conditional breakpoints** — DAP `condition` field on breakpoints, evaluated by the VM
+1. **Scan cycle status bar** — show `scan_count` and a "step scan" button (the toolbar button itself ships in Phase 5)
+2. **Process image inspection** — view %I, %Q, %M regions with bit/byte/word addressing
+3. **Conditional breakpoints** — DAP `condition` field on breakpoints, evaluated by the VM (requires the v1 evaluate restriction to be lifted first)
+4. **Compound expression evaluation** — full `evaluate` (arithmetic, function calls), via a sandboxed evaluator that reuses the constant-folder
 5. **Logpoints** — DAP `logMessage` field, VM prints message without stopping
 6. **Hot reload during debug** — recompile and online-change while paused, preserving breakpoints
-7. **Multi-task debugging** — when multi-task scheduling is implemented, show tasks as DAP threads
+7. **Multi-task and multi-instance debugging** — expose tasks/instances as DAP threads; per-instance breakpoint filters
+8. **Type-name string deduplication** — intern `type_name` strings in a separate sub-table to shrink debug sections
+
+## Optimizer Contract
+
+The bytecode optimizer (`compiler/codegen/src/optimize.rs`) removes instructions and shifts jump targets. Source-level debugging requires a stable contract between the optimizer and debug info:
+
+1. **Line map remapping is mandatory.** Any pass that changes the bytecode must rewrite the line map through its old→new offset table. `optimize_with_source_map` (per `2026-04-07-debug-source-map-and-hook.md`) is the only legal way to invoke optimization when debug info is enabled.
+2. **Snap-forward for removed instructions.** When the offset that an entry references is removed, the entry's offset advances to the *next surviving instruction*; consecutive duplicate entries collapse.
+3. **Instruction-boundary invariant.** Every line-map offset in the optimized stream must land on the first byte of an instruction. A property test in `compiler/codegen/tests/` enforces this on a corpus of programs.
+4. **Breakpoint resolution is post-optimization.** The DAP server resolves source lines against the line map *as emitted* (already remapped). It then reports the resolved line back to the client in the `Breakpoint` response so the editor highlights the actual stop line. Breakpoints requested on lines whose statements were entirely optimized away resolve to the next surviving line in the same function; if no such line exists, the breakpoint is reported `verified: false` with `message: "line eliminated by optimizer"`.
+5. **`--debug` build flag (codegen).** When set, the optimizer is configured to *preserve* user-visible source positions even when otherwise legal to remove them (e.g., it does not collapse a `LOAD_CONST_I32 0; STORE_VAR` if that sequence is the only line-map anchor for a statement). This trades some optimization quality for predictable stepping. Release builds keep the existing aggressive pipeline and accept that some statements may have no breakpoint location.
 
 ## Container Format Compatibility
 
@@ -1029,3 +1251,21 @@ This means bytecode debugging works even when the debug section is stripped — 
 3. **Ladder Diagram / FBD debugging** — graphical IEC 61131-3 languages (LD, FBD) have fundamentally different debugging UIs (highlighting rungs, showing power flow, animating contacts/coils). The debug section format reserves tags 7 (LD_RUNG_MAP) and 8 (FBD_NETWORK_MAP) for this purpose — future compilers can emit these sub-tables and existing ST debuggers will skip them harmlessly. However, the compilation pipeline, DAP server, and VS Code extension would all need LD/FBD-specific support. This is deferred until graphical language compilation is implemented.
 4. **Memory breakpoints** — breaking when a specific variable's value changes (hardware watchpoints). These require polling or page-fault tricks that are not practical in the VM.
 5. **Time-travel debugging** — recording and replaying execution. Would require snapshotting VM state at each scan cycle, which is a significant memory and performance cost.
+6. **Compound expression evaluation in `evaluate`** — v1 supports bare identifiers, dotted field access on identifiers, and constant subscripts only. Arithmetic, function calls, and non-constant subscripts return `evaluateUnsupported`. Lifted in Phase 6.
+7. **Conditional breakpoints / logpoints** — DAP `condition` and `logMessage` fields require compound expression evaluation; deferred to Phase 6.
+8. **Per-instance breakpoint filtering** — v1 breakpoints are global across all instances of a program. `ironplc/instances` exposes instance state for inspection but breakpoints fire on the first instance to reach them.
+
+## Summary of architectural changes from the original plan
+
+For reviewers familiar with the prior version of this document:
+
+1. **Iterative dispatch with explicit `FrameStack`** replaces the recursive `execute_with_hook`. This is the prerequisite for instruction-level pausing.
+2. **`DebugHook` trait extension** — `before_instruction` returns `HookAction`; new `before_call`/`after_return` callbacks; `function_id` parameter added. The existing `NoopDebugHook` + monomorphization model is retained, **not** replaced by `Option<&mut DebugState>`.
+3. **`DebuggerHook` is a `DebugHook` impl**, not a fourth-thing-named-`DebugState`. It owns the breakpoint table reference, step controller, and pause flag.
+4. **Concurrency model is explicit**: `ArcSwap<BreakpointTable>` for the breakpoint table, `AtomicBool` for the pause flag, and DAP request servicing happens *on the VM thread* while paused.
+5. **Pause/Resume protocol is defined**: a complete checkpoint table lists every piece of state preserved across a pause, plus a property test asserting bitwise resume parity.
+6. **Multi-instance pause semantics specified** (`current_instance_id` is the paused instance; later instances run on resume).
+7. **Optimizer contract** spelled out: post-optimization line map, snap-forward, instruction-boundary invariant, breakpoint-resolution feedback.
+8. **State machine documented** with a Phase enum and a per-DAP-request legality column.
+9. **Tag registry reconciled** with the existing `Tag 9 = ENUM_DEF` implementation.
+10. **DAP packaging** is `--features dap` on `vm-cli`, distributed as `ironplcvm-debug` for the VS Code extension.


### PR DESCRIPTION
Commits the design to an iterative VM dispatch with an explicit
FrameStack so the VM can pause between any two opcodes, including
inside nested CALLs. Reuses the existing DebugHook trait (extended
with HookAction return, function_id, and before_call/after_return
callbacks) instead of adding a runtime-branched DebugState. Adds
pause/resume protocol, concurrency model (ArcSwap breakpoint table,
AtomicBool pause flag, VM-thread request servicing), state machine,
multi-instance pause semantics, optimizer contract, and reconciles
the tag registry with the existing Tag 9 = ENUM_DEF implementation.

https://claude.ai/code/session_01PZsmMEz6bK3tjXAdjnupeC