### PR TITLE
Redirect 46 previously-indexed URLs to their current locations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,9 +107,76 @@ path.append(abspath("./extensions"))
 
 extlinks = {'download_artifact': ('https://github.com/ironplc/ironplc/releases/download/v' + version + '/%s',
                       '%s')}
-extensions += ["sphinx_inline_tabs", "sphinx.ext.extlinks", "sphinx.ext.autosectionlabel", "sphinx_copybutton", "ironplc_problemcode", "ironplc_playground", "ironplc_flags"]
+extensions += ["sphinx_inline_tabs", "sphinx.ext.extlinks", "sphinx.ext.autosectionlabel", "sphinx_copybutton", "ironplc_problemcode", "ironplc_playground", "ironplc_flags", "ironplc_redirects"]
 
 autosectionlabel_prefix_document = True
+
+# -- Redirects for restructured pages ---------------------------------------
+# Maps previously-indexed URL paths to their current locations so external
+# links (and Google's index) keep working after a restructure. Keys and
+# values are paths relative to the site root. Add an entry whenever a page
+# is moved or renamed.
+_problems_index = "reference/compiler/problems/index.html"
+ironplc_redirects = {
+    # /compiler/* moved under /reference/compiler/*
+    "compiler/index.html": "reference/compiler/index.html",
+    "compiler/basicusage.html": "reference/compiler/overview.html",
+    "compiler/source-formats/plcopen-xml.html": "reference/compiler/source-formats/plcopen-xml.html",
+    "compiler/source-formats/text.html": "reference/compiler/source-formats/text.html",
+    "compiler/source-formats/twincat.html": "reference/compiler/source-formats/twincat.html",
+
+    # P0008 and P0009 still exist under the new path; the rest of the old
+    # P00xx codes were renumbered into the P2xxx/P4xxx scheme with no 1:1
+    # mapping, so they fall back to the problems index.
+    "compiler/problems/P0008.html": "reference/compiler/problems/P0008.html",
+    "compiler/problems/P0009.html": "reference/compiler/problems/P0009.html",
+    "compiler/problems/P0012.html": _problems_index,
+    "compiler/problems/P0013.html": _problems_index,
+    "compiler/problems/P0014.html": _problems_index,
+    "compiler/problems/P0015.html": _problems_index,
+    "compiler/problems/P0017.html": _problems_index,
+    "compiler/problems/P0019.html": _problems_index,
+    "compiler/problems/P0020.html": _problems_index,
+    "compiler/problems/P0021.html": _problems_index,
+    "compiler/problems/P0023.html": _problems_index,
+    "compiler/problems/P0025.html": _problems_index,
+    "compiler/problems/P0027.html": _problems_index,
+    "compiler/problems/P0029.html": _problems_index,
+    "compiler/problems/P0031.html": _problems_index,
+    "compiler/problems/P0032.html": _problems_index,
+    "compiler/problems/P0033.html": _problems_index,
+    "compiler/problems/P0034.html": _problems_index,
+    "compiler/problems/P0035.html": _problems_index,
+    "compiler/problems/P0036.html": _problems_index,
+    "compiler/problems/P0037.html": _problems_index,
+    "compiler/problems/P0040.html": _problems_index,
+    "compiler/problems/P0041.html": _problems_index,
+    "compiler/problems/P0042.html": _problems_index,
+    "compiler/problems/P0043.html": _problems_index,
+    "compiler/problems/P0044.html": _problems_index,
+    "compiler/problems/P0046.html": _problems_index,
+    "compiler/problems/P0048.html": _problems_index,
+
+    # Beremiz and TwinCAT how-to guides moved into per-tool subdirectories.
+    "how-to-guides/check-beremiz-projects.html": "how-to-guides/beremiz/check-beremiz-projects.html",
+    "how-to-guides/check-twincat-projects.html": "how-to-guides/twincat/check-twincat-projects.html",
+
+    # Data types split into elementary/ and derived/ subdirectories.
+    "reference/language/data-types/dint.html": "reference/language/data-types/elementary/dint.html",
+    "reference/language/data-types/int.html": "reference/language/data-types/elementary/int.html",
+    "reference/language/data-types/lreal.html": "reference/language/data-types/elementary/lreal.html",
+    "reference/language/data-types/ltime-of-day.html": "reference/language/data-types/elementary/ltime-of-day.html",
+    "reference/language/data-types/lword.html": "reference/language/data-types/elementary/lword.html",
+    "reference/language/data-types/ulint.html": "reference/language/data-types/elementary/ulint.html",
+    "reference/language/data-types/word.html": "reference/language/data-types/elementary/word.html",
+    "reference/language/data-types/reference-types.html": "reference/language/data-types/derived/reference-types.html",
+    "reference/language/data-types/subrange-types.html": "reference/language/data-types/derived/subrange-types.html",
+
+    # /vscode/* moved under /reference/editor/* (and troubleshooting joined how-to-guides).
+    "vscode/overview.html": "reference/editor/overview.html",
+    "vscode/settings.html": "reference/editor/settings.html",
+    "vscode/troubleshooting.html": "how-to-guides/troubleshoot-editor.html",
+}
 
 # -- Open Graph configuration --------------------------------------------------
 

--- a/docs/extensions/ironplc_redirects.py
+++ b/docs/extensions/ironplc_redirects.py
@@ -1,0 +1,51 @@
+'''
+Emits HTML redirect stubs at old URL paths so previously-indexed pages still
+resolve after a content restructure.
+
+Reads ``ironplc_redirects`` from conf.py: a dict mapping old build-root-relative
+paths (the URLs Google has indexed) to new build-root-relative paths. Each old
+path becomes a small static HTML file with ``<meta http-equiv="refresh">`` and
+``<link rel="canonical">`` pointing at the new URL, plus ``noindex`` so Google
+treats the stub itself as throwaway and consolidates link signals on the target.
+
+The stubs are written after Sphinx finishes building, into the output directory
+alongside the rest of the site.
+'''
+from pathlib import Path
+
+
+_TEMPLATE = '''<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Redirecting&hellip;</title>
+<link rel="canonical" href="{new_url}">
+<meta http-equiv="refresh" content="0; url={new_url}">
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>This page has moved. <a href="{new_url}">Continue to the new location</a>.</p>
+</body>
+</html>
+'''
+
+
+def _emit_redirects(app, exception):
+    if exception is not None:
+        return
+    redirects = app.config.ironplc_redirects or {}
+    if not redirects:
+        return
+    base_url = (app.config.html_baseurl or '').rstrip('/')
+    outdir = Path(app.outdir)
+    for old_path, new_path in redirects.items():
+        new_url = f"{base_url}/{new_path.lstrip('/')}"
+        target = outdir / old_path.lstrip('/')
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_TEMPLATE.format(new_url=new_url), encoding='utf-8')
+
+
+def setup(app):
+    app.add_config_value('ironplc_redirects', {}, 'env')
+    app.connect('build-finished', _emit_redirects)
+    return {'version': '1.0', 'parallel_read_safe': True}


### PR DESCRIPTION
After a series of doc restructures, Google Search Console kept reporting
"Not found (404)" warnings for paths like /reference/language/data-types/
dint.html (now under elementary/), /vscode/* (now /reference/editor/*),
and several /compiler/* and /how-to-guides/* URLs that picked up extra
path segments.

Adds an ironplc_redirects Sphinx extension that takes a {old_path:
new_path} dict from conf.py and writes a small meta-refresh + canonical
+ noindex stub at each old path during build-finished, so the externally
indexed URLs resolve again and Google can consolidate them onto the new
pages on its next crawl. Old P00xx problem codes that no longer have a
1:1 successor under the renumbered scheme fall back to the problems
index.

https://claude.ai/code/session_013AyAikJbiVa9RMReLeuwDh