### PR TITLE
Update Swatinem/rust-cache to v2.9.1

### DIFF
--- a/.github/workflows/partial_compiler.yaml
+++ b/.github/workflows/partial_compiler.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           components: rustfmt, clippy
           target: ${{ matrix.rust_target }}
-      - uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "compiler -> target"
           # Include target triple in cache key for cross-compilation


### PR DESCRIPTION
Updates Swatinem/rust-cache from ad397744b0d591a723ab90405b7247fac0e6b8db to c19371144df3bb44fab255c43d04cbc2ab54d1c4 (v2.9.1) which uses Node.js 20+.