### PR TITLE
Refactor string handling to prepare for WSTRING support

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -116,9 +116,6 @@ pub(crate) enum PoolConstant {
 /// The IEC 61131-3 default maximum length for STRING (254 characters).
 pub(crate) const DEFAULT_STRING_MAX_LENGTH_U16: u16 = 254;
 
-/// STRING_HEADER_BYTES re-exported as u32 for arithmetic in compile_array.
-pub(crate) const STRING_HEADER_BYTES_U32: u32 = STRING_HEADER_BYTES as u32;
-
 /// Metadata for a STRING variable allocated in the data region.
 #[derive(Clone)]
 pub(crate) struct StringVarInfo {
@@ -126,6 +123,29 @@ pub(crate) struct StringVarInfo {
     pub(crate) data_offset: u32,
     /// Maximum number of characters this string can hold.
     pub(crate) max_length: u16,
+    /// Bytes per character: 1 for STRING, 2 for WSTRING (not yet supported).
+    pub(crate) char_width: u16,
+}
+
+/// Bytes per character for STRING. WSTRING (when supported) will use 2.
+pub(crate) const STRING_CHAR_WIDTH: u16 = 1;
+
+/// Total bytes needed in the data region for a STRING value with the given
+/// maximum length: header plus per-character storage.
+pub(crate) fn string_region_size(max_length: u16) -> u32 {
+    STRING_HEADER_BYTES as u32 + (max_length as u32) * (STRING_CHAR_WIDTH as u32)
+}
+
+/// Encode a character-string literal into bytes for the constant pool.
+///
+/// `char_width` selects the encoding: 1 for STRING (Latin-1 per ADR-0016).
+/// WSTRING (`char_width = 2`) is not yet supported and will panic; the
+/// parameter exists so call sites already pass the value.
+pub(crate) fn encode_string_literal(chars: &[char], char_width: u16) -> Vec<u8> {
+    match char_width {
+        STRING_CHAR_WIDTH => chars.iter().map(|&ch| ch as u8).collect(),
+        _ => unreachable!("WSTRING literal encoding is not yet supported"),
+    }
 }
 
 /// Compiles a library into a bytecode container.
@@ -449,7 +469,7 @@ fn compile_program_with_functions(
         if ctx.num_temp_bufs > 0 {
             builder = builder
                 .num_temp_bufs(ctx.num_temp_bufs)
-                .max_temp_buf_bytes((STRING_HEADER_BYTES as u16 + ctx.max_string_capacity) as u32);
+                .max_temp_buf_bytes(string_region_size(ctx.max_string_capacity));
         }
     }
 
@@ -575,6 +595,9 @@ pub(crate) struct StringParamInfo {
     pub(crate) data_offset: u32,
     /// Maximum number of characters this parameter can hold.
     pub(crate) max_length: u16,
+    /// Bytes per character: 1 for STRING, 2 for WSTRING (not yet supported).
+    #[allow(dead_code)]
+    pub(crate) char_width: u16,
 }
 
 /// Metadata for a STRING return value in a user-defined function.
@@ -587,6 +610,9 @@ pub(crate) struct StringReturnInfo {
     pub(crate) data_offset: u32,
     /// Maximum number of characters the return string can hold.
     pub(crate) max_length: u16,
+    /// Bytes per character: 1 for STRING, 2 for WSTRING (not yet supported).
+    #[allow(dead_code)]
+    pub(crate) char_width: u16,
 }
 
 /// Metadata for a compiled user-defined function.

--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -558,7 +558,7 @@ pub(crate) fn register_array_variable(
     let data_offset = ctx.data_region_offset;
     let total_bytes = if is_string {
         // STRING elements: each element is [max_len:u16][cur_len:u16][data:max_len bytes]
-        let element_stride = super::compile::STRING_HEADER_BYTES_U32 + string_max_len as u32;
+        let element_stride = super::compile::string_region_size(string_max_len);
         total_elements.checked_mul(element_stride).ok_or_else(|| {
             Diagnostic::problem(
                 Problem::NotImplemented,

--- a/compiler/codegen/src/compile_expr.rs
+++ b/compiler/codegen/src/compile_expr.rs
@@ -16,7 +16,10 @@ use ironplc_dsl::textual::{
 };
 use ironplc_problems::Problem;
 
-use super::compile::{CompileContext, OpType, OpWidth, Signedness, VarTypeInfo, DEFAULT_OP_TYPE};
+use super::compile::{
+    encode_string_literal, CompileContext, OpType, OpWidth, Signedness, VarTypeInfo,
+    DEFAULT_OP_TYPE, STRING_CHAR_WIDTH,
+};
 use super::compile_call::compile_function_call;
 use super::compile_setup::resolve_type_name;
 use super::compile_string::compile_string_compare;
@@ -374,7 +377,7 @@ pub(crate) fn compile_constant(
             // Load the string literal into a temp buffer, leaving buf_idx on the stack.
             // The caller (e.g., string assignment path) will consume the buf_idx via
             // emit_str_store_var to copy the value into the target data region.
-            let bytes: Vec<u8> = lit.value.iter().map(|&ch| ch as u8).collect();
+            let bytes = encode_string_literal(&lit.value, STRING_CHAR_WIDTH);
             let pool_index = ctx.add_str_constant(bytes);
             ctx.num_temp_bufs += 1;
             emitter.emit_load_const_str(pool_index);

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -4,7 +4,7 @@
 //! including variable setup, body compilation, and metadata registration.
 //! Separated from compile.rs to keep module sizes within the 1000-line guideline.
 
-use ironplc_container::{ContainerBuilder, VarIndex, STRING_HEADER_BYTES};
+use ironplc_container::{ContainerBuilder, VarIndex};
 use ironplc_dsl::common::{
     FunctionBlockDeclaration, FunctionDeclaration, FunctionReturnType, InitialValueAssignmentKind,
     VarDecl, VariableType,
@@ -16,9 +16,9 @@ use ironplc_problems::Problem;
 use ironplc_analyzer::{FunctionEnvironment, TypeEnvironment};
 
 use super::compile::{
-    finalize_function, CompileContext, CompiledFunction, CurrentFunctionReturn, OpType, OpWidth,
-    Signedness, StringParamInfo, StringReturnInfo, StringVarInfo, UserFunctionInfo, VarTypeInfo,
-    DEFAULT_OP_TYPE,
+    finalize_function, string_region_size, CompileContext, CompiledFunction, CurrentFunctionReturn,
+    OpType, OpWidth, Signedness, StringParamInfo, StringReturnInfo, StringVarInfo,
+    UserFunctionInfo, VarTypeInfo, DEFAULT_OP_TYPE, STRING_CHAR_WIDTH,
 };
 use super::compile_expr::emit_load_var;
 use super::compile_setup::{emit_function_local_prologue, resolve_type_name};
@@ -109,7 +109,7 @@ pub(crate) fn compile_user_function(
                     let max_length = resolve_string_max_length(string_init)?;
 
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+                    let total_bytes = string_region_size(max_length);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -129,6 +129,7 @@ pub(crate) fn compile_user_function(
                         StringVarInfo {
                             data_offset,
                             max_length,
+                            char_width: STRING_CHAR_WIDTH,
                         },
                     );
                 }
@@ -173,7 +174,7 @@ pub(crate) fn compile_user_function(
                     let max_length = resolve_string_max_length(string_init)?;
 
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+                    let total_bytes = string_region_size(max_length);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -193,6 +194,7 @@ pub(crate) fn compile_user_function(
                         StringVarInfo {
                             data_offset,
                             max_length,
+                            char_width: STRING_CHAR_WIDTH,
                         },
                     );
                 }
@@ -230,7 +232,7 @@ pub(crate) fn compile_user_function(
             let max_length = resolve_string_spec_max_length(spec)?;
 
             let data_offset = ctx.data_region_offset;
-            let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+            let total_bytes = string_region_size(max_length);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
@@ -245,11 +247,13 @@ pub(crate) fn compile_user_function(
                 StringVarInfo {
                     data_offset,
                     max_length,
+                    char_width: STRING_CHAR_WIDTH,
                 },
             );
             Some(StringReturnInfo {
                 data_offset,
                 max_length,
+                char_width: STRING_CHAR_WIDTH,
             })
         }
         FunctionReturnType::Named(_) => {
@@ -353,6 +357,7 @@ pub(crate) fn compile_user_function(
                         param_string_info.push(Some(StringParamInfo {
                             data_offset: info.data_offset,
                             max_length: info.max_length,
+                            char_width: info.char_width,
                         }));
                     } else {
                         param_string_info.push(None);
@@ -528,7 +533,7 @@ pub(crate) fn compile_user_function_block(
                     let max_length = resolve_string_max_length(string_init)?;
 
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+                    let total_bytes = string_region_size(max_length);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -548,6 +553,7 @@ pub(crate) fn compile_user_function_block(
                         StringVarInfo {
                             data_offset,
                             max_length,
+                            char_width: STRING_CHAR_WIDTH,
                         },
                     );
                 }

--- a/compiler/codegen/src/compile_setup.rs
+++ b/compiler/codegen/src/compile_setup.rs
@@ -5,7 +5,7 @@
 //! keep module sizes within the 1000-line guideline.
 
 use ironplc_container::debug_section::{function_id, iec_type_tag, var_section, VarNameEntry};
-use ironplc_container::{ContainerBuilder, VarIndex, STRING_HEADER_BYTES};
+use ironplc_container::{ContainerBuilder, VarIndex};
 use ironplc_dsl::common::{
     ElementaryTypeName, FunctionDeclaration, GenericTypeName, InitialValueAssignmentKind,
     ReferenceInitialValue, SpecificationKind, VarDecl, VariableType,
@@ -18,8 +18,8 @@ use ironplc_analyzer::intermediate_type::IntermediateType;
 use ironplc_analyzer::TypeEnvironment;
 
 use super::compile::{
-    CompileContext, FbInstanceInfo, OpType, OpWidth, Signedness, StringVarInfo, VarTypeInfo,
-    DEFAULT_OP_TYPE,
+    encode_string_literal, string_region_size, CompileContext, FbInstanceInfo, OpType, OpWidth,
+    Signedness, StringVarInfo, VarTypeInfo, DEFAULT_OP_TYPE, STRING_CHAR_WIDTH,
 };
 use super::compile_call::resolve_fb_type;
 use super::compile_expr::{compile_constant, emit_store_var, emit_truncation, resolve_variable};
@@ -82,7 +82,7 @@ pub(crate) fn assign_variables(
 
                     // Allocate space in the data region: [max_length: u16][cur_length: u16][data]
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+                    let total_bytes = string_region_size(max_length);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -102,6 +102,7 @@ pub(crate) fn assign_variables(
                         StringVarInfo {
                             data_offset,
                             max_length,
+                            char_width: STRING_CHAR_WIDTH,
                         },
                     );
                     (iec_type_tag::STRING, "STRING".into())
@@ -403,8 +404,7 @@ pub(crate) fn emit_initial_values(
 
                         // If there's an initial value, load and store it.
                         if let Some(chars) = &string_init.initial_value {
-                            // Convert chars to Latin-1 bytes (STRING encoding per ADR-0016).
-                            let bytes: Vec<u8> = chars.iter().map(|&ch| ch as u8).collect();
+                            let bytes = encode_string_literal(chars, STRING_CHAR_WIDTH);
                             let pool_index = ctx.add_str_constant(bytes);
                             ctx.num_temp_bufs += 1;
                             emitter.emit_load_const_str(pool_index);
@@ -654,7 +654,7 @@ pub(crate) fn emit_function_local_prologue(
                         emitter.emit_str_init(data_offset, max_length);
 
                         if let Some(chars) = &string_init.initial_value {
-                            let bytes: Vec<u8> = chars.iter().map(|&ch| ch as u8).collect();
+                            let bytes = encode_string_literal(chars, STRING_CHAR_WIDTH);
                             let pool_index = ctx.add_str_constant(bytes);
                             ctx.num_temp_bufs += 1;
                             emitter.emit_load_const_str(pool_index);

--- a/compiler/codegen/src/compile_string.rs
+++ b/compiler/codegen/src/compile_string.rs
@@ -4,13 +4,16 @@
 //! INSERT, DELETE, LEFT, RIGHT, MID, CONCAT) and string comparison.
 //! Separated from compile.rs to keep module sizes within the 1000-line guideline.
 
-use ironplc_container::{opcode, STRING_HEADER_BYTES};
+use ironplc_container::opcode;
 use ironplc_dsl::common::ConstantKind;
 use ironplc_dsl::core::{Located, SourceSpan};
 use ironplc_dsl::diagnostic::Diagnostic;
 use ironplc_dsl::textual::{CompareExpr, CompareOp, Expr, ExprKind, Function, ParamAssignmentKind};
 
-use super::compile::{CompileContext, DEFAULT_OP_TYPE, DEFAULT_STRING_MAX_LENGTH_U16};
+use super::compile::{
+    encode_string_literal, string_region_size, CompileContext, DEFAULT_OP_TYPE,
+    DEFAULT_STRING_MAX_LENGTH_U16, STRING_CHAR_WIDTH,
+};
 use super::compile_expr::{compile_expr, resolve_variable_name};
 use crate::emit::Emitter;
 
@@ -121,7 +124,7 @@ pub(crate) fn resolve_string_arg(
             // through to the general expression path below.
             let max_length = DEFAULT_STRING_MAX_LENGTH_U16;
             let data_offset = ctx.data_region_offset;
-            let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+            let total_bytes = string_region_size(max_length);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
@@ -141,10 +144,10 @@ pub(crate) fn resolve_string_arg(
         }
         ExprKind::Const(ConstantKind::CharacterString(lit)) => {
             // Allocate space in the data region for this string literal.
-            let bytes: Vec<u8> = lit.value.iter().map(|&ch| ch as u8).collect();
+            let bytes = encode_string_literal(&lit.value, STRING_CHAR_WIDTH);
             let max_length = DEFAULT_STRING_MAX_LENGTH_U16;
             let data_offset = ctx.data_region_offset;
-            let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+            let total_bytes = string_region_size(max_length);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
@@ -170,7 +173,7 @@ pub(crate) fn resolve_string_arg(
             // temporary data region slot so the caller gets a data_offset.
             let max_length = DEFAULT_STRING_MAX_LENGTH_U16;
             let data_offset = ctx.data_region_offset;
-            let total_bytes = STRING_HEADER_BYTES as u32 + max_length as u32;
+            let total_bytes = string_region_size(max_length);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)

--- a/compiler/codegen/src/compile_struct.rs
+++ b/compiler/codegen/src/compile_struct.rs
@@ -533,7 +533,7 @@ pub(crate) fn initialize_struct_fields(
                 let total_elements = array_dims
                     .iter()
                     .fold(1u32, |acc, d| acc * (d.upper - d.lower + 1) as u32);
-                let stride = super::compile::STRING_HEADER_BYTES_U32 + max_length as u32;
+                let stride = super::compile::string_region_size(max_length);
                 let field_byte_offset = struct_data_offset + slot_idx.raw() * 8;
                 for i in 0..total_elements {
                     let elem_byte_offset = field_byte_offset + i * stride;

--- a/compiler/vm/src/string_ops.rs
+++ b/compiler/vm/src/string_ops.rs
@@ -2,6 +2,11 @@ use ironplc_container::STRING_HEADER_BYTES;
 
 use crate::error::Trap;
 
+/// Byte offset of the `max_length` field within a string header.
+pub(crate) const MAX_LEN_OFFSET: usize = 0;
+/// Byte offset of the `cur_length` field within a string header.
+pub(crate) const CUR_LEN_OFFSET: usize = 2;
+
 /// Metadata for an allocated temp buffer slot.
 pub(crate) struct TempBufferSlot {
     /// Index of this buffer slot (the value pushed onto the stack).
@@ -64,7 +69,10 @@ pub(crate) fn read_string_header(
     if offset + STRING_HEADER_BYTES > data_region.len() {
         return Err(Trap::DataRegionOutOfBounds(offset as u32));
     }
-    let cur_len = u16::from_le_bytes([data_region[offset + 2], data_region[offset + 3]]) as usize;
+    let cur_len = u16::from_le_bytes([
+        data_region[offset + CUR_LEN_OFFSET],
+        data_region[offset + CUR_LEN_OFFSET + 1],
+    ]) as usize;
     let data_start = offset + STRING_HEADER_BYTES;
     Ok((cur_len, data_start))
 }
@@ -79,8 +87,9 @@ pub(crate) fn write_string_header(
     result_len: usize,
 ) -> (u16, usize) {
     let cur_len = (result_len as u16).min(max_len);
-    temp_buf[buf_start..buf_start + 2].copy_from_slice(&max_len.to_le_bytes());
-    temp_buf[buf_start + 2..buf_start + STRING_HEADER_BYTES]
+    temp_buf[buf_start + MAX_LEN_OFFSET..buf_start + MAX_LEN_OFFSET + 2]
+        .copy_from_slice(&max_len.to_le_bytes());
+    temp_buf[buf_start + CUR_LEN_OFFSET..buf_start + STRING_HEADER_BYTES]
         .copy_from_slice(&cur_len.to_le_bytes());
     let data_start = buf_start + STRING_HEADER_BYTES;
     (cur_len, data_start)
@@ -88,18 +97,26 @@ pub(crate) fn write_string_header(
 
 /// Read max_length from a string header at `offset` in `buf`.
 pub(crate) fn str_read_max_len(buf: &[u8], offset: usize) -> u16 {
-    u16::from_le_bytes([buf[offset], buf[offset + 1]])
+    u16::from_le_bytes([
+        buf[offset + MAX_LEN_OFFSET],
+        buf[offset + MAX_LEN_OFFSET + 1],
+    ])
 }
 
 /// Read cur_length from a string header at `offset` in `buf`.
 pub(crate) fn str_read_cur_len(buf: &[u8], offset: usize) -> u16 {
-    u16::from_le_bytes([buf[offset + 2], buf[offset + 3]])
+    u16::from_le_bytes([
+        buf[offset + CUR_LEN_OFFSET],
+        buf[offset + CUR_LEN_OFFSET + 1],
+    ])
 }
 
 /// Write a string header (max_length, cur_length) at `offset` in `buf`.
 pub(crate) fn str_write_header(buf: &mut [u8], offset: usize, max_len: u16, cur_len: u16) {
-    buf[offset..offset + 2].copy_from_slice(&max_len.to_le_bytes());
-    buf[offset + 2..offset + STRING_HEADER_BYTES].copy_from_slice(&cur_len.to_le_bytes());
+    buf[offset + MAX_LEN_OFFSET..offset + MAX_LEN_OFFSET + 2]
+        .copy_from_slice(&max_len.to_le_bytes());
+    buf[offset + CUR_LEN_OFFSET..offset + STRING_HEADER_BYTES]
+        .copy_from_slice(&cur_len.to_le_bytes());
 }
 
 #[cfg(test)]

--- a/specs/plans/2026-05-04-wstring-prep-refactor.md
+++ b/specs/plans/2026-05-04-wstring-prep-refactor.md
@@ -1,0 +1,51 @@
+# WSTRING Prep Refactor
+
+## Goal
+
+Land mechanical, behavior-preserving refactors that put width-dependent string logic behind clean seams, so a future WSTRING change becomes a value substitution rather than a structural rewrite.
+
+This change does **not** add WSTRING support. It only prepares the codebase for it.
+
+## Architecture
+
+Currently STRING is byte-oriented throughout codegen and VM. The width assumption (`1 byte per character`) is hard-coded at many call sites. WSTRING (16-bit characters) will need to thread a `char_width` value through the same code paths.
+
+The prep work consolidates each pattern at one site:
+
+1. **String region sizing** — three call sites compute `STRING_HEADER_BYTES + max_length` inline. Replace with a `string_region_size(max_length)` helper.
+2. **String literal encoding** — four call sites do `lit.value.iter().map(|&ch| ch as u8).collect()`. Replace with an `encode_string_literal(chars, char_width)` helper that today only supports `char_width = 1`.
+3. **String info structs** — `StringVarInfo`, `StringParamInfo`, `StringReturnInfo` carry `data_offset` and `max_length`. Add a `char_width: u16` field (always `1` today) so the value flows through codegen without further plumbing later.
+4. **VM string-header offsets** — `string_ops.rs` uses magic `+ 2`, `+ 3` to access the `cur_length` field. Replace with named constants (`MAX_LEN_OFFSET`, `CUR_LEN_OFFSET`).
+
+Each refactor is a 1:1 substitution preserving exact byte output and runtime behavior.
+
+## File Map
+
+Modified:
+
+- `compiler/codegen/src/compile.rs` — define the helpers and add `char_width` to the three info structs.
+- `compiler/codegen/src/compile_string.rs` — call `string_region_size` and `encode_string_literal`.
+- `compiler/codegen/src/compile_expr.rs` — call `encode_string_literal`.
+- `compiler/codegen/src/compile_setup.rs` — call `encode_string_literal`; populate `char_width` at struct construction.
+- `compiler/codegen/src/compile_fn.rs` — populate `char_width` at struct construction.
+- `compiler/vm/src/string_ops.rs` — introduce named header offset constants.
+
+Not modified: parser, analyzer, opcodes, container format, plc2plc.
+
+## Tasks
+
+- [ ] Add `char_width: u16` to `StringVarInfo`, `StringParamInfo`, `StringReturnInfo` and populate at all construction sites with `1`.
+- [ ] Add `string_region_size(max_length: u16) -> u32` helper in `compile.rs` and use at three call sites in `compile_string.rs`.
+- [ ] Add `encode_string_literal(chars: &[char], char_width: u16) -> Vec<u8>` helper in `compile.rs` and use at four call sites.
+- [ ] Add `MAX_LEN_OFFSET`, `CUR_LEN_OFFSET` constants in `string_ops.rs` and use them in place of magic offsets.
+- [ ] Run `cd compiler && just` and verify all checks pass.
+
+## Verification
+
+Behavior is preserved iff:
+
+- All existing tests pass.
+- Coverage stays at or above the prior baseline (no untested branches added).
+- `cargo clippy` and `cargo fmt` pass.
+
+No new tests are required — these are internal refactors with no observable behavior change.


### PR DESCRIPTION
## Summary

This is a mechanical, behavior-preserving refactor that consolidates width-dependent string logic behind clean abstractions. It prepares the codebase for future WSTRING (16-bit character) support without adding that support yet. All existing tests pass and byte output is identical.

## Key Changes

- **Added `char_width` field** to `StringVarInfo`, `StringParamInfo`, and `StringReturnInfo` structs (always set to `1` for STRING). This allows the value to flow through codegen without additional plumbing when WSTRING support is added.

- **Introduced `string_region_size(max_length)` helper** in `compile.rs` to replace three inline calculations of `STRING_HEADER_BYTES + max_length`. Centralizes the sizing logic at one location.

- **Introduced `encode_string_literal(chars, char_width)` helper** in `compile.rs` to replace four inline `.map(|&ch| ch as u8).collect()` patterns. Currently only supports `char_width = 1`; the parameter exists so call sites already pass the value for future WSTRING support.

- **Added named constants** `MAX_LEN_OFFSET` and `CUR_LEN_OFFSET` in `string_ops.rs` to replace magic offsets (`+ 2`, `+ 3`) when accessing string header fields. Improves readability and maintainability.

- **Updated all call sites** in `compile_fn.rs`, `compile_setup.rs`, `compile_string.rs`, `compile_expr.rs`, `compile_array.rs`, and `compile_struct.rs` to use the new helpers and populate `char_width` at struct construction.

## Implementation Details

- All refactors are 1:1 substitutions with no observable behavior change.
- The `encode_string_literal` function will panic if called with `char_width != 1`, preventing accidental WSTRING encoding before support is implemented.
- `#[allow(dead_code)]` annotations on `char_width` fields in `StringParamInfo` and `StringReturnInfo` acknowledge that these fields are not yet used in the current implementation.
- No changes to parser, analyzer, opcodes, container format, or plc2plc.

https://claude.ai/code/session_01JxTgPzW5ks22ViD8nzbJVC