### PR TITLE
Implement Located for ConstantKind, Variable, Expr, and ExprKind

### DIFF
--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -42,6 +42,22 @@ impl ConstantKind {
     }
 }
 
+impl Located for ConstantKind {
+    fn span(&self) -> SourceSpan {
+        match self {
+            ConstantKind::IntegerLiteral(lit) => lit.value.value.span(),
+            ConstantKind::BitStringLiteral(lit) => lit.value.span(),
+            ConstantKind::RealLiteral(_)
+            | ConstantKind::Boolean(_)
+            | ConstantKind::CharacterString(_)
+            | ConstantKind::Duration(_)
+            | ConstantKind::TimeOfDay(_)
+            | ConstantKind::Date(_)
+            | ConstantKind::DateAndTime(_) => SourceSpan::default(),
+        }
+    }
+}
+
 impl fmt::Display for ConstantKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -105,6 +105,15 @@ impl Located for SymbolicVariableKind {
     }
 }
 
+impl Located for Variable {
+    fn span(&self) -> SourceSpan {
+        match self {
+            Variable::Direct(addr) => addr.position.clone(),
+            Variable::Symbolic(sym) => sym.span(),
+        }
+    }
+}
+
 impl Variable {
     pub fn named(name: &str) -> Variable {
         Variable::Symbolic(SymbolicVariableKind::Named(NamedVariable {
@@ -399,6 +408,31 @@ impl Expr {
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.kind)
+    }
+}
+
+impl Located for Expr {
+    fn span(&self) -> SourceSpan {
+        self.kind.span()
+    }
+}
+
+impl Located for ExprKind {
+    fn span(&self) -> SourceSpan {
+        match self {
+            ExprKind::Compare(expr) => SourceSpan::join(&expr.left.span(), &expr.right.span()),
+            ExprKind::BinaryOp(expr) => SourceSpan::join(&expr.left.span(), &expr.right.span()),
+            ExprKind::UnaryOp(expr) => expr.term.span(),
+            ExprKind::Expression(inner) => inner.span(),
+            ExprKind::Const(constant) => constant.span(),
+            ExprKind::EnumeratedValue(value) => value.span(),
+            ExprKind::Variable(var) => var.span(),
+            ExprKind::Function(func) => func.name.span(),
+            ExprKind::LateBound(late) => late.value.span(),
+            ExprKind::Ref(var) => var.span(),
+            ExprKind::Deref(expr) => expr.span(),
+            ExprKind::Null(span) => span.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
Extends location tracking to expression-level AST nodes, complementing the statement-level Located impls added in #1017.

ConstantKind delegates to its inner literal's span where one is available (IntegerLiteral via SignedInteger.value, BitStringLiteral via its Integer value); other variants return SourceSpan::default() since they lack explicit source positions in the AST.

Variable returns the AddressAssignment position for Direct variants and delegates to SymbolicVariableKind for Symbolic variants.

Expr delegates to its kind. ExprKind joins operand spans for Compare and BinaryOp, delegates to inner nodes for the unary/wrapping variants, and returns the stored span for Null.

Salvaged from PR #1020.