### PR TITLE
elide per-iteration exit JMP in FOR loops

### DIFF
--- a/compiler/codegen/src/compile_stmt.rs
+++ b/compiler/codegen/src/compile_stmt.rs
@@ -22,9 +22,9 @@ use super::compile::{
 };
 use super::compile_expr::{
     compile_bit_access_assignment, compile_expr, compile_partial_access_assignment,
-    condition_op_type, emit_add, emit_ge, emit_gt, emit_le, emit_load_var, emit_lt, emit_store_var,
-    emit_truncation, extract_bit_access_target, extract_partial_access_target, op_type,
-    resolve_variable, resolve_variable_name, signed_integer_to_i64, variable_span,
+    condition_op_type, emit_add, emit_ge, emit_le, emit_load_var, emit_store_var, emit_truncation,
+    extract_bit_access_target, extract_partial_access_target, op_type, resolve_variable,
+    resolve_variable_name, signed_integer_to_i64, variable_span,
 };
 use crate::emit::Emitter;
 
@@ -876,10 +876,8 @@ fn for_loop_trunc_can_be_elided(
 /// LOOP:
 ///   LOAD_VAR control
 ///   compile(to)
-///   GT_I32 (or LT_I32 for negative step)
-///   JMP_IF_NOT → BODY
-///   JMP → END
-/// BODY:
+///   LE_I32 (or GE_I32 for negative step)  // continuation predicate
+///   JMP_IF_NOT → END                       // exit when continuation fails
 ///   compile(body)
 ///   LOAD_VAR control
 ///   compile(step)  // default: LOAD_CONST 1
@@ -888,6 +886,11 @@ fn for_loop_trunc_can_be_elided(
 ///   JMP → LOOP
 /// END:
 /// ```
+///
+/// The continuation predicate is `i <= to` (positive step) / `i >= to`
+/// (negative step). Inverting the predicate lets the body fall through
+/// from the conditional branch, eliminating one `JMP` dispatch per
+/// iteration. See `specs/plans/2026-04-30-elide-for-loop-exit-jmp.md`.
 fn compile_for(
     emitter: &mut Emitter,
     ctx: &mut CompileContext,
@@ -933,22 +936,20 @@ fn compile_for(
     emit_store_var(emitter, var_index, op_type);
 
     let loop_label = emitter.create_label();
-    let body_label = emitter.create_label();
     let end_label = emitter.create_label();
 
-    // LOOP: check termination condition
+    // LOOP: check continuation condition; exit straight to END when it
+    // fails so the body falls through without an extra JMP dispatch.
     emitter.bind_label(loop_label);
     emit_load_var(emitter, var_index, op_type);
     compile_expr(emitter, ctx, &for_stmt.to, op_type)?;
     match step_sign {
-        StepSign::Positive => emit_gt(emitter, op_type),
-        StepSign::Negative => emit_lt(emitter, op_type),
+        StepSign::Positive => emit_le(emitter, op_type),
+        StepSign::Negative => emit_ge(emitter, op_type),
     }
-    emitter.emit_jmp_if_not(body_label);
-    emitter.emit_jmp(end_label);
+    emitter.emit_jmp_if_not(end_label);
 
     // BODY:
-    emitter.bind_label(body_label);
     ctx.loop_exit_labels.push(end_label);
     compile_stmts(emitter, ctx, &for_stmt.body)?;
     ctx.loop_exit_labels.pop();

--- a/compiler/codegen/tests/compile_loops.rs
+++ b/compiler/codegen/tests/compile_loops.rs
@@ -115,7 +115,7 @@ END_PROGRAM
 }
 
 #[test]
-fn compile_when_for_default_step_then_produces_loop_with_gt() {
+fn compile_when_for_default_step_then_produces_loop_with_le() {
     let source = "
 PROGRAM main
   VAR
@@ -131,31 +131,41 @@ END_PROGRAM
 
     // i=var:0, y=var:1
     // constants: pool:0=1, pool:1=5
-    // Bytecode layout:
+    // Bytecode layout (specs/plans/2026-04-30-elide-for-loop-exit-jmp.md):
     //   0: LOAD_CONST_I32 pool:0 (1)   (from value)
     //   3: STORE_VAR_I32 var:0         (i := 1)
     //   6: LOAD_VAR_I32 var:0          (LOOP: load i)
     //   9: LOAD_CONST_I32 pool:1 (5)   (to value)
-    //  12: GT_I32                       (i > 5?)
-    //  13: JMP_IF_NOT offset:+3 -> 19  (if not past limit, go to BODY)
-    //  16: JMP offset:+23 -> 42        (exit loop)
-    //  19: LOAD_VAR_I32 var:1          (BODY: y)
-    //  22: LOAD_VAR_I32 var:0          (i)
-    //  25: ADD_I32                      (y + i)
-    //  26: STORE_VAR_I32 var:1         (y := ...)
-    //  29: LOAD_VAR_I32 var:0          (increment: i)
-    //  32: LOAD_CONST_I32 pool:0 (1)   (step: 1)
-    //  35: ADD_I32                      (i + 1)
-    //  36: STORE_VAR_I32 var:0         (i := ...)
-    //  39: JMP offset:-36 -> 6         (back to LOOP)
-    //  42: RET_VOID
+    //  12: LE_I32                       (i <= 5? continuation)
+    //  13: JMP_IF_NOT offset:+23 -> 39 (exit when i > 5)
+    //  16: LOAD_VAR_I32 var:1          (BODY: y)
+    //  19: LOAD_VAR_I32 var:0          (i)
+    //  22: ADD_I32                      (y + i)
+    //  23: STORE_VAR_I32 var:1         (y := ...)
+    //  26: LOAD_VAR_I32 var:0          (increment: i)
+    //  29: LOAD_CONST_I32 pool:0 (1)   (step: 1)
+    //  32: ADD_I32                      (i + 1)
+    //  33: STORE_VAR_I32 var:0         (i := ...)
+    //  36: JMP offset:-33 -> 6         (back to LOOP)
+    //  39: RET_VOID
     let bytecode = container
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
 
-    // Verify GT_I32 for positive step
-    assert_eq!(bytecode[12], 0x6C); // GT_I32
+    // Verify LE_I32 for positive step (replaces old GT_I32)
+    assert_eq!(bytecode[12], opcode::LE_I32);
+
+    // Exactly one JMP_IF_NOT (the exit) and one JMP (the loop back-edge) —
+    // the per-iteration exit JMP that used to follow JMP_IF_NOT body_label is
+    // now elided.
+    let jmp_if_not_count = bytecode
+        .iter()
+        .filter(|&&b| b == opcode::JMP_IF_NOT)
+        .count();
+    let jmp_count = bytecode.iter().filter(|&&b| b == opcode::JMP).count();
+    assert_eq!(jmp_if_not_count, 1, "bytecode = {bytecode:?}");
+    assert_eq!(jmp_count, 1, "bytecode = {bytecode:?}");
 
     // Verify structure
     assert_eq!(
@@ -165,9 +175,8 @@ END_PROGRAM
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
             0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
             0x01, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (5)
-            0x6C, // GT_I32
-            0xB2, 0x03, 0x00, // JMP_IF_NOT offset:+3
-            0xB0, 0x17, 0x00, // JMP offset:+23
+            0x6B, // LE_I32
+            0xB2, 0x17, 0x00, // JMP_IF_NOT offset:+23
             0x10, 0x01, 0x00, // LOAD_VAR_I32 var:1
             0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
             0x30, // ADD_I32
@@ -176,14 +185,14 @@ END_PROGRAM
             0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
             0x30, // ADD_I32
             0x18, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0xB0, 0xDC, 0xFF, // JMP offset:-36
+            0xB0, 0xDF, 0xFF, // JMP offset:-33
             0xB5, // RET_VOID
         ]
     );
 }
 
 #[test]
-fn compile_when_for_negative_step_then_produces_loop_with_lt() {
+fn compile_when_for_negative_step_then_produces_loop_with_ge() {
     let source = "
 PROGRAM main
   VAR
@@ -202,8 +211,17 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
 
-    // Verify LT_I32 for negative step (instead of GT_I32)
-    assert_eq!(bytecode[12], 0x6A); // LT_I32
+    // Verify GE_I32 for negative step (continuation predicate; replaces old LT_I32)
+    assert_eq!(bytecode[12], opcode::GE_I32);
+
+    // And confirm the per-iteration exit JMP is gone here too.
+    let jmp_if_not_count = bytecode
+        .iter()
+        .filter(|&&b| b == opcode::JMP_IF_NOT)
+        .count();
+    let jmp_count = bytecode.iter().filter(|&&b| b == opcode::JMP).count();
+    assert_eq!(jmp_if_not_count, 1, "bytecode = {bytecode:?}");
+    assert_eq!(jmp_count, 1, "bytecode = {bytecode:?}");
 }
 
 // FOR-loop TRUNC elision (specs/plans/2026-04-30-elide-for-loop-trunc.md):

--- a/specs/plans/2026-04-30-elide-for-loop-exit-jmp.md
+++ b/specs/plans/2026-04-30-elide-for-loop-exit-jmp.md
@@ -1,0 +1,123 @@
+# Plan: Elide Per-Iteration Exit `JMP` in FOR Loops
+
+## Context
+
+FOR-loop bodies are roughly 200x slower than native code in IronPLC. The
+`vm-performance.md` roadmap lists several Tier-1 levers (verifier-gated
+unchecked execution, superinstructions, register translation), but each
+either requires `unsafe` paths in the VM or new opcodes. The opcode set
+is currently in flux, and we want to defer `unsafe` execution paths
+until the bytecode verifier lands. That filter narrows the next win to
+**codegen-level FOR-loop emission**, where the recent TRUNC-elision
+work (`specs/plans/2026-04-30-elide-for-loop-trunc.md`) already cut one
+opcode per iteration.
+
+Today `compile_for` (`compiler/codegen/src/compile_stmt.rs:891-992`)
+emits at the top of every iteration:
+
+```text
+LOAD_VAR control
+compile(to)
+GT  (or LT for negative step)
+JMP_IF_NOT body_label
+JMP end_label
+body_label:                  ; bound on the very next instruction
+  ...body...
+```
+
+The `JMP_IF_NOT body_label` jumps 3 bytes forward to the instruction
+that already comes next — a near-no-op branch — and the unconditional
+`JMP end_label` after it executes on every successful iteration. For a
+100-iteration loop that's 99 wasted `JMP` dispatches through the VM's
+~96-arm match (`compiler/vm/src/vm.rs`); for nested loops the cost
+compounds.
+
+## Approach
+
+Invert the loop's continuation predicate so the *survival* condition is
+on the stack, then exit the loop in a single conditional branch and let
+the body fall through. The new emission is:
+
+```text
+LOAD_VAR control
+compile(to)
+LE  (or GE for negative step)   ; continue while i <= to
+JMP_IF_NOT end_label            ; exit when continuation fails
+  ...body...
+```
+
+Per iteration this removes one `JMP` dispatch, cuts 3 bytes of bytecode
+per FOR loop, and does not change observable behavior: `LE` is the
+exact logical negation of `GT` over IEC integer/real types, and likewise
+`GE` for `LT`. (Both `from`-then-`to` and `step` are already required
+to be constant, so no surprises around side-effecting bounds.)
+
+### Reused helpers
+
+All required infrastructure already exists:
+
+- Comparison emitters: `emit_le`, `emit_ge` in
+  `compiler/codegen/src/compile_expr.rs:1740,1762`.
+- Comparison opcodes for every integer/real width:
+  `LE_I32`/`GE_I32` (`compiler/container/src/opcode.rs:64,72`),
+  `LE_I64`/`GE_I64` (`:467,475`), `LE_U32`/`GE_U32` (`:485,493`),
+  `LE_U64`/`GE_U64` (`:501,509`), `LE_F32`/`GE_F32` (`:527,535`),
+  `LE_F64`/`GE_F64` (`:553,561`).
+- `JMP_IF_NOT` opcode: `compiler/container/src/opcode.rs:130`.
+
+No new opcodes. No VM changes. No verifier work. No `unsafe`.
+
+## Changes
+
+### `compiler/codegen/src/compile_for` (lines ~935-988)
+
+1. Remove `let body_label = emitter.create_label();` (line 936) and the
+   matching `emitter.bind_label(body_label);` call (line 951).
+2. In the loop-head emission (lines 943-948):
+   - Change `StepSign::Positive` arm from `emit_gt` to `emit_le`.
+   - Change `StepSign::Negative` arm from `emit_lt` to `emit_ge`.
+   - Replace the `emit_jmp_if_not(body_label)` + `emit_jmp(end_label)`
+     pair with a single `emit_jmp_if_not(end_label)`.
+3. Update the docstring at lines 873-889 to reflect the new shape.
+
+The increment block (lines 957-986) and the END label binding (line
+989) are unchanged.
+
+### Tests
+
+- New unit test alongside the existing `for_loop_trunc_*` tests in
+  `compiler/codegen/`: assert that for a representative
+  `FOR i:DINT := 1 TO 10 DO i := i; END_FOR`, the emitted bytecode
+  contains:
+  - exactly **one** `JMP` (the back-edge),
+  - exactly **one** `JMP_IF_NOT` (targeting END),
+  - `LE_I32` (not `GT_I32`) at the loop head.
+- Symmetric test for negative step asserting `GE_I32` at the loop head.
+
+### Behavior verification
+
+- The existing FOR-loop integration tests and the `profile_for_loop`
+  benchmark in `compiler/benchmarks/tests/` already cover positive-step
+  loops, zero-iteration loops (`from > to`), and the boundary case
+  `FOR i:INT := 32760 TO 32767`. They must continue to pass unchanged.
+
+## Verification
+
+1. `cd compiler && just compile` — must succeed.
+2. `cd compiler && just test` — full test suite (including any added
+   asserts above) green.
+3. `cd compiler && just` — full CI pipeline (clippy, fmt, coverage)
+   green per `CLAUDE.md` requirement before PR.
+4. Re-run `compiler/benchmarks/tests/profile_for_loop.rs` with
+   profiling: total `JMP` opcode count for a 100-iteration loop should
+   drop by ~99.
+5. `compiler/benchmarks/benches/st_benchmark.rs` — `st_for_loop` and
+   `st_nested_loops` should show a small but measurable improvement.
+
+## Out of scope
+
+- Verifier + verified-unchecked execution (Tier 1, blocked on `unsafe`).
+- Superinstructions / fused increment / register translation (require
+  new opcodes).
+- String-op `copy_from_slice` (high ROI, but unrelated to FOR loops;
+  natural follow-up).


### PR DESCRIPTION
Adds a plan for a codegen-only FOR-loop optimisation: invert the
continuation predicate (GT->LE, LT->GE) and exit with a single
JMP_IF_NOT to the end label so the body falls through. Removes one JMP
dispatch and 3 bytes of bytecode per FOR loop with no new opcodes, no
verifier work, and no unsafe.