### PR TITLE
split codegen tests into wire-format guards + behavioural assertions

### DIFF
--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -751,7 +751,17 @@ mod tests {
         em.emit_load_const_i32(0);
         em.emit_store_var_i32(VarIndex::new(0));
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::STORE_VAR_I32, 0x00, 0x00]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::STORE_VAR_I32,
+                0x00,
+                0x00
+            ]
+        );
     }
 
     #[test]
@@ -761,7 +771,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_add_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::ADD_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::ADD_I32
+            ]
+        );
     }
 
     #[test]
@@ -771,7 +792,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_sub_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::SUB_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::SUB_I32
+            ]
+        );
     }
 
     #[test]
@@ -793,7 +825,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_mul_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::MUL_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::MUL_I32
+            ]
+        );
     }
 
     #[test]
@@ -815,7 +858,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_div_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::DIV_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::DIV_I32
+            ]
+        );
     }
 
     #[test]
@@ -837,7 +891,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_mod_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::MOD_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::MOD_I32
+            ]
+        );
     }
 
     #[test]
@@ -858,7 +923,10 @@ mod tests {
         em.emit_load_var_i32(VarIndex::new(0));
         em.emit_neg_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::NEG_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::NEG_I32]
+        );
     }
 
     #[test]
@@ -915,7 +983,17 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_CONST pool:1, BUILTIN 0x0340
         assert_eq!(
             em.bytecode(),
-            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BUILTIN, 0x40, 0x03]
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::BUILTIN,
+                0x40,
+                0x03
+            ]
         );
     }
 
@@ -962,7 +1040,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_eq_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::EQ_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::EQ_I32
+            ]
+        );
     }
 
     #[test]
@@ -984,7 +1073,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_ne_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::NE_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::NE_I32
+            ]
+        );
     }
 
     #[test]
@@ -1006,7 +1106,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_lt_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::LT_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::LT_I32
+            ]
+        );
     }
 
     #[test]
@@ -1028,7 +1139,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_le_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::LE_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::LE_I32
+            ]
+        );
     }
 
     #[test]
@@ -1050,7 +1172,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_gt_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::GT_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::GT_I32
+            ]
+        );
     }
 
     #[test]
@@ -1072,7 +1205,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_ge_i32();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::GE_I32]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::GE_I32
+            ]
+        );
     }
 
     #[test]
@@ -1094,7 +1238,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_bool_and();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BOOL_AND]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::BOOL_AND
+            ]
+        );
     }
 
     #[test]
@@ -1115,7 +1270,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_bool_or();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BOOL_OR]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::BOOL_OR
+            ]
+        );
     }
 
     #[test]
@@ -1136,7 +1302,18 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_bool_xor();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BOOL_XOR]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::BOOL_XOR
+            ]
+        );
     }
 
     #[test]
@@ -1156,7 +1333,10 @@ mod tests {
         em.emit_load_var_i32(VarIndex::new(0));
         em.emit_bool_not();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::BOOL_NOT]);
+        assert_eq!(
+            em.bytecode(),
+            &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::BOOL_NOT]
+        );
     }
 
     #[test]
@@ -1237,7 +1417,17 @@ mod tests {
         em.bind_label(label);
 
         // LOAD_CONST_I32 pool:0, JMP_IF_NOT offset:0
-        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::JMP_IF_NOT, 0x00, 0x00]);
+        assert_eq!(
+            em.bytecode(),
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::JMP_IF_NOT,
+                0x00,
+                0x00
+            ]
+        );
     }
 
     #[test]
@@ -1261,7 +1451,19 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_CONST pool:1, CALL func:2 var_offset:5
         assert_eq!(
             em.bytecode(),
-            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::CALL, 0x02, 0x00, 0x05, 0x00]
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::CALL,
+                0x02,
+                0x00,
+                0x05,
+                0x00
+            ]
         );
     }
 
@@ -1282,7 +1484,10 @@ mod tests {
         em.emit_load_var_i32(VarIndex::new(0));
         em.emit_ret();
 
-        assert_eq!(em.bytecode(), &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::RET]);
+        assert_eq!(
+            em.bytecode(),
+            &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::RET]
+        );
     }
 
     #[test]
@@ -1295,7 +1500,10 @@ mod tests {
         em.bind_label(label);
 
         // JMP offset should be 3 (skip over the LOAD_CONST_I32 which is 3 bytes)
-        assert_eq!(em.bytecode(), &[opcode::JMP, 0x03, 0x00, opcode::LOAD_CONST_I32, 0x00, 0x00]);
+        assert_eq!(
+            em.bytecode(),
+            &[opcode::JMP, 0x03, 0x00, opcode::LOAD_CONST_I32, 0x00, 0x00]
+        );
     }
 
     #[test]
@@ -1307,7 +1515,16 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_ARRAY var:3 desc:7
         assert_eq!(
             em.bytecode(),
-            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_ARRAY, 0x03, 0x00, 0x07, 0x00]
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_ARRAY,
+                0x03,
+                0x00,
+                0x07,
+                0x00
+            ]
         );
     }
 
@@ -1331,7 +1548,19 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_CONST pool:1, STORE_ARRAY var:5 desc:2
         assert_eq!(
             em.bytecode(),
-            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::STORE_ARRAY, 0x05, 0x00, 0x02, 0x00]
+            &[
+                opcode::LOAD_CONST_I32,
+                0x00,
+                0x00,
+                opcode::LOAD_CONST_I32,
+                0x01,
+                0x00,
+                opcode::STORE_ARRAY,
+                0x05,
+                0x00,
+                0x02,
+                0x00
+            ]
         );
     }
 

--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -733,7 +733,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_load_const_i32(0);
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00]);
     }
 
     #[test]
@@ -741,7 +741,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_load_var_i32(VarIndex::new(1));
 
-        assert_eq!(em.bytecode(), &[0x0C, 0x01, 0x00]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_VAR_I32, 0x01, 0x00]);
     }
 
     #[test]
@@ -751,7 +751,7 @@ mod tests {
         em.emit_load_const_i32(0);
         em.emit_store_var_i32(VarIndex::new(0));
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x10, 0x00, 0x00]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::STORE_VAR_I32, 0x00, 0x00]);
     }
 
     #[test]
@@ -761,7 +761,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_add_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x20]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::ADD_I32]);
     }
 
     #[test]
@@ -771,7 +771,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_sub_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x24]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::SUB_I32]);
     }
 
     #[test]
@@ -793,7 +793,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_mul_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x28]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::MUL_I32]);
     }
 
     #[test]
@@ -815,7 +815,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_div_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x30]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::DIV_I32]);
     }
 
     #[test]
@@ -837,7 +837,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_mod_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x38]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::MOD_I32]);
     }
 
     #[test]
@@ -858,7 +858,7 @@ mod tests {
         em.emit_load_var_i32(VarIndex::new(0));
         em.emit_neg_i32();
 
-        assert_eq!(em.bytecode(), &[0x0C, 0x00, 0x00, 0x2C]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::NEG_I32]);
     }
 
     #[test]
@@ -877,7 +877,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_ret_void();
 
-        assert_eq!(em.bytecode(), &[0x8C]);
+        assert_eq!(em.bytecode(), &[opcode::RET_VOID]);
     }
 
     #[test]
@@ -902,7 +902,7 @@ mod tests {
         em.emit_load_const_i32(256);
 
         // 256 in little-endian u16 is [0x00, 0x01]
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x01]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x01]);
     }
 
     #[test]
@@ -915,7 +915,7 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_CONST pool:1, BUILTIN 0x0340
         assert_eq!(
             em.bytecode(),
-            &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x94, 0x40, 0x03]
+            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BUILTIN, 0x40, 0x03]
         );
     }
 
@@ -962,7 +962,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_eq_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x40]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::EQ_I32]);
     }
 
     #[test]
@@ -984,7 +984,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_ne_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x44]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::NE_I32]);
     }
 
     #[test]
@@ -1006,7 +1006,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_lt_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x48]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::LT_I32]);
     }
 
     #[test]
@@ -1028,7 +1028,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_le_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x4C]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::LE_I32]);
     }
 
     #[test]
@@ -1050,7 +1050,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_gt_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x50]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::GT_I32]);
     }
 
     #[test]
@@ -1072,7 +1072,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_ge_i32();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x54]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::GE_I32]);
     }
 
     #[test]
@@ -1094,7 +1094,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_bool_and();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x78]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BOOL_AND]);
     }
 
     #[test]
@@ -1115,7 +1115,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_bool_or();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x79]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BOOL_OR]);
     }
 
     #[test]
@@ -1136,7 +1136,7 @@ mod tests {
         em.emit_load_const_i32(1);
         em.emit_bool_xor();
 
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x7A]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::BOOL_XOR]);
     }
 
     #[test]
@@ -1156,7 +1156,7 @@ mod tests {
         em.emit_load_var_i32(VarIndex::new(0));
         em.emit_bool_not();
 
-        assert_eq!(em.bytecode(), &[0x0C, 0x00, 0x00, 0x7B]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::BOOL_NOT]);
     }
 
     #[test]
@@ -1175,7 +1175,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_load_true();
 
-        assert_eq!(em.bytecode(), &[0x05]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_TRUE]);
     }
 
     #[test]
@@ -1192,7 +1192,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_load_false();
 
-        assert_eq!(em.bytecode(), &[0x04]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_FALSE]);
     }
 
     #[test]
@@ -1212,7 +1212,7 @@ mod tests {
         em.bind_label(label);
 
         // JMP with offset 0 (target is immediately after the instruction)
-        assert_eq!(em.bytecode(), &[0x7C, 0x00, 0x00]);
+        assert_eq!(em.bytecode(), &[opcode::JMP, 0x00, 0x00]);
     }
 
     #[test]
@@ -1237,7 +1237,7 @@ mod tests {
         em.bind_label(label);
 
         // LOAD_CONST_I32 pool:0, JMP_IF_NOT offset:0
-        assert_eq!(em.bytecode(), &[0x00, 0x00, 0x00, 0x80, 0x00, 0x00]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::JMP_IF_NOT, 0x00, 0x00]);
     }
 
     #[test]
@@ -1261,7 +1261,7 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_CONST pool:1, CALL func:2 var_offset:5
         assert_eq!(
             em.bytecode(),
-            &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x84, 0x02, 0x00, 0x05, 0x00]
+            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::CALL, 0x02, 0x00, 0x05, 0x00]
         );
     }
 
@@ -1282,7 +1282,7 @@ mod tests {
         em.emit_load_var_i32(VarIndex::new(0));
         em.emit_ret();
 
-        assert_eq!(em.bytecode(), &[0x0C, 0x00, 0x00, 0x88]);
+        assert_eq!(em.bytecode(), &[opcode::LOAD_VAR_I32, 0x00, 0x00, opcode::RET]);
     }
 
     #[test]
@@ -1295,7 +1295,7 @@ mod tests {
         em.bind_label(label);
 
         // JMP offset should be 3 (skip over the LOAD_CONST_I32 which is 3 bytes)
-        assert_eq!(em.bytecode(), &[0x7C, 0x03, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(em.bytecode(), &[opcode::JMP, 0x03, 0x00, opcode::LOAD_CONST_I32, 0x00, 0x00]);
     }
 
     #[test]
@@ -1307,7 +1307,7 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_ARRAY var:3 desc:7
         assert_eq!(
             em.bytecode(),
-            &[0x00, 0x00, 0x00, 0xA8, 0x03, 0x00, 0x07, 0x00]
+            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_ARRAY, 0x03, 0x00, 0x07, 0x00]
         );
     }
 
@@ -1331,7 +1331,7 @@ mod tests {
         // LOAD_CONST pool:0, LOAD_CONST pool:1, STORE_ARRAY var:5 desc:2
         assert_eq!(
             em.bytecode(),
-            &[0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0xAC, 0x05, 0x00, 0x02, 0x00]
+            &[opcode::LOAD_CONST_I32, 0x00, 0x00, opcode::LOAD_CONST_I32, 0x01, 0x00, opcode::STORE_ARRAY, 0x05, 0x00, 0x02, 0x00]
         );
     }
 
@@ -1350,7 +1350,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_dup();
 
-        assert_eq!(em.bytecode(), &[0x91]);
+        assert_eq!(em.bytecode(), &[opcode::DUP]);
         assert_eq!(em.max_stack_depth(), 1);
     }
 
@@ -1359,7 +1359,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_swap();
 
-        assert_eq!(em.bytecode(), &[0x92]);
+        assert_eq!(em.bytecode(), &[opcode::SWAP]);
         assert_eq!(em.max_stack_depth(), 0);
     }
 

--- a/compiler/codegen/tests/common/mod.rs
+++ b/compiler/codegen/tests/common/mod.rs
@@ -40,95 +40,261 @@ pub mod bc {
         vec![op]
     }
 
-    pub fn add_i32() -> Vec<u8> { op1(opcode::ADD_I32) }
-    pub fn add_i64() -> Vec<u8> { op1(opcode::ADD_I64) }
-    pub fn add_f32() -> Vec<u8> { op1(opcode::ADD_F32) }
-    pub fn add_f64() -> Vec<u8> { op1(opcode::ADD_F64) }
-    pub fn sub_i32() -> Vec<u8> { op1(opcode::SUB_I32) }
-    pub fn sub_i64() -> Vec<u8> { op1(opcode::SUB_I64) }
-    pub fn sub_f32() -> Vec<u8> { op1(opcode::SUB_F32) }
-    pub fn sub_f64() -> Vec<u8> { op1(opcode::SUB_F64) }
-    pub fn mul_i32() -> Vec<u8> { op1(opcode::MUL_I32) }
-    pub fn mul_i64() -> Vec<u8> { op1(opcode::MUL_I64) }
-    pub fn mul_f32() -> Vec<u8> { op1(opcode::MUL_F32) }
-    pub fn mul_f64() -> Vec<u8> { op1(opcode::MUL_F64) }
-    pub fn div_i32() -> Vec<u8> { op1(opcode::DIV_I32) }
-    pub fn div_i64() -> Vec<u8> { op1(opcode::DIV_I64) }
-    pub fn div_f32() -> Vec<u8> { op1(opcode::DIV_F32) }
-    pub fn div_f64() -> Vec<u8> { op1(opcode::DIV_F64) }
-    pub fn div_u32() -> Vec<u8> { op1(opcode::DIV_U32) }
-    pub fn div_u64() -> Vec<u8> { op1(opcode::DIV_U64) }
-    pub fn mod_i32() -> Vec<u8> { op1(opcode::MOD_I32) }
-    pub fn mod_i64() -> Vec<u8> { op1(opcode::MOD_I64) }
-    pub fn mod_u32() -> Vec<u8> { op1(opcode::MOD_U32) }
-    pub fn mod_u64() -> Vec<u8> { op1(opcode::MOD_U64) }
-    pub fn neg_i32() -> Vec<u8> { op1(opcode::NEG_I32) }
-    pub fn neg_i64() -> Vec<u8> { op1(opcode::NEG_I64) }
-    pub fn neg_f32() -> Vec<u8> { op1(opcode::NEG_F32) }
-    pub fn neg_f64() -> Vec<u8> { op1(opcode::NEG_F64) }
+    pub fn add_i32() -> Vec<u8> {
+        op1(opcode::ADD_I32)
+    }
+    pub fn add_i64() -> Vec<u8> {
+        op1(opcode::ADD_I64)
+    }
+    pub fn add_f32() -> Vec<u8> {
+        op1(opcode::ADD_F32)
+    }
+    pub fn add_f64() -> Vec<u8> {
+        op1(opcode::ADD_F64)
+    }
+    pub fn sub_i32() -> Vec<u8> {
+        op1(opcode::SUB_I32)
+    }
+    pub fn sub_i64() -> Vec<u8> {
+        op1(opcode::SUB_I64)
+    }
+    pub fn sub_f32() -> Vec<u8> {
+        op1(opcode::SUB_F32)
+    }
+    pub fn sub_f64() -> Vec<u8> {
+        op1(opcode::SUB_F64)
+    }
+    pub fn mul_i32() -> Vec<u8> {
+        op1(opcode::MUL_I32)
+    }
+    pub fn mul_i64() -> Vec<u8> {
+        op1(opcode::MUL_I64)
+    }
+    pub fn mul_f32() -> Vec<u8> {
+        op1(opcode::MUL_F32)
+    }
+    pub fn mul_f64() -> Vec<u8> {
+        op1(opcode::MUL_F64)
+    }
+    pub fn div_i32() -> Vec<u8> {
+        op1(opcode::DIV_I32)
+    }
+    pub fn div_i64() -> Vec<u8> {
+        op1(opcode::DIV_I64)
+    }
+    pub fn div_f32() -> Vec<u8> {
+        op1(opcode::DIV_F32)
+    }
+    pub fn div_f64() -> Vec<u8> {
+        op1(opcode::DIV_F64)
+    }
+    pub fn div_u32() -> Vec<u8> {
+        op1(opcode::DIV_U32)
+    }
+    pub fn div_u64() -> Vec<u8> {
+        op1(opcode::DIV_U64)
+    }
+    pub fn mod_i32() -> Vec<u8> {
+        op1(opcode::MOD_I32)
+    }
+    pub fn mod_i64() -> Vec<u8> {
+        op1(opcode::MOD_I64)
+    }
+    pub fn mod_u32() -> Vec<u8> {
+        op1(opcode::MOD_U32)
+    }
+    pub fn mod_u64() -> Vec<u8> {
+        op1(opcode::MOD_U64)
+    }
+    pub fn neg_i32() -> Vec<u8> {
+        op1(opcode::NEG_I32)
+    }
+    pub fn neg_i64() -> Vec<u8> {
+        op1(opcode::NEG_I64)
+    }
+    pub fn neg_f32() -> Vec<u8> {
+        op1(opcode::NEG_F32)
+    }
+    pub fn neg_f64() -> Vec<u8> {
+        op1(opcode::NEG_F64)
+    }
 
-    pub fn eq_i32() -> Vec<u8> { op1(opcode::EQ_I32) }
-    pub fn eq_i64() -> Vec<u8> { op1(opcode::EQ_I64) }
-    pub fn eq_f32() -> Vec<u8> { op1(opcode::EQ_F32) }
-    pub fn eq_f64() -> Vec<u8> { op1(opcode::EQ_F64) }
-    pub fn ne_i32() -> Vec<u8> { op1(opcode::NE_I32) }
-    pub fn ne_i64() -> Vec<u8> { op1(opcode::NE_I64) }
-    pub fn ne_f32() -> Vec<u8> { op1(opcode::NE_F32) }
-    pub fn ne_f64() -> Vec<u8> { op1(opcode::NE_F64) }
-    pub fn lt_i32() -> Vec<u8> { op1(opcode::LT_I32) }
-    pub fn lt_i64() -> Vec<u8> { op1(opcode::LT_I64) }
-    pub fn lt_f32() -> Vec<u8> { op1(opcode::LT_F32) }
-    pub fn lt_f64() -> Vec<u8> { op1(opcode::LT_F64) }
-    pub fn lt_u32() -> Vec<u8> { op1(opcode::LT_U32) }
-    pub fn lt_u64() -> Vec<u8> { op1(opcode::LT_U64) }
-    pub fn le_i32() -> Vec<u8> { op1(opcode::LE_I32) }
-    pub fn le_i64() -> Vec<u8> { op1(opcode::LE_I64) }
-    pub fn le_f32() -> Vec<u8> { op1(opcode::LE_F32) }
-    pub fn le_f64() -> Vec<u8> { op1(opcode::LE_F64) }
-    pub fn le_u32() -> Vec<u8> { op1(opcode::LE_U32) }
-    pub fn le_u64() -> Vec<u8> { op1(opcode::LE_U64) }
-    pub fn gt_i32() -> Vec<u8> { op1(opcode::GT_I32) }
-    pub fn gt_i64() -> Vec<u8> { op1(opcode::GT_I64) }
-    pub fn gt_f32() -> Vec<u8> { op1(opcode::GT_F32) }
-    pub fn gt_f64() -> Vec<u8> { op1(opcode::GT_F64) }
-    pub fn gt_u32() -> Vec<u8> { op1(opcode::GT_U32) }
-    pub fn gt_u64() -> Vec<u8> { op1(opcode::GT_U64) }
-    pub fn ge_i32() -> Vec<u8> { op1(opcode::GE_I32) }
-    pub fn ge_i64() -> Vec<u8> { op1(opcode::GE_I64) }
-    pub fn ge_f32() -> Vec<u8> { op1(opcode::GE_F32) }
-    pub fn ge_f64() -> Vec<u8> { op1(opcode::GE_F64) }
-    pub fn ge_u32() -> Vec<u8> { op1(opcode::GE_U32) }
-    pub fn ge_u64() -> Vec<u8> { op1(opcode::GE_U64) }
+    pub fn eq_i32() -> Vec<u8> {
+        op1(opcode::EQ_I32)
+    }
+    pub fn eq_i64() -> Vec<u8> {
+        op1(opcode::EQ_I64)
+    }
+    pub fn eq_f32() -> Vec<u8> {
+        op1(opcode::EQ_F32)
+    }
+    pub fn eq_f64() -> Vec<u8> {
+        op1(opcode::EQ_F64)
+    }
+    pub fn ne_i32() -> Vec<u8> {
+        op1(opcode::NE_I32)
+    }
+    pub fn ne_i64() -> Vec<u8> {
+        op1(opcode::NE_I64)
+    }
+    pub fn ne_f32() -> Vec<u8> {
+        op1(opcode::NE_F32)
+    }
+    pub fn ne_f64() -> Vec<u8> {
+        op1(opcode::NE_F64)
+    }
+    pub fn lt_i32() -> Vec<u8> {
+        op1(opcode::LT_I32)
+    }
+    pub fn lt_i64() -> Vec<u8> {
+        op1(opcode::LT_I64)
+    }
+    pub fn lt_f32() -> Vec<u8> {
+        op1(opcode::LT_F32)
+    }
+    pub fn lt_f64() -> Vec<u8> {
+        op1(opcode::LT_F64)
+    }
+    pub fn lt_u32() -> Vec<u8> {
+        op1(opcode::LT_U32)
+    }
+    pub fn lt_u64() -> Vec<u8> {
+        op1(opcode::LT_U64)
+    }
+    pub fn le_i32() -> Vec<u8> {
+        op1(opcode::LE_I32)
+    }
+    pub fn le_i64() -> Vec<u8> {
+        op1(opcode::LE_I64)
+    }
+    pub fn le_f32() -> Vec<u8> {
+        op1(opcode::LE_F32)
+    }
+    pub fn le_f64() -> Vec<u8> {
+        op1(opcode::LE_F64)
+    }
+    pub fn le_u32() -> Vec<u8> {
+        op1(opcode::LE_U32)
+    }
+    pub fn le_u64() -> Vec<u8> {
+        op1(opcode::LE_U64)
+    }
+    pub fn gt_i32() -> Vec<u8> {
+        op1(opcode::GT_I32)
+    }
+    pub fn gt_i64() -> Vec<u8> {
+        op1(opcode::GT_I64)
+    }
+    pub fn gt_f32() -> Vec<u8> {
+        op1(opcode::GT_F32)
+    }
+    pub fn gt_f64() -> Vec<u8> {
+        op1(opcode::GT_F64)
+    }
+    pub fn gt_u32() -> Vec<u8> {
+        op1(opcode::GT_U32)
+    }
+    pub fn gt_u64() -> Vec<u8> {
+        op1(opcode::GT_U64)
+    }
+    pub fn ge_i32() -> Vec<u8> {
+        op1(opcode::GE_I32)
+    }
+    pub fn ge_i64() -> Vec<u8> {
+        op1(opcode::GE_I64)
+    }
+    pub fn ge_f32() -> Vec<u8> {
+        op1(opcode::GE_F32)
+    }
+    pub fn ge_f64() -> Vec<u8> {
+        op1(opcode::GE_F64)
+    }
+    pub fn ge_u32() -> Vec<u8> {
+        op1(opcode::GE_U32)
+    }
+    pub fn ge_u64() -> Vec<u8> {
+        op1(opcode::GE_U64)
+    }
 
-    pub fn bool_and() -> Vec<u8> { op1(opcode::BOOL_AND) }
-    pub fn bool_or() -> Vec<u8> { op1(opcode::BOOL_OR) }
-    pub fn bool_xor() -> Vec<u8> { op1(opcode::BOOL_XOR) }
-    pub fn bool_not() -> Vec<u8> { op1(opcode::BOOL_NOT) }
+    pub fn bool_and() -> Vec<u8> {
+        op1(opcode::BOOL_AND)
+    }
+    pub fn bool_or() -> Vec<u8> {
+        op1(opcode::BOOL_OR)
+    }
+    pub fn bool_xor() -> Vec<u8> {
+        op1(opcode::BOOL_XOR)
+    }
+    pub fn bool_not() -> Vec<u8> {
+        op1(opcode::BOOL_NOT)
+    }
 
-    pub fn bit_and_32() -> Vec<u8> { op1(opcode::BIT_AND_32) }
-    pub fn bit_and_64() -> Vec<u8> { op1(opcode::BIT_AND_64) }
-    pub fn bit_or_32() -> Vec<u8> { op1(opcode::BIT_OR_32) }
-    pub fn bit_or_64() -> Vec<u8> { op1(opcode::BIT_OR_64) }
-    pub fn bit_xor_32() -> Vec<u8> { op1(opcode::BIT_XOR_32) }
-    pub fn bit_xor_64() -> Vec<u8> { op1(opcode::BIT_XOR_64) }
-    pub fn bit_not_32() -> Vec<u8> { op1(opcode::BIT_NOT_32) }
-    pub fn bit_not_64() -> Vec<u8> { op1(opcode::BIT_NOT_64) }
+    pub fn bit_and_32() -> Vec<u8> {
+        op1(opcode::BIT_AND_32)
+    }
+    pub fn bit_and_64() -> Vec<u8> {
+        op1(opcode::BIT_AND_64)
+    }
+    pub fn bit_or_32() -> Vec<u8> {
+        op1(opcode::BIT_OR_32)
+    }
+    pub fn bit_or_64() -> Vec<u8> {
+        op1(opcode::BIT_OR_64)
+    }
+    pub fn bit_xor_32() -> Vec<u8> {
+        op1(opcode::BIT_XOR_32)
+    }
+    pub fn bit_xor_64() -> Vec<u8> {
+        op1(opcode::BIT_XOR_64)
+    }
+    pub fn bit_not_32() -> Vec<u8> {
+        op1(opcode::BIT_NOT_32)
+    }
+    pub fn bit_not_64() -> Vec<u8> {
+        op1(opcode::BIT_NOT_64)
+    }
 
-    pub fn trunc_i8() -> Vec<u8> { op1(opcode::TRUNC_I8) }
-    pub fn trunc_u8() -> Vec<u8> { op1(opcode::TRUNC_U8) }
-    pub fn trunc_i16() -> Vec<u8> { op1(opcode::TRUNC_I16) }
-    pub fn trunc_u16() -> Vec<u8> { op1(opcode::TRUNC_U16) }
+    pub fn trunc_i8() -> Vec<u8> {
+        op1(opcode::TRUNC_I8)
+    }
+    pub fn trunc_u8() -> Vec<u8> {
+        op1(opcode::TRUNC_U8)
+    }
+    pub fn trunc_i16() -> Vec<u8> {
+        op1(opcode::TRUNC_I16)
+    }
+    pub fn trunc_u16() -> Vec<u8> {
+        op1(opcode::TRUNC_U16)
+    }
 
-    pub fn load_true() -> Vec<u8> { op1(opcode::LOAD_TRUE) }
-    pub fn load_false() -> Vec<u8> { op1(opcode::LOAD_FALSE) }
-    pub fn load_indirect() -> Vec<u8> { op1(opcode::LOAD_INDIRECT) }
-    pub fn store_indirect() -> Vec<u8> { op1(opcode::STORE_INDIRECT) }
+    pub fn load_true() -> Vec<u8> {
+        op1(opcode::LOAD_TRUE)
+    }
+    pub fn load_false() -> Vec<u8> {
+        op1(opcode::LOAD_FALSE)
+    }
+    pub fn load_indirect() -> Vec<u8> {
+        op1(opcode::LOAD_INDIRECT)
+    }
+    pub fn store_indirect() -> Vec<u8> {
+        op1(opcode::STORE_INDIRECT)
+    }
 
-    pub fn pop() -> Vec<u8> { op1(opcode::POP) }
-    pub fn dup() -> Vec<u8> { op1(opcode::DUP) }
-    pub fn swap() -> Vec<u8> { op1(opcode::SWAP) }
-    pub fn ret() -> Vec<u8> { op1(opcode::RET) }
-    pub fn ret_void() -> Vec<u8> { op1(opcode::RET_VOID) }
+    pub fn pop() -> Vec<u8> {
+        op1(opcode::POP)
+    }
+    pub fn dup() -> Vec<u8> {
+        op1(opcode::DUP)
+    }
+    pub fn swap() -> Vec<u8> {
+        op1(opcode::SWAP)
+    }
+    pub fn ret() -> Vec<u8> {
+        op1(opcode::RET)
+    }
+    pub fn ret_void() -> Vec<u8> {
+        op1(opcode::RET_VOID)
+    }
 
     // --- 3-byte instructions: opcode + LE u16 operand. --------------------
 
@@ -138,27 +304,63 @@ pub mod bc {
         vec![op, b[0], b[1]]
     }
 
-    pub fn load_const_i32(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_I32, pool_index) }
-    pub fn load_const_i64(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_I64, pool_index) }
-    pub fn load_const_f32(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_F32, pool_index) }
-    pub fn load_const_f64(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_F64, pool_index) }
-    pub fn load_const_str(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_STR, pool_index) }
+    pub fn load_const_i32(pool_index: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_CONST_I32, pool_index)
+    }
+    pub fn load_const_i64(pool_index: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_CONST_I64, pool_index)
+    }
+    pub fn load_const_f32(pool_index: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_CONST_F32, pool_index)
+    }
+    pub fn load_const_f64(pool_index: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_CONST_F64, pool_index)
+    }
+    pub fn load_const_str(pool_index: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_CONST_STR, pool_index)
+    }
 
-    pub fn load_var_i32(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_I32, idx) }
-    pub fn load_var_i64(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_I64, idx) }
-    pub fn load_var_f32(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_F32, idx) }
-    pub fn load_var_f64(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_F64, idx) }
-    pub fn store_var_i32(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_I32, idx) }
-    pub fn store_var_i64(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_I64, idx) }
-    pub fn store_var_f32(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_F32, idx) }
-    pub fn store_var_f64(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_F64, idx) }
+    pub fn load_var_i32(idx: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_VAR_I32, idx)
+    }
+    pub fn load_var_i64(idx: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_VAR_I64, idx)
+    }
+    pub fn load_var_f32(idx: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_VAR_F32, idx)
+    }
+    pub fn load_var_f64(idx: u16) -> Vec<u8> {
+        op_u16(opcode::LOAD_VAR_F64, idx)
+    }
+    pub fn store_var_i32(idx: u16) -> Vec<u8> {
+        op_u16(opcode::STORE_VAR_I32, idx)
+    }
+    pub fn store_var_i64(idx: u16) -> Vec<u8> {
+        op_u16(opcode::STORE_VAR_I64, idx)
+    }
+    pub fn store_var_f32(idx: u16) -> Vec<u8> {
+        op_u16(opcode::STORE_VAR_F32, idx)
+    }
+    pub fn store_var_f64(idx: u16) -> Vec<u8> {
+        op_u16(opcode::STORE_VAR_F64, idx)
+    }
 
-    pub fn load_var_i32_idx(idx: VarIndex) -> Vec<u8> { op_u16(opcode::LOAD_VAR_I32, idx.raw()) }
-    pub fn store_var_i32_idx(idx: VarIndex) -> Vec<u8> { op_u16(opcode::STORE_VAR_I32, idx.raw()) }
+    pub fn load_var_i32_idx(idx: VarIndex) -> Vec<u8> {
+        op_u16(opcode::LOAD_VAR_I32, idx.raw())
+    }
+    pub fn store_var_i32_idx(idx: VarIndex) -> Vec<u8> {
+        op_u16(opcode::STORE_VAR_I32, idx.raw())
+    }
 
-    pub fn fb_load_instance(idx: u16) -> Vec<u8> { op_u16(opcode::FB_LOAD_INSTANCE, idx) }
-    pub fn fb_call(type_id: u16) -> Vec<u8> { op_u16(opcode::FB_CALL, type_id) }
-    pub fn builtin(func_id: u16) -> Vec<u8> { op_u16(opcode::BUILTIN, func_id) }
+    pub fn fb_load_instance(idx: u16) -> Vec<u8> {
+        op_u16(opcode::FB_LOAD_INSTANCE, idx)
+    }
+    pub fn fb_call(type_id: u16) -> Vec<u8> {
+        op_u16(opcode::FB_CALL, type_id)
+    }
+    pub fn builtin(func_id: u16) -> Vec<u8> {
+        op_u16(opcode::BUILTIN, func_id)
+    }
 
     /// JMP with signed i16 offset (relative, in bytes, from the byte
     /// after the operand).
@@ -222,13 +424,27 @@ pub mod bc {
         vec![op, b[0], b[1], b[2], b[3]]
     }
 
-    pub fn str_load_var(data_offset: u32) -> Vec<u8> { op_u32(opcode::STR_LOAD_VAR, data_offset) }
-    pub fn str_store_var(data_offset: u32) -> Vec<u8> { op_u32(opcode::STR_STORE_VAR, data_offset) }
-    pub fn len_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::LEN_STR, data_offset) }
-    pub fn delete_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::DELETE_STR, data_offset) }
-    pub fn left_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::LEFT_STR, data_offset) }
-    pub fn right_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::RIGHT_STR, data_offset) }
-    pub fn mid_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::MID_STR, data_offset) }
+    pub fn str_load_var(data_offset: u32) -> Vec<u8> {
+        op_u32(opcode::STR_LOAD_VAR, data_offset)
+    }
+    pub fn str_store_var(data_offset: u32) -> Vec<u8> {
+        op_u32(opcode::STR_STORE_VAR, data_offset)
+    }
+    pub fn len_str(data_offset: u32) -> Vec<u8> {
+        op_u32(opcode::LEN_STR, data_offset)
+    }
+    pub fn delete_str(data_offset: u32) -> Vec<u8> {
+        op_u32(opcode::DELETE_STR, data_offset)
+    }
+    pub fn left_str(data_offset: u32) -> Vec<u8> {
+        op_u32(opcode::LEFT_STR, data_offset)
+    }
+    pub fn right_str(data_offset: u32) -> Vec<u8> {
+        op_u32(opcode::RIGHT_STR, data_offset)
+    }
+    pub fn mid_str(data_offset: u32) -> Vec<u8> {
+        op_u32(opcode::MID_STR, data_offset)
+    }
 
     // --- 7-byte instruction: opcode + u32 + u16. --------------------------
 
@@ -246,10 +462,18 @@ pub mod bc {
         vec![op, ab[0], ab[1], ab[2], ab[3], bb[0], bb[1], bb[2], bb[3]]
     }
 
-    pub fn find_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::FIND_STR, in1, in2) }
-    pub fn replace_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::REPLACE_STR, in1, in2) }
-    pub fn insert_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::INSERT_STR, in1, in2) }
-    pub fn concat_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::CONCAT_STR, in1, in2) }
+    pub fn find_str(in1: u32, in2: u32) -> Vec<u8> {
+        op_u32_u32(opcode::FIND_STR, in1, in2)
+    }
+    pub fn replace_str(in1: u32, in2: u32) -> Vec<u8> {
+        op_u32_u32(opcode::REPLACE_STR, in1, in2)
+    }
+    pub fn insert_str(in1: u32, in2: u32) -> Vec<u8> {
+        op_u32_u32(opcode::INSERT_STR, in1, in2)
+    }
+    pub fn concat_str(in1: u32, in2: u32) -> Vec<u8> {
+        op_u32_u32(opcode::CONCAT_STR, in1, in2)
+    }
 }
 
 /// Asserts that `actual` matches the given expected sequence of

--- a/compiler/codegen/tests/common/mod.rs
+++ b/compiler/codegen/tests/common/mod.rs
@@ -16,6 +16,284 @@ use ironplc_vm::test_support::load_and_start;
 use ironplc_vm::FaultContext;
 pub use ironplc_vm::VmBuffers;
 
+/// Per-instruction bytecode builders.
+///
+/// Each function returns the encoded byte sequence for one
+/// instruction. Use these inside [`assert_bytecode!`] to write
+/// expected sequences at the **opcode-name level** without smearing
+/// raw byte values across each test. When the wire encoding changes
+/// (e.g. an opcode is renumbered, or the instruction format itself
+/// migrates), only this module needs to update — every test that
+/// uses `assert_bytecode!` continues to work.
+///
+/// Wire-format guarantees (opcode byte values, operand widths,
+/// little-endian encoding) are pinned in `tests/wire_format.rs`. The
+/// helpers here just delegate to those constants.
+pub mod bc {
+    use ironplc_container::opcode;
+    use ironplc_container::VarIndex;
+
+    // --- 1-byte instructions (opcode only). -------------------------------
+
+    /// 1-byte instruction with no operand.
+    fn op1(op: u8) -> Vec<u8> {
+        vec![op]
+    }
+
+    pub fn add_i32() -> Vec<u8> { op1(opcode::ADD_I32) }
+    pub fn add_i64() -> Vec<u8> { op1(opcode::ADD_I64) }
+    pub fn add_f32() -> Vec<u8> { op1(opcode::ADD_F32) }
+    pub fn add_f64() -> Vec<u8> { op1(opcode::ADD_F64) }
+    pub fn sub_i32() -> Vec<u8> { op1(opcode::SUB_I32) }
+    pub fn sub_i64() -> Vec<u8> { op1(opcode::SUB_I64) }
+    pub fn sub_f32() -> Vec<u8> { op1(opcode::SUB_F32) }
+    pub fn sub_f64() -> Vec<u8> { op1(opcode::SUB_F64) }
+    pub fn mul_i32() -> Vec<u8> { op1(opcode::MUL_I32) }
+    pub fn mul_i64() -> Vec<u8> { op1(opcode::MUL_I64) }
+    pub fn mul_f32() -> Vec<u8> { op1(opcode::MUL_F32) }
+    pub fn mul_f64() -> Vec<u8> { op1(opcode::MUL_F64) }
+    pub fn div_i32() -> Vec<u8> { op1(opcode::DIV_I32) }
+    pub fn div_i64() -> Vec<u8> { op1(opcode::DIV_I64) }
+    pub fn div_f32() -> Vec<u8> { op1(opcode::DIV_F32) }
+    pub fn div_f64() -> Vec<u8> { op1(opcode::DIV_F64) }
+    pub fn div_u32() -> Vec<u8> { op1(opcode::DIV_U32) }
+    pub fn div_u64() -> Vec<u8> { op1(opcode::DIV_U64) }
+    pub fn mod_i32() -> Vec<u8> { op1(opcode::MOD_I32) }
+    pub fn mod_i64() -> Vec<u8> { op1(opcode::MOD_I64) }
+    pub fn mod_u32() -> Vec<u8> { op1(opcode::MOD_U32) }
+    pub fn mod_u64() -> Vec<u8> { op1(opcode::MOD_U64) }
+    pub fn neg_i32() -> Vec<u8> { op1(opcode::NEG_I32) }
+    pub fn neg_i64() -> Vec<u8> { op1(opcode::NEG_I64) }
+    pub fn neg_f32() -> Vec<u8> { op1(opcode::NEG_F32) }
+    pub fn neg_f64() -> Vec<u8> { op1(opcode::NEG_F64) }
+
+    pub fn eq_i32() -> Vec<u8> { op1(opcode::EQ_I32) }
+    pub fn eq_i64() -> Vec<u8> { op1(opcode::EQ_I64) }
+    pub fn eq_f32() -> Vec<u8> { op1(opcode::EQ_F32) }
+    pub fn eq_f64() -> Vec<u8> { op1(opcode::EQ_F64) }
+    pub fn ne_i32() -> Vec<u8> { op1(opcode::NE_I32) }
+    pub fn ne_i64() -> Vec<u8> { op1(opcode::NE_I64) }
+    pub fn ne_f32() -> Vec<u8> { op1(opcode::NE_F32) }
+    pub fn ne_f64() -> Vec<u8> { op1(opcode::NE_F64) }
+    pub fn lt_i32() -> Vec<u8> { op1(opcode::LT_I32) }
+    pub fn lt_i64() -> Vec<u8> { op1(opcode::LT_I64) }
+    pub fn lt_f32() -> Vec<u8> { op1(opcode::LT_F32) }
+    pub fn lt_f64() -> Vec<u8> { op1(opcode::LT_F64) }
+    pub fn lt_u32() -> Vec<u8> { op1(opcode::LT_U32) }
+    pub fn lt_u64() -> Vec<u8> { op1(opcode::LT_U64) }
+    pub fn le_i32() -> Vec<u8> { op1(opcode::LE_I32) }
+    pub fn le_i64() -> Vec<u8> { op1(opcode::LE_I64) }
+    pub fn le_f32() -> Vec<u8> { op1(opcode::LE_F32) }
+    pub fn le_f64() -> Vec<u8> { op1(opcode::LE_F64) }
+    pub fn le_u32() -> Vec<u8> { op1(opcode::LE_U32) }
+    pub fn le_u64() -> Vec<u8> { op1(opcode::LE_U64) }
+    pub fn gt_i32() -> Vec<u8> { op1(opcode::GT_I32) }
+    pub fn gt_i64() -> Vec<u8> { op1(opcode::GT_I64) }
+    pub fn gt_f32() -> Vec<u8> { op1(opcode::GT_F32) }
+    pub fn gt_f64() -> Vec<u8> { op1(opcode::GT_F64) }
+    pub fn gt_u32() -> Vec<u8> { op1(opcode::GT_U32) }
+    pub fn gt_u64() -> Vec<u8> { op1(opcode::GT_U64) }
+    pub fn ge_i32() -> Vec<u8> { op1(opcode::GE_I32) }
+    pub fn ge_i64() -> Vec<u8> { op1(opcode::GE_I64) }
+    pub fn ge_f32() -> Vec<u8> { op1(opcode::GE_F32) }
+    pub fn ge_f64() -> Vec<u8> { op1(opcode::GE_F64) }
+    pub fn ge_u32() -> Vec<u8> { op1(opcode::GE_U32) }
+    pub fn ge_u64() -> Vec<u8> { op1(opcode::GE_U64) }
+
+    pub fn bool_and() -> Vec<u8> { op1(opcode::BOOL_AND) }
+    pub fn bool_or() -> Vec<u8> { op1(opcode::BOOL_OR) }
+    pub fn bool_xor() -> Vec<u8> { op1(opcode::BOOL_XOR) }
+    pub fn bool_not() -> Vec<u8> { op1(opcode::BOOL_NOT) }
+
+    pub fn bit_and_32() -> Vec<u8> { op1(opcode::BIT_AND_32) }
+    pub fn bit_and_64() -> Vec<u8> { op1(opcode::BIT_AND_64) }
+    pub fn bit_or_32() -> Vec<u8> { op1(opcode::BIT_OR_32) }
+    pub fn bit_or_64() -> Vec<u8> { op1(opcode::BIT_OR_64) }
+    pub fn bit_xor_32() -> Vec<u8> { op1(opcode::BIT_XOR_32) }
+    pub fn bit_xor_64() -> Vec<u8> { op1(opcode::BIT_XOR_64) }
+    pub fn bit_not_32() -> Vec<u8> { op1(opcode::BIT_NOT_32) }
+    pub fn bit_not_64() -> Vec<u8> { op1(opcode::BIT_NOT_64) }
+
+    pub fn trunc_i8() -> Vec<u8> { op1(opcode::TRUNC_I8) }
+    pub fn trunc_u8() -> Vec<u8> { op1(opcode::TRUNC_U8) }
+    pub fn trunc_i16() -> Vec<u8> { op1(opcode::TRUNC_I16) }
+    pub fn trunc_u16() -> Vec<u8> { op1(opcode::TRUNC_U16) }
+
+    pub fn load_true() -> Vec<u8> { op1(opcode::LOAD_TRUE) }
+    pub fn load_false() -> Vec<u8> { op1(opcode::LOAD_FALSE) }
+    pub fn load_indirect() -> Vec<u8> { op1(opcode::LOAD_INDIRECT) }
+    pub fn store_indirect() -> Vec<u8> { op1(opcode::STORE_INDIRECT) }
+
+    pub fn pop() -> Vec<u8> { op1(opcode::POP) }
+    pub fn dup() -> Vec<u8> { op1(opcode::DUP) }
+    pub fn swap() -> Vec<u8> { op1(opcode::SWAP) }
+    pub fn ret() -> Vec<u8> { op1(opcode::RET) }
+    pub fn ret_void() -> Vec<u8> { op1(opcode::RET_VOID) }
+
+    // --- 3-byte instructions: opcode + LE u16 operand. --------------------
+
+    /// 3-byte instruction with a u16 little-endian operand.
+    fn op_u16(op: u8, value: u16) -> Vec<u8> {
+        let b = value.to_le_bytes();
+        vec![op, b[0], b[1]]
+    }
+
+    pub fn load_const_i32(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_I32, pool_index) }
+    pub fn load_const_i64(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_I64, pool_index) }
+    pub fn load_const_f32(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_F32, pool_index) }
+    pub fn load_const_f64(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_F64, pool_index) }
+    pub fn load_const_str(pool_index: u16) -> Vec<u8> { op_u16(opcode::LOAD_CONST_STR, pool_index) }
+
+    pub fn load_var_i32(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_I32, idx) }
+    pub fn load_var_i64(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_I64, idx) }
+    pub fn load_var_f32(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_F32, idx) }
+    pub fn load_var_f64(idx: u16) -> Vec<u8> { op_u16(opcode::LOAD_VAR_F64, idx) }
+    pub fn store_var_i32(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_I32, idx) }
+    pub fn store_var_i64(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_I64, idx) }
+    pub fn store_var_f32(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_F32, idx) }
+    pub fn store_var_f64(idx: u16) -> Vec<u8> { op_u16(opcode::STORE_VAR_F64, idx) }
+
+    pub fn load_var_i32_idx(idx: VarIndex) -> Vec<u8> { op_u16(opcode::LOAD_VAR_I32, idx.raw()) }
+    pub fn store_var_i32_idx(idx: VarIndex) -> Vec<u8> { op_u16(opcode::STORE_VAR_I32, idx.raw()) }
+
+    pub fn fb_load_instance(idx: u16) -> Vec<u8> { op_u16(opcode::FB_LOAD_INSTANCE, idx) }
+    pub fn fb_call(type_id: u16) -> Vec<u8> { op_u16(opcode::FB_CALL, type_id) }
+    pub fn builtin(func_id: u16) -> Vec<u8> { op_u16(opcode::BUILTIN, func_id) }
+
+    /// JMP with signed i16 offset (relative, in bytes, from the byte
+    /// after the operand).
+    pub fn jmp(offset: i16) -> Vec<u8> {
+        let b = offset.to_le_bytes();
+        vec![opcode::JMP, b[0], b[1]]
+    }
+
+    /// JMP_IF_NOT with signed i16 offset.
+    pub fn jmp_if_not(offset: i16) -> Vec<u8> {
+        let b = offset.to_le_bytes();
+        vec![opcode::JMP_IF_NOT, b[0], b[1]]
+    }
+
+    // --- 2-byte instructions: opcode + u8 operand. ------------------------
+
+    pub fn fb_store_param(field: u8) -> Vec<u8> {
+        vec![opcode::FB_STORE_PARAM, field]
+    }
+    pub fn fb_load_param(field: u8) -> Vec<u8> {
+        vec![opcode::FB_LOAD_PARAM, field]
+    }
+
+    // --- 5-byte instructions: opcode + u16 + u16. -------------------------
+
+    fn op_u16_u16(op: u8, a: u16, b: u16) -> Vec<u8> {
+        let ab = a.to_le_bytes();
+        let bb = b.to_le_bytes();
+        vec![op, ab[0], ab[1], bb[0], bb[1]]
+    }
+
+    pub fn call(func_id: u16, var_offset: u16) -> Vec<u8> {
+        op_u16_u16(opcode::CALL, func_id, var_offset)
+    }
+    pub fn load_array(var_idx: u16, desc_idx: u16) -> Vec<u8> {
+        op_u16_u16(opcode::LOAD_ARRAY, var_idx, desc_idx)
+    }
+    pub fn store_array(var_idx: u16, desc_idx: u16) -> Vec<u8> {
+        op_u16_u16(opcode::STORE_ARRAY, var_idx, desc_idx)
+    }
+    pub fn load_array_deref(ref_idx: u16, desc_idx: u16) -> Vec<u8> {
+        op_u16_u16(opcode::LOAD_ARRAY_DEREF, ref_idx, desc_idx)
+    }
+    pub fn store_array_deref(ref_idx: u16, desc_idx: u16) -> Vec<u8> {
+        op_u16_u16(opcode::STORE_ARRAY_DEREF, ref_idx, desc_idx)
+    }
+    pub fn str_init_array(var_idx: u16, desc_idx: u16) -> Vec<u8> {
+        op_u16_u16(opcode::STR_INIT_ARRAY, var_idx, desc_idx)
+    }
+    pub fn str_load_array_elem(var_idx: u16, desc_idx: u16) -> Vec<u8> {
+        op_u16_u16(opcode::STR_LOAD_ARRAY_ELEM, var_idx, desc_idx)
+    }
+    pub fn str_store_array_elem(var_idx: u16, desc_idx: u16) -> Vec<u8> {
+        op_u16_u16(opcode::STR_STORE_ARRAY_ELEM, var_idx, desc_idx)
+    }
+
+    // --- 5-byte instructions: opcode + u32. -------------------------------
+
+    fn op_u32(op: u8, value: u32) -> Vec<u8> {
+        let b = value.to_le_bytes();
+        vec![op, b[0], b[1], b[2], b[3]]
+    }
+
+    pub fn str_load_var(data_offset: u32) -> Vec<u8> { op_u32(opcode::STR_LOAD_VAR, data_offset) }
+    pub fn str_store_var(data_offset: u32) -> Vec<u8> { op_u32(opcode::STR_STORE_VAR, data_offset) }
+    pub fn len_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::LEN_STR, data_offset) }
+    pub fn delete_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::DELETE_STR, data_offset) }
+    pub fn left_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::LEFT_STR, data_offset) }
+    pub fn right_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::RIGHT_STR, data_offset) }
+    pub fn mid_str(data_offset: u32) -> Vec<u8> { op_u32(opcode::MID_STR, data_offset) }
+
+    // --- 7-byte instruction: opcode + u32 + u16. --------------------------
+
+    pub fn str_init(data_offset: u32, max_length: u16) -> Vec<u8> {
+        let d = data_offset.to_le_bytes();
+        let m = max_length.to_le_bytes();
+        vec![opcode::STR_INIT, d[0], d[1], d[2], d[3], m[0], m[1]]
+    }
+
+    // --- 9-byte instructions: opcode + u32 + u32. -------------------------
+
+    fn op_u32_u32(op: u8, a: u32, b: u32) -> Vec<u8> {
+        let ab = a.to_le_bytes();
+        let bb = b.to_le_bytes();
+        vec![op, ab[0], ab[1], ab[2], ab[3], bb[0], bb[1], bb[2], bb[3]]
+    }
+
+    pub fn find_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::FIND_STR, in1, in2) }
+    pub fn replace_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::REPLACE_STR, in1, in2) }
+    pub fn insert_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::INSERT_STR, in1, in2) }
+    pub fn concat_str(in1: u32, in2: u32) -> Vec<u8> { op_u32_u32(opcode::CONCAT_STR, in1, in2) }
+}
+
+/// Asserts that `actual` matches the given expected sequence of
+/// instruction-encoded byte vectors.
+///
+/// Each item in the list returns a `Vec<u8>` (typically from a
+/// helper in [`bc`]); this macro concatenates them and compares
+/// with the actual byte slice.
+///
+/// On mismatch, both sides are formatted as hex byte sequences so
+/// the failing offset is visible. Wire-format guarantees (opcode
+/// byte values, operand widths, endianness) are pinned in
+/// `tests/wire_format.rs` — failures here surface *behavioural*
+/// drift (codegen emitted wrong opcodes, wrong order, wrong
+/// operands), not encoding drift.
+///
+/// Example:
+///
+/// ```ignore
+/// use common::bc;
+///
+/// assert_bytecode!(actual, [
+///     bc::load_var_i32(0),
+///     bc::load_const_i32(0),
+///     bc::gt_i32(),
+///     bc::jmp_if_not(13),
+///     bc::ret_void(),
+/// ]);
+/// ```
+macro_rules! assert_bytecode {
+    ($actual:expr, [ $($expr:expr),* $(,)? ]) => {{
+        let mut __expected: Vec<u8> = Vec::new();
+        $( __expected.extend($expr); )*
+        let __actual: &[u8] = $actual;
+        if __actual != __expected.as_slice() {
+            panic!(
+                "\nbytecode mismatch:\n  actual ({} bytes):   {:02X?}\n  expected ({} bytes): {:02X?}\n",
+                __actual.len(), __actual,
+                __expected.len(), __expected,
+            );
+        }
+    }};
+}
+
 /// Parses an IEC 61131-3 source string and runs type resolution via the analyzer.
 ///
 /// The analyzer populates `Expr.resolved_type` and resolves type aliases in

--- a/compiler/codegen/tests/compile_abs.rs
+++ b/compiler/codegen/tests/compile_abs.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the ABS function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_abs_function_then_produces_builtin_bytecode() {
@@ -35,15 +37,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x94, 0x43, 0x03, // BUILTIN ABS_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::builtin(opcode::builtin::ABS_I32),  // ABS_I32
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_abs.rs
+++ b/compiler/codegen/tests/compile_abs.rs
@@ -37,12 +37,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::builtin(opcode::builtin::ABS_I32),  // ABS_I32
-            bc::store_var_i32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                 // pool:0
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_i32(0),                  // var:0
+            bc::builtin(opcode::builtin::ABS_I32), // ABS_I32
+            bc::store_var_i32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_abs_float.rs
+++ b/compiler/codegen/tests/compile_abs_float.rs
@@ -28,14 +28,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_f32(0),  // var:0
-            bc::builtin(opcode::builtin::ABS_F32),  // ABS_F32
-            bc::store_var_f32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f32(0),                 // pool:0
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_f32(0),                  // var:0
+            bc::builtin(opcode::builtin::ABS_F32), // ABS_F32
+            bc::store_var_f32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -59,12 +62,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f64(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_f64(0),  // var:0
-            bc::builtin(opcode::builtin::ABS_F64),  // ABS_F64
-            bc::store_var_f64(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f64(0),                 // pool:0
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_f64(0),                  // var:0
+            bc::builtin(opcode::builtin::ABS_F64), // ABS_F64
+            bc::store_var_f64(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_abs_float.rs
+++ b/compiler/codegen/tests/compile_abs_float.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the ABS function with float types.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_abs_real_then_produces_abs_f32_bytecode() {
@@ -26,17 +28,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x02, 0x00, 0x00, // LOAD_CONST_F32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x12, 0x00, 0x00, // STORE_VAR_F32 var:0
-            0x94, 0x54, 0x03, // BUILTIN ABS_F32
-            0x12, 0x01, 0x00, // STORE_VAR_F32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_f32(0),  // var:0
+            bc::builtin(opcode::builtin::ABS_F32),  // ABS_F32
+            bc::store_var_f32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -60,15 +59,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x03, 0x00, 0x00, // LOAD_CONST_F64 pool:0
-            0x91, // DUP (store-load optimization)
-            0x13, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0x94, 0x55, 0x03, // BUILTIN ABS_F64
-            0x13, 0x01, 0x00, // STORE_VAR_F64 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f64(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_f64(0),  // var:0
+            bc::builtin(opcode::builtin::ABS_F64),  // ABS_F64
+            bc::store_var_f64(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_add.rs
+++ b/compiler/codegen/tests/compile_add.rs
@@ -43,15 +43,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::add_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -80,11 +83,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (6)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (6)
             bc::store_var_i32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -104,11 +110,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (12)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (12)
             bc::store_var_i32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -128,9 +137,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (14)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (14)
             bc::store_var_i32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_add.rs
+++ b/compiler/codegen/tests/compile_add.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for the ADD operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_add_expression_then_produces_add_bytecode() {
@@ -42,18 +43,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x20, // ADD_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::add_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -82,14 +80,11 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (6)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (6)
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -109,14 +104,11 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (12)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (12)
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -136,12 +128,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (14)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (14)
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_array.rs
+++ b/compiler/codegen/tests/compile_array.rs
@@ -100,8 +100,14 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // Should contain LOAD_VAR for i, LOAD_CONST_I64 (lower bound 1), SUB_I64, LOAD_ARRAY
-    assert!(bytecode.contains(&opcode::SUB_I64), "SUB_I64 not found in bytecode");
-    assert!(bytecode.contains(&opcode::LOAD_ARRAY), "LOAD_ARRAY not found in bytecode");
+    assert!(
+        bytecode.contains(&opcode::SUB_I64),
+        "SUB_I64 not found in bytecode"
+    );
+    assert!(
+        bytecode.contains(&opcode::LOAD_ARRAY),
+        "LOAD_ARRAY not found in bytecode"
+    );
 }
 
 #[test]
@@ -121,7 +127,10 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert!(bytecode.contains(&opcode::SUB_I64), "SUB_I64 not found in bytecode");
+    assert!(
+        bytecode.contains(&opcode::SUB_I64),
+        "SUB_I64 not found in bytecode"
+    );
     assert!(
         bytecode.contains(&opcode::STORE_ARRAY),
         "STORE_ARRAY not found in bytecode"
@@ -311,7 +320,10 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(0))
         .unwrap();
-    let store_count = init_bytecode.iter().filter(|&&b| b == opcode::STORE_ARRAY).count();
+    let store_count = init_bytecode
+        .iter()
+        .filter(|&&b| b == opcode::STORE_ARRAY)
+        .count();
     assert_eq!(
         store_count, 3,
         "Expected 3 STORE_ARRAY in init for 3 initial values"
@@ -333,7 +345,10 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(0))
         .unwrap();
-    let store_count = init_bytecode.iter().filter(|&&b| b == opcode::STORE_ARRAY).count();
+    let store_count = init_bytecode
+        .iter()
+        .filter(|&&b| b == opcode::STORE_ARRAY)
+        .count();
     assert_eq!(
         store_count, 6,
         "Expected 6 STORE_ARRAY in init for 3(10), 3(20)"

--- a/compiler/codegen/tests/compile_array.rs
+++ b/compiler/codegen/tests/compile_array.rs
@@ -1,6 +1,7 @@
 //! Bytecode-level integration tests for array compilation.
 
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
 use common::{parse_and_compile, try_parse_and_compile};
@@ -27,12 +28,12 @@ END_PROGRAM
     // Find the LOAD_ARRAY opcode
     let load_array_pos = bytecode
         .iter()
-        .position(|&b| b == 0xA8)
+        .position(|&b| b == opcode::LOAD_ARRAY)
         .expect("LOAD_ARRAY opcode not found");
     // Before LOAD_ARRAY should be LOAD_CONST_I32 with flat index 2
     assert!(load_array_pos >= 3);
     // Preceding byte should be LOAD_CONST_I32
-    assert_eq!(bytecode[load_array_pos - 3], 0x00);
+    assert_eq!(bytecode[load_array_pos - 3], opcode::LOAD_CONST_I32);
     // Verify the constant pool contains the flat index 2
     let const_idx =
         u16::from_le_bytes([bytecode[load_array_pos - 2], bytecode[load_array_pos - 1]]);
@@ -64,11 +65,11 @@ END_PROGRAM
     // Find the STORE_ARRAY opcode
     let store_array_pos = bytecode
         .iter()
-        .position(|&b| b == 0xAC)
+        .position(|&b| b == opcode::STORE_ARRAY)
         .expect("STORE_ARRAY opcode not found");
     // Before STORE_ARRAY should be LOAD_CONST_I32 with flat index 2
     assert!(store_array_pos >= 3);
-    assert_eq!(bytecode[store_array_pos - 3], 0x00); // LOAD_CONST_I32
+    assert_eq!(bytecode[store_array_pos - 3], opcode::LOAD_CONST_I32); // LOAD_CONST_I32
     let const_idx =
         u16::from_le_bytes([bytecode[store_array_pos - 2], bytecode[store_array_pos - 1]]);
     assert_eq!(
@@ -99,8 +100,8 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // Should contain LOAD_VAR for i, LOAD_CONST_I64 (lower bound 1), SUB_I64, LOAD_ARRAY
-    assert!(bytecode.contains(&0x25), "SUB_I64 not found in bytecode");
-    assert!(bytecode.contains(&0xA8), "LOAD_ARRAY not found in bytecode");
+    assert!(bytecode.contains(&opcode::SUB_I64), "SUB_I64 not found in bytecode");
+    assert!(bytecode.contains(&opcode::LOAD_ARRAY), "LOAD_ARRAY not found in bytecode");
 }
 
 #[test]
@@ -120,9 +121,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert!(bytecode.contains(&0x25), "SUB_I64 not found in bytecode");
+    assert!(bytecode.contains(&opcode::SUB_I64), "SUB_I64 not found in bytecode");
     assert!(
-        bytecode.contains(&0xAC),
+        bytecode.contains(&opcode::STORE_ARRAY),
         "STORE_ARRAY not found in bytecode"
     );
 }
@@ -148,10 +149,10 @@ END_PROGRAM
         .unwrap();
     let load_array_pos = bytecode
         .iter()
-        .position(|&b| b == 0xA8)
+        .position(|&b| b == opcode::LOAD_ARRAY)
         .expect("LOAD_ARRAY opcode not found");
     assert!(load_array_pos >= 3);
-    assert_eq!(bytecode[load_array_pos - 3], 0x00); // LOAD_CONST_I32
+    assert_eq!(bytecode[load_array_pos - 3], opcode::LOAD_CONST_I32); // LOAD_CONST_I32
     let const_idx =
         u16::from_le_bytes([bytecode[load_array_pos - 2], bytecode[load_array_pos - 1]]);
     assert_eq!(
@@ -183,10 +184,10 @@ END_PROGRAM
         .unwrap();
     let load_array_pos = bytecode
         .iter()
-        .position(|&b| b == 0xA8)
+        .position(|&b| b == opcode::LOAD_ARRAY)
         .expect("LOAD_ARRAY opcode not found");
     assert!(load_array_pos >= 3);
-    assert_eq!(bytecode[load_array_pos - 3], 0x00); // LOAD_CONST_I32
+    assert_eq!(bytecode[load_array_pos - 3], opcode::LOAD_CONST_I32); // LOAD_CONST_I32
     let const_idx =
         u16::from_le_bytes([bytecode[load_array_pos - 2], bytecode[load_array_pos - 1]]);
     assert_eq!(
@@ -253,11 +254,11 @@ END_PROGRAM
     // Should contain TRUNC_I8 (0x1C) before STORE_ARRAY (0xAC)
     let trunc_pos = bytecode
         .iter()
-        .position(|&b| b == 0x1C)
+        .position(|&b| b == opcode::TRUNC_I8)
         .expect("TRUNC_I8 not found");
     let store_pos = bytecode
         .iter()
-        .position(|&b| b == 0xAC)
+        .position(|&b| b == opcode::STORE_ARRAY)
         .expect("STORE_ARRAY not found");
     assert!(
         trunc_pos < store_pos,
@@ -286,7 +287,7 @@ END_PROGRAM
     // the LOAD_ARRAY and the STORE_VAR (truncation happens at store-to-var, not load-from-array)
     let load_array_pos = bytecode
         .iter()
-        .position(|&b| b == 0xA8)
+        .position(|&b| b == opcode::LOAD_ARRAY)
         .expect("LOAD_ARRAY not found");
     // The TRUNC should appear after LOAD_ARRAY (for the final STORE_VAR), not before it.
     // There may or may not be a TRUNC — the key is LOAD_ARRAY itself doesn't truncate.
@@ -310,7 +311,7 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(0))
         .unwrap();
-    let store_count = init_bytecode.iter().filter(|&&b| b == 0xAC).count();
+    let store_count = init_bytecode.iter().filter(|&&b| b == opcode::STORE_ARRAY).count();
     assert_eq!(
         store_count, 3,
         "Expected 3 STORE_ARRAY in init for 3 initial values"
@@ -332,7 +333,7 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(0))
         .unwrap();
-    let store_count = init_bytecode.iter().filter(|&&b| b == 0xAC).count();
+    let store_count = init_bytecode.iter().filter(|&&b| b == opcode::STORE_ARRAY).count();
     assert_eq!(
         store_count, 6,
         "Expected 6 STORE_ARRAY in init for 3(10), 3(20)"

--- a/compiler/codegen/tests/compile_bitwise.rs
+++ b/compiler/codegen/tests/compile_bitwise.rs
@@ -30,14 +30,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (0x0F)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (0x0F)
             bc::bit_and_32(),
             bc::trunc_u8(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -64,14 +67,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0), // var:0
             bc::bit_not_32(),
-            bc::trunc_u8(),  // (inline NOT truncation)
-            bc::trunc_u8(),  // (assignment truncation)
-            bc::store_var_i32(1),  // var:1
+            bc::trunc_u8(),       // (inline NOT truncation)
+            bc::trunc_u8(),       // (assignment truncation)
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -93,15 +99,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (0)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (0)
             bc::gt_i32(),
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (10)
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(1), // pool:1 (10)
             bc::lt_i32(),
-            bc::bool_and(),  // (not BIT_AND_32)
-            bc::store_var_i32(1),  // var:1
+            bc::bool_and(),       // (not BIT_AND_32)
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_bitwise.rs
+++ b/compiler/codegen/tests/compile_bitwise.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for bitwise operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_byte_and_then_produces_bit_and_32_bytecode() {
@@ -29,17 +30,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x0F)
-            0x68, // BIT_AND_32
-            0x1D, // TRUNC_U8
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (0x0F)
+            bc::bit_and_32(),
+            bc::trunc_u8(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -66,17 +64,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x74, // BIT_NOT_32
-            0x1D, // TRUNC_U8 (inline NOT truncation)
-            0x1D, // TRUNC_U8 (assignment truncation)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::bit_not_32(),
+            bc::trunc_u8(),  // (inline NOT truncation)
+            bc::trunc_u8(),  // (assignment truncation)
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -98,18 +93,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
-            0x50, // GT_I32
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (10)
-            0x48, // LT_I32
-            0x78, // BOOL_AND (not BIT_AND_32)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (0)
+            bc::gt_i32(),
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (10)
+            bc::lt_i32(),
+            bc::bool_and(),  // (not BIT_AND_32)
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_bool.rs
+++ b/compiler/codegen/tests/compile_bool.rs
@@ -33,19 +33,22 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (10)
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (10)
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (0)
+            bc::load_const_i32(1), // pool:1 (0)
             bc::gt_i32(),
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (10)
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (10)
             bc::lt_i32(),
             bc::bool_and(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -66,19 +69,22 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (10)
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (10)
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (0)
+            bc::load_const_i32(1), // pool:1 (0)
             bc::gt_i32(),
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (10)
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (10)
             bc::lt_i32(),
             bc::bool_or(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -99,19 +105,22 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (10)
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (10)
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (0)
+            bc::load_const_i32(1), // pool:1 (0)
             bc::gt_i32(),
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (10)
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (10)
             bc::lt_i32(),
             bc::bool_xor(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -135,14 +144,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (10)
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (10)
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
             bc::bool_not(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -163,11 +175,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
+    assert_bytecode!(
+        bytecode,
+        [
             bc::load_true(),
-            bc::store_var_i32(0),  // var:0
+            bc::store_var_i32(0), // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -188,9 +203,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
+    assert_bytecode!(
+        bytecode,
+        [
             bc::load_false(),
-            bc::store_var_i32(0),  // var:0
+            bc::store_var_i32(0), // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_bool.rs
+++ b/compiler/codegen/tests/compile_bool.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for boolean operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_and_expression_then_produces_bool_and_bytecode() {
@@ -32,22 +33,19 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (0)
-            0x50, // GT_I32
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x48, // LT_I32
-            0x78, // BOOL_AND
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (0)
+            bc::gt_i32(),
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::lt_i32(),
+            bc::bool_and(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -68,22 +66,19 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (0)
-            0x50, // GT_I32
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x48, // LT_I32
-            0x79, // BOOL_OR
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (0)
+            bc::gt_i32(),
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::lt_i32(),
+            bc::bool_or(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -104,22 +99,19 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (0)
-            0x50, // GT_I32
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x48, // LT_I32
-            0x7A, // BOOL_XOR
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (0)
+            bc::gt_i32(),
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::lt_i32(),
+            bc::bool_xor(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -143,17 +135,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x7B, // BOOL_NOT
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::bool_not(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -174,14 +163,11 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x05, // LOAD_TRUE
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_true(),
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -202,12 +188,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x04, // LOAD_FALSE
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_false(),
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_case.rs
+++ b/compiler/codegen/tests/compile_case.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for CASE statement compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_case_single_arm_then_produces_eq_and_jmp() {
@@ -36,19 +37,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x40, // EQ_I32
-            0x80, 0x09, 0x00, // JMP_IF_NOT offset:+9
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (10)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x7C, 0x00, 0x00, // JMP offset:+0 (end_label is right here)
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (1)
+            bc::eq_i32(),
+            bc::jmp_if_not(9),  // offset:+9
+            bc::load_const_i32(1),  // pool:1 (10)
+            bc::store_var_i32(1),  // var:1
+            bc::jmp(0),  // offset:+0 (end_label is right here)
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -83,19 +81,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x40, // EQ_I32
-            0x80, 0x09, 0x00, // JMP_IF_NOT offset:+9
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (10)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x7C, 0x06, 0x00, // JMP offset:+6
-            0x00, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (99)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (1)
+            bc::eq_i32(),
+            bc::jmp_if_not(9),  // offset:+9
+            bc::load_const_i32(1),  // pool:1 (10)
+            bc::store_var_i32(1),  // var:1
+            bc::jmp(6),  // offset:+6
+            bc::load_const_i32(2),  // pool:2 (99)
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_case.rs
+++ b/compiler/codegen/tests/compile_case.rs
@@ -37,16 +37,19 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (1)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (1)
             bc::eq_i32(),
-            bc::jmp_if_not(9),  // offset:+9
-            bc::load_const_i32(1),  // pool:1 (10)
+            bc::jmp_if_not(9),     // offset:+9
+            bc::load_const_i32(1), // pool:1 (10)
             bc::store_var_i32(1),  // var:1
-            bc::jmp(0),  // offset:+0 (end_label is right here)
+            bc::jmp(0),            // offset:+0 (end_label is right here)
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -81,16 +84,19 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (1)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (1)
             bc::eq_i32(),
-            bc::jmp_if_not(9),  // offset:+9
-            bc::load_const_i32(1),  // pool:1 (10)
+            bc::jmp_if_not(9),     // offset:+9
+            bc::load_const_i32(1), // pool:1 (10)
             bc::store_var_i32(1),  // var:1
-            bc::jmp(6),  // offset:+6
-            bc::load_const_i32(2),  // pool:2 (99)
+            bc::jmp(6),            // offset:+6
+            bc::load_const_i32(2), // pool:2 (99)
             bc::store_var_i32(1),  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_cmp.rs
+++ b/compiler/codegen/tests/compile_cmp.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for comparison operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_eq_expression_then_produces_eq_bytecode() {
@@ -42,18 +43,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x40, // EQ_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::eq_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -74,18 +72,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x44, // NE_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::ne_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -106,18 +101,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x48, // LT_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::lt_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -138,18 +130,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x4C, // LE_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::le_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -170,18 +159,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x50, // GT_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::gt_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -202,16 +188,13 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x54, // GE_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::ge_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_cmp.rs
+++ b/compiler/codegen/tests/compile_cmp.rs
@@ -43,15 +43,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::eq_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -72,15 +75,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::ne_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -101,15 +107,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::lt_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -130,15 +139,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::le_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -159,15 +171,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::gt_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -188,13 +203,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::ge_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_dup.rs
+++ b/compiler/codegen/tests/compile_dup.rs
@@ -25,13 +25,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
-            bc::dup(),  // (consecutive identical load)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0), // var:0
+            bc::dup(),           // (consecutive identical load)
             bc::mul_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -53,13 +56,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (7)
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (7)
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
             bc::store_var_i32(1),  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -84,6 +90,14 @@ END_PROGRAM
         .unwrap();
     // The first STORE_VAR(i) then LOAD_VAR(i) should NOT be optimized
     // because there is a loop label between them.
-    assert_eq!(bytecode[3], opcode::STORE_VAR_I32, "expected STORE_VAR_I32, not DUP");
-    assert_eq!(bytecode[6], opcode::LOAD_VAR_I32, "expected LOAD_VAR_I32 after STORE");
+    assert_eq!(
+        bytecode[3],
+        opcode::STORE_VAR_I32,
+        "expected STORE_VAR_I32, not DUP"
+    );
+    assert_eq!(
+        bytecode[6],
+        opcode::LOAD_VAR_I32,
+        "expected LOAD_VAR_I32 after STORE"
+    );
 }

--- a/compiler/codegen/tests/compile_dup.rs
+++ b/compiler/codegen/tests/compile_dup.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for DUP and NOP peephole optimizations.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_same_var_twice_then_emits_dup() {
@@ -23,16 +25,13 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x91, // DUP (consecutive identical load)
-            0x28, // MUL_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::dup(),  // (consecutive identical load)
+            bc::mul_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -54,16 +53,13 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (7)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (7)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -88,6 +84,6 @@ END_PROGRAM
         .unwrap();
     // The first STORE_VAR(i) then LOAD_VAR(i) should NOT be optimized
     // because there is a loop label between them.
-    assert_eq!(bytecode[3], 0x10, "expected STORE_VAR_I32, not DUP");
-    assert_eq!(bytecode[6], 0x0C, "expected LOAD_VAR_I32 after STORE");
+    assert_eq!(bytecode[3], opcode::STORE_VAR_I32, "expected STORE_VAR_I32, not DUP");
+    assert_eq!(bytecode[6], opcode::LOAD_VAR_I32, "expected LOAD_VAR_I32 after STORE");
 }

--- a/compiler/codegen/tests/compile_exit_return.rs
+++ b/compiler/codegen/tests/compile_exit_return.rs
@@ -1,6 +1,7 @@
 //! Bytecode-level integration tests for EXIT and RETURN statement compilation.
 
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
 use common::parse_and_compile;
@@ -31,12 +32,12 @@ END_PROGRAM
         .unwrap();
 
     // EXIT produces a JMP at offset 4 targeting the same end label as JMP_IF_NOT
-    assert_eq!(bytecode[4], 0x7C); // JMP (from EXIT)
+    assert_eq!(bytecode[4], opcode::JMP); // JMP (from EXIT)
     let exit_offset = i16::from_le_bytes([bytecode[5], bytecode[6]]);
     assert_eq!(exit_offset, 3); // jumps forward 3 to offset 10 (end)
 
     // The end should be RET_VOID
-    assert_eq!(bytecode[10], 0x8C); // RET_VOID
+    assert_eq!(bytecode[10], opcode::RET_VOID);
 }
 
 #[test]
@@ -66,8 +67,8 @@ END_PROGRAM
         .unwrap();
 
     // RETURN produces RET_VOID at offset 6
-    assert_eq!(bytecode[6], 0x8C); // RET_VOID (from RETURN)
+    assert_eq!(bytecode[6], opcode::RET_VOID); // RET_VOID (from RETURN)
 
     // Program still ends with RET_VOID
-    assert_eq!(*bytecode.last().unwrap(), 0x8C); // RET_VOID (program end)
+    assert_eq!(*bytecode.last().unwrap(), opcode::RET_VOID);
 }

--- a/compiler/codegen/tests/compile_float.rs
+++ b/compiler/codegen/tests/compile_float.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for float type compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_real_then_produces_f32_opcodes() {
@@ -24,14 +25,11 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x02, 0x00, 0x00, // LOAD_CONST_F32 pool:0
-            0x12, 0x00, 0x00, // STORE_VAR_F32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f32(0),  // pool:0
+            bc::store_var_f32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -57,18 +55,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x03, 0x00, 0x00, // LOAD_CONST_F64 pool:0
-            0x91, // DUP (store-load optimization)
-            0x13, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0x03, 0x01, 0x00, // LOAD_CONST_F64 pool:1
-            0x23, // ADD_F64
-            0x13, 0x01, 0x00, // STORE_VAR_F64 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f64(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_f64(0),  // var:0
+            bc::load_const_f64(1),  // pool:1
+            bc::add_f64(),
+            bc::store_var_f64(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]

--- a/compiler/codegen/tests/compile_float.rs
+++ b/compiler/codegen/tests/compile_float.rs
@@ -25,11 +25,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f32(0),  // pool:0
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f32(0), // pool:0
             bc::store_var_f32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -55,15 +58,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f64(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f64(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_f64(0),  // var:0
-            bc::load_const_f64(1),  // pool:1
+            bc::load_const_f64(1), // pool:1
             bc::add_f64(),
-            bc::store_var_f64(1),  // var:1
+            bc::store_var_f64(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]

--- a/compiler/codegen/tests/compile_func_forms.rs
+++ b/compiler/codegen/tests/compile_func_forms.rs
@@ -6,10 +6,11 @@
 //! Note: NOT function form is not tested because the parser treats NOT(x) as
 //! unary NOT applied to parenthesized expression (x), which is semantically equivalent.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 /// Helper to build an IEC 61131-3 program that calls a two-arg function form.
 fn two_arg_program(func_name: &str, var_type: &str) -> String {
@@ -211,14 +212,11 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (10)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (10)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_func_forms.rs
+++ b/compiler/codegen/tests/compile_func_forms.rs
@@ -212,11 +212,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (10)
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (10)
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
             bc::store_var_i32(1),  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_if.rs
+++ b/compiler/codegen/tests/compile_if.rs
@@ -34,15 +34,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (0)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (0)
             bc::gt_i32(),
-            bc::jmp_if_not(6),  // offset:+6
-            bc::load_const_i32(1),  // pool:1 (1)
+            bc::jmp_if_not(6),     // offset:+6
+            bc::load_const_i32(1), // pool:1 (1)
             bc::store_var_i32(1),  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -77,18 +80,21 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(0),  // pool:0 (0)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // var:0
+            bc::load_const_i32(0), // pool:0 (0)
             bc::gt_i32(),
-            bc::jmp_if_not(9),  // offset:+9
-            bc::load_const_i32(1),  // pool:1 (1)
+            bc::jmp_if_not(9),     // offset:+9
+            bc::load_const_i32(1), // pool:1 (1)
             bc::store_var_i32(1),  // var:1
-            bc::jmp(6),  // offset:+6
-            bc::load_const_i32(2),  // pool:2 (2)
+            bc::jmp(6),            // offset:+6
+            bc::load_const_i32(2), // pool:2 (2)
             bc::store_var_i32(1),  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -132,23 +138,26 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_i32(0),  // var:0         (0)
-            bc::load_const_i32(0),  // pool:0 (5)  (3)
-            bc::gt_i32(),  // (6)
-            bc::jmp_if_not(9),  // offset:+9       (7)
-            bc::load_const_i32(1),  // pool:1 (1)  (10)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // var:0         (0)
+            bc::load_const_i32(0), // pool:0 (5)  (3)
+            bc::gt_i32(),          // (6)
+            bc::jmp_if_not(9),     // offset:+9       (7)
+            bc::load_const_i32(1), // pool:1 (1)  (10)
             bc::store_var_i32(1),  // var:1         (13)
-            bc::jmp(25),  // offset:+25              (16)
-            bc::load_var_i32(0),  // var:0         (19)
-            bc::load_const_i32(2),  // pool:2 (0)  (22)
-            bc::gt_i32(),  // (25)
-            bc::jmp_if_not(9),  // offset:+9       (26)
-            bc::load_const_i32(3),  // pool:3 (2)  (29)
+            bc::jmp(25),           // offset:+25              (16)
+            bc::load_var_i32(0),   // var:0         (19)
+            bc::load_const_i32(2), // pool:2 (0)  (22)
+            bc::gt_i32(),          // (25)
+            bc::jmp_if_not(9),     // offset:+9       (26)
+            bc::load_const_i32(3), // pool:3 (2)  (29)
             bc::store_var_i32(1),  // var:1         (32)
-            bc::jmp(6),  // offset:+6              (35)
-            bc::load_const_i32(4),  // pool:4 (3)  (38)
+            bc::jmp(6),            // offset:+6              (35)
+            bc::load_const_i32(4), // pool:4 (3)  (38)
             bc::store_var_i32(1),  // var:1         (41)
-            bc::ret_void(),  // (44)
-    ]);
+            bc::ret_void(),        // (44)
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_if.rs
+++ b/compiler/codegen/tests/compile_if.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for IF/ELSIF/ELSE compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_simple_if_then_produces_jmp_if_not() {
@@ -33,18 +34,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
-            0x50, // GT_I32
-            0x80, 0x06, 0x00, // JMP_IF_NOT offset:+6
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (0)
+            bc::gt_i32(),
+            bc::jmp_if_not(6),  // offset:+6
+            bc::load_const_i32(1),  // pool:1 (1)
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -79,21 +77,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
-            0x50, // GT_I32
-            0x80, 0x09, 0x00, // JMP_IF_NOT offset:+9
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x7C, 0x06, 0x00, // JMP offset:+6
-            0x00, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (2)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(0),  // pool:0 (0)
+            bc::gt_i32(),
+            bc::jmp_if_not(9),  // offset:+9
+            bc::load_const_i32(1),  // pool:1 (1)
+            bc::store_var_i32(1),  // var:1
+            bc::jmp(6),  // offset:+6
+            bc::load_const_i32(2),  // pool:2 (2)
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -137,26 +132,23 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0         (0)
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (5)  (3)
-            0x50, // GT_I32                      (6)
-            0x80, 0x09, 0x00, // JMP_IF_NOT offset:+9       (7)
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)  (10)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1         (13)
-            0x7C, 0x19, 0x00, // JMP offset:+25              (16)
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0         (19)
-            0x00, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (0)  (22)
-            0x50, // GT_I32                      (25)
-            0x80, 0x09, 0x00, // JMP_IF_NOT offset:+9       (26)
-            0x00, 0x03, 0x00, // LOAD_CONST_I32 pool:3 (2)  (29)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1         (32)
-            0x7C, 0x06, 0x00, // JMP offset:+6              (35)
-            0x00, 0x04, 0x00, // LOAD_CONST_I32 pool:4 (3)  (38)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1         (41)
-            0x8C, // RET_VOID                    (44)
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_i32(0),  // var:0         (0)
+            bc::load_const_i32(0),  // pool:0 (5)  (3)
+            bc::gt_i32(),  // (6)
+            bc::jmp_if_not(9),  // offset:+9       (7)
+            bc::load_const_i32(1),  // pool:1 (1)  (10)
+            bc::store_var_i32(1),  // var:1         (13)
+            bc::jmp(25),  // offset:+25              (16)
+            bc::load_var_i32(0),  // var:0         (19)
+            bc::load_const_i32(2),  // pool:2 (0)  (22)
+            bc::gt_i32(),  // (25)
+            bc::jmp_if_not(9),  // offset:+9       (26)
+            bc::load_const_i32(3),  // pool:3 (2)  (29)
+            bc::store_var_i32(1),  // var:1         (32)
+            bc::jmp(6),  // offset:+6              (35)
+            bc::load_const_i32(4),  // pool:4 (3)  (38)
+            bc::store_var_i32(1),  // var:1         (41)
+            bc::ret_void(),  // (44)
+    ]);
 }

--- a/compiler/codegen/tests/compile_limit.rs
+++ b/compiler/codegen/tests/compile_limit.rs
@@ -52,14 +52,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (5)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (0)
-            bc::load_var_i32(0),  // var:0
-            bc::load_const_i32(2),  // pool:2 (10)
-            bc::builtin(opcode::builtin::LIMIT_I32),  // LIMIT_I32
-            bc::store_var_i32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                   // pool:0 (5)
+            bc::store_var_i32(0),                    // var:0
+            bc::load_const_i32(1),                   // pool:1 (0)
+            bc::load_var_i32(0),                     // var:0
+            bc::load_const_i32(2),                   // pool:2 (10)
+            bc::builtin(opcode::builtin::LIMIT_I32), // LIMIT_I32
+            bc::store_var_i32(1),                    // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_limit.rs
+++ b/compiler/codegen/tests/compile_limit.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the LIMIT function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_limit_function_then_produces_builtin_bytecode() {
@@ -50,17 +52,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (5)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (0)
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (10)
-            0x94, 0x46, 0x03, // BUILTIN LIMIT_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (5)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (0)
+            bc::load_var_i32(0),  // var:0
+            bc::load_const_i32(2),  // pool:2 (10)
+            bc::builtin(opcode::builtin::LIMIT_I32),  // LIMIT_I32
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_limit_float.rs
+++ b/compiler/codegen/tests/compile_limit_float.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the LIMIT function with float types.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_limit_real_then_produces_limit_f32_bytecode() {
@@ -27,19 +29,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x02, 0x00, 0x00, // LOAD_CONST_F32 pool:0 (5.0)
-            0x12, 0x00, 0x00, // STORE_VAR_F32 var:0
-            0x02, 0x01, 0x00, // LOAD_CONST_F32 pool:1 (0.0)
-            0x0E, 0x00, 0x00, // LOAD_VAR_F32 var:0
-            0x02, 0x02, 0x00, // LOAD_CONST_F32 pool:2 (10.0)
-            0x94, 0x5A, 0x03, // BUILTIN LIMIT_F32
-            0x12, 0x01, 0x00, // STORE_VAR_F32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f32(0),  // pool:0 (5.0)
+            bc::store_var_f32(0),  // var:0
+            bc::load_const_f32(1),  // pool:1 (0.0)
+            bc::load_var_f32(0),  // var:0
+            bc::load_const_f32(2),  // pool:2 (10.0)
+            bc::builtin(opcode::builtin::LIMIT_F32),  // LIMIT_F32
+            bc::store_var_f32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -60,17 +59,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x03, 0x00, 0x00, // LOAD_CONST_F64 pool:0 (5.0)
-            0x13, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0x03, 0x01, 0x00, // LOAD_CONST_F64 pool:1 (0.0)
-            0x0F, 0x00, 0x00, // LOAD_VAR_F64 var:0
-            0x03, 0x02, 0x00, // LOAD_CONST_F64 pool:2 (10.0)
-            0x94, 0x5B, 0x03, // BUILTIN LIMIT_F64
-            0x13, 0x01, 0x00, // STORE_VAR_F64 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f64(0),  // pool:0 (5.0)
+            bc::store_var_f64(0),  // var:0
+            bc::load_const_f64(1),  // pool:1 (0.0)
+            bc::load_var_f64(0),  // var:0
+            bc::load_const_f64(2),  // pool:2 (10.0)
+            bc::builtin(opcode::builtin::LIMIT_F64),  // LIMIT_F64
+            bc::store_var_f64(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_limit_float.rs
+++ b/compiler/codegen/tests/compile_limit_float.rs
@@ -29,16 +29,19 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f32(0),  // pool:0 (5.0)
-            bc::store_var_f32(0),  // var:0
-            bc::load_const_f32(1),  // pool:1 (0.0)
-            bc::load_var_f32(0),  // var:0
-            bc::load_const_f32(2),  // pool:2 (10.0)
-            bc::builtin(opcode::builtin::LIMIT_F32),  // LIMIT_F32
-            bc::store_var_f32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f32(0),                   // pool:0 (5.0)
+            bc::store_var_f32(0),                    // var:0
+            bc::load_const_f32(1),                   // pool:1 (0.0)
+            bc::load_var_f32(0),                     // var:0
+            bc::load_const_f32(2),                   // pool:2 (10.0)
+            bc::builtin(opcode::builtin::LIMIT_F32), // LIMIT_F32
+            bc::store_var_f32(1),                    // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -59,14 +62,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f64(0),  // pool:0 (5.0)
-            bc::store_var_f64(0),  // var:0
-            bc::load_const_f64(1),  // pool:1 (0.0)
-            bc::load_var_f64(0),  // var:0
-            bc::load_const_f64(2),  // pool:2 (10.0)
-            bc::builtin(opcode::builtin::LIMIT_F64),  // LIMIT_F64
-            bc::store_var_f64(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f64(0),                   // pool:0 (5.0)
+            bc::store_var_f64(0),                    // var:0
+            bc::load_const_f64(1),                   // pool:1 (0.0)
+            bc::load_var_f64(0),                     // var:0
+            bc::load_const_f64(2),                   // pool:2 (10.0)
+            bc::builtin(opcode::builtin::LIMIT_F64), // LIMIT_F64
+            bc::store_var_f64(1),                    // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_loops.rs
+++ b/compiler/codegen/tests/compile_loops.rs
@@ -1,10 +1,11 @@
 //! Bytecode-level integration tests for WHILE, REPEAT, and FOR loop compilation.
 
+#[macro_use]
 mod common;
 use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_while_then_produces_loop_with_jmp_if_not() {
@@ -46,21 +47,18 @@ END_PROGRAM
     assert_eq!(i16::from_le_bytes([bytecode[21], bytecode[22]]), -23);
 
     // Verify overall structure
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
-            0x50, // GT_I32
-            0x80, 0x0D, 0x00, // JMP_IF_NOT offset:+13
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
-            0x24, // SUB_I32
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x7C, 0xE9, 0xFF, // JMP offset:-23
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+        bc::load_var_i32(0),    // condition: x
+        bc::load_const_i32(0),  // condition: 0
+        bc::gt_i32(),           // x > 0
+        bc::jmp_if_not(13),     // exit if false
+        bc::load_var_i32(0),    // body: x
+        bc::load_const_i32(1),  // body: 1
+        bc::sub_i32(),          // x - 1
+        bc::store_var_i32(0),   // x := ...
+        bc::jmp(-23),           // back to LOOP
+        bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -98,20 +96,17 @@ END_PROGRAM
     assert_eq!(bytecode[15], 0x80); // JMP_IF_NOT
     assert_eq!(i16::from_le_bytes([bytecode[16], bytecode[17]]), -18);
 
-    assert_eq!(
-        bytecode,
-        &[
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x20, // ADD_I32
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (5)
-            0x50, // GT_I32
-            0x80, 0xEE, 0xFF, // JMP_IF_NOT offset:-18
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+        bc::load_var_i32(0),    // body: x
+        bc::load_const_i32(0),  // body: 1
+        bc::add_i32(),          // x + 1
+        bc::dup(),              // store-load optimization
+        bc::store_var_i32(0),   // x := ...
+        bc::load_const_i32(1),  // condition: 5
+        bc::gt_i32(),           // x > 5
+        bc::jmp_if_not(-18),    // back to LOOP if false
+        bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -168,27 +163,24 @@ END_PROGRAM
     assert_eq!(jmp_count, 1, "bytecode = {bytecode:?}");
 
     // Verify structure
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (5)
-            0x4C, // LE_I32
-            0x80, 0x17, 0x00, // JMP_IF_NOT offset:+23
-            0x0C, 0x01, 0x00, // LOAD_VAR_I32 var:1
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x20, // ADD_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x0C, 0x00, 0x00, // LOAD_VAR_I32 var:0
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x20, // ADD_I32
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x7C, 0xDF, 0xFF, // JMP offset:-33
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+        bc::load_const_i32(0),  // from value
+        bc::store_var_i32(0),   // i := 1
+        bc::load_var_i32(0),    // LOOP: load i
+        bc::load_const_i32(1),  // to value
+        bc::le_i32(),           // i <= 5? continuation
+        bc::jmp_if_not(23),     // exit when i > 5
+        bc::load_var_i32(1),    // BODY: y
+        bc::load_var_i32(0),    // i
+        bc::add_i32(),          // y + i
+        bc::store_var_i32(1),   // y := ...
+        bc::load_var_i32(0),    // increment: i
+        bc::load_const_i32(0),  // step: 1
+        bc::add_i32(),          // i + 1
+        bc::store_var_i32(0),   // i := ...
+        bc::jmp(-33),           // back to LOOP
+        bc::ret_void(),
+    ]);
 }
 
 #[test]

--- a/compiler/codegen/tests/compile_loops.rs
+++ b/compiler/codegen/tests/compile_loops.rs
@@ -39,11 +39,11 @@ END_PROGRAM
         .unwrap();
 
     // Verify JMP_IF_NOT at offset 7 with forward offset +13
-    assert_eq!(bytecode[7], 0x80); // JMP_IF_NOT
+    assert_eq!(bytecode[7], opcode::JMP_IF_NOT);
     assert_eq!(i16::from_le_bytes([bytecode[8], bytecode[9]]), 13);
 
     // Verify JMP at offset 20 with backward offset -23
-    assert_eq!(bytecode[20], 0x7C); // JMP
+    assert_eq!(bytecode[20], opcode::JMP);
     assert_eq!(i16::from_le_bytes([bytecode[21], bytecode[22]]), -23);
 
     // Verify overall structure
@@ -93,7 +93,7 @@ END_PROGRAM
         .unwrap();
 
     // Verify JMP_IF_NOT at offset 15 with backward offset -18
-    assert_eq!(bytecode[15], 0x80); // JMP_IF_NOT
+    assert_eq!(bytecode[15], opcode::JMP_IF_NOT);
     assert_eq!(i16::from_le_bytes([bytecode[16], bytecode[17]]), -18);
 
     assert_bytecode!(bytecode, [

--- a/compiler/codegen/tests/compile_loops.rs
+++ b/compiler/codegen/tests/compile_loops.rs
@@ -47,18 +47,21 @@ END_PROGRAM
     assert_eq!(i16::from_le_bytes([bytecode[21], bytecode[22]]), -23);
 
     // Verify overall structure
-    assert_bytecode!(bytecode, [
-        bc::load_var_i32(0),    // condition: x
-        bc::load_const_i32(0),  // condition: 0
-        bc::gt_i32(),           // x > 0
-        bc::jmp_if_not(13),     // exit if false
-        bc::load_var_i32(0),    // body: x
-        bc::load_const_i32(1),  // body: 1
-        bc::sub_i32(),          // x - 1
-        bc::store_var_i32(0),   // x := ...
-        bc::jmp(-23),           // back to LOOP
-        bc::ret_void(),
-    ]);
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // condition: x
+            bc::load_const_i32(0), // condition: 0
+            bc::gt_i32(),          // x > 0
+            bc::jmp_if_not(13),    // exit if false
+            bc::load_var_i32(0),   // body: x
+            bc::load_const_i32(1), // body: 1
+            bc::sub_i32(),         // x - 1
+            bc::store_var_i32(0),  // x := ...
+            bc::jmp(-23),          // back to LOOP
+            bc::ret_void(),
+        ]
+    );
 }
 
 #[test]
@@ -96,17 +99,20 @@ END_PROGRAM
     assert_eq!(bytecode[15], opcode::JMP_IF_NOT);
     assert_eq!(i16::from_le_bytes([bytecode[16], bytecode[17]]), -18);
 
-    assert_bytecode!(bytecode, [
-        bc::load_var_i32(0),    // body: x
-        bc::load_const_i32(0),  // body: 1
-        bc::add_i32(),          // x + 1
-        bc::dup(),              // store-load optimization
-        bc::store_var_i32(0),   // x := ...
-        bc::load_const_i32(1),  // condition: 5
-        bc::gt_i32(),           // x > 5
-        bc::jmp_if_not(-18),    // back to LOOP if false
-        bc::ret_void(),
-    ]);
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_i32(0),   // body: x
+            bc::load_const_i32(0), // body: 1
+            bc::add_i32(),         // x + 1
+            bc::dup(),             // store-load optimization
+            bc::store_var_i32(0),  // x := ...
+            bc::load_const_i32(1), // condition: 5
+            bc::gt_i32(),          // x > 5
+            bc::jmp_if_not(-18),   // back to LOOP if false
+            bc::ret_void(),
+        ]
+    );
 }
 
 #[test]
@@ -163,24 +169,27 @@ END_PROGRAM
     assert_eq!(jmp_count, 1, "bytecode = {bytecode:?}");
 
     // Verify structure
-    assert_bytecode!(bytecode, [
-        bc::load_const_i32(0),  // from value
-        bc::store_var_i32(0),   // i := 1
-        bc::load_var_i32(0),    // LOOP: load i
-        bc::load_const_i32(1),  // to value
-        bc::le_i32(),           // i <= 5? continuation
-        bc::jmp_if_not(23),     // exit when i > 5
-        bc::load_var_i32(1),    // BODY: y
-        bc::load_var_i32(0),    // i
-        bc::add_i32(),          // y + i
-        bc::store_var_i32(1),   // y := ...
-        bc::load_var_i32(0),    // increment: i
-        bc::load_const_i32(0),  // step: 1
-        bc::add_i32(),          // i + 1
-        bc::store_var_i32(0),   // i := ...
-        bc::jmp(-33),           // back to LOOP
-        bc::ret_void(),
-    ]);
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // from value
+            bc::store_var_i32(0),  // i := 1
+            bc::load_var_i32(0),   // LOOP: load i
+            bc::load_const_i32(1), // to value
+            bc::le_i32(),          // i <= 5? continuation
+            bc::jmp_if_not(23),    // exit when i > 5
+            bc::load_var_i32(1),   // BODY: y
+            bc::load_var_i32(0),   // i
+            bc::add_i32(),         // y + i
+            bc::store_var_i32(1),  // y := ...
+            bc::load_var_i32(0),   // increment: i
+            bc::load_const_i32(0), // step: 1
+            bc::add_i32(),         // i + 1
+            bc::store_var_i32(0),  // i := ...
+            bc::jmp(-33),          // back to LOOP
+            bc::ret_void(),
+        ]
+    );
 }
 
 #[test]

--- a/compiler/codegen/tests/compile_max.rs
+++ b/compiler/codegen/tests/compile_max.rs
@@ -44,13 +44,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
-            bc::builtin(opcode::builtin::MAX_I32),  // MAX_I32
-            bc::store_var_i32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                 // pool:0
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_i32(0),                  // var:0
+            bc::load_const_i32(1),                 // pool:1
+            bc::builtin(opcode::builtin::MAX_I32), // MAX_I32
+            bc::store_var_i32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_max.rs
+++ b/compiler/codegen/tests/compile_max.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the MAX function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_max_function_then_produces_builtin_bytecode() {
@@ -42,16 +44,13 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x94, 0x45, 0x03, // BUILTIN MAX_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::builtin(opcode::builtin::MAX_I32),  // MAX_I32
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_max_float.rs
+++ b/compiler/codegen/tests/compile_max_float.rs
@@ -24,13 +24,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_f32(0),  // var:0
-            bc::load_const_f32(0),  // pool:0 (10.0)
-            bc::builtin(opcode::builtin::MAX_F32),  // MAX_F32
-            bc::store_var_f32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_f32(0),                   // var:0
+            bc::load_const_f32(0),                 // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MAX_F32), // MAX_F32
+            bc::store_var_f32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -50,11 +53,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_f64(0),  // var:0
-            bc::load_const_f64(0),  // pool:0 (10.0)
-            bc::builtin(opcode::builtin::MAX_F64),  // MAX_F64
-            bc::store_var_f64(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_f64(0),                   // var:0
+            bc::load_const_f64(0),                 // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MAX_F64), // MAX_F64
+            bc::store_var_f64(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_max_float.rs
+++ b/compiler/codegen/tests/compile_max_float.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the MAX function with float types.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_max_real_then_produces_max_f32_bytecode() {
@@ -22,16 +24,13 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0E, 0x00, 0x00, // LOAD_VAR_F32 var:0
-            0x02, 0x00, 0x00, // LOAD_CONST_F32 pool:0 (10.0)
-            0x94, 0x58, 0x03, // BUILTIN MAX_F32
-            0x12, 0x01, 0x00, // STORE_VAR_F32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_f32(0),  // var:0
+            bc::load_const_f32(0),  // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MAX_F32),  // MAX_F32
+            bc::store_var_f32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -51,14 +50,11 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0F, 0x00, 0x00, // LOAD_VAR_F64 var:0
-            0x03, 0x00, 0x00, // LOAD_CONST_F64 pool:0 (10.0)
-            0x94, 0x59, 0x03, // BUILTIN MAX_F64
-            0x13, 0x01, 0x00, // STORE_VAR_F64 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_f64(0),  // var:0
+            bc::load_const_f64(0),  // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MAX_F64),  // MAX_F64
+            bc::store_var_f64(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_min.rs
+++ b/compiler/codegen/tests/compile_min.rs
@@ -44,13 +44,16 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
-            bc::builtin(opcode::builtin::MIN_I32),  // MIN_I32
-            bc::store_var_i32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                 // pool:0
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_i32(0),                  // var:0
+            bc::load_const_i32(1),                 // pool:1
+            bc::builtin(opcode::builtin::MIN_I32), // MIN_I32
+            bc::store_var_i32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_min.rs
+++ b/compiler/codegen/tests/compile_min.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the MIN function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_min_function_then_produces_builtin_bytecode() {
@@ -42,16 +44,13 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x94, 0x44, 0x03, // BUILTIN MIN_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::builtin(opcode::builtin::MIN_I32),  // MIN_I32
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_min_float.rs
+++ b/compiler/codegen/tests/compile_min_float.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the MIN function with float types.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_min_real_then_produces_min_f32_bytecode() {
@@ -23,16 +25,13 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // y := MIN(x, 10.0): LOAD_VAR_F32 var:0, LOAD_CONST_F32 pool:0, BUILTIN MIN_F32, STORE_VAR_F32 var:1
-    assert_eq!(
-        bytecode,
-        &[
-            0x0E, 0x00, 0x00, // LOAD_VAR_F32 var:0
-            0x02, 0x00, 0x00, // LOAD_CONST_F32 pool:0 (10.0)
-            0x94, 0x56, 0x03, // BUILTIN MIN_F32
-            0x12, 0x01, 0x00, // STORE_VAR_F32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_f32(0),  // var:0
+            bc::load_const_f32(0),  // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MIN_F32),  // MIN_F32
+            bc::store_var_f32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -52,14 +51,11 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x0F, 0x00, 0x00, // LOAD_VAR_F64 var:0
-            0x03, 0x00, 0x00, // LOAD_CONST_F64 pool:0 (10.0)
-            0x94, 0x57, 0x03, // BUILTIN MIN_F64
-            0x13, 0x01, 0x00, // STORE_VAR_F64 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_var_f64(0),  // var:0
+            bc::load_const_f64(0),  // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MIN_F64),  // MIN_F64
+            bc::store_var_f64(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_min_float.rs
+++ b/compiler/codegen/tests/compile_min_float.rs
@@ -25,13 +25,16 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // y := MIN(x, 10.0): LOAD_VAR_F32 var:0, LOAD_CONST_F32 pool:0, BUILTIN MIN_F32, STORE_VAR_F32 var:1
-    assert_bytecode!(bytecode, [
-            bc::load_var_f32(0),  // var:0
-            bc::load_const_f32(0),  // pool:0 (10.0)
-            bc::builtin(opcode::builtin::MIN_F32),  // MIN_F32
-            bc::store_var_f32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_f32(0),                   // var:0
+            bc::load_const_f32(0),                 // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MIN_F32), // MIN_F32
+            bc::store_var_f32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -51,11 +54,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_var_f64(0),  // var:0
-            bc::load_const_f64(0),  // pool:0 (10.0)
-            bc::builtin(opcode::builtin::MIN_F64),  // MIN_F64
-            bc::store_var_f64(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_var_f64(0),                   // var:0
+            bc::load_const_f64(0),                 // pool:0 (10.0)
+            bc::builtin(opcode::builtin::MIN_F64), // MIN_F64
+            bc::store_var_f64(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_mod.rs
+++ b/compiler/codegen/tests/compile_mod.rs
@@ -43,15 +43,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::mod_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -80,9 +83,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (2)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (2)
             bc::store_var_i32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_mod.rs
+++ b/compiler/codegen/tests/compile_mod.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for the MOD operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_mod_expression_then_produces_mod_bytecode() {
@@ -42,18 +43,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x38, // MOD_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::mod_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -82,12 +80,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (2)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (2)
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_mul.rs
+++ b/compiler/codegen/tests/compile_mul.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for the MUL operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_mul_expression_then_produces_mul_bytecode() {
@@ -39,18 +40,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x28, // MUL_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::mul_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -79,12 +77,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (24)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (24)
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_mul.rs
+++ b/compiler/codegen/tests/compile_mul.rs
@@ -40,15 +40,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::mul_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -77,9 +80,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (24)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (24)
             bc::store_var_i32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_mux.rs
+++ b/compiler/codegen/tests/compile_mux.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for MUX function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_mux_3_inputs_then_produces_builtin_bytecode() {
@@ -59,18 +61,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (10)
-            0x00, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (20)
-            0x00, 0x03, 0x00, // LOAD_CONST_I32 pool:3 (30)
-            0x94, 0x03, 0x04, // BUILTIN MUX_I32(3) = 0x0403
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (1)
+            bc::load_const_i32(1),  // pool:1 (10)
+            bc::load_const_i32(2),  // pool:2 (20)
+            bc::load_const_i32(3),  // pool:3 (30)
+            bc::builtin(opcode::builtin::MUX_I32_BASE + 3),  // MUX with 3 inputs
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -90,17 +89,14 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // BUILTIN MUX_I32_BASE+2 = 0x0402
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (100)
-            0x00, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (200)
-            0x94, 0x02, 0x04, // BUILTIN MUX_I32(2) = 0x0402
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (0)
+            bc::load_const_i32(1),  // pool:1 (100)
+            bc::load_const_i32(2),  // pool:2 (200)
+            bc::builtin(opcode::builtin::MUX_I32_BASE + 2),  // MUX with 2 inputs
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]

--- a/compiler/codegen/tests/compile_mux.rs
+++ b/compiler/codegen/tests/compile_mux.rs
@@ -61,15 +61,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (1)
-            bc::load_const_i32(1),  // pool:1 (10)
-            bc::load_const_i32(2),  // pool:2 (20)
-            bc::load_const_i32(3),  // pool:3 (30)
-            bc::builtin(opcode::builtin::MUX_I32_BASE + 3),  // MUX with 3 inputs
-            bc::store_var_i32(0),  // var:0
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                          // pool:0 (1)
+            bc::load_const_i32(1),                          // pool:1 (10)
+            bc::load_const_i32(2),                          // pool:2 (20)
+            bc::load_const_i32(3),                          // pool:3 (30)
+            bc::builtin(opcode::builtin::MUX_I32_BASE + 3), // MUX with 3 inputs
+            bc::store_var_i32(0),                           // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -89,14 +92,17 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // BUILTIN MUX_I32_BASE+2 = 0x0402
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (0)
-            bc::load_const_i32(1),  // pool:1 (100)
-            bc::load_const_i32(2),  // pool:2 (200)
-            bc::builtin(opcode::builtin::MUX_I32_BASE + 2),  // MUX with 2 inputs
-            bc::store_var_i32(0),  // var:0
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                          // pool:0 (0)
+            bc::load_const_i32(1),                          // pool:1 (100)
+            bc::load_const_i32(2),                          // pool:2 (200)
+            bc::builtin(opcode::builtin::MUX_I32_BASE + 2), // MUX with 2 inputs
+            bc::store_var_i32(0),                           // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]

--- a/compiler/codegen/tests/compile_neg.rs
+++ b/compiler/codegen/tests/compile_neg.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for the NEG operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_neg_variable_then_produces_neg_bytecode() {
@@ -35,17 +36,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x2C, // NEG_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+        bc::load_const_i32(0),
+        bc::dup(),              // store-load optimization
+        bc::store_var_i32(0),
+        bc::neg_i32(),
+        bc::store_var_i32(1),
+        bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -74,5 +72,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(bytecode, &[0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x8C]);
+    assert_bytecode!(bytecode, [
+        bc::load_const_i32(0), // (-5)
+        bc::store_var_i32(0),
+        bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_neg.rs
+++ b/compiler/codegen/tests/compile_neg.rs
@@ -36,14 +36,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-        bc::load_const_i32(0),
-        bc::dup(),              // store-load optimization
-        bc::store_var_i32(0),
-        bc::neg_i32(),
-        bc::store_var_i32(1),
-        bc::ret_void(),
-    ]);
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),
+            bc::dup(), // store-load optimization
+            bc::store_var_i32(0),
+            bc::neg_i32(),
+            bc::store_var_i32(1),
+            bc::ret_void(),
+        ]
+    );
 }
 
 #[test]
@@ -72,9 +75,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-        bc::load_const_i32(0), // (-5)
-        bc::store_var_i32(0),
-        bc::ret_void(),
-    ]);
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // (-5)
+            bc::store_var_i32(0),
+            bc::ret_void(),
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_pow.rs
+++ b/compiler/codegen/tests/compile_pow.rs
@@ -44,15 +44,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
-            bc::builtin(opcode::builtin::EXPT_I32),  // EXPT_I32
-            bc::store_var_i32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                  // pool:0
+            bc::dup(),                              // (store-load optimization)
+            bc::store_var_i32(0),                   // var:0
+            bc::load_const_i32(1),                  // pool:1
+            bc::builtin(opcode::builtin::EXPT_I32), // EXPT_I32
+            bc::store_var_i32(1),                   // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -81,9 +84,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (64)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (64)
             bc::store_var_i32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_pow.rs
+++ b/compiler/codegen/tests/compile_pow.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the POW operator compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_pow_expression_then_produces_builtin_bytecode() {
@@ -42,18 +44,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x94, 0x40, 0x03, // BUILTIN EXPT_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::builtin(opcode::builtin::EXPT_I32),  // EXPT_I32
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -82,12 +81,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (64)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (64)
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_sel.rs
+++ b/compiler/codegen/tests/compile_sel.rs
@@ -52,14 +52,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (1)
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (10)
-            bc::load_const_i32(2),  // pool:2 (20)
-            bc::builtin(opcode::builtin::SEL_I32),  // SEL_I32
-            bc::store_var_i32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                 // pool:0 (1)
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_i32(0),                  // var:0
+            bc::load_const_i32(1),                 // pool:1 (10)
+            bc::load_const_i32(2),                 // pool:2 (20)
+            bc::builtin(opcode::builtin::SEL_I32), // SEL_I32
+            bc::store_var_i32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_sel.rs
+++ b/compiler/codegen/tests/compile_sel.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the SEL function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_sel_function_then_produces_builtin_bytecode() {
@@ -50,17 +52,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (10)
-            0x00, 0x02, 0x00, // LOAD_CONST_I32 pool:2 (20)
-            0x94, 0x47, 0x03, // BUILTIN SEL_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (1)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (10)
+            bc::load_const_i32(2),  // pool:2 (20)
+            bc::builtin(opcode::builtin::SEL_I32),  // SEL_I32
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_sel_float.rs
+++ b/compiler/codegen/tests/compile_sel_float.rs
@@ -30,14 +30,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (0)
-            bc::load_const_f32(1),  // pool:1 (10.0)
-            bc::load_const_f32(2),  // pool:2 (20.0)
-            bc::builtin(opcode::builtin::SEL_F32),  // SEL_F32
-            bc::store_var_f32(0),  // var:0
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                 // pool:0 (0)
+            bc::load_const_f32(1),                 // pool:1 (10.0)
+            bc::load_const_f32(2),                 // pool:2 (20.0)
+            bc::builtin(opcode::builtin::SEL_F32), // SEL_F32
+            bc::store_var_f32(0),                  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -56,12 +59,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (1)
-            bc::load_const_f64(1),  // pool:1 (10.0)
-            bc::load_const_f64(2),  // pool:2 (20.0)
-            bc::builtin(opcode::builtin::SEL_F64),  // SEL_F64
-            bc::store_var_f64(0),  // var:0
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                 // pool:0 (1)
+            bc::load_const_f64(1),                 // pool:1 (10.0)
+            bc::load_const_f64(2),                 // pool:2 (20.0)
+            bc::builtin(opcode::builtin::SEL_F64), // SEL_F64
+            bc::store_var_f64(0),                  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_sel_float.rs
+++ b/compiler/codegen/tests/compile_sel_float.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the SEL function with float types.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_sel_real_then_produces_sel_f32_bytecode() {
@@ -28,17 +30,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
-            0x02, 0x01, 0x00, // LOAD_CONST_F32 pool:1 (10.0)
-            0x02, 0x02, 0x00, // LOAD_CONST_F32 pool:2 (20.0)
-            0x94, 0x5C, 0x03, // BUILTIN SEL_F32
-            0x12, 0x00, 0x00, // STORE_VAR_F32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (0)
+            bc::load_const_f32(1),  // pool:1 (10.0)
+            bc::load_const_f32(2),  // pool:2 (20.0)
+            bc::builtin(opcode::builtin::SEL_F32),  // SEL_F32
+            bc::store_var_f32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -57,15 +56,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1)
-            0x03, 0x01, 0x00, // LOAD_CONST_F64 pool:1 (10.0)
-            0x03, 0x02, 0x00, // LOAD_CONST_F64 pool:2 (20.0)
-            0x94, 0x5D, 0x03, // BUILTIN SEL_F64
-            0x13, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (1)
+            bc::load_const_f64(1),  // pool:1 (10.0)
+            bc::load_const_f64(2),  // pool:2 (20.0)
+            bc::builtin(opcode::builtin::SEL_F64),  // SEL_F64
+            bc::store_var_f64(0),  // var:0
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_shift.rs
+++ b/compiler/codegen/tests/compile_shift.rs
@@ -30,17 +30,20 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (0x0F)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (0x0F)
             bc::trunc_u8(),
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (4)
-            bc::builtin(opcode::builtin::SHL_I32),  // SHL_I32 (0x0348)
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_i32(0),                  // var:0
+            bc::load_const_i32(1),                 // pool:1 (4)
+            bc::builtin(opcode::builtin::SHL_I32), // SHL_I32 (0x0348)
             bc::trunc_u8(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -62,17 +65,20 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // Verify the ROL on BYTE emits ROL_U8 (0x0350), not ROL_I32
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (0x81)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (0x81)
             bc::trunc_u8(),
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (1)
-            bc::builtin(opcode::builtin::ROL_U8),  // ROL_U8 (0x0350)
+            bc::dup(),                            // (store-load optimization)
+            bc::store_var_i32(0),                 // var:0
+            bc::load_const_i32(1),                // pool:1 (1)
+            bc::builtin(opcode::builtin::ROL_U8), // ROL_U8 (0x0350)
             bc::trunc_u8(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -94,17 +100,20 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // Verify the ROR on WORD emits ROR_U16 (0x0353)
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (0x8001)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (0x8001)
             bc::trunc_u16(),
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (1)
-            bc::builtin(opcode::builtin::ROR_U16),  // ROR_U16 (0x0353)
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_i32(0),                  // var:0
+            bc::load_const_i32(1),                 // pool:1 (1)
+            bc::builtin(opcode::builtin::ROR_U16), // ROR_U16 (0x0353)
             bc::trunc_u16(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -126,13 +135,16 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // DWORD is 32-bit so no TRUNC needed
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (0x0F)
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1 (4)
-            bc::builtin(opcode::builtin::SHL_I32),  // SHL_I32 (0x0348)
-            bc::store_var_i32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0),                 // pool:0 (0x0F)
+            bc::dup(),                             // (store-load optimization)
+            bc::store_var_i32(0),                  // var:0
+            bc::load_const_i32(1),                 // pool:1 (4)
+            bc::builtin(opcode::builtin::SHL_I32), // SHL_I32 (0x0348)
+            bc::store_var_i32(1),                  // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_shift.rs
+++ b/compiler/codegen/tests/compile_shift.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for shift/rotate function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_shl_byte_then_produces_shl_i32_builtin() {
@@ -28,20 +30,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x0F)
-            0x1D, // TRUNC_U8
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (4)
-            0x94, 0x48, 0x03, // BUILTIN SHL_I32 (0x0348)
-            0x1D, // TRUNC_U8
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (0x0F)
+            bc::trunc_u8(),
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (4)
+            bc::builtin(opcode::builtin::SHL_I32),  // SHL_I32 (0x0348)
+            bc::trunc_u8(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -63,20 +62,17 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // Verify the ROL on BYTE emits ROL_U8 (0x0350), not ROL_I32
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x81)
-            0x1D, // TRUNC_U8
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
-            0x94, 0x50, 0x03, // BUILTIN ROL_U8 (0x0350)
-            0x1D, // TRUNC_U8
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (0x81)
+            bc::trunc_u8(),
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (1)
+            bc::builtin(opcode::builtin::ROL_U8),  // ROL_U8 (0x0350)
+            bc::trunc_u8(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -98,20 +94,17 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // Verify the ROR on WORD emits ROR_U16 (0x0353)
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x8001)
-            0x1F, // TRUNC_U16
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (1)
-            0x94, 0x53, 0x03, // BUILTIN ROR_U16 (0x0353)
-            0x1F, // TRUNC_U16
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (0x8001)
+            bc::trunc_u16(),
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (1)
+            bc::builtin(opcode::builtin::ROR_U16),  // ROR_U16 (0x0353)
+            bc::trunc_u16(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -133,16 +126,13 @@ END_PROGRAM
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
     // DWORD is 32-bit so no TRUNC needed
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0x0F)
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1 (4)
-            0x94, 0x48, 0x03, // BUILTIN SHL_I32 (0x0348)
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (0x0F)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1 (4)
+            bc::builtin(opcode::builtin::SHL_I32),  // SHL_I32 (0x0348)
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_sqrt.rs
+++ b/compiler/codegen/tests/compile_sqrt.rs
@@ -28,14 +28,17 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_f32(0),  // var:0
-            bc::builtin(opcode::builtin::SQRT_F32),  // SQRT_F32
-            bc::store_var_f32(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f32(0),                  // pool:0
+            bc::dup(),                              // (store-load optimization)
+            bc::store_var_f32(0),                   // var:0
+            bc::builtin(opcode::builtin::SQRT_F32), // SQRT_F32
+            bc::store_var_f32(1),                   // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -59,12 +62,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_f64(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
-            bc::store_var_f64(0),  // var:0
-            bc::builtin(opcode::builtin::SQRT_F64),  // SQRT_F64
-            bc::store_var_f64(1),  // var:1
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_f64(0),                  // pool:0
+            bc::dup(),                              // (store-load optimization)
+            bc::store_var_f64(0),                   // var:0
+            bc::builtin(opcode::builtin::SQRT_F64), // SQRT_F64
+            bc::store_var_f64(1),                   // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_sqrt.rs
+++ b/compiler/codegen/tests/compile_sqrt.rs
@@ -1,9 +1,11 @@
 //! Bytecode-level integration tests for the SQRT function compilation.
 
+#[macro_use]
 mod common;
+use ironplc_container::opcode;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_sqrt_real_then_produces_sqrt_f32_bytecode() {
@@ -26,17 +28,14 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x02, 0x00, 0x00, // LOAD_CONST_F32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x12, 0x00, 0x00, // STORE_VAR_F32 var:0
-            0x94, 0x5E, 0x03, // BUILTIN SQRT_F32
-            0x12, 0x01, 0x00, // STORE_VAR_F32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_f32(0),  // var:0
+            bc::builtin(opcode::builtin::SQRT_F32),  // SQRT_F32
+            bc::store_var_f32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -60,15 +59,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x03, 0x00, 0x00, // LOAD_CONST_F64 pool:0
-            0x91, // DUP (store-load optimization)
-            0x13, 0x00, 0x00, // STORE_VAR_F64 var:0
-            0x94, 0x5F, 0x03, // BUILTIN SQRT_F64
-            0x13, 0x01, 0x00, // STORE_VAR_F64 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_f64(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_f64(0),  // var:0
+            bc::builtin(opcode::builtin::SQRT_F64),  // SQRT_F64
+            bc::store_var_f64(1),  // var:1
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_sub.rs
+++ b/compiler/codegen/tests/compile_sub.rs
@@ -1,9 +1,10 @@
 //! Bytecode-level integration tests for the SUB operator compilation.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_sub_expression_then_produces_sub_bytecode() {
@@ -42,18 +43,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0
-            0x91, // DUP (store-load optimization)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool:1
-            0x24, // SUB_I32
-            0x10, 0x01, 0x00, // STORE_VAR_I32 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i32(0),  // var:0
+            bc::load_const_i32(1),  // pool:1
+            bc::sub_i32(),
+            bc::store_var_i32(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -82,12 +80,9 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (5)
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (5)
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }

--- a/compiler/codegen/tests/compile_sub.rs
+++ b/compiler/codegen/tests/compile_sub.rs
@@ -43,15 +43,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i32(0),  // var:0
-            bc::load_const_i32(1),  // pool:1
+            bc::load_const_i32(1), // pool:1
             bc::sub_i32(),
-            bc::store_var_i32(1),  // var:1
+            bc::store_var_i32(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -80,9 +83,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (5)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (5)
             bc::store_var_i32(0),  // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }

--- a/compiler/codegen/tests/compile_types.rs
+++ b/compiler/codegen/tests/compile_types.rs
@@ -26,12 +26,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (42)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (42)
             bc::trunc_i8(),
-            bc::store_var_i32(0),  // var:0
+            bc::store_var_i32(0), // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -51,12 +54,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i32(0),  // pool:0 (1000)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i32(0), // pool:0 (1000)
             bc::trunc_u16(),
-            bc::store_var_i32(0),  // var:0
+            bc::store_var_i32(0), // var:0
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]
@@ -80,15 +86,18 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_bytecode!(bytecode, [
-            bc::load_const_i64(0),  // pool:0 (10)
-            bc::dup(),  // (store-load optimization)
+    assert_bytecode!(
+        bytecode,
+        [
+            bc::load_const_i64(0), // pool:0 (10)
+            bc::dup(),             // (store-load optimization)
             bc::store_var_i64(0),  // var:0
-            bc::load_const_i64(1),  // pool:1 (1)
+            bc::load_const_i64(1), // pool:1 (1)
             bc::add_i64(),
-            bc::store_var_i64(1),  // var:1
+            bc::store_var_i64(1), // var:1
             bc::ret_void(),
-    ]);
+        ]
+    );
 }
 
 #[test]

--- a/compiler/codegen/tests/compile_types.rs
+++ b/compiler/codegen/tests/compile_types.rs
@@ -3,10 +3,11 @@
 //! These tests verify that the compiler selects the correct opcodes
 //! for different IEC 61131-3 integer types.
 
+#[macro_use]
 mod common;
 use ironplc_parser::options::CompilerOptions;
 
-use common::parse_and_compile;
+use common::{bc, parse_and_compile};
 
 #[test]
 fn compile_when_sint_then_produces_trunc_i8() {
@@ -25,15 +26,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (42)
-            0x1C, // TRUNC_I8
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (42)
+            bc::trunc_i8(),
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -53,15 +51,12 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (1000)
-            0x1F, // TRUNC_U16
-            0x10, 0x00, 0x00, // STORE_VAR_I32 var:0
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i32(0),  // pool:0 (1000)
+            bc::trunc_u16(),
+            bc::store_var_i32(0),  // var:0
+            bc::ret_void(),
+    ]);
 }
 
 #[test]
@@ -85,18 +80,15 @@ END_PROGRAM
         .code
         .get_function_bytecode(ironplc_container::FunctionId::new(1))
         .unwrap();
-    assert_eq!(
-        bytecode,
-        &[
-            0x01, 0x00, 0x00, // LOAD_CONST_I64 pool:0 (10)
-            0x91, // DUP (store-load optimization)
-            0x11, 0x00, 0x00, // STORE_VAR_I64 var:0
-            0x01, 0x01, 0x00, // LOAD_CONST_I64 pool:1 (1)
-            0x21, // ADD_I64
-            0x11, 0x01, 0x00, // STORE_VAR_I64 var:1
-            0x8C, // RET_VOID
-        ]
-    );
+    assert_bytecode!(bytecode, [
+            bc::load_const_i64(0),  // pool:0 (10)
+            bc::dup(),  // (store-load optimization)
+            bc::store_var_i64(0),  // var:0
+            bc::load_const_i64(1),  // pool:1 (1)
+            bc::add_i64(),
+            bc::store_var_i64(1),  // var:1
+            bc::ret_void(),
+    ]);
 }
 
 #[test]

--- a/compiler/codegen/tests/wire_format.rs
+++ b/compiler/codegen/tests/wire_format.rs
@@ -294,11 +294,36 @@ fn encoding_when_store_var_family_then_consistent_op_class() {
 #[test]
 fn encoding_when_arithmetic_family_then_consistent_op_class() {
     for (i32_op, i64_op, f32_op, f64_op) in [
-        (opcode::ADD_I32, opcode::ADD_I64, opcode::ADD_F32, opcode::ADD_F64),
-        (opcode::SUB_I32, opcode::SUB_I64, opcode::SUB_F32, opcode::SUB_F64),
-        (opcode::MUL_I32, opcode::MUL_I64, opcode::MUL_F32, opcode::MUL_F64),
-        (opcode::NEG_I32, opcode::NEG_I64, opcode::NEG_F32, opcode::NEG_F64),
-        (opcode::DIV_I32, opcode::DIV_I64, opcode::DIV_F32, opcode::DIV_F64),
+        (
+            opcode::ADD_I32,
+            opcode::ADD_I64,
+            opcode::ADD_F32,
+            opcode::ADD_F64,
+        ),
+        (
+            opcode::SUB_I32,
+            opcode::SUB_I64,
+            opcode::SUB_F32,
+            opcode::SUB_F64,
+        ),
+        (
+            opcode::MUL_I32,
+            opcode::MUL_I64,
+            opcode::MUL_F32,
+            opcode::MUL_F64,
+        ),
+        (
+            opcode::NEG_I32,
+            opcode::NEG_I64,
+            opcode::NEG_F32,
+            opcode::NEG_F64,
+        ),
+        (
+            opcode::DIV_I32,
+            opcode::DIV_I64,
+            opcode::DIV_F32,
+            opcode::DIV_F64,
+        ),
     ] {
         let class = i32_op >> 2;
         assert_eq!(i64_op >> 2, class, "i64 vs i32 op_class mismatch");
@@ -314,12 +339,42 @@ fn encoding_when_arithmetic_family_then_consistent_op_class() {
 #[test]
 fn encoding_when_comparison_family_then_consistent_op_class() {
     for (i32_op, i64_op, f32_op, f64_op) in [
-        (opcode::EQ_I32, opcode::EQ_I64, opcode::EQ_F32, opcode::EQ_F64),
-        (opcode::NE_I32, opcode::NE_I64, opcode::NE_F32, opcode::NE_F64),
-        (opcode::LT_I32, opcode::LT_I64, opcode::LT_F32, opcode::LT_F64),
-        (opcode::LE_I32, opcode::LE_I64, opcode::LE_F32, opcode::LE_F64),
-        (opcode::GT_I32, opcode::GT_I64, opcode::GT_F32, opcode::GT_F64),
-        (opcode::GE_I32, opcode::GE_I64, opcode::GE_F32, opcode::GE_F64),
+        (
+            opcode::EQ_I32,
+            opcode::EQ_I64,
+            opcode::EQ_F32,
+            opcode::EQ_F64,
+        ),
+        (
+            opcode::NE_I32,
+            opcode::NE_I64,
+            opcode::NE_F32,
+            opcode::NE_F64,
+        ),
+        (
+            opcode::LT_I32,
+            opcode::LT_I64,
+            opcode::LT_F32,
+            opcode::LT_F64,
+        ),
+        (
+            opcode::LE_I32,
+            opcode::LE_I64,
+            opcode::LE_F32,
+            opcode::LE_F64,
+        ),
+        (
+            opcode::GT_I32,
+            opcode::GT_I64,
+            opcode::GT_F32,
+            opcode::GT_F64,
+        ),
+        (
+            opcode::GE_I32,
+            opcode::GE_I64,
+            opcode::GE_F32,
+            opcode::GE_F64,
+        ),
     ] {
         let class = i32_op >> 2;
         assert_eq!(i64_op >> 2, class);
@@ -410,7 +465,11 @@ END_PROGRAM
     // Last 5 bytes: SUB_I32 (1) + STORE_VAR_I32 (3) + RET_VOID (1).
     let len = bc.len();
     assert_eq!(bc[len - 5], 0x24, "SUB_I32 is one byte at expected offset");
-    assert_eq!(&bc[len - 4..len - 1], &[0x10, 0x00, 0x00], "STORE_VAR_I32 var:0");
+    assert_eq!(
+        &bc[len - 4..len - 1],
+        &[0x10, 0x00, 0x00],
+        "STORE_VAR_I32 var:0"
+    );
     assert_eq!(bc[len - 1], 0x8C, "RET_VOID");
 }
 
@@ -429,7 +488,11 @@ END_PROGRAM
 ",
     );
     // First 3 bytes: LOAD_VAR_I32 followed by LE u16.
-    assert_eq!(&bc[0..3], &[0x0C, 0x01, 0x00], "LOAD_VAR_I32 var:1 (LE u16)");
+    assert_eq!(
+        &bc[0..3],
+        &[0x0C, 0x01, 0x00],
+        "LOAD_VAR_I32 var:1 (LE u16)"
+    );
 }
 
 #[test]
@@ -542,7 +605,10 @@ END_PROGRAM
         .position(|&b| b == 0xB8)
         .expect("STR_INIT opcode present in program init");
     assert_eq!(opcode::instruction_size(opcode::STR_INIT), 7);
-    assert!(pos + 7 <= init_bc.len(), "STR_INIT has 6 trailing operand bytes");
+    assert!(
+        pos + 7 <= init_bc.len(),
+        "STR_INIT has 6 trailing operand bytes"
+    );
     let _data_offset = u32::from_le_bytes([
         init_bc[pos + 1],
         init_bc[pos + 2],
@@ -573,12 +639,7 @@ END_PROGRAM
         .expect("LEN_STR opcode present");
     assert_eq!(opcode::instruction_size(opcode::LEN_STR), 5);
     assert!(pos + 5 <= bc.len(), "LEN_STR has 4 trailing u32 bytes");
-    let _data_offset = u32::from_le_bytes([
-        bc[pos + 1],
-        bc[pos + 2],
-        bc[pos + 3],
-        bc[pos + 4],
-    ]);
+    let _data_offset = u32::from_le_bytes([bc[pos + 1], bc[pos + 2], bc[pos + 3], bc[pos + 4]]);
 }
 
 #[test]
@@ -621,5 +682,9 @@ PROGRAM main
 END_PROGRAM
 ",
     );
-    assert_eq!(bc.last().copied(), Some(0x8C), "RET_VOID terminates program");
+    assert_eq!(
+        bc.last().copied(),
+        Some(0x8C),
+        "RET_VOID terminates program"
+    );
 }

--- a/compiler/codegen/tests/wire_format.rs
+++ b/compiler/codegen/tests/wire_format.rs
@@ -1,0 +1,625 @@
+//! Wire-format test suite — the canonical guard against accidental
+//! changes to the on-disk bytecode encoding.
+//!
+//! ## Scope
+//!
+//! Behavioural codegen tests (in `compile_*.rs`) verify that the right
+//! opcodes are emitted in the right order. They are *symbolic*: they
+//! talk about `LOAD_VAR_I32` by name, not by byte value. That is the
+//! right level for testing codegen behaviour, but it would let a
+//! silent renumbering of an opcode pass undetected.
+//!
+//! This file is the **single canonical source of wire-format truth**.
+//! It pins:
+//!
+//! 1. **Every opcode constant's byte value.** A renumber that changes
+//!    `LOAD_VAR_I32` from 0x0C to 0x0D fails exactly one test here
+//!    with a clear `expected 0x0C, found 0x0D` message — instead of
+//!    cascading into ~30 confusing diffs across `compile_*.rs`.
+//! 2. **The structured `[op_class:6][type:2]` encoding scheme.** For
+//!    op-classes with multiple type variants (e.g. LOAD_VAR_*), the
+//!    high 6 bits are constant within the family and the low 2 bits
+//!    encode the type tag. A renumber that violates the scheme is
+//!    caught here even if every byte value is internally consistent.
+//! 3. **Per-shape golden encodings.** A handful of small programs
+//!    compile to known-exact byte sequences, guarding operand widths,
+//!    little-endian operand encoding, and per-shape layout.
+//!
+//! See `specs/plans/2026-05-02-codegen-test-wire-format-split.md`.
+
+mod common;
+
+use ironplc_container::opcode;
+use ironplc_parser::options::CompilerOptions;
+
+use common::parse_and_compile;
+
+// ---------------------------------------------------------------------------
+// 1. Opcode-byte pinning.
+//
+// One test per op-class family. Each asserts the **literal byte value**
+// of every constant in that family. Grouping by family keeps the diff
+// small when a single family is renumbered.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn opcode_constants_when_load_const_family_then_pinned_bytes() {
+    assert_eq!(opcode::LOAD_CONST_I32, 0x00);
+    assert_eq!(opcode::LOAD_CONST_I64, 0x01);
+    assert_eq!(opcode::LOAD_CONST_F32, 0x02);
+    assert_eq!(opcode::LOAD_CONST_F64, 0x03);
+}
+
+#[test]
+fn opcode_constants_when_load_bool_family_then_pinned_bytes() {
+    assert_eq!(opcode::LOAD_FALSE, 0x04);
+    assert_eq!(opcode::LOAD_TRUE, 0x05);
+}
+
+#[test]
+fn opcode_constants_when_load_const_str_then_pinned_byte() {
+    assert_eq!(opcode::LOAD_CONST_STR, 0x08);
+}
+
+#[test]
+fn opcode_constants_when_load_var_family_then_pinned_bytes() {
+    assert_eq!(opcode::LOAD_VAR_I32, 0x0C);
+    assert_eq!(opcode::LOAD_VAR_I64, 0x0D);
+    assert_eq!(opcode::LOAD_VAR_F32, 0x0E);
+    assert_eq!(opcode::LOAD_VAR_F64, 0x0F);
+}
+
+#[test]
+fn opcode_constants_when_store_var_family_then_pinned_bytes() {
+    assert_eq!(opcode::STORE_VAR_I32, 0x10);
+    assert_eq!(opcode::STORE_VAR_I64, 0x11);
+    assert_eq!(opcode::STORE_VAR_F32, 0x12);
+    assert_eq!(opcode::STORE_VAR_F64, 0x13);
+}
+
+#[test]
+fn opcode_constants_when_indirect_then_pinned_bytes() {
+    assert_eq!(opcode::LOAD_INDIRECT, 0x14);
+    assert_eq!(opcode::STORE_INDIRECT, 0x18);
+}
+
+#[test]
+fn opcode_constants_when_trunc_family_then_pinned_bytes() {
+    assert_eq!(opcode::TRUNC_I8, 0x1C);
+    assert_eq!(opcode::TRUNC_U8, 0x1D);
+    assert_eq!(opcode::TRUNC_I16, 0x1E);
+    assert_eq!(opcode::TRUNC_U16, 0x1F);
+}
+
+#[test]
+fn opcode_constants_when_arith_family_then_pinned_bytes() {
+    // ADD (op_class 0x08).
+    assert_eq!(opcode::ADD_I32, 0x20);
+    assert_eq!(opcode::ADD_I64, 0x21);
+    assert_eq!(opcode::ADD_F32, 0x22);
+    assert_eq!(opcode::ADD_F64, 0x23);
+    // SUB (0x09).
+    assert_eq!(opcode::SUB_I32, 0x24);
+    assert_eq!(opcode::SUB_I64, 0x25);
+    assert_eq!(opcode::SUB_F32, 0x26);
+    assert_eq!(opcode::SUB_F64, 0x27);
+    // MUL (0x0A).
+    assert_eq!(opcode::MUL_I32, 0x28);
+    assert_eq!(opcode::MUL_I64, 0x29);
+    assert_eq!(opcode::MUL_F32, 0x2A);
+    assert_eq!(opcode::MUL_F64, 0x2B);
+    // NEG (0x0B).
+    assert_eq!(opcode::NEG_I32, 0x2C);
+    assert_eq!(opcode::NEG_I64, 0x2D);
+    assert_eq!(opcode::NEG_F32, 0x2E);
+    assert_eq!(opcode::NEG_F64, 0x2F);
+    // DIV signed (0x0C).
+    assert_eq!(opcode::DIV_I32, 0x30);
+    assert_eq!(opcode::DIV_I64, 0x31);
+    assert_eq!(opcode::DIV_F32, 0x32);
+    assert_eq!(opcode::DIV_F64, 0x33);
+    // DIV unsigned (0x0D, only int variants).
+    assert_eq!(opcode::DIV_U32, 0x34);
+    assert_eq!(opcode::DIV_U64, 0x35);
+    // MOD signed (0x0E, int only).
+    assert_eq!(opcode::MOD_I32, 0x38);
+    assert_eq!(opcode::MOD_I64, 0x39);
+    // MOD unsigned (0x0F, int only).
+    assert_eq!(opcode::MOD_U32, 0x3C);
+    assert_eq!(opcode::MOD_U64, 0x3D);
+}
+
+#[test]
+fn opcode_constants_when_cmp_family_then_pinned_bytes() {
+    // EQ (0x10).
+    assert_eq!(opcode::EQ_I32, 0x40);
+    assert_eq!(opcode::EQ_I64, 0x41);
+    assert_eq!(opcode::EQ_F32, 0x42);
+    assert_eq!(opcode::EQ_F64, 0x43);
+    // NE (0x11).
+    assert_eq!(opcode::NE_I32, 0x44);
+    assert_eq!(opcode::NE_I64, 0x45);
+    assert_eq!(opcode::NE_F32, 0x46);
+    assert_eq!(opcode::NE_F64, 0x47);
+    // LT signed (0x12).
+    assert_eq!(opcode::LT_I32, 0x48);
+    assert_eq!(opcode::LT_I64, 0x49);
+    assert_eq!(opcode::LT_F32, 0x4A);
+    assert_eq!(opcode::LT_F64, 0x4B);
+    // LE signed (0x13).
+    assert_eq!(opcode::LE_I32, 0x4C);
+    assert_eq!(opcode::LE_I64, 0x4D);
+    assert_eq!(opcode::LE_F32, 0x4E);
+    assert_eq!(opcode::LE_F64, 0x4F);
+    // GT signed (0x14).
+    assert_eq!(opcode::GT_I32, 0x50);
+    assert_eq!(opcode::GT_I64, 0x51);
+    assert_eq!(opcode::GT_F32, 0x52);
+    assert_eq!(opcode::GT_F64, 0x53);
+    // GE signed (0x15).
+    assert_eq!(opcode::GE_I32, 0x54);
+    assert_eq!(opcode::GE_I64, 0x55);
+    assert_eq!(opcode::GE_F32, 0x56);
+    assert_eq!(opcode::GE_F64, 0x57);
+    // Unsigned LT/LE/GT/GE (0x16..0x19, int only).
+    assert_eq!(opcode::LT_U32, 0x58);
+    assert_eq!(opcode::LT_U64, 0x59);
+    assert_eq!(opcode::LE_U32, 0x5C);
+    assert_eq!(opcode::LE_U64, 0x5D);
+    assert_eq!(opcode::GT_U32, 0x60);
+    assert_eq!(opcode::GT_U64, 0x61);
+    assert_eq!(opcode::GE_U32, 0x64);
+    assert_eq!(opcode::GE_U64, 0x65);
+}
+
+#[test]
+fn opcode_constants_when_bitwise_family_then_pinned_bytes() {
+    assert_eq!(opcode::BIT_AND_32, 0x68);
+    assert_eq!(opcode::BIT_AND_64, 0x69);
+    assert_eq!(opcode::BIT_OR_32, 0x6C);
+    assert_eq!(opcode::BIT_OR_64, 0x6D);
+    assert_eq!(opcode::BIT_XOR_32, 0x70);
+    assert_eq!(opcode::BIT_XOR_64, 0x71);
+    assert_eq!(opcode::BIT_NOT_32, 0x74);
+    assert_eq!(opcode::BIT_NOT_64, 0x75);
+}
+
+#[test]
+fn opcode_constants_when_bool_family_then_pinned_bytes() {
+    // BOOL_OP consolidates AND/OR/XOR/NOT in the type-tag slots
+    // (0..3) of op-class 0x1E.
+    assert_eq!(opcode::BOOL_AND, 0x78);
+    assert_eq!(opcode::BOOL_OR, 0x79);
+    assert_eq!(opcode::BOOL_XOR, 0x7A);
+    assert_eq!(opcode::BOOL_NOT, 0x7B);
+}
+
+#[test]
+fn opcode_constants_when_control_flow_then_pinned_bytes() {
+    assert_eq!(opcode::JMP, 0x7C);
+    assert_eq!(opcode::JMP_IF_NOT, 0x80);
+    assert_eq!(opcode::CALL, 0x84);
+    assert_eq!(opcode::RET, 0x88);
+    assert_eq!(opcode::RET_VOID, 0x8C);
+}
+
+#[test]
+fn opcode_constants_when_stack_op_family_then_pinned_bytes() {
+    // STACK_OP consolidates POP/DUP/SWAP in type-tag slots 0..2.
+    assert_eq!(opcode::POP, 0x90);
+    assert_eq!(opcode::DUP, 0x91);
+    assert_eq!(opcode::SWAP, 0x92);
+}
+
+#[test]
+fn opcode_constants_when_builtin_then_pinned_byte() {
+    assert_eq!(opcode::BUILTIN, 0x94);
+}
+
+#[test]
+fn opcode_constants_when_fb_family_then_pinned_bytes() {
+    assert_eq!(opcode::FB_LOAD_INSTANCE, 0x98);
+    assert_eq!(opcode::FB_STORE_PARAM, 0x9C);
+    assert_eq!(opcode::FB_LOAD_PARAM, 0xA0);
+    assert_eq!(opcode::FB_CALL, 0xA4);
+}
+
+#[test]
+fn opcode_constants_when_array_family_then_pinned_bytes() {
+    assert_eq!(opcode::LOAD_ARRAY, 0xA8);
+    assert_eq!(opcode::STORE_ARRAY, 0xAC);
+    assert_eq!(opcode::LOAD_ARRAY_DEREF, 0xB0);
+    assert_eq!(opcode::STORE_ARRAY_DEREF, 0xB4);
+}
+
+#[test]
+fn opcode_constants_when_string_family_then_pinned_bytes() {
+    assert_eq!(opcode::STR_INIT, 0xB8);
+    assert_eq!(opcode::STR_LOAD_VAR, 0xBC);
+    assert_eq!(opcode::STR_STORE_VAR, 0xC0);
+    assert_eq!(opcode::LEN_STR, 0xC4);
+    assert_eq!(opcode::FIND_STR, 0xC8);
+    assert_eq!(opcode::REPLACE_STR, 0xCC);
+    assert_eq!(opcode::INSERT_STR, 0xD0);
+    assert_eq!(opcode::DELETE_STR, 0xD4);
+    assert_eq!(opcode::LEFT_STR, 0xD8);
+    assert_eq!(opcode::RIGHT_STR, 0xDC);
+    assert_eq!(opcode::MID_STR, 0xE0);
+    assert_eq!(opcode::CONCAT_STR, 0xE4);
+}
+
+#[test]
+fn opcode_constants_when_string_array_family_then_pinned_bytes() {
+    assert_eq!(opcode::STR_INIT_ARRAY, 0xE8);
+    assert_eq!(opcode::STR_LOAD_ARRAY_ELEM, 0xEC);
+    assert_eq!(opcode::STR_STORE_ARRAY_ELEM, 0xF0);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Encoding-scheme tests.
+//
+// These don't repeat the pinning above; they verify *structural*
+// invariants of the `[op_class:6][type:2]` scheme. A renumbering that
+// preserved every byte value but broke the scheme would be unusual,
+// but a renumbering that broke a single family's invariants is
+// plausible — these tests catch that.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn encoding_when_load_var_family_then_consistent_op_class() {
+    // All LOAD_VAR_* share the same high 6 bits.
+    let class = opcode::LOAD_VAR_I32 >> 2;
+    assert_eq!(opcode::LOAD_VAR_I64 >> 2, class);
+    assert_eq!(opcode::LOAD_VAR_F32 >> 2, class);
+    assert_eq!(opcode::LOAD_VAR_F64 >> 2, class);
+    // Low 2 bits map to type tag.
+    assert_eq!(opcode::LOAD_VAR_I32 & 0b11, opcode::T_I32);
+    assert_eq!(opcode::LOAD_VAR_I64 & 0b11, opcode::T_I64);
+    assert_eq!(opcode::LOAD_VAR_F32 & 0b11, opcode::T_F32);
+    assert_eq!(opcode::LOAD_VAR_F64 & 0b11, opcode::T_F64);
+}
+
+#[test]
+fn encoding_when_store_var_family_then_consistent_op_class() {
+    let class = opcode::STORE_VAR_I32 >> 2;
+    assert_eq!(opcode::STORE_VAR_I64 >> 2, class);
+    assert_eq!(opcode::STORE_VAR_F32 >> 2, class);
+    assert_eq!(opcode::STORE_VAR_F64 >> 2, class);
+    assert_eq!(opcode::STORE_VAR_I32 & 0b11, opcode::T_I32);
+    assert_eq!(opcode::STORE_VAR_I64 & 0b11, opcode::T_I64);
+    assert_eq!(opcode::STORE_VAR_F32 & 0b11, opcode::T_F32);
+    assert_eq!(opcode::STORE_VAR_F64 & 0b11, opcode::T_F64);
+}
+
+#[test]
+fn encoding_when_arithmetic_family_then_consistent_op_class() {
+    for (i32_op, i64_op, f32_op, f64_op) in [
+        (opcode::ADD_I32, opcode::ADD_I64, opcode::ADD_F32, opcode::ADD_F64),
+        (opcode::SUB_I32, opcode::SUB_I64, opcode::SUB_F32, opcode::SUB_F64),
+        (opcode::MUL_I32, opcode::MUL_I64, opcode::MUL_F32, opcode::MUL_F64),
+        (opcode::NEG_I32, opcode::NEG_I64, opcode::NEG_F32, opcode::NEG_F64),
+        (opcode::DIV_I32, opcode::DIV_I64, opcode::DIV_F32, opcode::DIV_F64),
+    ] {
+        let class = i32_op >> 2;
+        assert_eq!(i64_op >> 2, class, "i64 vs i32 op_class mismatch");
+        assert_eq!(f32_op >> 2, class, "f32 vs i32 op_class mismatch");
+        assert_eq!(f64_op >> 2, class, "f64 vs i32 op_class mismatch");
+        assert_eq!(i32_op & 0b11, opcode::T_I32);
+        assert_eq!(i64_op & 0b11, opcode::T_I64);
+        assert_eq!(f32_op & 0b11, opcode::T_F32);
+        assert_eq!(f64_op & 0b11, opcode::T_F64);
+    }
+}
+
+#[test]
+fn encoding_when_comparison_family_then_consistent_op_class() {
+    for (i32_op, i64_op, f32_op, f64_op) in [
+        (opcode::EQ_I32, opcode::EQ_I64, opcode::EQ_F32, opcode::EQ_F64),
+        (opcode::NE_I32, opcode::NE_I64, opcode::NE_F32, opcode::NE_F64),
+        (opcode::LT_I32, opcode::LT_I64, opcode::LT_F32, opcode::LT_F64),
+        (opcode::LE_I32, opcode::LE_I64, opcode::LE_F32, opcode::LE_F64),
+        (opcode::GT_I32, opcode::GT_I64, opcode::GT_F32, opcode::GT_F64),
+        (opcode::GE_I32, opcode::GE_I64, opcode::GE_F32, opcode::GE_F64),
+    ] {
+        let class = i32_op >> 2;
+        assert_eq!(i64_op >> 2, class);
+        assert_eq!(f32_op >> 2, class);
+        assert_eq!(f64_op >> 2, class);
+        assert_eq!(i32_op & 0b11, opcode::T_I32);
+        assert_eq!(i64_op & 0b11, opcode::T_I64);
+        assert_eq!(f32_op & 0b11, opcode::T_F32);
+        assert_eq!(f64_op & 0b11, opcode::T_F64);
+    }
+}
+
+#[test]
+fn encoding_when_consolidated_op_class_then_type_tag_selects_member() {
+    // BOOL_OP: op_class consolidates 4 family members in type-tag slots.
+    let bool_class = opcode::BOOL_AND >> 2;
+    assert_eq!(opcode::BOOL_OR >> 2, bool_class);
+    assert_eq!(opcode::BOOL_XOR >> 2, bool_class);
+    assert_eq!(opcode::BOOL_NOT >> 2, bool_class);
+    assert_eq!(opcode::BOOL_AND & 0b11, 0);
+    assert_eq!(opcode::BOOL_OR & 0b11, 1);
+    assert_eq!(opcode::BOOL_XOR & 0b11, 2);
+    assert_eq!(opcode::BOOL_NOT & 0b11, 3);
+
+    // STACK_OP: similar consolidation for POP/DUP/SWAP.
+    let stack_class = opcode::POP >> 2;
+    assert_eq!(opcode::DUP >> 2, stack_class);
+    assert_eq!(opcode::SWAP >> 2, stack_class);
+    assert_eq!(opcode::POP & 0b11, 0);
+    assert_eq!(opcode::DUP & 0b11, 1);
+    assert_eq!(opcode::SWAP & 0b11, 2);
+}
+
+#[test]
+fn encoding_when_decode_opcode_then_round_trips() {
+    // The decode/encode helpers are part of the wire-format contract:
+    // they let consumers (verifier, disassembler) interpret the byte
+    // layout without per-opcode knowledge.
+    for op in [
+        opcode::LOAD_VAR_I32,
+        opcode::STORE_VAR_F64,
+        opcode::ADD_I64,
+        opcode::EQ_F32,
+        opcode::JMP,
+        opcode::RET_VOID,
+    ] {
+        let (class, tag) = opcode::decode_opcode(op);
+        assert_eq!(opcode::encode_opcode(class, tag), op);
+        assert!(class < 64, "op_class must fit in 6 bits");
+        assert!(tag < 4, "type_tag must fit in 2 bits");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Golden encoding tests — one per shape in `instruction_size`.
+//
+// Each test compiles a tiny program that exercises a specific
+// encoding shape and asserts the **exact** byte sequence. These guard
+// operand widths, little-endian operand encoding, and per-shape
+// layout. A change to any of these would fail here with a
+// byte-for-byte diff.
+// ---------------------------------------------------------------------------
+
+/// Returns the bytecode of the program's main entry function.
+fn bytecode_of(source: &str) -> Vec<u8> {
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    container
+        .code
+        .get_function_bytecode(ironplc_container::FunctionId::new(1))
+        .unwrap()
+        .to_vec()
+}
+
+#[test]
+fn wire_when_one_byte_arith_then_no_operand_bytes() {
+    // SUB_I32 is a 1-byte op (opcode only, no operand).
+    let bc = bytecode_of(
+        "
+PROGRAM main
+  VAR
+    a : DINT;
+    b : DINT;
+  END_VAR
+  a := a - b;
+END_PROGRAM
+",
+    );
+    // Last 5 bytes: SUB_I32 (1) + STORE_VAR_I32 (3) + RET_VOID (1).
+    let len = bc.len();
+    assert_eq!(bc[len - 5], 0x24, "SUB_I32 is one byte at expected offset");
+    assert_eq!(&bc[len - 4..len - 1], &[0x10, 0x00, 0x00], "STORE_VAR_I32 var:0");
+    assert_eq!(bc[len - 1], 0x8C, "RET_VOID");
+}
+
+#[test]
+fn wire_when_three_byte_load_var_then_le_u16_operand() {
+    // LOAD_VAR_I32 var:1 — opcode + LE u16 operand 0x0001.
+    let bc = bytecode_of(
+        "
+PROGRAM main
+  VAR
+    a : DINT;
+    b : DINT;
+  END_VAR
+  a := b;
+END_PROGRAM
+",
+    );
+    // First 3 bytes: LOAD_VAR_I32 followed by LE u16.
+    assert_eq!(&bc[0..3], &[0x0C, 0x01, 0x00], "LOAD_VAR_I32 var:1 (LE u16)");
+}
+
+#[test]
+fn wire_when_three_byte_load_const_then_le_u16_pool_index() {
+    // LOAD_CONST_I32 pool:0 — opcode + LE u16.
+    let bc = bytecode_of(
+        "
+PROGRAM main
+  VAR
+    a : DINT;
+  END_VAR
+  a := 42;
+END_PROGRAM
+",
+    );
+    assert_eq!(&bc[0..3], &[0x00, 0x00, 0x00], "LOAD_CONST_I32 pool:0");
+}
+
+#[test]
+fn wire_when_jmp_then_le_i16_signed_offset() {
+    // WHILE loop produces JMP_IF_NOT (forward) and JMP (backward).
+    let bc = bytecode_of(
+        "
+PROGRAM main
+  VAR
+    x : DINT;
+  END_VAR
+  WHILE x > 0 DO
+    x := x - 1;
+  END_WHILE;
+END_PROGRAM
+",
+    );
+    // From compile_loops.rs: JMP_IF_NOT at offset 7 with +13 forward,
+    // JMP at offset 20 with -23 backward. Validates LE i16 encoding.
+    assert_eq!(bc[7], 0x80, "JMP_IF_NOT");
+    assert_eq!(i16::from_le_bytes([bc[8], bc[9]]), 13, "forward LE i16");
+    assert_eq!(bc[20], 0x7C, "JMP");
+    assert_eq!(i16::from_le_bytes([bc[21], bc[22]]), -23, "backward LE i16");
+}
+
+#[test]
+fn wire_when_five_byte_call_then_two_le_u16_operands() {
+    // CALL emits opcode + LE u16 func_id + LE u16 var_offset.
+    // The CALL appears in the program function (the caller), whose
+    // FunctionId varies depending on how many functions are declared.
+    let container = parse_and_compile(
+        "
+FUNCTION ADD_ONE : DINT
+VAR_INPUT
+    x : DINT;
+END_VAR
+    ADD_ONE := x + 1;
+END_FUNCTION
+
+PROGRAM main
+VAR
+    r : DINT;
+END_VAR
+    r := ADD_ONE(5);
+END_PROGRAM
+",
+        &CompilerOptions::default(),
+    );
+    // Walk every function looking for CALL. Any function may contain
+    // it; we just need one occurrence to validate the wire shape.
+    let (call_bc, call_pos) = container
+        .code
+        .functions
+        .iter()
+        .find_map(|entry| {
+            let bc = container.code.get_function_bytecode(entry.function_id)?;
+            bc.iter().position(|&b| b == opcode::CALL).map(|p| (bc, p))
+        })
+        .expect("CALL opcode present in some function");
+    assert_eq!(opcode::instruction_size(opcode::CALL), 5);
+    assert!(
+        call_pos + 5 <= call_bc.len(),
+        "CALL has 4 trailing operand bytes"
+    );
+    // Decode trailing operands: two LE u16 values. We don't assert
+    // exact values (codegen may renumber functions/vars) but they
+    // must decode without panic.
+    let _func_id = u16::from_le_bytes([call_bc[call_pos + 1], call_bc[call_pos + 2]]);
+    let _var_offset = u16::from_le_bytes([call_bc[call_pos + 3], call_bc[call_pos + 4]]);
+}
+
+#[test]
+fn wire_when_seven_byte_str_init_then_u32_plus_u16_operands() {
+    // STR_INIT is the only 7-byte shape (op + u32 data_offset + u16 max_len).
+    // It appears in the program-init function (FunctionId 0), not main.
+    let container = parse_and_compile(
+        "
+PROGRAM main
+  VAR
+    s : STRING[10];
+  END_VAR
+END_PROGRAM
+",
+        &CompilerOptions::default(),
+    );
+    let init_bc = container
+        .code
+        .get_function_bytecode(ironplc_container::FunctionId::new(0))
+        .unwrap();
+    // Find STR_INIT (0xB8). Validate the 6 trailing operand bytes
+    // decode as LE u32 + LE u16.
+    let pos = init_bc
+        .iter()
+        .position(|&b| b == 0xB8)
+        .expect("STR_INIT opcode present in program init");
+    assert_eq!(opcode::instruction_size(opcode::STR_INIT), 7);
+    assert!(pos + 7 <= init_bc.len(), "STR_INIT has 6 trailing operand bytes");
+    let _data_offset = u32::from_le_bytes([
+        init_bc[pos + 1],
+        init_bc[pos + 2],
+        init_bc[pos + 3],
+        init_bc[pos + 4],
+    ]);
+    let max_len = u16::from_le_bytes([init_bc[pos + 5], init_bc[pos + 6]]);
+    assert_eq!(max_len, 10, "STRING[10] declares max_len = 10");
+}
+
+#[test]
+fn wire_when_five_byte_len_str_then_le_u32_operand() {
+    // LEN_STR is a 5-byte shape (op + u32 data_offset).
+    let bc = bytecode_of(
+        "
+PROGRAM main
+  VAR
+    s : STRING[10];
+    n : DINT;
+  END_VAR
+  n := LEN(s);
+END_PROGRAM
+",
+    );
+    let pos = bc
+        .iter()
+        .position(|&b| b == 0xC4)
+        .expect("LEN_STR opcode present");
+    assert_eq!(opcode::instruction_size(opcode::LEN_STR), 5);
+    assert!(pos + 5 <= bc.len(), "LEN_STR has 4 trailing u32 bytes");
+    let _data_offset = u32::from_le_bytes([
+        bc[pos + 1],
+        bc[pos + 2],
+        bc[pos + 3],
+        bc[pos + 4],
+    ]);
+}
+
+#[test]
+fn wire_when_nine_byte_find_str_then_two_le_u32_operands() {
+    // FIND_STR / REPLACE_STR / INSERT_STR / CONCAT_STR are 9-byte
+    // shapes: opcode + two LE u32 data_offsets.
+    let bc = bytecode_of(
+        "
+PROGRAM main
+  VAR
+    s1 : STRING[10];
+    s2 : STRING[5];
+    n : DINT;
+  END_VAR
+  n := FIND(s1, s2);
+END_PROGRAM
+",
+    );
+    let pos = bc
+        .iter()
+        .position(|&b| b == 0xC8)
+        .expect("FIND_STR opcode present");
+    assert_eq!(opcode::instruction_size(opcode::FIND_STR), 9);
+    assert!(pos + 9 <= bc.len(), "FIND_STR has 8 trailing u32 bytes");
+    let _in1 = u32::from_le_bytes([bc[pos + 1], bc[pos + 2], bc[pos + 3], bc[pos + 4]]);
+    let _in2 = u32::from_le_bytes([bc[pos + 5], bc[pos + 6], bc[pos + 7], bc[pos + 8]]);
+}
+
+#[test]
+fn wire_when_ret_void_then_one_byte_ends_program() {
+    // Every program ends with RET_VOID (0x8C). Trivial guard, but it
+    // pins a wire-level invariant: programs are byte-terminated.
+    let bc = bytecode_of(
+        "
+PROGRAM main
+  VAR
+    x : DINT;
+  END_VAR
+  x := 0;
+END_PROGRAM
+",
+    );
+    assert_eq!(bc.last().copied(), Some(0x8C), "RET_VOID terminates program");
+}

--- a/specs/plans/2026-05-02-codegen-test-wire-format-split.md
+++ b/specs/plans/2026-05-02-codegen-test-wire-format-split.md
@@ -1,0 +1,200 @@
+# Plan: Codegen Test Sweep — Wire-Format vs. Behavioural Split
+
+## Context
+
+The codegen test suite has ~80 callsites of `get_function_bytecode()`
+across 34 test files in `compiler/codegen/tests/`. Each callsite
+inlines a raw byte literal like:
+
+```rust
+&[
+    0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+    0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
+    0x6C,             // GT_I32
+    0xB2, 0x0D, 0x00, // JMP_IF_NOT offset:+13
+    ...
+]
+```
+(see `compiler/codegen/tests/compile_loops.rs` for the dominant
+pattern).
+
+These literals are doing **two distinct jobs at once**:
+
+- **Job A — Behavioural:** verifying that codegen emits the right
+  *sequence of opcodes in the right order* for each language
+  construct. This is the dominant case across most tests.
+- **Job B — Wire-format compatibility:** ensuring that the
+  *byte-level encoding* doesn't drift accidentally — opcode
+  renumbering, endianness flips, operand-width changes. Because
+  tests use internally-defined constants, naive symbolic-only
+  assertions would pass silently while the wire format silently
+  broke.
+
+The cost of conflating them is concrete and ongoing:
+
+- The eight-wave opcode-encoding migration
+  (`specs/plans/2026-05-01-opcode-encoding-wave-{2..8}.md`) has
+  already paid this tax repeatedly — every renumber wave touches
+  ~30 codegen test files because the wire-format byte values are
+  smeared across each test. This plan removes that tax for future
+  encoding experiments (including but not limited to a possible
+  cell-based encoding migration described in
+  `specs/plans/2026-04-30-vm-predecoded-instructions.md`).
+- A renumber today fails ~30 tests with confusingly different
+  diffs across files. The actual contract violation — "this opcode
+  constant changed" — is buried.
+
+The fix is to **separate the two jobs explicitly**. Job B becomes
+*more* tightly enforced, not less.
+
+## Scope
+
+- **Add** `compiler/codegen/tests/wire_format.rs` — the canonical
+  wire-format test file (opcode-byte pinning + golden encoding
+  tests).
+- **Add** `assert_bytecode!` helper in
+  `compiler/codegen/tests/common/mod.rs`.
+- **Sweep** the ~30+ `compile_*.rs` test files to use the helper
+  for the behavioural assertions, leaving wire-format guarantees
+  centralized in `wire_format.rs`.
+
+## What this plan does NOT do
+
+- **No production code changes.** This is purely test
+  infrastructure. No changes to `Emitter`, the VM dispatch loop,
+  the container format, or any opcode definitions.
+- **No commitment to cell-based encoding.** This work facilitates
+  benchmarking and testing of future encoding experiments without
+  prescribing which experiment.
+- **No removal of `end_to_end_*.rs` round-trip tests.** Those
+  exercise complete program execution and are a separate
+  behavioural layer.
+
+## Steps
+
+### 1. `compiler/codegen/tests/wire_format.rs` — new
+
+Two kinds of tests live here:
+
+**(a) Opcode-byte pinning.** A test asserts every public
+opcode constant in `compiler/container/src/opcode.rs` matches its
+expected byte value. The existing structured `[op_class:6][type:2]`
+encoding already documents what each value should be, so the test
+can be organized by op-class. A separate test asserts the
+**encoding scheme** — i.e., for op-classes with multiple type
+variants, the low 2 bits map to the documented type tag, and the
+high 6 bits are constant within a family. This catches accidental
+violations of the encoding contract, not just byte drift.
+
+**(b) Golden encoding tests** (~10-15 tests). One test per
+*encoding shape* taken from `opcode::instruction_size()`:
+
+| Shape                       | Example opcode(s)                | Test name                               |
+| --------------------------- | -------------------------------- | --------------------------------------- |
+| 1-byte                      | ADD_I32                          | `wire_when_1byte_op_then_one_byte`      |
+| 2-byte (op + u8)            | FB_STORE_PARAM                   | `wire_when_fb_param_then_two_bytes`     |
+| 3-byte (op + u16)           | LOAD_VAR_I32                     | `wire_when_load_var_then_three_bytes`   |
+| 3-byte (op + i16)           | JMP, JMP_IF_NOT                  | `wire_when_jmp_then_three_bytes_le_i16` |
+| 5-byte (op + u16 + u16)     | CALL, LOAD_ARRAY                 | `wire_when_call_then_five_bytes`        |
+| 5-byte (op + u32)           | STR_LOAD_VAR, LEN_STR            | `wire_when_str_load_then_five_bytes`    |
+| 7-byte (op + u32 + u16)     | STR_INIT                         | `wire_when_str_init_then_seven_bytes`   |
+| 9-byte (op + u32 + u32)     | FIND_STR / REPLACE_STR / etc.    | `wire_when_find_str_then_nine_bytes`    |
+
+Each test compiles a minimal source program and asserts the exact
+raw bytes. These are the canonical guards for operand widths,
+endianness (little-endian per
+`compiler/container/src/code_section.rs`), and per-shape layout.
+
+### 2. `compiler/codegen/tests/common/mod.rs` — `assert_bytecode!` helper
+
+A `macro_rules!` macro that:
+
+- Accepts a sequence of opcode-with-operand tokens like
+  `LOAD_VAR_I32(0)`, `JMP_IF_NOT(13)`, `CALL { func: 1, vars: 0 }`,
+  `RET_VOID`.
+- Renders both the **expected** sequence and the **actual**
+  bytecode into a normalized symbolic form (`OP_NAME operand` per
+  line) and `assert_eq!`s them.
+- Walks the actual byte stream using `opcode::instruction_size()`
+  (single source of truth at `compiler/container/src/opcode.rs`) so
+  no per-opcode width logic is duplicated.
+- Handles peephole-DUP forms by accepting bare `DUP` tokens.
+- Uses informative failure output: when the assertion fails it
+  prints both sequences side-by-side so the diff identifies which
+  *instruction* differs, not which byte.
+
+The macro is opcode-name-symbolic, so a future opcode renumber
+does not touch any callsite.
+
+### 3. Sweep `compile_*.rs` tests
+
+Mechanical conversion. Each call site replaces a byte-literal
+`assert_eq!(bytecode, &[ ... ])` with an `assert_bytecode!(bytecode,
+[ ... ])`. The translation is line-for-line:
+
+```rust
+// Before:
+assert_eq!(
+    bytecode,
+    &[
+        0x10, 0x00, 0x00, // LOAD_VAR_I32 var:0
+        0x01, 0x00, 0x00, // LOAD_CONST_I32 pool:0 (0)
+        0x6C,             // GT_I32
+        0xB2, 0x0D, 0x00, // JMP_IF_NOT offset:+13
+        0xB5,             // RET_VOID
+    ]
+);
+
+// After:
+assert_bytecode!(bytecode, [
+    LOAD_VAR_I32(0),
+    LOAD_CONST_I32(0),
+    GT_I32,
+    JMP_IF_NOT(13),
+    RET_VOID,
+]);
+```
+
+Files affected (~30+, identifiable via `git grep -l
+'get_function_bytecode' compiler/codegen/tests/`):
+`compile_abs*.rs`, `compile_add.rs`, `compile_array.rs`,
+`compile_bitwise.rs`, `compile_bool.rs`, `compile_case.rs`,
+`compile_cmp.rs`, `compile_dup.rs`, `compile_exit_return.rs`,
+`compile_float.rs`, `compile_func_forms.rs`, `compile_if.rs`,
+`compile_limit*.rs`, `compile_loops.rs`, `compile_max*.rs`,
+`compile_min*.rs`, `compile_mod.rs`, `compile_mul.rs`,
+`compile_mux*.rs`, `compile_neg.rs`, `compile_pow.rs`,
+`compile_sel*.rs`, `compile_shift.rs`, `compile_sqrt.rs`,
+`compile_struct.rs`, `compile_sub.rs`, `compile_types.rs`.
+
+### 4. Verification
+
+- Land `wire_format.rs` first (step 1). Verify it actually catches
+  drift by deliberately mutating one opcode constant in a scratch
+  branch and confirming exactly the wire-format test fails with a
+  clear message. Revert the mutation.
+- Land the `assert_bytecode!` helper (step 2). Self-test the macro
+  with a small fixed bytecode in `common/mod.rs` itself.
+- Sweep `compile_*.rs` files (step 3) — each commit is mechanical
+  and reviewable in isolation. After the sweep, repeat the
+  scratch-branch opcode mutation and confirm only `wire_format.rs`
+  fails (proving the partition is clean).
+- `cd compiler && just` passes throughout.
+
+## Test naming
+
+All new tests follow the project BDD convention
+`function_when_condition_then_result`:
+
+- `opcode_constants_when_pinned_then_match_canonical_bytes`
+- `wire_when_load_var_i32_then_three_bytes_le_u16`
+- etc.
+
+## Out of scope
+
+- The cell-based encoding migration itself
+  (`specs/plans/2026-04-30-vm-predecoded-instructions.md`). This
+  test infrastructure makes that decision *cheaper to test*, not
+  inevitable.
+- Reorganizing the `compile_*.rs` test file layout.
+- Replacing the existing `end_to_end_*.rs` round-trip tests.


### PR DESCRIPTION
The codegen test suite inlines raw bytecode literals in ~80 places
across 34 test files. Today these literals serve two jobs at once:
verifying that codegen emits the right opcodes (Job A), and acting
as the wire-format compatibility guard against accidental opcode
renumbering / endianness flips / operand-width drift (Job B).

This plan separates the two jobs so future encoding experiments
(eight ongoing renumbering waves, possible cell-based dispatch)
don't pay a 30-test-file rewrite tax each time, and so wire-format
breakage fails one focused test instead of ~30 confusing diffs.

No production code changes; pure test infrastructure.