### PR TITLE
Fix LTIME variables not showing graph in playground variable display

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -593,7 +593,7 @@ function parseNumericValue(value, typeName) {
     return null;
   }
 
-  if (t === "TIME") {
+  if (t === "TIME" || t === "LTIME") {
     return parseTimeValue(value);
   }
 


### PR DESCRIPTION
LTIME was missing from the parseNumericValue() type check in app.js, causing it to return null and skip graph rendering. LTIME uses the same T#<value>ms/s format as TIME, so it reuses parseTimeValue().

https://claude.ai/code/session_01XJH7UyVwxsSVCqoaFtBfE1