### PR TITLE
Size playground iframe to fit the variables table

### DIFF
--- a/docs/extensions/ironplc_playground.py
+++ b/docs/extensions/ironplc_playground.py
@@ -50,7 +50,6 @@ Options (playground-link only):
 """
 
 from base64 import b64encode
-from math import ceil
 from urllib.parse import quote
 
 from docutils import nodes
@@ -58,38 +57,53 @@ from docutils.parsers.rst import Directive, directives
 
 PLAYGROUND_URL = "https://playground.ironplc.com/"
 
-# Maximum number of visible lines before the editor scrolls.
+# Maximum number of visible code lines before the editor scrolls.
 _MAX_VISIBLE_LINES = 15
+# Minimum / maximum number of variable rows the output panel sizes for.
+# The CSS in the playground enforces a matching minimum so at least
+# _MIN_VISIBLE_VARS rows are always visible without scrolling.
+_MIN_VISIBLE_VARS = 3
+_MAX_VISIBLE_VARS = 8
 # Minimum iframe height in pixels.
 _MIN_HEIGHT_PX = 300
 
 
 def _auto_height(code_lines, scaffold=False, vars_decl=""):
-    """Calculate an iframe height that shows the full example (up to a limit).
+    """Calculate an iframe height that shows the example and its variables.
 
-    Accounts for the scaffold wrapper lines that the playground adds when
-    ``scaffold=true`` (PROGRAM, VAR/END_VAR, END_PROGRAM) so the editor is
-    tall enough to display them without scrolling.
+    The iframe contains two stacked panes in embed mode: the editor (top)
+    and the output panel that hosts the variables table (bottom). Each
+    pane is sized independently so adding more variables grows the
+    output pane without squeezing the editor.
     """
-    total_lines = code_lines
+    var_count = 0
+    if scaffold and vars_decl:
+        var_count = len([v for v in vars_decl.split(";") if v.strip()])
 
+    editor_lines = code_lines
     if scaffold:
         # PROGRAM main + END_PROGRAM
-        total_lines += 2
-        if vars_decl:
-            var_count = len([v for v in vars_decl.split(";") if v.strip()])
+        editor_lines += 2
+        if var_count:
             # VAR + each declaration + END_VAR
-            total_lines += 2 + var_count
+            editor_lines += 2 + var_count
 
-    visible = min(total_lines, _MAX_VISIBLE_LINES)
+    editor_visible = min(editor_lines, _MAX_VISIBLE_LINES)
+    # Editor pane: toolbar ≈ 42 px, padding ≈ 24 px, border ≈ 1 px ≈ 70 px
+    # of chrome, plus ~20 px per visible line (0.8rem × 1.5 line-height).
+    editor_px = editor_visible * 20 + 70
 
-    # The editor section gets ~70% of total height (see embed CSS).
-    # Inside that: toolbar ≈ 42 px, padding ≈ 24 px, border ≈ 1 px → 67 px.
-    # Use 70 px to leave a small safety margin for font-rendering variance.
-    # Each line ≈ 20 px (0.8rem font × 1.5 line-height at 16px base).
-    # Solve for total:  0.70 × total − 70 ≥ visible × 20
-    #                   total ≥ (visible × 20 + 70) / 0.70
-    height = ceil((visible * 20 + 70) / 0.70)
+    # Output pane sizes for at least _MIN_VISIBLE_VARS rows so the table
+    # is usable even when the example declares fewer variables, and grows
+    # up to _MAX_VISIBLE_VARS so very long var lists scroll instead of
+    # ballooning the iframe.
+    output_visible = min(max(var_count, _MIN_VISIBLE_VARS), _MAX_VISIBLE_VARS)
+    # Output pane: tabs ≈ 33 px, table header ≈ 24 px, panel padding ≈
+    # 16 px ≈ 73 px of chrome, plus ~30 px per row (the sparkline cell
+    # is 18 px tall with padding, which dominates the row pitch).
+    output_px = output_visible * 30 + 73
+
+    height = editor_px + output_px
 
     return f"{max(_MIN_HEIGHT_PX, height)}px"
 

--- a/playground/style.css
+++ b/playground/style.css
@@ -218,6 +218,9 @@ main {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  /* Allow the panel inside to shrink and own the scrollbar instead of
+     letting the table push the section past its flex allocation. */
+  min-height: 0;
 }
 
 .output-tabs {
@@ -243,6 +246,7 @@ main {
 .panel {
   display: none;
   flex: 1;
+  min-height: 0;
   overflow: auto;
   padding: 1rem;
   font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", "Consolas", monospace;
@@ -373,6 +377,11 @@ body.embed .editor-section {
 
 body.embed .output-section {
   flex: 1 1 30%;
+  /* Keep the variables table tall enough to show the header plus at
+     least three rows even when the editor is short. Matches
+     _MIN_VISIBLE_VARS in docs/extensions/ironplc_playground.py
+     (~73 px of chrome + 3 × ~30 px rows). */
+  min-height: 170px;
 }
 
 body.embed .toolbar {


### PR DESCRIPTION
The iframe height was computed only from code-line count, so examples
with several declared variables had their variables table clipped once
the user pressed Start. Size the editor and output panes independently
so the output gets enough room for the variables table, give the
output panel a 170 px floor (header plus three rows) in embed mode,
and ensure the panel scrolls when content exceeds its allotment.