### PR TITLE
Fix 404 page styling by emitting absolute asset URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,15 @@ path.append(abspath("./extensions"))
 
 extlinks = {'download_artifact': ('https://github.com/ironplc/ironplc/releases/download/v' + version + '/%s',
                       '%s')}
-extensions += ["sphinx_inline_tabs", "sphinx.ext.extlinks", "sphinx.ext.autosectionlabel", "sphinx_copybutton", "ironplc_problemcode", "ironplc_playground", "ironplc_flags"]
+extensions += ["sphinx_inline_tabs", "sphinx.ext.extlinks", "sphinx.ext.autosectionlabel", "sphinx_copybutton", "notfound.extension", "ironplc_problemcode", "ironplc_playground", "ironplc_flags"]
+
+# -- 404 page configuration ----------------------------------------------------
+
+# Use the existing 404.rst as the source for the 404 page and ensure it is
+# emitted at /404.html with absolute URLs to static assets so the page renders
+# correctly when served from any non-existent path.
+notfound_pagename = "404"
+notfound_urls_prefix = "/"
 
 autosectionlabel_prefix_document = True
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,5 @@ sphinx-copybutton
 sphinx-design
 sphinx-sitemap
 sphinxext-opengraph
+sphinx-notfound-page
 pytz


### PR DESCRIPTION
The Sphinx-generated 404.html used relative paths to _static/ assets,
so when GitHub Pages served the page from a non-existent path like
/foo/bar/baz the browser tried to load CSS/JS from
/foo/bar/_static/... and failed. Add the sphinx-notfound-page
extension and configure it to emit /404.html with absolute URLs so the
page renders correctly regardless of the request path.

https://claude.ai/code/session_01X8dcoVMNqZpNbGuuLA1GGR