### PR TITLE
Add measurement findings for bytecode dispatch bounds-check elision

### DIFF
--- a/compiler/benchmarks/examples/vm_vs_native.rs
+++ b/compiler/benchmarks/examples/vm_vs_native.rs
@@ -1,0 +1,108 @@
+//! Throwaway comparison binary: VM counter loop vs native counter loop.
+//!
+//! Run under callgrind to get instruction counts:
+//!   cargo build --release --example vm_vs_native -p ironplc-benchmarks
+//!   valgrind --tool=callgrind --callgrind-out-file=/tmp/vm.cg \
+//!     target/release/examples/vm_vs_native vm 10000
+//!   valgrind --tool=callgrind --callgrind-out-file=/tmp/native.cg \
+//!     target/release/examples/vm_vs_native native 10000
+//!   callgrind_annotate /tmp/vm.cg | head -40
+//!   callgrind_annotate /tmp/native.cg | head -40
+//!
+//! Or run directly for wall-clock comparison:
+//!   target/release/examples/vm_vs_native compare 100000
+
+use ironplc_benchmarks::compile_st;
+use ironplc_vm::test_support::load_and_start;
+use ironplc_vm::{Slot, VmBuffers};
+use std::env;
+use std::hint::black_box;
+use std::time::Instant;
+
+// Sums i from `iterations` down to 1 in a counter-style loop.
+// `total` is observable so the compiler can't fold the loop away.
+const COUNTER_LOOP: &str = "PROGRAM main
+  VAR counter : DINT; total : DINT; END_VAR
+  WHILE counter > 0 DO
+    total := total + counter;
+    counter := counter - 1;
+  END_WHILE;
+END_PROGRAM";
+
+#[inline(never)]
+fn run_native(iterations: i32) -> i32 {
+    let mut counter = black_box(iterations);
+    let mut total: i32 = black_box(0);
+    while black_box(counter) > 0 {
+        total = black_box(total.wrapping_add(counter));
+        counter = black_box(counter - 1);
+    }
+    black_box(total)
+}
+
+// Pre-built container; we time only execution.
+fn run_vm_prebuilt(container: &ironplc_container::Container, iterations: i32) {
+    let mut bufs = VmBuffers::from_container(container);
+    bufs.vars[0] = Slot::from_i32(iterations);
+    bufs.vars[1] = Slot::from_i32(0);
+    let mut vm = load_and_start(container, &mut bufs).unwrap();
+    vm.run_round(0).unwrap();
+    black_box(&bufs);
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mode = args.get(1).map(|s| s.as_str()).unwrap_or("compare");
+    let iters: i32 = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10_000);
+
+    match mode {
+        "vm" => {
+            // For callgrind: hoist compilation, then execute many times.
+            let container = compile_st(COUNTER_LOOP);
+            for _ in 0..1000 {
+                run_vm_prebuilt(&container, iters);
+            }
+        }
+        "native" => {
+            let mut acc: i32 = 0;
+            for _ in 0..1000 {
+                acc = acc.wrapping_add(run_native(iters));
+            }
+            black_box(acc);
+        }
+        "compare" => {
+            let container = compile_st(COUNTER_LOOP);
+
+            const REPS: u32 = 200;
+
+            for _ in 0..10 {
+                black_box(run_native(iters));
+                run_vm_prebuilt(&container, iters);
+            }
+
+            let t0 = Instant::now();
+            for _ in 0..REPS {
+                black_box(run_native(iters));
+            }
+            let native_dt = t0.elapsed() / REPS;
+
+            let t0 = Instant::now();
+            for _ in 0..REPS {
+                run_vm_prebuilt(&container, iters);
+            }
+            let vm_dt = t0.elapsed() / REPS;
+
+            let ratio = vm_dt.as_nanos() as f64 / native_dt.as_nanos() as f64;
+            let ns_per_iter_vm = vm_dt.as_nanos() as f64 / iters as f64;
+            let ns_per_iter_native = native_dt.as_nanos() as f64 / iters as f64;
+            println!(
+                "iters={iters} native={:?} ({:.2} ns/iter) vm={:?} ({:.2} ns/iter) ratio={:.1}x",
+                native_dt, ns_per_iter_native, vm_dt, ns_per_iter_vm, ratio
+            );
+        }
+        other => eprintln!("unknown mode: {other}"),
+    }
+}

--- a/specs/plans/2026-05-02-bytecode-dispatch-bounds-check-measurement.md
+++ b/specs/plans/2026-05-02-bytecode-dispatch-bounds-check-measurement.md
@@ -1,0 +1,99 @@
+# Bytecode Dispatch Bounds-Check Measurement
+
+**Date:** 2026-05-02
+**Branch:** `claude/bytecode-cells-optimization-LNlzN` (measurement done on `measurement/bounds-check-experiment`)
+**Status:** Investigation complete — no action recommended.
+
+## Question
+
+Are per-instruction bounds checks in the VM dispatch loop a meaningful bottleneck? If so, would restructuring bytecode storage (cells / enum-decoded array) be worth the RAM cost, complexity, and loss of zero-copy in the no_std `ContainerRef` flow?
+
+## Method
+
+Three layers, on the existing criterion benchmarks at `compiler/benchmarks/benches/st_benchmark.rs`:
+
+1. **Baseline** — current code, no changes.
+2. **Variant A (safe-Rust slice fix)** — rewrite `read_u16_le`/`read_u32_le`/`read_i16_le` in `compiler/vm/src/vm.rs:2074-2118` to use `bytecode.get(*pc..end).ok_or(...)?` plus `slice.try_into()` instead of byte-by-byte indexing. Same semantics, no `unsafe`.
+3. **Variant B (unsafe upper-bound)** — replace each per-byte `bytecode[*pc + N]` with `unsafe { *bytecode.get_unchecked(*pc + N) }`, keeping the explicit bounds guard. This is the absolute ceiling on any safe-or-unsafe approach.
+
+Disassembly inspection via `cargo rustc --release --emit=asm`. All measurements on this branch's machine; criterion default settings.
+
+## Findings
+
+### 1. Source has redundant per-byte bounds checks the optimizer doesn't elide
+
+Standalone `read_u32_le` asm shows **5 bounds checks for one 4-byte read**: the explicit `if end > bytecode.len()` guard plus 4 redundant per-byte checks (`bytecode[*pc]`, `bytecode[*pc+1]`, `bytecode[*pc+2]`, `bytecode[*pc+3]`). LLVM does not propagate the explicit guard's proof to the byte indexing.
+
+In the inlined dispatch function `execute_with_hook`:
+- 29 `panic_bounds_check` call sites
+- 647 `cmp` instructions
+- 525 unsigned conditional jumps (mostly bounds-related)
+
+### 2. Variant A reduces asm bounds checks by 55% but changes inlining
+
+| Metric | Baseline | Variant A |
+|---|---|---|
+| `execute_with_hook` size | 7634 lines | 7131 lines (-6.6%) |
+| `panic_bounds_check` sites | 29 | 13 (-55%) |
+| `cmp` instructions | 647 | 614 |
+
+Asm clearly improved. Runtime impact: confounded by environmental drift (see #4 below).
+
+### 3. Variant B (unsafe upper-bound) is ~9% **slower** than steady-state baseline
+
+| Bench | Baseline (steady) | Variant B | Δ |
+|---|---|---|---|
+| `st_counter_loop/10000` | 287.45 µs | 314.05 µs | **+9.3%** |
+| `st_arithmetic_i32/1000` | 25.90 µs | 28.95 µs | **+11.8%** |
+| `st_for_loop/10000` | 392.05 µs | 422.51 µs | **+7.8%** |
+| `st_nested_loops/100x100` | 433.81 µs | 486.11 µs | **+12.1%** |
+
+Removing bounds checks **regressed performance** consistently across dispatch-heavy benches. Most likely cause: the bounds branches were well-predicted (always succeed), and removing them changed code layout, register allocation, and inlining decisions in ways that hurt overall throughput.
+
+### 4. Benchmark environment drift exceeds plausible win
+
+The same baseline code, run three times, produced 232 µs / 288 µs / 287 µs for `st_counter_loop/10000` — a **~24% drift** between cold and steady-state runs. Reliable A/B differentiation in this environment requires effects larger than ~5–10%, and ideally back-to-back runs. The bounds-check effect we set out to measure is below this floor.
+
+## Conclusion
+
+**The cells / enum-decoded array restructuring is not justified.**
+
+- Variant B sets the absolute ceiling on what any bounds-check-elimination strategy (cells, enum array, threaded code, unsafe `get_unchecked`) can achieve. That ceiling is **negative** — removing checks made the dispatch loop slower in steady state.
+- The CPU is already hiding the per-instruction bounds-check cost via branch prediction (the checks always succeed) and instruction-level parallelism. The asm shows checks; the pipeline schedules around them for free.
+- Therefore, no structural change is warranted purely for bounds-check elimination. The cost of cells (RAM growth, broken zero-copy in `ContainerRef`, breaking std/no_std uniformity) buys nothing.
+
+## Recommendations
+
+### Don't do
+- **Cells / enum-decoded instruction array.** No measurable upside; real downside (RAM, zero-copy loss).
+- **Variant A's safe-Rust rewrite of `read_*` helpers.** Asm looks better but real-world impact is at best neutral and possibly negative; not worth the churn.
+- **Streaming decoder via `BufReader`.** Only relevant if cells were chosen.
+
+### Maybe worth investigating later (separate plans)
+- **Where the actual VM time goes.** Profile (`perf record` or `cargo flamegraph`) on `st_counter_loop/10000` to find the real hot spots — likely stack push/pop, value boxing/unboxing in `Slot`, or constant-pool access, not opcode fetch.
+- **Per-opcode hot-path specialization.** `st_diverse_opcodes` is ~10× slower per-instruction than `st_counter_loop` (2.95 vs 43 Melem/s). Worth understanding why.
+- **Stable benchmarking environment.** Pin frequency, isolate cores, fix the 24% drift before any future micro-optimization claims.
+
+## Critical Files (for the record)
+
+- `compiler/vm/src/vm.rs:682-688` — main dispatch loop
+- `compiler/vm/src/vm.rs:2074-2118` — `read_u8`/`read_u16_le`/`read_u32_le`/`read_i16_le`
+- `compiler/container/src/code_section.rs:26` — `Vec<u8>` storage
+- `compiler/container/src/container_ref.rs:47` — no_std zero-copy view (would be invalidated by cells)
+- `compiler/benchmarks/benches/st_benchmark.rs:38` — `st_counter_loop` ("dispatch overhead baseline")
+- `compiler/vm/src/profile.rs` — existing per-opcode profiling (gated on `profiling` feature) — useful for the hot-spot follow-up
+
+## Raw Data
+
+Saved at `/tmp/measure/` on the measurement machine (not committed):
+- `baseline.txt`, `baseline2.txt`, `baseline3.txt` — three baseline runs
+- `variant_a.txt` — variant A benches
+- `variant_b.txt`, `variant_b2.txt` — variant B benches
+- `asm_variantB.s` — variant B disassembly
+- `criterion-baseline/` — criterion JSON outputs
+
+## Out of Scope
+
+- Implementing any of the structural changes considered (cells, enum array, threaded code).
+- Fixing the criterion environment drift.
+- Profiling for non-bounds-check bottlenecks.

--- a/specs/plans/2026-05-02-bytecode-dispatch-bounds-check-measurement.md
+++ b/specs/plans/2026-05-02-bytecode-dispatch-bounds-check-measurement.md
@@ -62,6 +62,54 @@ The same baseline code, run three times, produced 232 µs / 288 µs / 287 µs fo
 - The CPU is already hiding the per-instruction bounds-check cost via branch prediction (the checks always succeed) and instruction-level parallelism. The asm shows checks; the pipeline schedules around them for free.
 - Therefore, no structural change is warranted purely for bounds-check elimination. The cost of cells (RAM growth, broken zero-copy in `ContainerRef`, breaking std/no_std uniformity) buys nothing.
 
+## Where the VM cost actually goes (callgrind)
+
+The original investigation was prompted by a "VM is ~200x slower than native" observation. To see whether bounds checks could possibly explain that gap, we measured exact instruction counts via callgrind on a counter-loop workload (`total := total + counter; counter := counter - 1;`) — see `compiler/benchmarks/examples/vm_vs_native.rs`.
+
+| Workload | Wall-clock per iter | Instructions per iter |
+|---|---|---|
+| Native scalar Rust (with `black_box`) | ~3 ns | 7.59 |
+| IronPLC VM | ~45 ns | 499.71 |
+| **Ratio** | **~15x** | **~66x** |
+
+Wall-clock VM:native is ~15x — not 200x. The wider gap to "200x" almost certainly comes from comparing IronPLC against a **compiled** native-PLC runtime (MATIEC, RuSTy compile ST → native machine code with loop optimizations), where native achieves ~1-2 instrs/iter and the ratio jumps to ~250x. That is fundamentally a "interpreter vs compiler" gap, not a "bounds check" gap.
+
+**Where the 500 VM instructions per iteration go:**
+
+| Function | Instr % | Per VM iter |
+|---|---|---|
+| `vm::execute_with_hook` (dispatch + handlers) | **90.33%** | ~451 instr |
+| `container::ConstantPool::get_i32` | **8.01%** | ~40 instr (called 2x/iter) |
+| Everything else (malloc, memcpy, container setup) | <2% | ~9 instr |
+
+The body `total := total + counter; counter := counter - 1;` compiles to roughly 12 VM opcodes per iteration (load_var ×3, load_const ×2, add, sub, store_var ×2, plus the WHILE comparison/branch). At 451 dispatch instructions for ~12 opcodes, that's **~37 native instructions per VM opcode**.
+
+The ~37 instr/opcode breaks down (per the asm at vm.rs dispatch loop and handlers):
+
+- **~10 instr** dispatch overhead per opcode: load pc from stack, bounds check, fetch opcode, jump-table lookup, indirect jump. PC lives on the stack (`[rsp+64]`) because the function is too register-pressured — every opcode pays 2 memory ops just to maintain pc.
+- **~15-20 instr** for stack push/pop with type tags (each `Slot` carries a tag, every push/pop checks/sets it).
+- **~5-10 instr** for the actual operation (add, load var, etc.).
+
+## Two concrete bottlenecks visible in this data
+
+1. **`ConstantPool::get_i32` is unnecessarily expensive (~40 instr/call, 8% of total).** In `compiler/container/src/constant_pool.rs:75`, `ConstEntry` stores `value: Vec<u8>` (heap allocation per constant). Every i32 load does: vec bounds check → pointer chase to ConstEntry → pointer chase to its inner Vec → `copy_from_slice` + `from_le_bytes`. A dense `Vec<i32>` (or inline u8 array) would cut this to ~5 instr. Estimated win: ~7% wall-clock on constant-heavy workloads.
+
+2. **The dispatch function is monolithic and stack-spilled.** 7600 lines of asm, 2200-byte stack frame, pc lives in memory. This is exactly what the existing `specs/design/vm-performance.md` Tier 1 (superinstructions, fused load-op-store, opcode consolidation) and Tier 2 (register-based translation, tail-call threading) are designed to attack. Bounds-check elimination — what we measured here — is *not* the lever; the structural improvements in that doc are.
+
+## Concrete recommendations
+
+### Skip
+- Cells / enum-decoded instruction array — provably no benefit (variant B was slower).
+- Variant A's safe-Rust `read_*` rewrite — no measurable benefit, possibly negative.
+- Streaming load via `BufReader` — was only relevant if cells.
+
+### Worth doing
+- **Restructure `ConstantPool` storage** — separate `Vec<i32>`/`Vec<f32>`/`Vec<f64>` per type, or inline-typed bytes. Eliminates the heap-Vec-per-entry indirection. Small, mechanical change. ~7% expected win on constant-heavy code, possibly more.
+- **Pursue items already cataloged in `specs/design/vm-performance.md`** — superinstructions, fused load-op-store, opcode consolidation (Tier 1), then register-based translation or tail-call threading (Tier 2). These attack the per-opcode count and per-opcode dispatch cost, which is where the 90% lives. They were always the right answer; this measurement just confirms it.
+
+### Worth doing first (orthogonal)
+- **Stabilize the criterion bench environment.** 24% drift between cold and warm runs makes any future micro-optimization claim noisy. Pin CPU frequency and isolate cores before any of the above optimizations are landed.
+
 ## Recommendations
 
 ### Don't do

--- a/specs/plans/2026-05-02-cold-path-split-experiment.md
+++ b/specs/plans/2026-05-02-cold-path-split-experiment.md
@@ -1,0 +1,81 @@
+# Experiment: Cold-path-split via `#[inline(never)]` (option #1)
+
+**Date:** 2026-05-02
+**Branch:** `claude/bytecode-cells-optimization-LNlzN`
+**Driver:** [bytecode-dispatch-bounds-check measurement](2026-05-02-bytecode-dispatch-bounds-check-measurement.md)
+**Status:** Hypothesis falsified. No code change recommended.
+
+## Hypothesis
+
+Earlier callgrind data showed `vm::execute_with_hook` is 7634 asm lines with a 2200-byte stack frame, and pc lives at `[rsp+64]` (stack memory) every dispatch — strongly suggesting the function is too register-pressured for LLVM to keep pc in a register. The hypothesis: outlining cold opcode handlers as `#[inline(never)]` functions would shrink the hot dispatch enough to relieve register pressure, letting pc move to a register and saving ~2 memory ops per dispatch.
+
+The user's prior two-level-dispatch attempt failed; this experiment was meant to test whether the *register-pressure* angle (rather than dispatch-table-size angle) was the right diagnosis.
+
+## Method
+
+Two outlining sizes, both as `#[inline(never)]` functions called from a single fall-through arm in the main match:
+
+1. **Small outline**: the BUILTIN arm body (numeric ↔ STRING conversions + CMP_STR), ~118 source lines.
+2. **Larger outline**: the contiguous string opcode section (STR_INIT through STR_STORE_ARRAY_ELEM), ~602 source lines.
+
+Measured for each:
+- Asm size of `execute_with_hook` after release-mode build
+- Callgrind instruction count on `examples/vm_vs_native vm 1000` (counter-loop workload, 1M total iterations)
+- Wall-clock ns/iter on the same workload, median of 5 back-to-back runs
+
+Each variant was compared back-to-back with a re-measured baseline on the same machine to neutralise environmental drift (which had previously measured ~24% in this environment).
+
+## Results
+
+| Variant | `execute_with_hook` asm | `panic_bounds_check` sites | Callgrind Ir (1M iters) | Median wall-clock |
+|---|---|---|---|---|
+| Baseline | 7634 lines | 29 | 499,710,708 | 31.90 ns/iter |
+| BUILTIN outlined (118 lines) | 6960 (-9%) | 22 (-24%) | 510,723,786 (+2.2%) | 33.16 ns/iter (+4.0%) |
+| String section outlined (602 lines) | 4975 (-35%) | 14 (-52%) | 514,679,047 (+3.0%) | 33.32 ns/iter (+4.5%) |
+
+**The dispatch function shrank dramatically, but the experiment got *slower* in both retired-instruction count and wall-clock.**
+
+PC remained at `[rsp+48]` (stack memory) in the outlined version — the 35% function-size reduction did not relieve register pressure to the point where LLVM could keep pc in a register. The bottleneck registers are not being held by cold opcodes.
+
+## Diagnosis
+
+The hypothesis was wrong. The register pressure in the dispatch loop is dominated by the **hot opcodes themselves**, not the cold ones LLVM already separates into late basic blocks. Each of the ~25 hot opcode handlers (LOAD/STORE_VAR_*, ADD/SUB/MUL/DIV_*, comparison, control flow) needs its own state — bytecode operand decode, stack push/pop, var table access, container indirection. The cumulative working set is already too large for pc to fit in a register, even with 35% of cold code outlined.
+
+LLVM's existing layout already handles cold-vs-hot separation effectively — the explicit `#[inline(never)]` adds function-call overhead (register save/restore at the call boundary, plus the cold function's own prologue/epilogue) without freeing useful registers in the hot path.
+
+Two-level dispatch failing was consistent with this: smaller dispatch *tables* weren't the problem either; per-opcode work is.
+
+## Implication
+
+Architectural changes that reduce **per-opcode work** or **per-iteration opcode count** are the only paths forward for the dispatch loop. Cold-path split is a dead end.
+
+The other two options from the earlier discussion remain in play:
+
+- **Function-per-opcode dispatch table** — *might* help because each opcode handler becomes its own function with independent register allocation. But comes with call/ret overhead per dispatch (~10 instr) that may offset gains. Hard to predict; would require a substantial refactor to test (roughly 25-40 hot handlers each becoming a fn-pointer table entry).
+- **Superinstructions / fused opcodes** — attacks per-iteration opcode count directly. The counter-loop workload runs ~12 opcodes per iteration; fusing the common `LOAD_VAR + LOAD_CONST + BINOP + STORE_VAR` pattern halves that. Codegen change, not VM-architecture change. Already cataloged in `specs/design/vm-performance.md` Tier 1 §4.
+- **Register-based VM** (vm-performance.md Tier 2) — eliminates stack push/pop entirely; operands are register indices baked into bytecode. Big refactor but fundamentally addresses the per-opcode work problem.
+
+## Recommendations
+
+### Don't do
+- Cold-path split via `#[inline(never)]`. Falsified at two scales.
+- Two-level dispatch (already tried). Same root cause.
+
+### Most actionable next step
+- **Superinstructions for the hot pattern** in `specs/design/vm-performance.md` Tier 1 §4. This is the cheapest architectural win that attacks the right axis (per-iter opcode count). It's a codegen change, doesn't disturb the VM dispatch architecture, and the design is already specified.
+
+### Worth considering after that
+- If the superinstruction win isn't enough, **register-based VM** (Tier 2 §5). The major lever still on the table; substantial work but the design is documented.
+
+## Critical files referenced
+
+- `compiler/vm/src/vm.rs:665` — `execute_with_hook`
+- `compiler/vm/src/vm.rs:693-2067` — the dispatch match
+- `compiler/benchmarks/examples/vm_vs_native.rs` — measurement harness
+- `specs/design/vm-performance.md` — existing optimization catalog (Tier 1 §4 superinstructions, Tier 2 §5 register-based)
+
+## Out of scope
+
+- Function-per-opcode dispatch table (would require 25-40 handler refactors; a separate experiment).
+- Wider outline including FB_CALL / array ops (would require generic-on-H signature for FB_CALL recursion).
+- Stable bench environment (orthogonal; mentioned in the parent measurement plan).

--- a/specs/plans/2026-05-02-constant-pool-restructure.md
+++ b/specs/plans/2026-05-02-constant-pool-restructure.md
@@ -1,0 +1,170 @@
+# Restructure `ConstantPool` in-memory layout
+
+**Date:** 2026-05-02
+**Branch:** `claude/bytecode-cells-optimization-LNlzN`
+**Driver:** [bytecode-dispatch-bounds-check measurement](2026-05-02-bytecode-dispatch-bounds-check-measurement.md)
+
+## Context
+
+The bounds-check measurement on the counter-loop workload showed `ConstantPool::get_i32` consumes **8.01% of all VM-retired instructions**, called twice per iteration at ~40 native instructions per call.
+
+Looking at `compiler/container/src/constant_pool.rs:9-14`:
+```rust
+pub struct ConstEntry {
+    pub const_type: ConstType,
+    pub value: Vec<u8>,   // ← heap allocation per constant
+}
+
+pub struct ConstantPool {
+    entries: Vec<ConstEntry>,
+}
+```
+
+Every `get_i32` call walks: `entries.get(idx)?` → load `ConstEntry` → check `const_type` tag → dereference inner `Vec<u8>` → `copy_from_slice` 4 bytes into a stack array → `from_le_bytes`. Two pointer chases (entry → inner Vec → heap data), a small memcpy, and length checks on a slice whose size is statically known to be 4.
+
+For a 4-byte i32 constant, this costs ~40 native instructions when ~5 would suffice. The on-disk container format is fine; only the **in-memory representation** is wasteful.
+
+## Goal
+
+Replace the `ConstEntry { const_type, value: Vec<u8> }` shape with a typed enum variant so scalar constants are stored inline and `get_i32` / `get_i64` / `get_f32` / `get_f64` collapse to a bounds-check + match + return.
+
+**Non-goals:**
+- Changing the on-disk container format (FORMAT_VERSION stays put).
+- Touching `ContainerRef` (no_std zero-copy view, separate code path, no internal consumers in this repo).
+- Changing the builder API (`ContainerBuilder::add_i32_constant`, etc.) or `ConstantIndex` semantics. Same single u16 index space, same callers.
+
+Expected wins (callgrind, counter-loop workload):
+- `ConstantPool::get_i32` from ~40 instr/call → ~5–8 instr/call.
+- ~7% wall-clock improvement on constant-heavy code; potentially more on workloads that aren't bottlenecked by dispatch.
+
+## Approach
+
+### New in-memory shape
+
+`compiler/container/src/constant_pool.rs`:
+
+```rust
+#[derive(Clone, Debug)]
+pub enum ConstValue {
+    I32(i32),
+    U32(u32),
+    I64(i64),
+    U64(u64),
+    F32(f32),
+    F64(f64),
+    Str(Vec<u8>),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ConstantPool {
+    entries: Vec<ConstValue>,
+}
+```
+
+`Vec<u8>` is 24 bytes, so `ConstValue` is 24 + tag = ~32 bytes per entry (worst case). That's larger per-entry than the current `ConstEntry` proper (32 bytes vs 32 bytes — equivalent!), and crucially **inlines** the i32/i64/f32/f64 payload that today sits on a separate heap allocation. Cache-line locality also improves because there's no second pointer chase.
+
+`ConstEntry` (the public type) is renamed `ConstValue`. The public re-export at `compiler/container/src/lib.rs:51` updates accordingly. No external consumers exist (verified via grep).
+
+### Accessor rewrites
+
+```rust
+pub fn get_i32(&self, index: ConstantIndex) -> Result<i32, ContainerError> {
+    match self.entries.get(index.raw() as usize) {
+        Some(ConstValue::I32(v)) => Ok(*v),
+        Some(other) => Err(ContainerError::InvalidConstantType(other.const_type() as u8)),
+        None => Err(ContainerError::InvalidConstantIndex(index)),
+    }
+}
+```
+
+Equivalent rewrites for `get_u32` (NEW — see "Missing variant" below), `get_i64`, `get_u64`, `get_f32`, `get_f64`, and `get_str`. The `get_le_bytes::<N>` private helper is deleted.
+
+A small helper on `ConstValue`:
+```rust
+impl ConstValue {
+    pub fn const_type(&self) -> ConstType { /* match on variant */ }
+}
+```
+
+This preserves the disassembler's need to format an entry's type tag (used at `compiler/project/src/disassemble.rs:645`).
+
+### Missing variant: `U32`
+
+`ConstType::U32` exists in `compiler/container/src/const_type.rs:9` and is serializable, but the current pool exposes no `get_u32`. The new `ConstValue::U32` variant lights this up cleanly. Whether to wire a `get_u32` accessor and `add_u32_constant` builder method now is a small judgement call; default in this plan is to add both (parallel structure with the others, no behaviour change for code that doesn't use them).
+
+### Builder
+
+`compiler/container/src/builder.rs:92-134` — each `add_*_constant` method changes from
+```rust
+self.constant_pool.push(ConstEntry { const_type: ConstType::I32, value: value.to_le_bytes().to_vec() });
+```
+to
+```rust
+self.constant_pool.push(ConstValue::I32(value));
+```
+
+Mechanical 1:1 rewrite for all 5 (or 6, with U32) variants.
+
+### Serialization (unchanged on disk)
+
+`write_to` reads the variant, emits the existing `[type:1, reserved:1, size:2, payload]` byte sequence:
+```rust
+fn write_to(&self, w: &mut impl Write) -> Result<(), ContainerError> {
+    w.write_all(&(self.entries.len() as u16).to_le_bytes())?;
+    for entry in &self.entries {
+        let (ty, bytes) = entry.encoded();  // helper returning (ConstType, Cow<[u8]>)
+        w.write_all(&[ty as u8, 0])?;
+        w.write_all(&(bytes.len() as u16).to_le_bytes())?;
+        w.write_all(&bytes)?;
+    }
+    Ok(())
+}
+```
+
+`read_from` parses the on-disk format and constructs the matching enum variant per `ConstType`. The size field is still present per entry but only used to skip past `Str` payloads (scalars have implicit fixed size).
+
+### Iteration API
+
+`pub fn iter(&self) -> impl Iterator<Item = &ConstValue>` — same shape as today, returning `&ConstValue` instead of `&ConstEntry`. The disassembler's call site at `disassemble.rs:645` adjusts to:
+```rust
+match container.constant_pool.iter().nth(pool_index as usize) {
+    Some(v) => format!("= {}", format_const_value(v)),
+    None => format!("= <invalid pool index {}>", pool_index),
+}
+```
+where `format_const_value` matches on the enum directly (no separate `(ConstType, &[u8])` pair needed).
+
+## Critical files
+
+| File | Change |
+|---|---|
+| `compiler/container/src/constant_pool.rs` | Replace `ConstEntry` with `ConstValue` enum; rewrite accessors; rewrite `read_from`/`write_to`. Update tests. |
+| `compiler/container/src/lib.rs:51` | Re-export `ConstValue` instead of `ConstEntry`. |
+| `compiler/container/src/builder.rs:92-134` | Replace `ConstEntry { ... }` construction with `ConstValue::*(value)` pushes. |
+| `compiler/project/src/disassemble.rs:645` | Switch `format_const_value` from `(ConstType, &[u8])` to `&ConstValue`. |
+| `compiler/vm/src/vm.rs:611,1120` | No source change — `get_i32` / `get_str` signatures are unchanged. |
+
+## Verification
+
+1. **Unit tests in `constant_pool.rs`** — port all 12 existing tests; they currently exercise `get_i32`, `get_f32`, `get_f64`, `get_i64`, `get_str`, type-mismatch errors, out-of-bounds errors, write/read round-trip, and `iter`. Add 1-2 round-trip tests covering a mixed-type pool.
+2. **Container round-trip** — existing tests in `container/src/container.rs` parse/emit containers; they pass iff serialization is unchanged.
+3. **Codegen + VM execution tests** — the existing `compiler/vm/tests/scenarios.rs`, `steel_thread.rs`, `execute_*.rs` all run real ST programs end-to-end; they pass iff in-memory accessors still produce correct values.
+4. **Disassembler tests** — `compiler/project/src/disassemble.rs` tests cover constant formatting; they pass iff the rewritten `format_const_value` produces the same output.
+5. **Run `cd compiler && just`** — full CI (compile + coverage ≥85% + clippy + fmt) per CLAUDE.md.
+6. **Re-run callgrind on `compiler/benchmarks/examples/vm_vs_native.rs vm 1000`** — confirm `ConstantPool::get_i32` drops from ~8% of total instructions to <2%, and total per-iter VM instruction count drops by ~7-10% (40 instr × 2 calls/iter saved out of ~500).
+
+## Out of scope (separate plans)
+
+- **Touching `ContainerRef`'s `get_i32_constant`** (no_std path). Different code, different consumers (none internal). Worth doing later if a no_std VM emerges; not needed now.
+- **Splitting constants by type into dense per-type arrays** (e.g., `Vec<i32>`, `Vec<f32>`). Larger restructure, requires per-type sub-indexing, and the enum approach captures most of the available win without breaking the indexing scheme.
+- **Constant deduplication or interning.** Orthogonal to the layout change; could be a separate codegen optimization.
+- **Adding `U32` accessor and builder method.** Included in this plan as a small nicety alongside the variant; can be split out if it complicates review.
+
+## Risk
+
+Low. The change is mechanical and locally scoped:
+- Two crates touched (`container`, `project`).
+- Public API stable except `ConstEntry` → `ConstValue` rename (no external consumers).
+- On-disk format unchanged — existing containers continue to load.
+- Behaviour preserved (same errors on invalid index / type mismatch).
+- Win is not the ~10x the dispatch loop needs — it's a single-digit-percent improvement to a hot helper. The value is that it's cheap to do, removes obvious waste, and makes the constant pool stop showing up in the profile, leaving the next investigation focused on the 90% in dispatch.


### PR DESCRIPTION
Records the result of the measure-first investigation into whether
restructuring bytecode storage (cells / enum-decoded array) would
reduce per-instruction bounds-check overhead in the VM dispatch loop.

Conclusion: the unsafe get_unchecked upper-bound is ~9-12% slower than
baseline in steady state. The CPU already hides bounds-check cost via
branch prediction; removing them perturbs layout/inlining negatively.
No structural change is justified for bounds-check elision alone.