### PR TITLE
Fix early RETURN in value-returning functions to emit return value

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -674,6 +674,23 @@ pub(crate) struct CompileContext {
     pub(crate) user_fb_types: HashMap<String, UserFbTypeInfo>,
     /// Next available type ID for user-defined function blocks.
     next_user_fb_type_id: u16,
+    /// When compiling a function body that returns a value, describes how an
+    /// early `RETURN` statement should produce the return value before the
+    /// `RET` opcode. `None` for programs and FBs (RETURN emits `RET_VOID`).
+    pub(crate) current_function_return: Option<CurrentFunctionReturn>,
+}
+
+/// Describes how a `RETURN` statement should yield the function's value.
+#[derive(Clone, Copy)]
+pub(crate) enum CurrentFunctionReturn {
+    /// Scalar return: load the variable, then emit `RET`.
+    Scalar {
+        var_index: VarIndex,
+        op_type: OpType,
+    },
+    /// STRING/WSTRING return: load the string from the data region into a
+    /// temp buffer, then emit `RET`.
+    String { data_offset: u32 },
 }
 
 impl CompileContext {
@@ -695,6 +712,7 @@ impl CompileContext {
             user_fb_types: HashMap::new(),
             next_user_fb_type_id: 0x1000,
             enum_map: crate::compile_enum::EnumOrdinalMap::default(),
+            current_function_return: None,
         }
     }
 

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -16,8 +16,8 @@ use ironplc_problems::Problem;
 use ironplc_analyzer::{FunctionEnvironment, TypeEnvironment};
 
 use super::compile::{
-    finalize_function, CompileContext, CompiledFunction, OpType, OpWidth, Signedness,
-    StringParamInfo, StringReturnInfo, StringVarInfo, UserFunctionInfo, VarTypeInfo,
+    finalize_function, CompileContext, CompiledFunction, CurrentFunctionReturn, OpType, OpWidth,
+    Signedness, StringParamInfo, StringReturnInfo, StringVarInfo, UserFunctionInfo, VarTypeInfo,
     DEFAULT_OP_TYPE,
 };
 use super::compile_expr::emit_load_var;
@@ -301,7 +301,26 @@ pub(crate) fn compile_user_function(
     let body = ironplc_dsl::textual::Statements {
         body: func_decl.body.clone(),
     };
+
+    // Make the return descriptor visible to nested `RETURN` statements so an
+    // early RETURN produces the function's value before the RET opcode (rather
+    // than emitting a bare RET_VOID, which would leave the caller's stack
+    // empty and trigger a stack underflow on the assignment).
+    let saved_return_ctx = ctx.current_function_return.take();
+    ctx.current_function_return = Some(if let Some(ref str_info) = return_string_info {
+        CurrentFunctionReturn::String {
+            data_offset: str_info.data_offset,
+        }
+    } else {
+        CurrentFunctionReturn::Scalar {
+            var_index: return_var_index,
+            op_type: return_op_type,
+        }
+    });
+
     compile_statements(&mut func_emitter, ctx, &body)?;
+
+    ctx.current_function_return = saved_return_ctx;
 
     // Load the return value and emit RET.
     if let Some(ref str_info) = return_string_info {

--- a/compiler/codegen/src/compile_stmt.rs
+++ b/compiler/codegen/src/compile_stmt.rs
@@ -17,8 +17,8 @@ use ironplc_dsl::textual::{
 use ironplc_problems::Problem;
 
 use super::compile::{
-    CompileContext, OpType, OpWidth, Signedness, VarTypeInfo, DEFAULT_OP_TYPE,
-    DEFAULT_STRING_MAX_LENGTH_U16,
+    CompileContext, CurrentFunctionReturn, OpType, OpWidth, Signedness, VarTypeInfo,
+    DEFAULT_OP_TYPE, DEFAULT_STRING_MAX_LENGTH_U16,
 };
 use super::compile_expr::{
     compile_bit_access_assignment, compile_expr, compile_partial_access_assignment,
@@ -343,7 +343,24 @@ fn compile_statement(
         StmtKind::While(while_stmt) => compile_while(emitter, ctx, while_stmt),
         StmtKind::Repeat(repeat_stmt) => compile_repeat(emitter, ctx, repeat_stmt),
         StmtKind::Return => {
-            emitter.emit_ret_void();
+            // Inside a function with a return value, an early RETURN must
+            // first push the current return-value variable so the caller
+            // sees a value on the stack (matching the trailing load+RET
+            // emitted at the end of the function body).
+            match ctx.current_function_return {
+                Some(CurrentFunctionReturn::Scalar { var_index, op_type }) => {
+                    emit_load_var(emitter, var_index, op_type);
+                    emitter.emit_ret();
+                }
+                Some(CurrentFunctionReturn::String { data_offset }) => {
+                    ctx.num_temp_bufs += 1;
+                    emitter.emit_str_load_var(data_offset);
+                    emitter.emit_ret();
+                }
+                None => {
+                    emitter.emit_ret_void();
+                }
+            }
             Ok(())
         }
         StmtKind::Exit(span) => {

--- a/compiler/codegen/tests/it/end_to_end_exit_return.rs
+++ b/compiler/codegen/tests/it/end_to_end_exit_return.rs
@@ -126,3 +126,38 @@ END_PROGRAM
     assert_eq!(bufs.vars[0].as_i32(), 1);
     assert_eq!(bufs.vars[1].as_i32(), 0); // y not assigned
 }
+
+#[test]
+fn end_to_end_when_early_return_in_function_then_caller_gets_assigned_value() {
+    // Regression: an early RETURN inside a value-returning FUNCTION used to
+    // emit RET_VOID, leaving the caller's stack empty and triggering a stack
+    // underflow when assigning the call result to a variable.
+    let source = "
+FUNCTION Divide : DINT
+    VAR_INPUT
+        numerator : DINT;
+        denominator : DINT;
+    END_VAR
+
+    IF denominator = 0 THEN
+        Divide := 0;
+        RETURN;
+    END_IF;
+
+    Divide := numerator / denominator;
+END_FUNCTION
+
+PROGRAM main
+    VAR
+        safe_result : DINT;
+        normal_result : DINT;
+    END_VAR
+
+    safe_result := Divide(10, 0);
+    normal_result := Divide(10, 3);
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[0].as_i32(), 0); // safe_result: early-return path
+    assert_eq!(bufs.vars[1].as_i32(), 3); // normal_result: 10 / 3
+}


### PR DESCRIPTION
## Summary
Fixed a regression where an early `RETURN` statement inside a value-returning `FUNCTION` would emit `RET_VOID` instead of properly pushing the return value onto the stack, causing a stack underflow when the caller tried to assign the result.

## Key Changes
- **Added `CurrentFunctionReturn` enum** in `compile.rs` to track how a function's return value should be produced during early `RETURN` statements, with variants for scalar and string returns
- **Extended `CompileContext`** with a `current_function_return` field to make return information available to nested `RETURN` statement handlers
- **Updated `compile_user_function`** in `compile_fn.rs` to set the return context before compiling the function body, ensuring early `RETURN` statements have access to the return variable information
- **Modified `RETURN` statement handling** in `compile_stmt.rs` to:
  - Load the return value (scalar or string) before emitting `RET` when inside a value-returning function
  - Emit `RET_VOID` only for programs and function blocks (where `current_function_return` is `None`)
- **Added regression test** `end_to_end_when_early_return_in_function_then_caller_gets_assigned_value` to verify early returns in functions properly deliver values to callers

## Implementation Details
The fix ensures that early `RETURN` statements in value-returning functions emit the same stack state as the implicit return at the end of the function body (load return value + `RET`), preventing stack underflow errors in the caller when assigning the function result to a variable.

https://claude.ai/code/session_017ULFXpvFKdY5tCtvy2e5WL