### PR TITLE
rename FuncEntry bytecode_offset/length to code_offset/length

### DIFF
--- a/compiler/container/src/builder.rs
+++ b/compiler/container/src/builder.rs
@@ -146,8 +146,8 @@ impl ContainerBuilder {
         let offset = self.bytecode.len() as u32;
         self.functions.push(FuncEntry {
             function_id,
-            bytecode_offset: offset,
-            bytecode_length: bytecode.len() as u32,
+            code_offset: offset,
+            code_length: bytecode.len() as u32,
             max_stack_depth,
             num_locals,
             num_params,

--- a/compiler/container/src/code_section.rs
+++ b/compiler/container/src/code_section.rs
@@ -12,8 +12,8 @@ const FUNC_ENTRY_SIZE: usize = 16;
 #[derive(Clone, Debug)]
 pub struct FuncEntry {
     pub function_id: FunctionId,
-    pub bytecode_offset: u32,
-    pub bytecode_length: u32,
+    pub code_offset: u32,
+    pub code_length: u32,
     pub max_stack_depth: u16,
     pub num_locals: u16,
     pub num_params: u16,
@@ -45,8 +45,8 @@ impl CodeSection {
     /// sequential indices starting from 0.
     pub fn get_function_bytecode(&self, function_id: FunctionId) -> Option<&[u8]> {
         let entry = self.functions.get(function_id.raw() as usize)?;
-        let start = entry.bytecode_offset as usize;
-        let end = start + entry.bytecode_length as usize;
+        let start = entry.code_offset as usize;
+        let end = start + entry.code_length as usize;
         self.bytecode.get(start..end)
     }
 
@@ -54,8 +54,8 @@ impl CodeSection {
     pub fn write_to(&self, w: &mut impl Write) -> Result<(), ContainerError> {
         for func in &self.functions {
             w.write_all(&func.function_id.to_le_bytes())?;
-            w.write_all(&func.bytecode_offset.to_le_bytes())?;
-            w.write_all(&func.bytecode_length.to_le_bytes())?;
+            w.write_all(&func.code_offset.to_le_bytes())?;
+            w.write_all(&func.code_length.to_le_bytes())?;
             w.write_all(&func.max_stack_depth.to_le_bytes())?;
             w.write_all(&func.num_locals.to_le_bytes())?;
             w.write_all(&func.num_params.to_le_bytes())?;
@@ -83,13 +83,13 @@ impl CodeSection {
             r.read_exact(&mut entry_buf)?;
             functions.push(FuncEntry {
                 function_id: FunctionId::new(u16::from_le_bytes([entry_buf[0], entry_buf[1]])),
-                bytecode_offset: u32::from_le_bytes([
+                code_offset: u32::from_le_bytes([
                     entry_buf[2],
                     entry_buf[3],
                     entry_buf[4],
                     entry_buf[5],
                 ]),
-                bytecode_length: u32::from_le_bytes([
+                code_length: u32::from_le_bytes([
                     entry_buf[6],
                     entry_buf[7],
                     entry_buf[8],
@@ -124,8 +124,8 @@ mod tests {
         let section = CodeSection {
             functions: vec![FuncEntry {
                 function_id: FunctionId::INIT,
-                bytecode_offset: 0,
-                bytecode_length: bytecode.len() as u32,
+                code_offset: 0,
+                code_length: bytecode.len() as u32,
                 max_stack_depth: 2,
                 num_locals: 1,
                 num_params: 0,
@@ -141,7 +141,7 @@ mod tests {
 
         assert_eq!(decoded.functions.len(), 1);
         assert_eq!(decoded.functions[0].function_id, FunctionId::INIT);
-        assert_eq!(decoded.functions[0].bytecode_length, 4);
+        assert_eq!(decoded.functions[0].code_length, 4);
         assert_eq!(decoded.functions[0].max_stack_depth, 2);
         assert_eq!(decoded.functions[0].num_locals, 1);
         assert_eq!(decoded.bytecode, vec![0x01, 0x00, 0x00, 0xB5]);
@@ -152,8 +152,8 @@ mod tests {
         let section = CodeSection {
             functions: vec![FuncEntry {
                 function_id: FunctionId::INIT,
-                bytecode_offset: 0,
-                bytecode_length: 0,
+                code_offset: 0,
+                code_length: 0,
                 max_stack_depth: 0,
                 num_locals: 0,
                 num_params: 0,

--- a/compiler/container/src/container_ref.rs
+++ b/compiler/container/src/container_ref.rs
@@ -237,14 +237,14 @@ impl<'a> ContainerRef<'a> {
         }
         let entry = &self.func_dir[entry_offset..entry_offset + FUNC_ENTRY_SIZE];
 
-        let bytecode_offset = u32::from_le_bytes([entry[2], entry[3], entry[4], entry[5]]) as usize;
-        let bytecode_length = u32::from_le_bytes([entry[6], entry[7], entry[8], entry[9]]) as usize;
+        let code_offset = u32::from_le_bytes([entry[2], entry[3], entry[4], entry[5]]) as usize;
+        let code_length = u32::from_le_bytes([entry[6], entry[7], entry[8], entry[9]]) as usize;
 
-        let end = bytecode_offset + bytecode_length;
+        let end = code_offset + code_length;
         if end > self.code_bytes.len() {
             return None;
         }
-        Some(&self.code_bytes[bytecode_offset..end])
+        Some(&self.code_bytes[code_offset..end])
     }
 
     /// Returns the number of tasks in the task table.
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn container_ref_get_function_bytecode_when_entry_length_exceeds_code_then_returns_none() {
-        // Tamper the function directory so the entry claims a bytecode_length
+        // Tamper the function directory so the entry claims a code_length
         // that runs past the end of code_bytes. from_slice validates the
         // outer section boundary but not individual func entries, so the
         // bounds check inside get_function_bytecode must catch it.
@@ -618,8 +618,8 @@ mod tests {
 
         let mut data = base.clone();
         // Function directory entry layout (16 bytes):
-        //   function_id(2) + bytecode_offset(4, at bytes 2..6)
-        //   + bytecode_length(4, at bytes 6..10) + ...
+        //   function_id(2) + code_offset(4, at bytes 2..6)
+        //   + code_length(4, at bytes 6..10) + ...
         let length_offset = code_start + 6;
         data[length_offset..length_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
 

--- a/compiler/project/src/disassemble.rs
+++ b/compiler/project/src/disassemble.rs
@@ -215,8 +215,8 @@ fn disassemble_functions(container: &Container) -> Value {
             let instructions = decode_instructions(bytecode, container);
             json!({
                 "id": func.function_id.raw(),
-                "bytecodeOffset": func.bytecode_offset,
-                "bytecodeLength": func.bytecode_length,
+                "bytecodeOffset": func.code_offset,
+                "bytecodeLength": func.code_length,
                 "maxStackDepth": func.max_stack_depth,
                 "numLocals": func.num_locals,
                 "instructions": instructions,


### PR DESCRIPTION
Pre-refactor for the cell-form change: decouple field naming from the unit (bytes vs cells) so the upcoming cell-form PR only has to change the unit, not the names.

https://claude.ai/code/session_019ToB4guPJh1YqMy2kAiN2w