### PR TITLE
Restructure standard-library function reference pages

### DIFF
--- a/docs/reference/standard-library/functions/abs.rst
+++ b/docs/reference/standard-library/functions/abs.rst
@@ -4,42 +4,25 @@ ABS
 
 Returns the absolute value of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   ABS   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``REAL``
-     - ``REAL``
-   * - 6
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION ABS : ANY_NUM
+     VAR_INPUT
+       IN : ANY_NUM;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``ABS`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``REAL``, ``LREAL``.
 
 Description
 -----------
@@ -60,5 +43,13 @@ Example
 See Also
 --------
 
-- :doc:`sqrt` — square root
-- :doc:`expt` — exponentiation
+* :doc:`sqrt` — square root
+* :doc:`expt` — exponentiation
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: ABS <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_abs.html>`_
+* `Beckhoff TwinCAT 3: ABS <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529095819.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/acos.rst
+++ b/docs/reference/standard-library/functions/acos.rst
@@ -4,30 +4,25 @@ ACOS
 
 Returns the arc cosine (inverse cosine) of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤  ACOS   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION ACOS : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``ACOS`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`cos` — cosine
-- :doc:`asin` — arc sine
-- :doc:`atan` — arc tangent
+* :doc:`cos` — cosine
+* :doc:`asin` — arc sine
+* :doc:`atan` — arc tangent
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: ACOS <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_acos.html>`_
+* `Beckhoff TwinCAT 3: ACOS <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529149579.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/add.rst
+++ b/docs/reference/standard-library/functions/add.rst
@@ -4,81 +4,30 @@ ADD
 
 Returns the sum of two or more inputs.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.3
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+       IN2 ─┤   ADD   ├─ OUT
+       IN3 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20 30
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-     - Support
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-     - Supported
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-     - Supported
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-     - Supported
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-     - Supported
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-     - Supported
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-     - Supported
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-     - Supported
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-     - Supported
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-     - Supported
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
-     - Supported
-   * - 11
-     - ``TIME``
-     - ``TIME``
-     - ``TIME``
-     - Not yet supported
+   FUNCTION ADD : ANY_NUM
+     VAR_INPUT
+       IN1 : ANY_NUM;
+       IN2 : ANY_NUM;
+       (* ... additional inputs ... *)
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``ADD`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``,
+``REAL``, ``LREAL``. All inputs must share the same type.
 
 Description
 -----------
@@ -100,6 +49,14 @@ Example
 See Also
 --------
 
-- :doc:`sub` — subtraction
-- :doc:`mul` — multiplication
-- :doc:`div` — division
+* :doc:`sub` — subtraction
+* :doc:`mul` — multiplication
+* :doc:`div` — division
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.3
+* `CODESYS: ADD <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_add.html>`_
+* `Beckhoff TwinCAT 3: ADD <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/18014401038341259.html>`_
+* `Fernhill SCADA: Arithmetic Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-arithmetic.html>`_

--- a/docs/reference/standard-library/functions/add_dt_time.rst
+++ b/docs/reference/standard-library/functions/add_dt_time.rst
@@ -4,29 +4,28 @@ ADD_DT_TIME
 
 Adds a duration to a date-and-time value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌──────────┐
+       IN1 ─┤          │
+            │ADD_DT_TIME├─ OUT
+       IN2 ─┤          │
+            └──────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``DATE_AND_TIME``
-     - ``TIME``
-     - ``DATE_AND_TIME``
+   FUNCTION ADD_DT_TIME : DATE_AND_TIME
+     VAR_INPUT
+       IN1 : DATE_AND_TIME;
+       IN2 : TIME;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``DATE_AND_TIME``. *IN1* is ``DATE_AND_TIME`` and
+*IN2* is ``TIME``.
 
 Description
 -----------
@@ -45,5 +44,13 @@ Example
 See Also
 --------
 
-- :doc:`sub_dt_time` — subtract duration from datetime
-- :doc:`sub_dt_dt` — difference between two datetimes
+* :doc:`sub_dt_time` — subtract duration from datetime
+* :doc:`sub_dt_dt` — difference between two datetimes
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: ADD (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_add.html>`_
+* `Beckhoff TwinCAT 3: ADD (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/18014401038341259.html>`_
+* `Fernhill SCADA: ADD_DT_TIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-add-dt.html>`_

--- a/docs/reference/standard-library/functions/add_time.rst
+++ b/docs/reference/standard-library/functions/add_time.rst
@@ -4,29 +4,27 @@ ADD_TIME
 
 Returns the sum of two time durations.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │ADD_TIME ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``TIME``
-     - ``TIME``
-     - ``TIME``
+   FUNCTION ADD_TIME : TIME
+     VAR_INPUT
+       IN1 : TIME;
+       IN2 : TIME;
+     END_VAR
+   END_FUNCTION
+
+Both inputs and the return value are ``TIME``.
 
 Description
 -----------
@@ -45,6 +43,14 @@ Example
 See Also
 --------
 
-- :doc:`sub_time` — subtract durations
-- :doc:`mul_time` — scale duration
-- :doc:`div_time` — divide duration
+* :doc:`sub_time` — subtract durations
+* :doc:`mul_time` — scale duration
+* :doc:`div_time` — divide duration
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: ADD (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_add.html>`_
+* `Beckhoff TwinCAT 3: ADD (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/18014401038341259.html>`_
+* `Fernhill SCADA: ADD_TIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-add.html>`_

--- a/docs/reference/standard-library/functions/add_tod_time.rst
+++ b/docs/reference/standard-library/functions/add_tod_time.rst
@@ -4,29 +4,28 @@ ADD_TOD_TIME
 
 Adds a duration to a time-of-day value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌────────────┐
+       IN1 ─┤            │
+            │ADD_TOD_TIME├─ OUT
+       IN2 ─┤            │
+            └────────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``TIME_OF_DAY``
-     - ``TIME``
-     - ``TIME_OF_DAY``
+   FUNCTION ADD_TOD_TIME : TIME_OF_DAY
+     VAR_INPUT
+       IN1 : TIME_OF_DAY;
+       IN2 : TIME;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME_OF_DAY``. *IN1* is ``TIME_OF_DAY`` and
+*IN2* is ``TIME``.
 
 Description
 -----------
@@ -45,5 +44,13 @@ Example
 See Also
 --------
 
-- :doc:`sub_tod_time` — subtract duration from time-of-day
-- :doc:`sub_tod_tod` — difference between two times-of-day
+* :doc:`sub_tod_time` — subtract duration from time-of-day
+* :doc:`sub_tod_tod` — difference between two times-of-day
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: ADD (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_add.html>`_
+* `Beckhoff TwinCAT 3: ADD (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/18014401038341259.html>`_
+* `Fernhill SCADA: ADD_TOD_TIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-add-tod.html>`_

--- a/docs/reference/standard-library/functions/asin.rst
+++ b/docs/reference/standard-library/functions/asin.rst
@@ -4,30 +4,25 @@ ASIN
 
 Returns the arc sine (inverse sine) of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤  ASIN   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION ASIN : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``ASIN`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`sin` — sine
-- :doc:`acos` — arc cosine
-- :doc:`atan` — arc tangent
+* :doc:`sin` — sine
+* :doc:`acos` — arc cosine
+* :doc:`atan` — arc tangent
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: ASIN <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_asin.html>`_
+* `Beckhoff TwinCAT 3: ASIN <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529144203.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/atan.rst
+++ b/docs/reference/standard-library/functions/atan.rst
@@ -4,30 +4,25 @@ ATAN
 
 Returns the arc tangent (inverse tangent) of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤  ATAN   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION ATAN : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``ATAN`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`tan` — tangent
-- :doc:`asin` — arc sine
-- :doc:`acos` — arc cosine
+* :doc:`tan` — tangent
+* :doc:`asin` — arc sine
+* :doc:`acos` — arc cosine
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: ATAN <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_atan.html>`_
+* `Beckhoff TwinCAT 3: ATAN <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529154955.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/bcd.rst
+++ b/docs/reference/standard-library/functions/bcd.rst
@@ -5,67 +5,48 @@ BCD_TO_INT / INT_TO_BCD
 Convert between Binary-Coded Decimal (BCD) encoded bit strings and
 integer values.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.1
-   * - **Support**
-     - Supported
+``BCD_TO_INT``:
 
-Signatures
-----------
+.. code-block:: text
 
-BCD_TO_INT
-^^^^^^^^^^
+           ┌─────────────┐
+       IN ─┤  BCD_TO_INT ├─ OUT
+           └─────────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``BYTE``
-     - ``USINT``
-   * - 2
-     - ``WORD``
-     - ``UINT``
-   * - 3
-     - ``DWORD``
-     - ``UDINT``
-   * - 4
-     - ``LWORD``
-     - ``ULINT``
+   FUNCTION BCD_TO_INT : ANY_INT
+     VAR_INPUT
+       IN : ANY_BIT;
+     END_VAR
+   END_FUNCTION
 
-INT_TO_BCD
-^^^^^^^^^^
+``BCD_TO_INT`` accepts ``BYTE``, ``WORD``, ``DWORD``, ``LWORD`` for
+*IN*; the return type is the corresponding unsigned integer (``USINT``,
+``UINT``, ``UDINT``, ``ULINT``).
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30 30
+``INT_TO_BCD``:
 
-   * - #
-     - Input (IN)
-     - Return Type
-     - Support
-   * - 1
-     - ``USINT``
-     - ``BYTE``
-     - Supported
-   * - 2
-     - ``UINT``
-     - ``WORD``
-     - Supported
-   * - 3
-     - ``UDINT``
-     - ``DWORD``
-     - Supported
-   * - 4
-     - ``ULINT``
-     - ``LWORD``
-     - Supported
+.. code-block:: text
+
+           ┌─────────────┐
+       IN ─┤  INT_TO_BCD ├─ OUT
+           └─────────────┘
+
+.. code-block:: text
+
+   FUNCTION INT_TO_BCD : ANY_BIT
+     VAR_INPUT
+       IN : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+``INT_TO_BCD`` accepts ``USINT``, ``UINT``, ``UDINT``, ``ULINT`` for
+*IN*; the return type is the corresponding bit string (``BYTE``,
+``WORD``, ``DWORD``, ``LWORD``).
 
 Description
 -----------
@@ -100,4 +81,13 @@ Example
 See Also
 --------
 
-- :doc:`type-conversions` — other type conversion functions
+* :doc:`type-conversions` — other type conversion functions
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.1
+* `CODESYS: Operators (overview) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_struct_reference_operators.html>`_
+* `Beckhoff TwinCAT 3: Type conversion (overview) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/63050398781277579.html>`_
+* `Fernhill SCADA: BCD_TO_INT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/conversion-functions/bcd-to-integer.html>`_
+* `Fernhill SCADA: INT_TO_BCD <https://www.fernhillsoftware.com/help/iec-61131/common-elements/conversion-functions/integer-to-bcd.html>`_

--- a/docs/reference/standard-library/functions/concat.rst
+++ b/docs/reference/standard-library/functions/concat.rst
@@ -4,36 +4,28 @@ CONCAT
 
 Concatenates two strings.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │ CONCAT  ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20 30
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``STRING``
-     - ``STRING``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``WSTRING``
-     - ``WSTRING``
-     - Not yet supported
+   FUNCTION CONCAT : ANY_STRING
+     VAR_INPUT
+       IN1 : ANY_STRING;
+       IN2 : ANY_STRING;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``CONCAT`` accepts ``STRING``.
+Both inputs must share the same type.
 
 Description
 -----------
@@ -52,6 +44,14 @@ Example
 See Also
 --------
 
-- :doc:`insert` — string insertion
-- :doc:`len` — string length
-- :doc:`left` — left substring
+* :doc:`insert` — string insertion
+* :doc:`len` — string length
+* :doc:`left` — left substring
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: CONCAT <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/CONCAT.html>`_
+* `Beckhoff TwinCAT 3: CONCAT <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74411019.html>`_
+* `Fernhill SCADA: CONCAT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-concat.html>`_

--- a/docs/reference/standard-library/functions/concat_date_tod.rst
+++ b/docs/reference/standard-library/functions/concat_date_tod.rst
@@ -4,29 +4,28 @@ CONCAT_DATE_TOD
 
 Combines a date and a time-of-day into a date-and-time value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌───────────────┐
+       IN1 ─┤               │
+            │CONCAT_DATE_TOD├─ OUT
+       IN2 ─┤               │
+            └───────────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``DATE``
-     - ``TIME_OF_DAY``
-     - ``DATE_AND_TIME``
+   FUNCTION CONCAT_DATE_TOD : DATE_AND_TIME
+     VAR_INPUT
+       IN1 : DATE;
+       IN2 : TIME_OF_DAY;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``DATE_AND_TIME``. *IN1* is ``DATE`` and *IN2* is
+``TIME_OF_DAY``.
 
 Description
 -----------
@@ -51,5 +50,14 @@ Example
 See Also
 --------
 
-- :doc:`add_dt_time` — add duration to datetime
-- :doc:`sub_dt_dt` — difference between two datetimes
+* :doc:`add_dt_time` — add duration to datetime
+* :doc:`sub_dt_dt` — difference between two datetimes
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: CONCAT (covers date/time concatenation) <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/CONCAT.html>`_
+* `Fernhill SCADA: CONCAT_DATE_TOD <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-concat-date-tod.html>`_
+
+.. Beckhoff TwinCAT 3 does not have a dedicated CONCAT_DATE_TOD page.

--- a/docs/reference/standard-library/functions/cos.rst
+++ b/docs/reference/standard-library/functions/cos.rst
@@ -4,30 +4,25 @@ COS
 
 Returns the cosine of an angle in radians.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   COS   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION COS : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``COS`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`sin` — sine
-- :doc:`tan` — tangent
-- :doc:`acos` — arc cosine
+* :doc:`sin` — sine
+* :doc:`tan` — tangent
+* :doc:`acos` — arc cosine
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: COS <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_cos.html>`_
+* `Beckhoff TwinCAT 3: COS <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/18014401038615435.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/delete.rst
+++ b/docs/reference/standard-library/functions/delete.rst
@@ -4,39 +4,29 @@ DELETE
 
 Deletes characters from a string.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+        L ─┤ DELETE  ├─ OUT
+        P ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 15 15 15 15 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (L)
-     - Input (P)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``INT``
-     - ``INT``
-     - ``STRING``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``INT``
-     - ``INT``
-     - ``WSTRING``
-     - Not yet supported
+   FUNCTION DELETE : ANY_STRING
+     VAR_INPUT
+       IN : ANY_STRING;
+       L  : ANY_INT;
+       P  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``DELETE`` accepts ``STRING``
+for *IN*; *L* and *P* are ``INT``.
 
 Description
 -----------
@@ -56,6 +46,14 @@ Example
 See Also
 --------
 
-- :doc:`insert` — string insertion
-- :doc:`replace` — string replacement
-- :doc:`mid` — middle substring
+* :doc:`insert` — string insertion
+* :doc:`replace` — string replacement
+* :doc:`mid` — middle substring
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: DELETE <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/DELETE.html>`_
+* `Beckhoff TwinCAT 3: DELETE <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74412555.html>`_
+* `Fernhill SCADA: DELETE <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-delete.html>`_

--- a/docs/reference/standard-library/functions/div.rst
+++ b/docs/reference/standard-library/functions/div.rst
@@ -4,65 +4,29 @@ DIV
 
 Returns the quotient of two inputs.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.3
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   DIV   ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION DIV : ANY_NUM
+     VAR_INPUT
+       IN1 : ANY_NUM;
+       IN2 : ANY_NUM;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``DIV`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``,
+``REAL``, ``LREAL``. Both inputs must share the same type.
 
 Description
 -----------
@@ -86,6 +50,14 @@ Example
 See Also
 --------
 
-- :doc:`mul` — multiplication
-- :doc:`mod` — modulo
-- :doc:`sub` — subtraction
+* :doc:`mul` — multiplication
+* :doc:`mod` — modulo
+* :doc:`sub` — subtraction
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.3
+* `CODESYS: DIV <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_div.html>`_
+* `Beckhoff TwinCAT 3: DIV <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528875403.html>`_
+* `Fernhill SCADA: Arithmetic Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-arithmetic.html>`_

--- a/docs/reference/standard-library/functions/div_time.rst
+++ b/docs/reference/standard-library/functions/div_time.rst
@@ -4,29 +4,27 @@ DIV_TIME
 
 Divides a time duration by a numeric value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │DIV_TIME ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``TIME``
-     - ``ANY_NUM``
-     - ``TIME``
+   FUNCTION DIV_TIME : TIME
+     VAR_INPUT
+       IN1 : TIME;
+       IN2 : ANY_NUM;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME``. *IN2* may be any numeric type.
 
 Description
 -----------
@@ -46,6 +44,14 @@ Example
 See Also
 --------
 
-- :doc:`mul_time` — scale duration
-- :doc:`add_time` — add durations
-- :doc:`sub_time` — subtract durations
+* :doc:`mul_time` — scale duration
+* :doc:`add_time` — add durations
+* :doc:`sub_time` — subtract durations
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: DIV (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_div.html>`_
+* `Beckhoff TwinCAT 3: DIV (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528875403.html>`_
+* `Fernhill SCADA: DIVTIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-div.html>`_

--- a/docs/reference/standard-library/functions/dt_to_date.rst
+++ b/docs/reference/standard-library/functions/dt_to_date.rst
@@ -4,27 +4,24 @@ DT_TO_DATE
 
 Extracts the date portion from a date-and-time value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌──────────┐
+       IN ─┤DT_TO_DATE├─ OUT
+           └──────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``DATE_AND_TIME``
-     - ``DATE``
+   FUNCTION DT_TO_DATE : DATE
+     VAR_INPUT
+       IN : DATE_AND_TIME;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``DATE``. *IN* is ``DATE_AND_TIME``.
 
 Description
 -----------
@@ -45,5 +42,13 @@ Example
 See Also
 --------
 
-- :doc:`dt_to_tod` --- extract time-of-day from datetime
-- :doc:`concat_date_tod` --- combine date and time-of-day
+* :doc:`dt_to_tod` — extract time-of-day from datetime
+* :doc:`concat_date_tod` — combine date and time-of-day
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5
+* `CODESYS: Operators (overview) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_struct_reference_operators.html>`_
+* `Beckhoff TwinCAT 3: Type conversion (overview) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/63050398781277579.html>`_
+* `Fernhill SCADA: Type Casts <https://www.fernhillsoftware.com/help/iec-61131/common-elements/conversion-functions/type-casts.html>`_

--- a/docs/reference/standard-library/functions/dt_to_tod.rst
+++ b/docs/reference/standard-library/functions/dt_to_tod.rst
@@ -4,27 +4,24 @@ DT_TO_TOD
 
 Extracts the time-of-day portion from a date-and-time value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤DT_TO_TOD├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``DATE_AND_TIME``
-     - ``TIME_OF_DAY``
+   FUNCTION DT_TO_TOD : TIME_OF_DAY
+     VAR_INPUT
+       IN : DATE_AND_TIME;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME_OF_DAY``. *IN* is ``DATE_AND_TIME``.
 
 Description
 -----------
@@ -45,5 +42,13 @@ Example
 See Also
 --------
 
-- :doc:`dt_to_date` --- extract date from datetime
-- :doc:`concat_date_tod` --- combine date and time-of-day
+* :doc:`dt_to_date` — extract date from datetime
+* :doc:`concat_date_tod` — combine date and time-of-day
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5
+* `CODESYS: Operators (overview) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_struct_reference_operators.html>`_
+* `Beckhoff TwinCAT 3: Type conversion (overview) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/63050398781277579.html>`_
+* `Fernhill SCADA: Type Casts <https://www.fernhillsoftware.com/help/iec-61131/common-elements/conversion-functions/type-casts.html>`_

--- a/docs/reference/standard-library/functions/eq.rst
+++ b/docs/reference/standard-library/functions/eq.rst
@@ -4,65 +4,29 @@ EQ
 
 Returns TRUE if two inputs are equal.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.4
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   EQ    ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``BOOL``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``BOOL``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``BOOL``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``BOOL``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``BOOL``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``BOOL``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``BOOL``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``BOOL``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``BOOL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``BOOL``
+   FUNCTION EQ : BOOL
+     VAR_INPUT
+       IN1 : ANY_ELEMENTARY;
+       IN2 : ANY_ELEMENTARY;
+     END_VAR
+   END_FUNCTION
+
+Returns ``BOOL``. ``EQ`` accepts ``SINT``, ``INT``, ``DINT``, ``LINT``,
+``USINT``, ``UINT``, ``UDINT``, ``ULINT``, ``REAL``, ``LREAL``. Both
+inputs must share the same type.
 
 Description
 -----------
@@ -87,6 +51,14 @@ Example
 See Also
 --------
 
-- :doc:`ne` — not equal
-- :doc:`gt` — greater than
-- :doc:`lt` — less than
+* :doc:`ne` — not equal
+* :doc:`gt` — greater than
+* :doc:`lt` — less than
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.4
+* `CODESYS: EQ <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_eq.html>`_
+* `Beckhoff TwinCAT 3: EQ <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529004427.html>`_
+* `Fernhill SCADA: EQ <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-comparison.html>`_

--- a/docs/reference/standard-library/functions/exp.rst
+++ b/docs/reference/standard-library/functions/exp.rst
@@ -4,30 +4,25 @@ EXP
 
 Returns the natural exponential of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   EXP   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION EXP : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``EXP`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,5 +42,13 @@ Example
 See Also
 --------
 
-- :doc:`ln` — natural logarithm
-- :doc:`expt` — exponentiation
+* :doc:`ln` — natural logarithm
+* :doc:`expt` — exponentiation
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: EXP <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_exp.html>`_
+* `Beckhoff TwinCAT 3: EXP <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529117323.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/expt.rst
+++ b/docs/reference/standard-library/functions/expt.rst
@@ -4,49 +4,28 @@ EXPT
 
 Returns the result of raising a base to an exponent.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │  EXPT   ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-   * - 6
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION EXPT : ANY_REAL
+     VAR_INPUT
+       IN1 : ANY_REAL;
+       IN2 : ANY_NUM;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN1*. ``EXPT`` accepts ``REAL``,
+``LREAL`` for the base and any numeric type for the exponent.
 
 Description
 -----------
@@ -67,6 +46,14 @@ Example
 See Also
 --------
 
-- :doc:`exp` — natural exponential (*e*\ :sup:`x`)
-- :doc:`sqrt` — square root
-- :doc:`abs` — absolute value
+* :doc:`exp` — natural exponential (*e*\ :sup:`x`)
+* :doc:`sqrt` — square root
+* :doc:`abs` — absolute value
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: EXPT <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_expt.html>`_
+* `Beckhoff TwinCAT 3: EXPT <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529122699.html>`_
+* `Fernhill SCADA: POW <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-arithmetic.html>`_

--- a/docs/reference/standard-library/functions/find.rst
+++ b/docs/reference/standard-library/functions/find.rst
@@ -4,36 +4,28 @@ FIND
 
 Searches for a substring within a string.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │  FIND   ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20 30
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``STRING``
-     - ``INT``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``WSTRING``
-     - ``INT``
-     - Not yet supported
+   FUNCTION FIND : ANY_INT
+     VAR_INPUT
+       IN1 : ANY_STRING;
+       IN2 : ANY_STRING;
+     END_VAR
+   END_FUNCTION
+
+Returns ``INT``. ``FIND`` accepts ``STRING`` for *IN1* and *IN2*. Both
+inputs must share the same type.
 
 Description
 -----------
@@ -55,6 +47,14 @@ Example
 See Also
 --------
 
-- :doc:`replace` — string replacement
-- :doc:`mid` — middle substring
-- :doc:`len` — string length
+* :doc:`replace` — string replacement
+* :doc:`mid` — middle substring
+* :doc:`len` — string length
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: FIND <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/FIND.html>`_
+* `Beckhoff TwinCAT 3: FIND <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74414091.html>`_
+* `Fernhill SCADA: FIND <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-find.html>`_

--- a/docs/reference/standard-library/functions/ge.rst
+++ b/docs/reference/standard-library/functions/ge.rst
@@ -4,65 +4,29 @@ GE
 
 Returns TRUE if the first input is greater than or equal to the second.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.4
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   GE    ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``BOOL``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``BOOL``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``BOOL``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``BOOL``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``BOOL``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``BOOL``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``BOOL``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``BOOL``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``BOOL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``BOOL``
+   FUNCTION GE : BOOL
+     VAR_INPUT
+       IN1 : ANY_ELEMENTARY;
+       IN2 : ANY_ELEMENTARY;
+     END_VAR
+   END_FUNCTION
+
+Returns ``BOOL``. ``GE`` accepts ``SINT``, ``INT``, ``DINT``, ``LINT``,
+``USINT``, ``UINT``, ``UDINT``, ``ULINT``, ``REAL``, ``LREAL``. Both
+inputs must share the same type.
 
 Description
 -----------
@@ -84,6 +48,14 @@ Example
 See Also
 --------
 
-- :doc:`gt` — greater than
-- :doc:`le` — less than or equal
-- :doc:`eq` — equal
+* :doc:`gt` — greater than
+* :doc:`le` — less than or equal
+* :doc:`eq` — equal
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.4
+* `CODESYS: GE <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_ge.html>`_
+* `Beckhoff TwinCAT 3: GE <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528999051.html>`_
+* `Fernhill SCADA: GE <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-comparison.html>`_

--- a/docs/reference/standard-library/functions/gt.rst
+++ b/docs/reference/standard-library/functions/gt.rst
@@ -4,65 +4,29 @@ GT
 
 Returns TRUE if the first input is greater than the second.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.4
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   GT    ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``BOOL``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``BOOL``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``BOOL``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``BOOL``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``BOOL``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``BOOL``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``BOOL``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``BOOL``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``BOOL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``BOOL``
+   FUNCTION GT : BOOL
+     VAR_INPUT
+       IN1 : ANY_ELEMENTARY;
+       IN2 : ANY_ELEMENTARY;
+     END_VAR
+   END_FUNCTION
+
+Returns ``BOOL``. ``GT`` accepts ``SINT``, ``INT``, ``DINT``, ``LINT``,
+``USINT``, ``UINT``, ``UDINT``, ``ULINT``, ``REAL``, ``LREAL``. Both
+inputs must share the same type.
 
 Description
 -----------
@@ -84,6 +48,14 @@ Example
 See Also
 --------
 
-- :doc:`ge` — greater than or equal
-- :doc:`lt` — less than
-- :doc:`eq` — equal
+* :doc:`ge` — greater than or equal
+* :doc:`lt` — less than
+* :doc:`eq` — equal
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.4
+* `CODESYS: GT <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_gt.html>`_
+* `Beckhoff TwinCAT 3: GT <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528982923.html>`_
+* `Fernhill SCADA: GT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-comparison.html>`_

--- a/docs/reference/standard-library/functions/insert.rst
+++ b/docs/reference/standard-library/functions/insert.rst
@@ -4,39 +4,30 @@ INSERT
 
 Inserts a string into another string at a specified position.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+       IN2 ─┤ INSERT  ├─ OUT
+         P ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 15 15 15 15 30
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Input (P)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``STRING``
-     - ``INT``
-     - ``STRING``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``WSTRING``
-     - ``INT``
-     - ``WSTRING``
-     - Not yet supported
+   FUNCTION INSERT : ANY_STRING
+     VAR_INPUT
+       IN1 : ANY_STRING;
+       IN2 : ANY_STRING;
+       P   : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``INSERT`` accepts ``STRING``
+for *IN1* and *IN2*; *P* is ``INT``. Both string inputs must share the
+same type.
 
 Description
 -----------
@@ -57,6 +48,14 @@ Example
 See Also
 --------
 
-- :doc:`delete` — string deletion
-- :doc:`replace` — string replacement
-- :doc:`concat` — string concatenation
+* :doc:`delete` — string deletion
+* :doc:`replace` — string replacement
+* :doc:`concat` — string concatenation
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: INSERT <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/INSERT.html>`_
+* `Beckhoff TwinCAT 3: INSERT <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74415627.html>`_
+* `Fernhill SCADA: INSERT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-insert.html>`_

--- a/docs/reference/standard-library/functions/le.rst
+++ b/docs/reference/standard-library/functions/le.rst
@@ -4,65 +4,29 @@ LE
 
 Returns TRUE if the first input is less than or equal to the second.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.4
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   LE    ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``BOOL``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``BOOL``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``BOOL``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``BOOL``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``BOOL``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``BOOL``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``BOOL``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``BOOL``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``BOOL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``BOOL``
+   FUNCTION LE : BOOL
+     VAR_INPUT
+       IN1 : ANY_ELEMENTARY;
+       IN2 : ANY_ELEMENTARY;
+     END_VAR
+   END_FUNCTION
+
+Returns ``BOOL``. ``LE`` accepts ``SINT``, ``INT``, ``DINT``, ``LINT``,
+``USINT``, ``UINT``, ``UDINT``, ``ULINT``, ``REAL``, ``LREAL``. Both
+inputs must share the same type.
 
 Description
 -----------
@@ -84,6 +48,14 @@ Example
 See Also
 --------
 
-- :doc:`lt` — less than
-- :doc:`ge` — greater than or equal
-- :doc:`eq` — equal
+* :doc:`lt` — less than
+* :doc:`ge` — greater than or equal
+* :doc:`eq` — equal
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.4
+* `CODESYS: LE <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_le.html>`_
+* `Beckhoff TwinCAT 3: LE <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528993675.html>`_
+* `Fernhill SCADA: LE <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-comparison.html>`_

--- a/docs/reference/standard-library/functions/left.rst
+++ b/docs/reference/standard-library/functions/left.rst
@@ -4,36 +4,28 @@ LEFT
 
 Returns the leftmost characters of a string.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+           │  LEFT   ├─ OUT
+        L ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (L)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``INT``
-     - ``STRING``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``INT``
-     - ``WSTRING``
-     - Not yet supported
+   FUNCTION LEFT : ANY_STRING
+     VAR_INPUT
+       IN : ANY_STRING;
+       L  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``LEFT`` accepts ``STRING``
+for *IN*; *L* is ``INT``.
 
 Description
 -----------
@@ -53,6 +45,14 @@ Example
 See Also
 --------
 
-- :doc:`right` — right substring
-- :doc:`mid` — middle substring
-- :doc:`len` — string length
+* :doc:`right` — right substring
+* :doc:`mid` — middle substring
+* :doc:`len` — string length
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: LEFT <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/LEFT.html>`_
+* `Beckhoff TwinCAT 3: LEFT <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74417163.html>`_
+* `Fernhill SCADA: LEFT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-left.html>`_

--- a/docs/reference/standard-library/functions/len.rst
+++ b/docs/reference/standard-library/functions/len.rst
@@ -4,33 +4,24 @@ LEN
 
 Returns the length of a string.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   LEN   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``INT``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``INT``
-     - Not yet supported
+   FUNCTION LEN : ANY_INT
+     VAR_INPUT
+       IN : ANY_STRING;
+     END_VAR
+   END_FUNCTION
+
+Returns ``INT``. ``LEN`` accepts ``STRING``.
 
 Description
 -----------
@@ -50,6 +41,14 @@ Example
 See Also
 --------
 
-- :doc:`left` — left substring
-- :doc:`right` — right substring
-- :doc:`mid` — middle substring
+* :doc:`left` — left substring
+* :doc:`right` — right substring
+* :doc:`mid` — middle substring
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: LEN <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/LEN.html>`_
+* `Beckhoff TwinCAT 3: LEN <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74418699.html>`_
+* `Fernhill SCADA: LEN <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-len.html>`_

--- a/docs/reference/standard-library/functions/limit.rst
+++ b/docs/reference/standard-library/functions/limit.rst
@@ -4,76 +4,30 @@ LIMIT
 
 Clamps a value to a specified range.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.5
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+        MN ─┤         │
+        IN ─┤  LIMIT  ├─ OUT
+        MX ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 15 15 15 15
+.. code-block:: text
 
-   * - #
-     - Input (MN)
-     - Input (IN)
-     - Input (MX)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION LIMIT : ANY
+     VAR_INPUT
+       MN : ANY;
+       IN : ANY;
+       MX : ANY;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``LIMIT`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``,
+``REAL``, ``LREAL``. All three inputs must share the same type.
 
 Description
 -----------
@@ -100,6 +54,14 @@ Example
 See Also
 --------
 
-- :doc:`max` — maximum of two values
-- :doc:`min` — minimum of two values
-- :doc:`sel` — binary selection
+* :doc:`max` — maximum of two values
+* :doc:`min` — minimum of two values
+* :doc:`sel` — binary selection
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.5
+* `CODESYS: LIMIT <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_limit.html>`_
+* `Beckhoff TwinCAT 3: LIMIT <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528972171.html>`_
+* `Fernhill SCADA: LIMIT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/selection-functions/limit.html>`_

--- a/docs/reference/standard-library/functions/ln.rst
+++ b/docs/reference/standard-library/functions/ln.rst
@@ -4,30 +4,25 @@ LN
 
 Returns the natural logarithm of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   LN    ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION LN : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``LN`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -48,5 +43,13 @@ Example
 See Also
 --------
 
-- :doc:`log` — base-10 logarithm
-- :doc:`exp` — natural exponential
+* :doc:`log` — base-10 logarithm
+* :doc:`exp` — natural exponential
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: LN <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_ln.html>`_
+* `Beckhoff TwinCAT 3: LN <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529106571.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/log.rst
+++ b/docs/reference/standard-library/functions/log.rst
@@ -4,30 +4,25 @@ LOG
 
 Returns the base-10 logarithm of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   LOG   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION LOG : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``LOG`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -48,5 +43,13 @@ Example
 See Also
 --------
 
-- :doc:`ln` — natural logarithm
-- :doc:`exp` — natural exponential
+* :doc:`ln` — natural logarithm
+* :doc:`exp` — natural exponential
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: LOG <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_log.html>`_
+* `Beckhoff TwinCAT 3: LOG <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529111947.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/lt.rst
+++ b/docs/reference/standard-library/functions/lt.rst
@@ -4,65 +4,29 @@ LT
 
 Returns TRUE if the first input is less than the second.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.4
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   LT    ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``BOOL``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``BOOL``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``BOOL``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``BOOL``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``BOOL``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``BOOL``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``BOOL``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``BOOL``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``BOOL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``BOOL``
+   FUNCTION LT : BOOL
+     VAR_INPUT
+       IN1 : ANY_ELEMENTARY;
+       IN2 : ANY_ELEMENTARY;
+     END_VAR
+   END_FUNCTION
+
+Returns ``BOOL``. ``LT`` accepts ``SINT``, ``INT``, ``DINT``, ``LINT``,
+``USINT``, ``UINT``, ``UDINT``, ``ULINT``, ``REAL``, ``LREAL``. Both
+inputs must share the same type.
 
 Description
 -----------
@@ -84,6 +48,14 @@ Example
 See Also
 --------
 
-- :doc:`le` — less than or equal
-- :doc:`gt` — greater than
-- :doc:`eq` — equal
+* :doc:`le` — less than or equal
+* :doc:`gt` — greater than
+* :doc:`eq` — equal
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.4
+* `CODESYS: LT <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_lt.html>`_
+* `Beckhoff TwinCAT 3: LT <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528988299.html>`_
+* `Fernhill SCADA: LT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-comparison.html>`_

--- a/docs/reference/standard-library/functions/max.rst
+++ b/docs/reference/standard-library/functions/max.rst
@@ -4,65 +4,29 @@ MAX
 
 Returns the larger of two inputs.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.5
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   MAX   ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION MAX : ANY
+     VAR_INPUT
+       IN1 : ANY;
+       IN2 : ANY;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``MAX`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``,
+``REAL``, ``LREAL``. Both inputs must share the same type.
 
 Description
 -----------
@@ -82,6 +46,14 @@ Example
 See Also
 --------
 
-- :doc:`min` — minimum of two values
-- :doc:`limit` — clamp to range
-- :doc:`sel` — binary selection
+* :doc:`min` — minimum of two values
+* :doc:`limit` — clamp to range
+* :doc:`sel` — binary selection
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.5
+* `CODESYS: MAX <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_max.html>`_
+* `Beckhoff TwinCAT 3: MAX <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528961419.html>`_
+* `Fernhill SCADA: MAX <https://www.fernhillsoftware.com/help/iec-61131/common-elements/selection-functions/maximum.html>`_

--- a/docs/reference/standard-library/functions/mid.rst
+++ b/docs/reference/standard-library/functions/mid.rst
@@ -4,39 +4,29 @@ MID
 
 Returns a substring from the middle of a string.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+        L ─┤   MID   ├─ OUT
+        P ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 15 15 15 15 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (L)
-     - Input (P)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``INT``
-     - ``INT``
-     - ``STRING``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``INT``
-     - ``INT``
-     - ``WSTRING``
-     - Not yet supported
+   FUNCTION MID : ANY_STRING
+     VAR_INPUT
+       IN : ANY_STRING;
+       L  : ANY_INT;
+       P  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``MID`` accepts ``STRING``
+for *IN*; *L* and *P* are ``INT``.
 
 Description
 -----------
@@ -57,6 +47,14 @@ Example
 See Also
 --------
 
-- :doc:`left` — left substring
-- :doc:`right` — right substring
-- :doc:`len` — string length
+* :doc:`left` — left substring
+* :doc:`right` — right substring
+* :doc:`len` — string length
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: MID <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/MID.html>`_
+* `Beckhoff TwinCAT 3: MID <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74420235.html>`_
+* `Fernhill SCADA: MID <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-mid.html>`_

--- a/docs/reference/standard-library/functions/min.rst
+++ b/docs/reference/standard-library/functions/min.rst
@@ -4,65 +4,29 @@ MIN
 
 Returns the smaller of two inputs.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.5
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   MIN   ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION MIN : ANY
+     VAR_INPUT
+       IN1 : ANY;
+       IN2 : ANY;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``MIN`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``,
+``REAL``, ``LREAL``. Both inputs must share the same type.
 
 Description
 -----------
@@ -82,6 +46,14 @@ Example
 See Also
 --------
 
-- :doc:`max` — maximum of two values
-- :doc:`limit` — clamp to range
-- :doc:`sel` — binary selection
+* :doc:`max` — maximum of two values
+* :doc:`limit` — clamp to range
+* :doc:`sel` — binary selection
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.5
+* `CODESYS: MIN <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_min.html>`_
+* `Beckhoff TwinCAT 3: MIN <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528966795.html>`_
+* `Fernhill SCADA: MIN <https://www.fernhillsoftware.com/help/iec-61131/common-elements/selection-functions/minimum.html>`_

--- a/docs/reference/standard-library/functions/mod.rst
+++ b/docs/reference/standard-library/functions/mod.rst
@@ -4,57 +4,29 @@ MOD
 
 Returns the remainder after integer division.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.3
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   MOD   ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
+   FUNCTION MOD : ANY_INT
+     VAR_INPUT
+       IN1 : ANY_INT;
+       IN2 : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``MOD`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``.
+Both inputs must share the same type.
 
 Description
 -----------
@@ -79,5 +51,13 @@ Example
 See Also
 --------
 
-- :doc:`div` — division
-- :doc:`mul` — multiplication
+* :doc:`div` — division
+* :doc:`mul` — multiplication
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.3
+* `CODESYS: MOD <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_mod.html>`_
+* `Beckhoff TwinCAT 3: MOD <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528880779.html>`_
+* `Fernhill SCADA: Arithmetic Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-arithmetic.html>`_

--- a/docs/reference/standard-library/functions/move.rst
+++ b/docs/reference/standard-library/functions/move.rst
@@ -4,54 +4,26 @@ MOVE
 
 Copies the input value to the output (assignment).
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.4
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤  MOVE   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION MOVE : ANY
+     VAR_INPUT
+       IN : ANY;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``MOVE`` accepts any type
+(``ANY``); IronPLC supports ``SINT``, ``INT``, ``DINT``, ``LINT``,
+``USINT``, ``UINT``, ``UDINT``, ``ULINT``, ``REAL``, ``LREAL``.
 
 Description
 -----------
@@ -72,5 +44,15 @@ Example
 See Also
 --------
 
-- :doc:`sel` — binary selection
-- :doc:`limit` — clamp to range
+* :doc:`sel` — binary selection
+* :doc:`limit` — clamp to range
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.4
+* `CODESYS: MOVE <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_move.html>`_
+* `Beckhoff TwinCAT 3: MOVE <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528886155.html>`_
+
+.. Fernhill SCADA does not have a dedicated MOVE page (assignment is
+   covered by the language reference rather than as a function).

--- a/docs/reference/standard-library/functions/mul.rst
+++ b/docs/reference/standard-library/functions/mul.rst
@@ -4,65 +4,30 @@ MUL
 
 Returns the product of two or more inputs.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.3
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+       IN2 ─┤   MUL   ├─ OUT
+       IN3 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION MUL : ANY_NUM
+     VAR_INPUT
+       IN1 : ANY_NUM;
+       IN2 : ANY_NUM;
+       (* ... additional inputs ... *)
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``MUL`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``,
+``REAL``, ``LREAL``. All inputs must share the same type.
 
 Description
 -----------
@@ -84,6 +49,14 @@ Example
 See Also
 --------
 
-- :doc:`add` — addition
-- :doc:`div` — division
-- :doc:`mod` — modulo
+* :doc:`add` — addition
+* :doc:`div` — division
+* :doc:`mod` — modulo
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.3
+* `CODESYS: MUL <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_mul.html>`_
+* `Beckhoff TwinCAT 3: MUL <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528864651.html>`_
+* `Fernhill SCADA: Arithmetic Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-arithmetic.html>`_

--- a/docs/reference/standard-library/functions/mul_time.rst
+++ b/docs/reference/standard-library/functions/mul_time.rst
@@ -4,29 +4,27 @@ MUL_TIME
 
 Scales a time duration by a numeric factor.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │MUL_TIME ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``TIME``
-     - ``ANY_NUM``
-     - ``TIME``
+   FUNCTION MUL_TIME : TIME
+     VAR_INPUT
+       IN1 : TIME;
+       IN2 : ANY_NUM;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME``. *IN2* may be any numeric type.
 
 Description
 -----------
@@ -46,6 +44,14 @@ Example
 See Also
 --------
 
-- :doc:`div_time` — divide duration
-- :doc:`add_time` — add durations
-- :doc:`sub_time` — subtract durations
+* :doc:`div_time` — divide duration
+* :doc:`add_time` — add durations
+* :doc:`sub_time` — subtract durations
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: MUL (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_mul.html>`_
+* `Beckhoff TwinCAT 3: MUL (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528864651.html>`_
+* `Fernhill SCADA: MULTIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-mul.html>`_

--- a/docs/reference/standard-library/functions/mux.rst
+++ b/docs/reference/standard-library/functions/mux.rst
@@ -4,31 +4,32 @@ MUX
 
 Multiplexer — selects one of several inputs by index.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.5
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+         K ─┤         │
+       IN0 ─┤         │
+       IN1 ─┤   MUX   ├─ OUT
+       IN2 ─┤         │
+       ... ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 15 15 15 15
+.. code-block:: text
 
-   * - #
-     - Input (K)
-     - Input (IN0)
-     - Input (IN1, ...)
-     - Return Type
-   * - 1
-     - ``INT``
-     - *ANY*
-     - *ANY*
-     - *ANY*
+   FUNCTION MUX : ANY
+     VAR_INPUT
+       K   : INT;
+       IN0 : ANY;
+       IN1 : ANY;
+       (* ... up to IN15 ... *)
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. All ``INn`` inputs must share
+the same type. ``MUX`` is polymorphic over any data type.
 
 Description
 -----------
@@ -60,5 +61,13 @@ Example
 See Also
 --------
 
-- :doc:`sel` — binary selection (two inputs)
-- :doc:`limit` — clamp to range
+* :doc:`sel` — binary selection (two inputs)
+* :doc:`limit` — clamp to range
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.5
+* `CODESYS: MUX <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_mux.html>`_
+* `Beckhoff TwinCAT 3: MUX <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528977547.html>`_
+* `Fernhill SCADA: MUX <https://www.fernhillsoftware.com/help/iec-61131/common-elements/selection-functions/mux.html>`_

--- a/docs/reference/standard-library/functions/ne.rst
+++ b/docs/reference/standard-library/functions/ne.rst
@@ -4,65 +4,29 @@ NE
 
 Returns TRUE if two inputs are not equal.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.4
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   NE    ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``BOOL``
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``BOOL``
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``BOOL``
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``BOOL``
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``BOOL``
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``BOOL``
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``BOOL``
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``BOOL``
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``BOOL``
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``BOOL``
+   FUNCTION NE : BOOL
+     VAR_INPUT
+       IN1 : ANY_ELEMENTARY;
+       IN2 : ANY_ELEMENTARY;
+     END_VAR
+   END_FUNCTION
+
+Returns ``BOOL``. ``NE`` accepts ``SINT``, ``INT``, ``DINT``, ``LINT``,
+``USINT``, ``UINT``, ``UDINT``, ``ULINT``, ``REAL``, ``LREAL``. Both
+inputs must share the same type.
 
 Description
 -----------
@@ -87,6 +51,14 @@ Example
 See Also
 --------
 
-- :doc:`eq` — equal
-- :doc:`gt` — greater than
-- :doc:`lt` — less than
+* :doc:`eq` — equal
+* :doc:`gt` — greater than
+* :doc:`lt` — less than
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.4
+* `CODESYS: NE <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_ne.html>`_
+* `Beckhoff TwinCAT 3: NE <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/27021600293232779.html>`_
+* `Fernhill SCADA: NE <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-comparison.html>`_

--- a/docs/reference/standard-library/functions/replace.rst
+++ b/docs/reference/standard-library/functions/replace.rst
@@ -4,42 +4,33 @@ REPLACE
 
 Replaces characters in a string.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+       IN2 ─┤         │
+            │ REPLACE ├─ OUT
+         L ─┤         │
+         P ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 12 12 12 12 12 30
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Input (L)
-     - Input (P)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``STRING``
-     - ``INT``
-     - ``INT``
-     - ``STRING``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``WSTRING``
-     - ``INT``
-     - ``INT``
-     - ``WSTRING``
-     - Not yet supported
+   FUNCTION REPLACE : ANY_STRING
+     VAR_INPUT
+       IN1 : ANY_STRING;
+       IN2 : ANY_STRING;
+       L   : ANY_INT;
+       P   : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``REPLACE`` accepts ``STRING``
+for *IN1* and *IN2*; *L* and *P* are ``INT``. Both string inputs must
+share the same type.
 
 Description
 -----------
@@ -62,6 +53,14 @@ Example
 See Also
 --------
 
-- :doc:`insert` — string insertion
-- :doc:`delete` — string deletion
-- :doc:`find` — string search
+* :doc:`insert` — string insertion
+* :doc:`delete` — string deletion
+* :doc:`find` — string search
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: REPLACE <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/REPLACE.html>`_
+* `Beckhoff TwinCAT 3: REPLACE <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74421771.html>`_
+* `Fernhill SCADA: REPLACE <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-replace.html>`_

--- a/docs/reference/standard-library/functions/right.rst
+++ b/docs/reference/standard-library/functions/right.rst
@@ -4,36 +4,28 @@ RIGHT
 
 Returns the rightmost characters of a string.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.7
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+           │  RIGHT  ├─ OUT
+        L ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (L)
-     - Return Type
-     - Support
-   * - 1
-     - ``STRING``
-     - ``INT``
-     - ``STRING``
-     - Supported
-   * - 2
-     - ``WSTRING``
-     - ``INT``
-     - ``WSTRING``
-     - Not yet supported
+   FUNCTION RIGHT : ANY_STRING
+     VAR_INPUT
+       IN : ANY_STRING;
+       L  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``RIGHT`` accepts ``STRING``
+for *IN*; *L* is ``INT``.
 
 Description
 -----------
@@ -53,6 +45,14 @@ Example
 See Also
 --------
 
-- :doc:`left` — left substring
-- :doc:`mid` — middle substring
-- :doc:`len` — string length
+* :doc:`left` — left substring
+* :doc:`mid` — middle substring
+* :doc:`len` — string length
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.7
+* `CODESYS: RIGHT <https://content.helpme-codesys.com/en/libs/Standard/Current/String-Functions/RIGHT.html>`_
+* `Beckhoff TwinCAT 3: RIGHT <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_standard/74423307.html>`_
+* `Fernhill SCADA: RIGHT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/string-functions/string-right.html>`_

--- a/docs/reference/standard-library/functions/rol.rst
+++ b/docs/reference/standard-library/functions/rol.rst
@@ -4,41 +4,28 @@ ROL
 
 Rotates a bit string left by a specified number of positions.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.6
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+           │   ROL   ├─ OUT
+        N ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (N)
-     - Return Type
-   * - 1
-     - ``BYTE``
-     - ``INT``
-     - ``BYTE``
-   * - 2
-     - ``WORD``
-     - ``INT``
-     - ``WORD``
-   * - 3
-     - ``DWORD``
-     - ``INT``
-     - ``DWORD``
-   * - 4
-     - ``LWORD``
-     - ``INT``
-     - ``LWORD``
+   FUNCTION ROL : ANY_BIT
+     VAR_INPUT
+       IN : ANY_BIT;
+       N  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``ROL`` accepts ``BYTE``,
+``WORD``, ``DWORD``, ``LWORD`` for *IN*; *N* is ``INT``.
 
 Description
 -----------
@@ -58,6 +45,14 @@ Example
 See Also
 --------
 
-- :doc:`ror` — rotate right
-- :doc:`shl` — shift left
-- :doc:`shr` — shift right
+* :doc:`ror` — rotate right
+* :doc:`shl` — shift left
+* :doc:`shr` — shift right
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.6
+* `CODESYS: ROL <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_rol.html>`_
+* `Beckhoff TwinCAT 3: ROL <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528945291.html>`_
+* `Fernhill SCADA: ROL <https://www.fernhillsoftware.com/help/iec-61131/common-elements/bitshift-functions/rotate-left.html>`_

--- a/docs/reference/standard-library/functions/ror.rst
+++ b/docs/reference/standard-library/functions/ror.rst
@@ -4,41 +4,28 @@ ROR
 
 Rotates a bit string right by a specified number of positions.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.6
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+           │   ROR   ├─ OUT
+        N ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (N)
-     - Return Type
-   * - 1
-     - ``BYTE``
-     - ``INT``
-     - ``BYTE``
-   * - 2
-     - ``WORD``
-     - ``INT``
-     - ``WORD``
-   * - 3
-     - ``DWORD``
-     - ``INT``
-     - ``DWORD``
-   * - 4
-     - ``LWORD``
-     - ``INT``
-     - ``LWORD``
+   FUNCTION ROR : ANY_BIT
+     VAR_INPUT
+       IN : ANY_BIT;
+       N  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``ROR`` accepts ``BYTE``,
+``WORD``, ``DWORD``, ``LWORD`` for *IN*; *N* is ``INT``.
 
 Description
 -----------
@@ -58,6 +45,14 @@ Example
 See Also
 --------
 
-- :doc:`rol` — rotate left
-- :doc:`shr` — shift right
-- :doc:`shl` — shift left
+* :doc:`rol` — rotate left
+* :doc:`shr` — shift right
+* :doc:`shl` — shift left
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.6
+* `CODESYS: ROR <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_ror.html>`_
+* `Beckhoff TwinCAT 3: ROR <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528950667.html>`_
+* `Fernhill SCADA: ROR <https://www.fernhillsoftware.com/help/iec-61131/common-elements/bitshift-functions/rotate-right.html>`_

--- a/docs/reference/standard-library/functions/sel.rst
+++ b/docs/reference/standard-library/functions/sel.rst
@@ -4,31 +4,29 @@ SEL
 
 Binary selection — selects one of two inputs based on a Boolean selector.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.5
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+         G ─┤         │
+       IN0 ─┤   SEL   ├─ OUT
+       IN1 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 15 15 15 15
+.. code-block:: text
 
-   * - #
-     - Input (G)
-     - Input (IN0)
-     - Input (IN1)
-     - Return Type
-   * - 1
-     - ``BOOL``
-     - *ANY*
-     - *ANY*
-     - *ANY*
+   FUNCTION SEL : ANY
+     VAR_INPUT
+       G   : BOOL;
+       IN0 : ANY;
+       IN1 : ANY;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN0* and *IN1*, which must be the
+same. ``SEL`` is polymorphic over any data type.
 
 Description
 -----------
@@ -52,6 +50,14 @@ Example
 See Also
 --------
 
-- :doc:`mux` — multiplexer (selects from multiple inputs)
-- :doc:`max` — maximum of two values
-- :doc:`min` — minimum of two values
+* :doc:`mux` — multiplexer (selects from multiple inputs)
+* :doc:`max` — maximum of two values
+* :doc:`min` — minimum of two values
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.5
+* `CODESYS: SEL <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sel.html>`_
+* `Beckhoff TwinCAT 3: SEL <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528956043.html>`_
+* `Fernhill SCADA: SEL <https://www.fernhillsoftware.com/help/iec-61131/common-elements/selection-functions/select.html>`_

--- a/docs/reference/standard-library/functions/shl.rst
+++ b/docs/reference/standard-library/functions/shl.rst
@@ -4,41 +4,28 @@ SHL
 
 Shifts a bit string left by a specified number of positions.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.6
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+           │   SHL   ├─ OUT
+        N ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (N)
-     - Return Type
-   * - 1
-     - ``BYTE``
-     - ``INT``
-     - ``BYTE``
-   * - 2
-     - ``WORD``
-     - ``INT``
-     - ``WORD``
-   * - 3
-     - ``DWORD``
-     - ``INT``
-     - ``DWORD``
-   * - 4
-     - ``LWORD``
-     - ``INT``
-     - ``LWORD``
+   FUNCTION SHL : ANY_BIT
+     VAR_INPUT
+       IN : ANY_BIT;
+       N  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``SHL`` accepts ``BYTE``,
+``WORD``, ``DWORD``, ``LWORD`` for *IN*; *N* is ``INT``.
 
 Description
 -----------
@@ -58,6 +45,14 @@ Example
 See Also
 --------
 
-- :doc:`shr` — shift right
-- :doc:`rol` — rotate left
-- :doc:`ror` — rotate right
+* :doc:`shr` — shift right
+* :doc:`rol` — rotate left
+* :doc:`ror` — rotate right
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.6
+* `CODESYS: SHL <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_shl.html>`_
+* `Beckhoff TwinCAT 3: SHL <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528934539.html>`_
+* `Fernhill SCADA: SHL <https://www.fernhillsoftware.com/help/iec-61131/common-elements/bitshift-functions/shift-left.html>`_

--- a/docs/reference/standard-library/functions/shr.rst
+++ b/docs/reference/standard-library/functions/shr.rst
@@ -4,41 +4,28 @@ SHR
 
 Shifts a bit string right by a specified number of positions.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.6
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤         │
+           │   SHR   ├─ OUT
+        N ─┤         │
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Input (N)
-     - Return Type
-   * - 1
-     - ``BYTE``
-     - ``INT``
-     - ``BYTE``
-   * - 2
-     - ``WORD``
-     - ``INT``
-     - ``WORD``
-   * - 3
-     - ``DWORD``
-     - ``INT``
-     - ``DWORD``
-   * - 4
-     - ``LWORD``
-     - ``INT``
-     - ``LWORD``
+   FUNCTION SHR : ANY_BIT
+     VAR_INPUT
+       IN : ANY_BIT;
+       N  : ANY_INT;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the type of *IN*. ``SHR`` accepts ``BYTE``,
+``WORD``, ``DWORD``, ``LWORD`` for *IN*; *N* is ``INT``.
 
 Description
 -----------
@@ -58,6 +45,14 @@ Example
 See Also
 --------
 
-- :doc:`shl` — shift left
-- :doc:`ror` — rotate right
-- :doc:`rol` — rotate left
+* :doc:`shl` — shift left
+* :doc:`ror` — rotate right
+* :doc:`rol` — rotate left
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.6
+* `CODESYS: SHR <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_shr.html>`_
+* `Beckhoff TwinCAT 3: SHR <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528939915.html>`_
+* `Fernhill SCADA: SHR <https://www.fernhillsoftware.com/help/iec-61131/common-elements/bitshift-functions/shift-right.html>`_

--- a/docs/reference/standard-library/functions/sin.rst
+++ b/docs/reference/standard-library/functions/sin.rst
@@ -4,30 +4,25 @@ SIN
 
 Returns the sine of an angle in radians.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   SIN   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION SIN : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``SIN`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`cos` — cosine
-- :doc:`tan` — tangent
-- :doc:`asin` — arc sine
+* :doc:`cos` — cosine
+* :doc:`tan` — tangent
+* :doc:`asin` — arc sine
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: SIN <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sin.html>`_
+* `Beckhoff TwinCAT 3: SIN <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/18014401038610059.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/sqrt.rst
+++ b/docs/reference/standard-library/functions/sqrt.rst
@@ -4,30 +4,25 @@ SQRT
 
 Returns the square root of a numeric input.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤  SQRT   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION SQRT : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``SQRT`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`abs` — absolute value
-- :doc:`expt` — exponentiation
-- :doc:`exp` — natural exponential
+* :doc:`abs` — absolute value
+* :doc:`expt` — exponentiation
+* :doc:`exp` — natural exponential
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: SQRT <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sqrt.html>`_
+* `Beckhoff TwinCAT 3: SQRT <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529101195.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/sub.rst
+++ b/docs/reference/standard-library/functions/sub.rst
@@ -4,81 +4,29 @@ SUB
 
 Returns the difference of two inputs.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.3
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │   SUB   ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20 30
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-     - Support
-   * - 1
-     - ``SINT``
-     - ``SINT``
-     - ``SINT``
-     - Supported
-   * - 2
-     - ``INT``
-     - ``INT``
-     - ``INT``
-     - Supported
-   * - 3
-     - ``DINT``
-     - ``DINT``
-     - ``DINT``
-     - Supported
-   * - 4
-     - ``LINT``
-     - ``LINT``
-     - ``LINT``
-     - Supported
-   * - 5
-     - ``USINT``
-     - ``USINT``
-     - ``USINT``
-     - Supported
-   * - 6
-     - ``UINT``
-     - ``UINT``
-     - ``UINT``
-     - Supported
-   * - 7
-     - ``UDINT``
-     - ``UDINT``
-     - ``UDINT``
-     - Supported
-   * - 8
-     - ``ULINT``
-     - ``ULINT``
-     - ``ULINT``
-     - Supported
-   * - 9
-     - ``REAL``
-     - ``REAL``
-     - ``REAL``
-     - Supported
-   * - 10
-     - ``LREAL``
-     - ``LREAL``
-     - ``LREAL``
-     - Supported
-   * - 11
-     - ``TIME``
-     - ``TIME``
-     - ``TIME``
-     - Not yet supported
+   FUNCTION SUB : ANY_NUM
+     VAR_INPUT
+       IN1 : ANY_NUM;
+       IN2 : ANY_NUM;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``SUB`` accepts ``SINT``,
+``INT``, ``DINT``, ``LINT``, ``USINT``, ``UINT``, ``UDINT``, ``ULINT``,
+``REAL``, ``LREAL``. Both inputs must share the same type.
 
 Description
 -----------
@@ -100,6 +48,14 @@ Example
 See Also
 --------
 
-- :doc:`add` — addition
-- :doc:`mul` — multiplication
-- :doc:`div` — division
+* :doc:`add` — addition
+* :doc:`mul` — multiplication
+* :doc:`div` — division
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.3
+* `CODESYS: SUB <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sub.html>`_
+* `Beckhoff TwinCAT 3: SUB <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528870027.html>`_
+* `Fernhill SCADA: Arithmetic Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-arithmetic.html>`_

--- a/docs/reference/standard-library/functions/sub_date_date.rst
+++ b/docs/reference/standard-library/functions/sub_date_date.rst
@@ -4,29 +4,27 @@ SUB_DATE_DATE
 
 Returns the difference between two dates as a duration.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌──────────────┐
+       IN1 ─┤              │
+            │ SUB_DATE_DATE├─ OUT
+       IN2 ─┤              │
+            └──────────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``DATE``
-     - ``DATE``
-     - ``TIME``
+   FUNCTION SUB_DATE_DATE : TIME
+     VAR_INPUT
+       IN1 : DATE;
+       IN2 : DATE;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME``. Both inputs are ``DATE``.
 
 Description
 -----------
@@ -47,4 +45,12 @@ Example
 See Also
 --------
 
-- :doc:`sub_dt_dt` — difference between two datetimes
+* :doc:`sub_dt_dt` — difference between two datetimes
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: SUB (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sub.html>`_
+* `Beckhoff TwinCAT 3: SUB (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528870027.html>`_
+* `Fernhill SCADA: SUB_DATE_DATE <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-sub-date.html>`_

--- a/docs/reference/standard-library/functions/sub_dt_dt.rst
+++ b/docs/reference/standard-library/functions/sub_dt_dt.rst
@@ -4,29 +4,27 @@ SUB_DT_DT
 
 Returns the difference between two date-and-time values as a duration.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │SUB_DT_DT├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``DATE_AND_TIME``
-     - ``DATE_AND_TIME``
-     - ``TIME``
+   FUNCTION SUB_DT_DT : TIME
+     VAR_INPUT
+       IN1 : DATE_AND_TIME;
+       IN2 : DATE_AND_TIME;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME``. Both inputs are ``DATE_AND_TIME``.
 
 Description
 -----------
@@ -47,5 +45,13 @@ Example
 See Also
 --------
 
-- :doc:`add_dt_time` — add duration to datetime
-- :doc:`sub_dt_time` — subtract duration from datetime
+* :doc:`add_dt_time` — add duration to datetime
+* :doc:`sub_dt_time` — subtract duration from datetime
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: SUB (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sub.html>`_
+* `Beckhoff TwinCAT 3: SUB (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528870027.html>`_
+* `Fernhill SCADA: SUB_DT_DT <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-sub-dt-dt.html>`_

--- a/docs/reference/standard-library/functions/sub_dt_time.rst
+++ b/docs/reference/standard-library/functions/sub_dt_time.rst
@@ -4,29 +4,28 @@ SUB_DT_TIME
 
 Subtracts a duration from a date-and-time value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌──────────┐
+       IN1 ─┤          │
+            │SUB_DT_TIME├─ OUT
+       IN2 ─┤          │
+            └──────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``DATE_AND_TIME``
-     - ``TIME``
-     - ``DATE_AND_TIME``
+   FUNCTION SUB_DT_TIME : DATE_AND_TIME
+     VAR_INPUT
+       IN1 : DATE_AND_TIME;
+       IN2 : TIME;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``DATE_AND_TIME``. *IN1* is ``DATE_AND_TIME`` and
+*IN2* is ``TIME``.
 
 Description
 -----------
@@ -45,5 +44,13 @@ Example
 See Also
 --------
 
-- :doc:`add_dt_time` — add duration to datetime
-- :doc:`sub_dt_dt` — difference between two datetimes
+* :doc:`add_dt_time` — add duration to datetime
+* :doc:`sub_dt_dt` — difference between two datetimes
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: SUB (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sub.html>`_
+* `Beckhoff TwinCAT 3: SUB (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528870027.html>`_
+* `Fernhill SCADA: SUB_DT_TIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-sub-dt-time.html>`_

--- a/docs/reference/standard-library/functions/sub_time.rst
+++ b/docs/reference/standard-library/functions/sub_time.rst
@@ -4,29 +4,27 @@ SUB_TIME
 
 Returns the difference of two time durations.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌─────────┐
+       IN1 ─┤         │
+            │SUB_TIME ├─ OUT
+       IN2 ─┤         │
+            └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``TIME``
-     - ``TIME``
-     - ``TIME``
+   FUNCTION SUB_TIME : TIME
+     VAR_INPUT
+       IN1 : TIME;
+       IN2 : TIME;
+     END_VAR
+   END_FUNCTION
+
+Both inputs and the return value are ``TIME``.
 
 Description
 -----------
@@ -44,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`add_time` — add durations
-- :doc:`mul_time` — scale duration
-- :doc:`div_time` — divide duration
+* :doc:`add_time` — add durations
+* :doc:`mul_time` — scale duration
+* :doc:`div_time` — divide duration
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: SUB (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sub.html>`_
+* `Beckhoff TwinCAT 3: SUB (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528870027.html>`_
+* `Fernhill SCADA: SUB_TIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-sub.html>`_

--- a/docs/reference/standard-library/functions/sub_tod_time.rst
+++ b/docs/reference/standard-library/functions/sub_tod_time.rst
@@ -4,29 +4,28 @@ SUB_TOD_TIME
 
 Subtracts a duration from a time-of-day value.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌────────────┐
+       IN1 ─┤            │
+            │SUB_TOD_TIME├─ OUT
+       IN2 ─┤            │
+            └────────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``TIME_OF_DAY``
-     - ``TIME``
-     - ``TIME_OF_DAY``
+   FUNCTION SUB_TOD_TIME : TIME_OF_DAY
+     VAR_INPUT
+       IN1 : TIME_OF_DAY;
+       IN2 : TIME;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME_OF_DAY``. *IN1* is ``TIME_OF_DAY`` and
+*IN2* is ``TIME``.
 
 Description
 -----------
@@ -45,5 +44,13 @@ Example
 See Also
 --------
 
-- :doc:`add_tod_time` — add duration to time-of-day
-- :doc:`sub_tod_tod` — difference between two times-of-day
+* :doc:`add_tod_time` — add duration to time-of-day
+* :doc:`sub_tod_tod` — difference between two times-of-day
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: SUB (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sub.html>`_
+* `Beckhoff TwinCAT 3: SUB (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528870027.html>`_
+* `Fernhill SCADA: SUB_TOD_TIME <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-sub-tod-time.html>`_

--- a/docs/reference/standard-library/functions/sub_tod_tod.rst
+++ b/docs/reference/standard-library/functions/sub_tod_tod.rst
@@ -4,29 +4,27 @@ SUB_TOD_TOD
 
 Returns the difference between two time-of-day values as a duration.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.8
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+            ┌───────────┐
+       IN1 ─┤           │
+            │SUB_TOD_TOD├─ OUT
+       IN2 ─┤           │
+            └───────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 20 20 20
+.. code-block:: text
 
-   * - #
-     - Input (IN1)
-     - Input (IN2)
-     - Return Type
-   * - 1
-     - ``TIME_OF_DAY``
-     - ``TIME_OF_DAY``
-     - ``TIME``
+   FUNCTION SUB_TOD_TOD : TIME
+     VAR_INPUT
+       IN1 : TIME_OF_DAY;
+       IN2 : TIME_OF_DAY;
+     END_VAR
+   END_FUNCTION
+
+The return type is ``TIME``. Both inputs are ``TIME_OF_DAY``.
 
 Description
 -----------
@@ -46,5 +44,13 @@ Example
 See Also
 --------
 
-- :doc:`add_tod_time` — add duration to time-of-day
-- :doc:`sub_tod_time` — subtract duration from time-of-day
+* :doc:`add_tod_time` — add duration to time-of-day
+* :doc:`sub_tod_time` — subtract duration from time-of-day
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.8
+* `CODESYS: SUB (covers time arithmetic) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_sub.html>`_
+* `Beckhoff TwinCAT 3: SUB (covers time arithmetic) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2528870027.html>`_
+* `Fernhill SCADA: SUB_TOD_TOD <https://www.fernhillsoftware.com/help/iec-61131/common-elements/date-time-functions/time-sub-tod-tod.html>`_

--- a/docs/reference/standard-library/functions/tan.rst
+++ b/docs/reference/standard-library/functions/tan.rst
@@ -4,30 +4,25 @@ TAN
 
 Returns the tangent of an angle in radians.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤   TAN   ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``REAL``
-   * - 2
-     - ``LREAL``
-     - ``LREAL``
+   FUNCTION TAN : ANY_REAL
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+The return type matches the input type. ``TAN`` accepts ``REAL``,
+``LREAL``.
 
 Description
 -----------
@@ -47,6 +42,14 @@ Example
 See Also
 --------
 
-- :doc:`sin` — sine
-- :doc:`cos` — cosine
-- :doc:`atan` — arc tangent
+* :doc:`sin` — sine
+* :doc:`cos` — cosine
+* :doc:`atan` — arc tangent
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: TAN <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_tan.html>`_
+* `Beckhoff TwinCAT 3: TAN <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529138827.html>`_
+* `Fernhill SCADA: Mathematical Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/functions-mathematical.html>`_

--- a/docs/reference/standard-library/functions/trunc.rst
+++ b/docs/reference/standard-library/functions/trunc.rst
@@ -5,48 +5,26 @@ TRUNC
 Truncates a real (floating-point) value toward zero, removing the
 fractional part and returning an integer.
 
-.. list-table::
-   :widths: 30 70
+Signature
+---------
 
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.2
-   * - **Support**
-     - Supported
+.. code-block:: text
 
-Signatures
-----------
+           ┌─────────┐
+       IN ─┤  TRUNC  ├─ OUT
+           └─────────┘
 
-.. list-table::
-   :header-rows: 1
-   :widths: 10 30 30
+.. code-block:: text
 
-   * - #
-     - Input (IN)
-     - Return Type
-   * - 1
-     - ``REAL``
-     - ``SINT``
-   * - 2
-     - ``REAL``
-     - ``INT``
-   * - 3
-     - ``REAL``
-     - ``DINT``
-   * - 4
-     - ``REAL``
-     - ``LINT``
-   * - 5
-     - ``LREAL``
-     - ``SINT``
-   * - 6
-     - ``LREAL``
-     - ``INT``
-   * - 7
-     - ``LREAL``
-     - ``DINT``
-   * - 8
-     - ``LREAL``
-     - ``LINT``
+   FUNCTION TRUNC : ANY_INT
+     VAR_INPUT
+       IN : ANY_REAL;
+     END_VAR
+   END_FUNCTION
+
+``TRUNC`` accepts ``REAL`` or ``LREAL`` for *IN*. The return type
+is determined by the variable being assigned to: ``SINT``, ``INT``,
+``DINT``, or ``LINT``.
 
 Description
 -----------
@@ -73,5 +51,13 @@ Example
 See Also
 --------
 
-- :doc:`type-conversions` — explicit type conversion functions
-- :doc:`abs` — absolute value
+* :doc:`type-conversions` — explicit type conversion functions
+* :doc:`abs` — absolute value
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.2
+* `CODESYS: TRUNC <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_trunc.html>`_
+* `Beckhoff TwinCAT 3: TRUNC <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529079691.html>`_
+* `Fernhill SCADA: TRUNC <https://www.fernhillsoftware.com/help/iec-61131/common-elements/conversion-functions/truncation.html>`_

--- a/docs/reference/standard-library/functions/type-conversions.rst
+++ b/docs/reference/standard-library/functions/type-conversions.rst
@@ -6,14 +6,6 @@ IEC 61131-3 defines a set of type conversion functions that convert
 values between data types. Each function follows the naming pattern
 ``<source>_TO_<target>``.
 
-.. list-table::
-   :widths: 30 70
-
-   * - **IEC 61131-3**
-     - Section 2.5.1.5.1
-   * - **Support** (numeric and time/date conversions)
-     - Partial
-
 Conversion Categories
 ---------------------
 
@@ -470,4 +462,12 @@ Example
 See Also
 --------
 
-- :doc:`/reference/language/data-types/index` — data type reference
+* :doc:`/reference/language/data-types/index` — data type reference
+
+References
+----------
+
+* IEC 61131-3 §2.5.1.5.1
+* `CODESYS: Operators (overview) <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_struct_reference_operators.html>`_
+* `Beckhoff TwinCAT 3: Type conversion (overview) <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/63050398781277579.html>`_
+* `Fernhill SCADA: Conversion Functions <https://www.fernhillsoftware.com/help/iec-61131/common-elements/conversion-functions/index.html>`_


### PR DESCRIPTION
Replace the per-page metadata table and per-type signatures table with a vendor-style layout: an FBD box (Unicode box-drawing), an ST function declaration, a one-sentence type rule, and the existing description and runnable example. Add a References section that combines the IEC section reference with links to the equivalent CODESYS, Beckhoff, and Fernhill pages.