### PR TITLE
Hide headerlink anchor on image-only H1 to remove stray pilcrow

### DIFF
--- a/docs/_static/overrides.css
+++ b/docs/_static/overrides.css
@@ -20,3 +20,11 @@
 .ironplc-playground {
     margin: 1rem 0;
 }
+
+/* The homepage uses an image substitution as its H1 title. Sphinx still
+   appends a headerlink (¶) to that heading, which Furo shows persistently
+   on touch devices (no hover) and which wraps under the image, producing
+   stray whitespace. Hide the anchor when the H1 is image-only. */
+h1:has(> img) > a.headerlink {
+    display: none;
+}


### PR DESCRIPTION
The homepage uses an image substitution (|logo|) as its H1 title.
Sphinx appends a permalink anchor (¶) to every heading, which Furo
hides on hover on desktop but shows persistently on touch devices.
With an image-only H1 the anchor wraps under the banner, leaving a
stray pilcrow and a block of empty space above the intro paragraph.

Hide the headerlink when the H1 contains an image. The page-title
anchor is redundant with the URL itself, so no functionality is lost.