### PR TITLE
Add dialect 2013 specification to LDATE/LTIME documentation examples

### DIFF
--- a/docs/reference/language/data-types/elementary/ldate-and-time.rst
+++ b/docs/reference/language/data-types/elementary/ldate-and-time.rst
@@ -30,6 +30,7 @@ Example
 -------
 
 .. playground-with-program::
+   :dialect: 2013
    :vars: event : LDATE_AND_TIME; deadline : LDATE_AND_TIME; on_time : BOOL;
 
    event := LDT#2024-06-15-10:30:00;

--- a/docs/reference/language/data-types/elementary/ldate.rst
+++ b/docs/reference/language/data-types/elementary/ldate.rst
@@ -30,6 +30,7 @@ Example
 -------
 
 .. playground-with-program::
+   :dialect: 2013
    :vars: today : LDATE; launch : LDATE; is_after : BOOL;
 
    today := LDATE#2024-06-15;

--- a/docs/reference/language/data-types/elementary/ltime-of-day.rst
+++ b/docs/reference/language/data-types/elementary/ltime-of-day.rst
@@ -31,6 +31,7 @@ Example
 -------
 
 .. playground-with-program::
+   :dialect: 2013
    :vars: shift_start : LTIME_OF_DAY; now : LTIME_OF_DAY; started : BOOL;
 
    shift_start := LTOD#08:00:00;

--- a/docs/reference/language/data-types/elementary/ltime.rst
+++ b/docs/reference/language/data-types/elementary/ltime.rst
@@ -22,6 +22,7 @@ Example
 -------
 
 .. playground-with-program::
+   :dialect: 2013
    :vars: a : LTIME; b : LTIME; c : LTIME;
 
    a := LTIME#1h;


### PR DESCRIPTION
## Summary
This PR adds the `:dialect: 2013` directive to playground code examples in the documentation for long date and time data types.

## Key Changes
- Added `:dialect: 2013` directive to the `playground-with-program` blocks in:
  - `ldate-and-time.rst` - LDATE_AND_TIME example
  - `ldate.rst` - LDATE example
  - `ltime-of-day.rst` - LTIME_OF_DAY example
  - `ltime.rst` - LTIME example

## Details
These changes ensure that the interactive playground examples for long date and time types explicitly specify the IEC 61131-3 2013 dialect, which is the appropriate standard for these data types. This improves consistency across the documentation and ensures examples render correctly in the playground environment.

https://claude.ai/code/session_013kbgizSutXFT7CL5tQN8ji