### PR TITLE
Publish LSP diagnostics for all files in workspace

### DIFF
--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -11,10 +11,11 @@ use lsp_types::{
     InitializeParams, OneOf, PublishDiagnosticsParams, SemanticTokens, SemanticTokensFullOptions,
     SemanticTokensLegend, SemanticTokensOptions, SemanticTokensResult,
     SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, WorkDoneProgressOptions, WorkspaceFoldersServerCapabilities,
+    TextDocumentSyncKind, Uri, WorkDoneProgressOptions, WorkspaceFoldersServerCapabilities,
     WorkspaceServerCapabilities,
 };
 use serde::{de::DeserializeOwned, Serialize};
+use std::collections::HashSet;
 use std::str::FromStr;
 
 use crate::lsp_project::{LspProject, TOKEN_TYPE_LEGEND};
@@ -136,9 +137,18 @@ fn start_with_connection(
     }
 }
 
+// `lsp_types::Uri` is safe to use as a key — see the comment on
+// `publish_workspace_diagnostics`.
+#[allow(clippy::mutable_key_type)]
 struct LspServer<'a> {
     sender: &'a Sender<Message>,
     project: LspProject,
+    /// URIs for which the server has an outstanding non-empty
+    /// `publishDiagnostics`. Tracking these lets the server send an
+    /// empty-diagnostics notification when previously-failing files
+    /// no longer have errors, so stale squiggles get cleared instead
+    /// of lingering forever.
+    published_uris: HashSet<Uri>,
 }
 
 impl<'a> LspServer<'a> {
@@ -177,7 +187,83 @@ impl<'a> LspServer<'a> {
     }
 
     fn new(sender: &'a Sender<Message>, project: LspProject) -> Self {
-        Self { sender, project }
+        Self {
+            sender,
+            project,
+            published_uris: HashSet::new(),
+        }
+    }
+
+    /// Run semantic analysis on the entire workspace and publish
+    /// diagnostics for every affected file. Sends an empty-clear
+    /// notification for every URI that previously had diagnostics
+    /// but no longer does. The version field is attached only to the
+    /// notification for `edited_uri` (the document that triggered
+    /// this round of analysis); other URIs receive `version: None`,
+    /// which the LSP spec permits and signals "out of band" to the
+    /// client.
+    // `lsp_types::Uri` wraps `fluent_uri::Uri`, which uses interior
+    // `Cell`s purely for parse-result caching — neither equality nor
+    // hashing reads them, so using `Uri` as a HashMap/HashSet key is
+    // safe even though Clippy can't see that.
+    #[allow(clippy::mutable_key_type)]
+    fn publish_workspace_diagnostics(&mut self, edited_uri: &Uri, edited_version: Option<i32>) {
+        let by_uri = self.project.semantic_all();
+        let mut new_published: HashSet<Uri> = HashSet::new();
+
+        for (uri, diagnostics) in by_uri {
+            if diagnostics.is_empty() {
+                continue;
+            }
+            let version = if &uri == edited_uri {
+                edited_version
+            } else {
+                None
+            };
+            new_published.insert(uri.clone());
+            self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
+                uri,
+                diagnostics,
+                version,
+            });
+        }
+
+        // Clear stale diagnostics: every URI we previously published
+        // that did not appear in this round.
+        let stale: Vec<Uri> = self
+            .published_uris
+            .iter()
+            .filter(|uri| !new_published.contains(*uri))
+            .cloned()
+            .collect();
+        for uri in stale {
+            let version = if &uri == edited_uri {
+                edited_version
+            } else {
+                None
+            };
+            self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
+                uri,
+                diagnostics: vec![],
+                version,
+            });
+        }
+
+        // The edited URI must always receive a notification, even
+        // when it is currently error-free and was never previously
+        // published. Without this the editor would never see the
+        // initial "no problems" state for a freshly-opened file and
+        // the LSP test harness — which expects one notification per
+        // edit — would block.
+        if !new_published.contains(edited_uri) && !self.published_uris.contains(edited_uri) {
+            self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
+                uri: edited_uri.clone(),
+                diagnostics: vec![],
+                version: edited_version,
+            });
+        }
+
+        self.published_uris = new_published;
     }
 
     /// The main event loop. The event loop receives messages from the other
@@ -344,25 +430,16 @@ impl<'a> LspServer<'a> {
         let notification =
             match Self::cast_notification::<notification::DidOpenTextDocument>(notification) {
                 Ok(params) => {
-                    trace!(
-                        "DidChangeTextDocument {}",
-                        params.text_document.uri.as_str()
-                    );
+                    trace!("DidOpenTextDocument {}", params.text_document.uri.as_str());
                     let contents = params.text_document.text;
                     let uri = params.text_document.uri;
                     let version = params.text_document.version;
 
                     self.project
                         .change_text_document(&uri, contents.as_str().to_string());
-                    let diagnostics = self.project.semantic(&uri);
+                    self.publish_workspace_diagnostics(&uri, Some(version));
 
-                    self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
-                        uri,
-                        diagnostics,
-                        version: Some(version),
-                    });
-
-                    return notification::DidChangeTextDocument::METHOD;
+                    return notification::DidOpenTextDocument::METHOD;
                 }
                 Err(notification) => notification,
             };
@@ -380,13 +457,7 @@ impl<'a> LspServer<'a> {
 
                     self.project
                         .change_text_document(&uri, contents.as_str().to_string());
-                    let diagnostics = self.project.semantic(&uri);
-
-                    self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
-                        uri,
-                        diagnostics,
-                        version: Some(version),
-                    });
+                    self.publish_workspace_diagnostics(&uri, Some(version));
 
                     return notification::DidChangeTextDocument::METHOD;
                 }
@@ -603,6 +674,22 @@ mod test {
             self.receive();
             let notification = self.notifications.pop().expect("Must have notification");
             serde_json::from_value::<T>(notification.params).unwrap()
+        }
+
+        /// Receive `n` `publishDiagnostics` notifications from the
+        /// server and return them keyed by URI. The server emits one
+        /// notification per affected file plus one per stale URI it
+        /// is clearing, so callers know exactly how many to expect.
+        /// HashMap iteration order in `semantic_all` is non-deterministic,
+        /// so tests must look notifications up by URI rather than position.
+        #[allow(clippy::mutable_key_type)]
+        fn receive_publishes(&mut self, n: usize) -> HashMap<Uri, PublishDiagnosticsParams> {
+            let mut out = HashMap::new();
+            for _ in 0..n {
+                let p = self.receive_notification::<PublishDiagnosticsParams>();
+                out.insert(p.uri.clone(), p);
+            }
+            out
         }
     }
 
@@ -982,5 +1069,191 @@ mod test {
             diagnostics.diagnostics.is_empty(),
             "Expected no diagnostics for LTIME with default options (demoted to identifier)"
         );
+    }
+
+    fn change_doc(uri: &Uri, version: i32, text: &str) -> DidChangeTextDocumentParams {
+        DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier {
+                uri: uri.clone(),
+                version,
+            },
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: text.to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn multi_file_when_two_broken_files_opened_then_publishes_for_each_uri() {
+        // Reproduces the user-reported bug: with two files in the
+        // workspace, both broken, the LSP must publish diagnostics for
+        // each URI rather than dropping the unedited file's errors.
+        let proj = Box::new(FileBackedProject::default());
+        let mut server = TestServer::new(proj);
+
+        let uri_a = Uri::from_str("file:///workspace/a.st").unwrap();
+        let uri_b = Uri::from_str("file:///workspace/b.st").unwrap();
+
+        // Open file A — broken.
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &uri_a,
+            1,
+            "this is not valid IEC 61131-3 in file a",
+        ));
+        // After this, only A is in the project so we expect one publish for A.
+        let n = server.receive_publishes(1);
+        assert!(n.contains_key(&uri_a));
+        assert!(!n[&uri_a].diagnostics.is_empty());
+
+        // Open file B — also broken. Server now re-analyses the
+        // workspace and publishes per-file: one for A, one for B.
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &uri_b,
+            1,
+            "this is not valid IEC 61131-3 in file b",
+        ));
+        let n = server.receive_publishes(2);
+        assert!(
+            n.contains_key(&uri_a),
+            "expected publish for url_a, got {:?}",
+            n.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            n.contains_key(&uri_b),
+            "expected publish for url_b, got {:?}",
+            n.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !n[&uri_a].diagnostics.is_empty(),
+            "url_a should still report its errors after url_b is opened"
+        );
+        assert!(!n[&uri_b].diagnostics.is_empty());
+
+        // Version is attached only to the URI we actually edited.
+        assert_eq!(n[&uri_b].version, Some(1));
+        assert!(n[&uri_a].version.is_none());
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn multi_file_when_error_fixed_in_second_file_then_clearing_diagnostics_published() {
+        // Open A (broken) and B (broken), then fix B. The server must
+        // emit a clearing publish (empty diagnostics) for B so the IDE
+        // erases the stale squiggle, while still re-publishing A's
+        // outstanding errors.
+        let proj = Box::new(FileBackedProject::default());
+        let mut server = TestServer::new(proj);
+
+        let uri_a = Uri::from_str("file:///workspace/a.st").unwrap();
+        let uri_b = Uri::from_str("file:///workspace/b.st").unwrap();
+
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &uri_a,
+            1,
+            "this is not valid IEC 61131-3 a",
+        ));
+        let _ = server.receive_publishes(1);
+
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &uri_b,
+            1,
+            "this is not valid IEC 61131-3 b",
+        ));
+        let _ = server.receive_publishes(2);
+
+        // Fix B by replacing it with a valid program.
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &uri_b,
+            2,
+            "PROGRAM Main\nVAR\n  x : BOOL;\nEND_VAR\nEND_PROGRAM",
+        ));
+
+        // Expect one publish for A (still broken) plus one clearing
+        // publish for B.
+        let n = server.receive_publishes(2);
+        assert!(n.contains_key(&uri_a), "expected publish for url_a");
+        assert!(n.contains_key(&uri_b), "expected clear for url_b");
+        assert!(!n[&uri_a].diagnostics.is_empty());
+        assert!(
+            n[&uri_b].diagnostics.is_empty(),
+            "url_b's clear notification must carry an empty diagnostics list, got {:?}",
+            n[&uri_b].diagnostics
+        );
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn single_file_when_error_introduced_then_cleared_then_clearing_notification_emitted() {
+        // Regression guard for the same-file case: introducing then
+        // fixing an error in one file should still produce a clearing
+        // publish so the squiggle goes away.
+        let proj = Box::new(FileBackedProject::default());
+        let mut server = TestServer::new(proj);
+
+        let uri = Uri::from_str("file:///workspace/only.st").unwrap();
+
+        // Broken first.
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &uri,
+            1,
+            "this is not valid IEC 61131-3 source",
+        ));
+        let n = server.receive_publishes(1);
+        assert!(!n[&uri].diagnostics.is_empty());
+
+        // Fix it.
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &uri,
+            2,
+            "PROGRAM Main\nVAR\n  x : BOOL;\nEND_VAR\nEND_PROGRAM",
+        ));
+        let n = server.receive_publishes(1);
+        assert!(
+            n[&uri].diagnostics.is_empty(),
+            "fixing the only file should emit a clear publish, got {:?}",
+            n[&uri].diagnostics
+        );
+        // The clear is in response to the edit, so the version should
+        // match the edit that produced it.
+        assert_eq!(n[&uri].version, Some(2));
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn multi_file_when_clean_file_opened_after_broken_file_then_each_publish_targets_its_uri() {
+        // After a broken file is open, opening a *clean* second file
+        // must not silently inherit or hide the broken one. The clean
+        // file gets an empty publish; the broken one gets a re-publish
+        // of its errors.
+        let proj = Box::new(FileBackedProject::default());
+        let mut server = TestServer::new(proj);
+
+        let broken = Uri::from_str("file:///workspace/broken.st").unwrap();
+        let clean = Uri::from_str("file:///workspace/clean.st").unwrap();
+
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &broken,
+            1,
+            "this is not valid IEC 61131-3 syntax",
+        ));
+        let _ = server.receive_publishes(1);
+
+        server.send_notification::<notification::DidChangeTextDocument>(change_doc(
+            &clean,
+            1,
+            "PROGRAM Clean\nVAR\n  x : BOOL;\nEND_VAR\nEND_PROGRAM",
+        ));
+
+        // Expect one publish for the broken file (re-published), and
+        // one empty publish for the clean file (so the editor knows
+        // the clean file has no problems).
+        let n = server.receive_publishes(2);
+        assert!(n.contains_key(&broken));
+        assert!(n.contains_key(&clean));
+        assert!(!n[&broken].diagnostics.is_empty());
+        assert!(n[&clean].diagnostics.is_empty());
     }
 }

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -18,7 +18,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashSet;
 use std::str::FromStr;
 
-use crate::lsp_project::{LspProject, TOKEN_TYPE_LEGEND};
+use crate::lsp_project::{LspProject, UriKey, TOKEN_TYPE_LEGEND};
 use ironplc_project::disassemble;
 use ironplc_project::FileBackedProject;
 
@@ -137,9 +137,6 @@ fn start_with_connection(
     }
 }
 
-// `lsp_types::Uri` is safe to use as a key — see the comment on
-// `publish_workspace_diagnostics`.
-#[allow(clippy::mutable_key_type)]
 struct LspServer<'a> {
     sender: &'a Sender<Message>,
     project: LspProject,
@@ -147,8 +144,10 @@ struct LspServer<'a> {
     /// `publishDiagnostics`. Tracking these lets the server send an
     /// empty-diagnostics notification when previously-failing files
     /// no longer have errors, so stale squiggles get cleared instead
-    /// of lingering forever.
-    published_uris: HashSet<Uri>,
+    /// of lingering forever. Stored as `UriKey` (a `String` newtype)
+    /// rather than `Uri` so the set is independent of `lsp_types::Uri`'s
+    /// interior `Cell`s.
+    published_uris: HashSet<UriKey>,
 }
 
 impl<'a> LspServer<'a> {
@@ -202,25 +201,22 @@ impl<'a> LspServer<'a> {
     /// this round of analysis); other URIs receive `version: None`,
     /// which the LSP spec permits and signals "out of band" to the
     /// client.
-    // `lsp_types::Uri` wraps `fluent_uri::Uri`, which uses interior
-    // `Cell`s purely for parse-result caching — neither equality nor
-    // hashing reads them, so using `Uri` as a HashMap/HashSet key is
-    // safe even though Clippy can't see that.
-    #[allow(clippy::mutable_key_type)]
     fn publish_workspace_diagnostics(&mut self, edited_uri: &Uri, edited_version: Option<i32>) {
-        let by_uri = self.project.semantic_all();
-        let mut new_published: HashSet<Uri> = HashSet::new();
+        let edited_key = UriKey::from_uri(edited_uri);
+        let by_key = self.project.semantic_all();
+        let mut new_published: HashSet<UriKey> = HashSet::new();
 
-        for (uri, diagnostics) in by_uri {
+        for (key, diagnostics) in by_key {
             if diagnostics.is_empty() {
                 continue;
             }
-            let version = if &uri == edited_uri {
+            let version = if key == edited_key {
                 edited_version
             } else {
                 None
             };
-            new_published.insert(uri.clone());
+            let uri = key.to_uri();
+            new_published.insert(key);
             self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
                 uri,
                 diagnostics,
@@ -230,20 +226,20 @@ impl<'a> LspServer<'a> {
 
         // Clear stale diagnostics: every URI we previously published
         // that did not appear in this round.
-        let stale: Vec<Uri> = self
+        let stale: Vec<UriKey> = self
             .published_uris
             .iter()
-            .filter(|uri| !new_published.contains(*uri))
+            .filter(|key| !new_published.contains(*key))
             .cloned()
             .collect();
-        for uri in stale {
-            let version = if &uri == edited_uri {
+        for key in stale {
+            let version = if key == edited_key {
                 edited_version
             } else {
                 None
             };
             self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
-                uri,
+                uri: key.to_uri(),
                 diagnostics: vec![],
                 version,
             });
@@ -255,7 +251,7 @@ impl<'a> LspServer<'a> {
         // initial "no problems" state for a freshly-opened file and
         // the LSP test harness — which expects one notification per
         // edit — would block.
-        if !new_published.contains(edited_uri) && !self.published_uris.contains(edited_uri) {
+        if !new_published.contains(&edited_key) && !self.published_uris.contains(&edited_key) {
             self.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
                 uri: edited_uri.clone(),
                 diagnostics: vec![],
@@ -525,7 +521,7 @@ mod test {
     use std::collections::HashMap;
     use std::str::FromStr;
 
-    use crate::lsp_project::LspProject;
+    use crate::lsp_project::{LspProject, UriKey};
     use ironplc_project::{FileBackedProject, Project};
 
     use super::start_with_connection;
@@ -682,12 +678,11 @@ mod test {
         /// is clearing, so callers know exactly how many to expect.
         /// HashMap iteration order in `semantic_all` is non-deterministic,
         /// so tests must look notifications up by URI rather than position.
-        #[allow(clippy::mutable_key_type)]
-        fn receive_publishes(&mut self, n: usize) -> HashMap<Uri, PublishDiagnosticsParams> {
+        fn receive_publishes(&mut self, n: usize) -> HashMap<UriKey, PublishDiagnosticsParams> {
             let mut out = HashMap::new();
             for _ in 0..n {
                 let p = self.receive_notification::<PublishDiagnosticsParams>();
-                out.insert(p.uri.clone(), p);
+                out.insert(UriKey::from_uri(&p.uri), p);
             }
             out
         }
@@ -1086,7 +1081,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn multi_file_when_two_broken_files_opened_then_publishes_for_each_uri() {
         // Reproduces the user-reported bug: with two files in the
         // workspace, both broken, the LSP must publish diagnostics for
@@ -1096,6 +1090,8 @@ mod test {
 
         let uri_a = Uri::from_str("file:///workspace/a.st").unwrap();
         let uri_b = Uri::from_str("file:///workspace/b.st").unwrap();
+        let key_a = UriKey::from_uri(&uri_a);
+        let key_b = UriKey::from_uri(&uri_b);
 
         // Open file A — broken.
         server.send_notification::<notification::DidChangeTextDocument>(change_doc(
@@ -1105,8 +1101,8 @@ mod test {
         ));
         // After this, only A is in the project so we expect one publish for A.
         let n = server.receive_publishes(1);
-        assert!(n.contains_key(&uri_a));
-        assert!(!n[&uri_a].diagnostics.is_empty());
+        assert!(n.contains_key(&key_a));
+        assert!(!n[&key_a].diagnostics.is_empty());
 
         // Open file B — also broken. Server now re-analyses the
         // workspace and publishes per-file: one for A, one for B.
@@ -1117,28 +1113,27 @@ mod test {
         ));
         let n = server.receive_publishes(2);
         assert!(
-            n.contains_key(&uri_a),
+            n.contains_key(&key_a),
             "expected publish for url_a, got {:?}",
             n.keys().collect::<Vec<_>>()
         );
         assert!(
-            n.contains_key(&uri_b),
+            n.contains_key(&key_b),
             "expected publish for url_b, got {:?}",
             n.keys().collect::<Vec<_>>()
         );
         assert!(
-            !n[&uri_a].diagnostics.is_empty(),
+            !n[&key_a].diagnostics.is_empty(),
             "url_a should still report its errors after url_b is opened"
         );
-        assert!(!n[&uri_b].diagnostics.is_empty());
+        assert!(!n[&key_b].diagnostics.is_empty());
 
         // Version is attached only to the URI we actually edited.
-        assert_eq!(n[&uri_b].version, Some(1));
-        assert!(n[&uri_a].version.is_none());
+        assert_eq!(n[&key_b].version, Some(1));
+        assert!(n[&key_a].version.is_none());
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn multi_file_when_error_fixed_in_second_file_then_clearing_diagnostics_published() {
         // Open A (broken) and B (broken), then fix B. The server must
         // emit a clearing publish (empty diagnostics) for B so the IDE
@@ -1149,6 +1144,8 @@ mod test {
 
         let uri_a = Uri::from_str("file:///workspace/a.st").unwrap();
         let uri_b = Uri::from_str("file:///workspace/b.st").unwrap();
+        let key_a = UriKey::from_uri(&uri_a);
+        let key_b = UriKey::from_uri(&uri_b);
 
         server.send_notification::<notification::DidChangeTextDocument>(change_doc(
             &uri_a,
@@ -1174,18 +1171,17 @@ mod test {
         // Expect one publish for A (still broken) plus one clearing
         // publish for B.
         let n = server.receive_publishes(2);
-        assert!(n.contains_key(&uri_a), "expected publish for url_a");
-        assert!(n.contains_key(&uri_b), "expected clear for url_b");
-        assert!(!n[&uri_a].diagnostics.is_empty());
+        assert!(n.contains_key(&key_a), "expected publish for url_a");
+        assert!(n.contains_key(&key_b), "expected clear for url_b");
+        assert!(!n[&key_a].diagnostics.is_empty());
         assert!(
-            n[&uri_b].diagnostics.is_empty(),
+            n[&key_b].diagnostics.is_empty(),
             "url_b's clear notification must carry an empty diagnostics list, got {:?}",
-            n[&uri_b].diagnostics
+            n[&key_b].diagnostics
         );
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn single_file_when_error_introduced_then_cleared_then_clearing_notification_emitted() {
         // Regression guard for the same-file case: introducing then
         // fixing an error in one file should still produce a clearing
@@ -1194,6 +1190,7 @@ mod test {
         let mut server = TestServer::new(proj);
 
         let uri = Uri::from_str("file:///workspace/only.st").unwrap();
+        let key = UriKey::from_uri(&uri);
 
         // Broken first.
         server.send_notification::<notification::DidChangeTextDocument>(change_doc(
@@ -1202,7 +1199,7 @@ mod test {
             "this is not valid IEC 61131-3 source",
         ));
         let n = server.receive_publishes(1);
-        assert!(!n[&uri].diagnostics.is_empty());
+        assert!(!n[&key].diagnostics.is_empty());
 
         // Fix it.
         server.send_notification::<notification::DidChangeTextDocument>(change_doc(
@@ -1212,17 +1209,16 @@ mod test {
         ));
         let n = server.receive_publishes(1);
         assert!(
-            n[&uri].diagnostics.is_empty(),
+            n[&key].diagnostics.is_empty(),
             "fixing the only file should emit a clear publish, got {:?}",
-            n[&uri].diagnostics
+            n[&key].diagnostics
         );
         // The clear is in response to the edit, so the version should
         // match the edit that produced it.
-        assert_eq!(n[&uri].version, Some(2));
+        assert_eq!(n[&key].version, Some(2));
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn multi_file_when_clean_file_opened_after_broken_file_then_each_publish_targets_its_uri() {
         // After a broken file is open, opening a *clean* second file
         // must not silently inherit or hide the broken one. The clean
@@ -1233,6 +1229,8 @@ mod test {
 
         let broken = Uri::from_str("file:///workspace/broken.st").unwrap();
         let clean = Uri::from_str("file:///workspace/clean.st").unwrap();
+        let broken_key = UriKey::from_uri(&broken);
+        let clean_key = UriKey::from_uri(&clean);
 
         server.send_notification::<notification::DidChangeTextDocument>(change_doc(
             &broken,
@@ -1251,9 +1249,9 @@ mod test {
         // one empty publish for the clean file (so the editor knows
         // the clean file has no problems).
         let n = server.receive_publishes(2);
-        assert!(n.contains_key(&broken));
-        assert!(n.contains_key(&clean));
-        assert!(!n[&broken].diagnostics.is_empty());
-        assert!(n[&clean].diagnostics.is_empty());
+        assert!(n.contains_key(&broken_key));
+        assert!(n.contains_key(&clean_key));
+        assert!(!n[&broken_key].diagnostics.is_empty());
+        assert!(n[&clean_key].diagnostics.is_empty());
     }
 }

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -41,6 +41,35 @@ impl UriKey {
         Self(uri.as_str().to_string())
     }
 
+    /// Build a `UriKey` from a compiler `FileId`.
+    ///
+    /// Returns `None` for `FileId::BuiltIn`, for `FileId::File` with an
+    /// empty path (which the analyzer uses as a placeholder for
+    /// whole-project diagnostics like "no source files"), and when the
+    /// path cannot be turned into a valid URI. Paths from
+    /// `FileId::from_path` use OS-native separators; this normalises
+    /// them and validates the result through `Uri::from_str` before
+    /// returning the key.
+    pub(crate) fn from_file_id(file_id: &FileId) -> Option<Self> {
+        match file_id {
+            FileId::File(path) => {
+                let s = path.as_ref();
+                if s.is_empty() {
+                    return None;
+                }
+                let normalised = s.replace('\\', "/");
+                let uri_str = if normalised.starts_with('/') {
+                    format!("file://{normalised}")
+                } else {
+                    format!("file:///{normalised}")
+                };
+                let parsed = Uri::from_str(&uri_str).ok()?;
+                Some(Self::from_uri(&parsed))
+            }
+            FileId::BuiltIn => None,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn as_str(&self) -> &str {
         &self.0
@@ -52,37 +81,6 @@ impl UriKey {
     /// succeed.
     pub(crate) fn to_uri(&self) -> Uri {
         Uri::from_str(&self.0).expect("UriKey was constructed from a valid Uri")
-    }
-}
-
-/// Reconstruct a `UriKey` from a `FileId` whose inner path was
-/// produced by `FileId::from_path`. Returns `None` for `FileId::BuiltIn`,
-/// for `FileId::File` with an empty path (which the analyzer uses as
-/// a placeholder for whole-project diagnostics like "no source files"),
-/// or when the path cannot be turned into a valid URI.
-fn file_id_to_uri_key(file_id: &FileId) -> Option<UriKey> {
-    match file_id {
-        FileId::File(path) => {
-            let s = path.as_ref();
-            if s.is_empty() {
-                return None;
-            }
-            // Paths created from `FileId::from_path` use the OS path
-            // separators. On Linux/macOS they begin with `/`; on Windows
-            // they look like `C:/foo`. Normalise so the resulting URI
-            // is `file:///...`.
-            let normalised = s.replace('\\', "/");
-            let uri_str = if normalised.starts_with('/') {
-                format!("file://{normalised}")
-            } else {
-                format!("file:///{normalised}")
-            };
-            // Round-trip through `Uri::from_str` to validate the
-            // string before stashing it in a key.
-            let parsed = Uri::from_str(&uri_str).ok()?;
-            Some(UriKey::from_uri(&parsed))
-        }
-        FileId::BuiltIn => None,
     }
 }
 
@@ -208,7 +206,7 @@ impl LspProject {
             // labels in the same file is published once for that file.
             let mut keys: Vec<UriKey> = Vec::new();
             for file_id in diagnostic.file_ids() {
-                if let Some(key) = file_id_to_uri_key(file_id) {
+                if let Some(key) = UriKey::from_file_id(file_id) {
                     if !keys.contains(&key) {
                         keys.push(key);
                     }
@@ -1559,8 +1557,8 @@ INVALID_SYNTAX"
     }
 
     #[test]
-    fn file_id_to_uri_key_when_round_trip_from_uri_path_then_matches_original() {
-        use super::file_id_to_uri_key;
+    fn uri_key_from_file_id_when_round_trip_from_uri_path_then_matches_original() {
+        use super::UriKey;
         use ironplc_dsl::core::FileId;
 
         let original = Uri::from_str(FAKE_PATH).unwrap();
@@ -1568,7 +1566,7 @@ INVALID_SYNTAX"
         let file_id = FileId::from_path(&path);
 
         let reconstructed =
-            file_id_to_uri_key(&file_id).expect("file id should map back to a URI key");
+            UriKey::from_file_id(&file_id).expect("file id should map back to a URI key");
         assert_eq!(
             reconstructed.as_str(),
             original.as_str(),
@@ -1577,11 +1575,11 @@ INVALID_SYNTAX"
     }
 
     #[test]
-    fn file_id_to_uri_key_when_builtin_then_returns_none() {
-        use super::file_id_to_uri_key;
+    fn uri_key_from_file_id_when_builtin_then_returns_none() {
+        use super::UriKey;
         use ironplc_dsl::core::FileId;
 
-        assert!(file_id_to_uri_key(&FileId::builtin()).is_none());
+        assert!(UriKey::from_file_id(&FileId::builtin()).is_none());
     }
 
     #[test]

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -24,12 +24,43 @@ fn to_path_buf(uri: &Uri) -> Result<PathBuf, ()> {
     Ok(PathBuf::from(uri.path().as_str()))
 }
 
-/// Reconstruct an LSP `file:` URI from a `FileId` whose inner path was
+/// A hashable, equality-comparable key derived from an LSP `Uri`.
+///
+/// `lsp_types::Uri` wraps `fluent_uri::Uri`, which contains interior
+/// `Cell`s for caching parse results. Although the `Hash` and `Eq`
+/// impls today only read the immutable string content, using such a
+/// type as a `HashMap`/`HashSet` key is brittle: a future change in
+/// the upstream crate could silently break lookups. Convert to this
+/// newtype at the boundary so the collections store nothing more
+/// than the canonical URI string.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub(crate) struct UriKey(String);
+
+impl UriKey {
+    pub(crate) fn from_uri(uri: &Uri) -> Self {
+        Self(uri.as_str().to_string())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Reconstruct an LSP `Uri` from this key for outbound LSP
+    /// notifications. The key only ever holds a string that was
+    /// previously produced by a valid `Uri`, so parsing must
+    /// succeed.
+    pub(crate) fn to_uri(&self) -> Uri {
+        Uri::from_str(&self.0).expect("UriKey was constructed from a valid Uri")
+    }
+}
+
+/// Reconstruct a `UriKey` from a `FileId` whose inner path was
 /// produced by `FileId::from_path`. Returns `None` for `FileId::BuiltIn`,
 /// for `FileId::File` with an empty path (which the analyzer uses as
 /// a placeholder for whole-project diagnostics like "no source files"),
 /// or when the path cannot be turned into a valid URI.
-fn file_id_to_uri(file_id: &FileId) -> Option<Uri> {
+fn file_id_to_uri_key(file_id: &FileId) -> Option<UriKey> {
     match file_id {
         FileId::File(path) => {
             let s = path.as_ref();
@@ -46,7 +77,10 @@ fn file_id_to_uri(file_id: &FileId) -> Option<Uri> {
             } else {
                 format!("file:///{normalised}")
             };
-            Uri::from_str(&uri_str).ok()
+            // Round-trip through `Uri::from_str` to validate the
+            // string before stashing it in a key.
+            let parsed = Uri::from_str(&uri_str).ok()?;
+            Some(UriKey::from_uri(&parsed))
         }
         FileId::BuiltIn => None,
     }
@@ -60,11 +94,11 @@ pub struct LspProject {
     runner: Option<VmRunner>,
     /// Compiler options used for compilation (cached for runner).
     compiler_options: ironplc_parser::options::CompilerOptions,
-    /// URI of the most recently changed text document. Used as a
+    /// Key for the most recently changed text document. Used as a
     /// fallback so that diagnostics whose `FileId` cannot be mapped
     /// back to a URI (e.g. `BuiltIn`) still surface in the editor
     /// instead of being silently dropped.
-    last_changed_uri: Option<Uri>,
+    last_changed_uri_key: Option<UriKey>,
 }
 
 impl LspProject {
@@ -73,7 +107,7 @@ impl LspProject {
             wrapped: project,
             runner: None,
             compiler_options: ironplc_parser::options::CompilerOptions::default(),
-            last_changed_uri: None,
+            last_changed_uri_key: None,
         }
     }
 
@@ -85,7 +119,7 @@ impl LspProject {
             wrapped: project,
             runner: None,
             compiler_options: options,
-            last_changed_uri: None,
+            last_changed_uri_key: None,
         }
     }
 
@@ -106,7 +140,7 @@ impl LspProject {
         if let Ok(path) = path {
             let file_id = FileId::from_path(&path);
             self.wrapped.change_text_document(&file_id, content);
-            self.last_changed_uri = Some(uri.clone());
+            self.last_changed_uri_key = Some(UriKey::from_uri(uri));
         } else {
             error!("URL must be convertible to a file path {}", uri.as_str());
         }
@@ -146,8 +180,8 @@ impl LspProject {
     }
 
     /// Run semantic analysis on the whole workspace and return all
-    /// resulting diagnostics grouped by the URI that should display
-    /// each one.
+    /// resulting diagnostics grouped by the URI key that should
+    /// display each one.
     ///
     /// Every diagnostic appears under each URI that its primary or
     /// secondary labels reference, so a cross-file diagnostic shows
@@ -159,12 +193,7 @@ impl LspProject {
     /// notifications for every URI in the returned map and for
     /// emitting empty notifications to clear URIs that previously
     /// had diagnostics but no longer do.
-    // `lsp_types::Uri` wraps `fluent_uri::Uri`, which uses interior
-    // `Cell`s purely for parse-result caching — neither equality nor
-    // hashing reads them, so using `Uri` as a HashMap key is safe
-    // even though Clippy can't see that.
-    #[allow(clippy::mutable_key_type)]
-    pub(crate) fn semantic_all(&mut self) -> HashMap<Uri, Vec<lsp_types::Diagnostic>> {
+    pub(crate) fn semantic_all(&mut self) -> HashMap<UriKey, Vec<lsp_types::Diagnostic>> {
         let semantic_result = self.wrapped.semantic();
 
         let diagnostics = match semantic_result {
@@ -172,46 +201,46 @@ impl LspProject {
             Err(diagnostics) => diagnostics,
         };
 
-        let mut by_uri: HashMap<Uri, Vec<lsp_types::Diagnostic>> = HashMap::new();
+        let mut by_key: HashMap<UriKey, Vec<lsp_types::Diagnostic>> = HashMap::new();
         for diagnostic in diagnostics {
-            // Resolve every file id this diagnostic touches into a URI.
+            // Resolve every file id this diagnostic touches into a key.
             // De-duplicate so a diagnostic with primary and secondary
             // labels in the same file is published once for that file.
-            let mut uris: Vec<Uri> = Vec::new();
+            let mut keys: Vec<UriKey> = Vec::new();
             for file_id in diagnostic.file_ids() {
-                if let Some(uri) = file_id_to_uri(file_id) {
-                    if !uris.contains(&uri) {
-                        uris.push(uri);
+                if let Some(key) = file_id_to_uri_key(file_id) {
+                    if !keys.contains(&key) {
+                        keys.push(key);
                     }
                 }
             }
-            if uris.is_empty() {
+            if keys.is_empty() {
                 // No usable URI on the diagnostic itself — fall back to
                 // the last edited document so we never silently drop it.
-                if let Some(fallback) = self.last_changed_uri.clone() {
-                    uris.push(fallback);
+                if let Some(fallback) = self.last_changed_uri_key.clone() {
+                    keys.push(fallback);
                 } else {
                     continue;
                 }
             }
 
             let mapped = map_diagnostic(diagnostic, self.wrapped.as_ref());
-            for uri in uris {
-                by_uri.entry(uri).or_default().push(mapped.clone());
+            for key in keys {
+                by_key.entry(key).or_default().push(mapped.clone());
             }
         }
 
-        by_uri
+        by_key
     }
 
     /// Run semantic analysis and return only the diagnostics that
     /// should be shown for `uri`. Retained as a thin wrapper over
     /// `semantic_all` for tests and callers that only need a single
     /// file's diagnostics.
-    #[allow(dead_code, clippy::mutable_key_type)]
+    #[allow(dead_code)]
     pub(crate) fn semantic(&mut self, uri: &Uri) -> Vec<lsp_types::Diagnostic> {
-        let mut by_uri = self.semantic_all();
-        by_uri.remove(uri).unwrap_or_default()
+        let mut by_key = self.semantic_all();
+        by_key.remove(&UriKey::from_uri(uri)).unwrap_or_default()
     }
 
     /// Returns the semantic context from the last successful analysis.
@@ -1451,7 +1480,6 @@ INVALID_SYNTAX"
     static FAKE_PATH_2: &str = "file:///localhost/second_steps.st";
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn semantic_all_when_no_errors_then_returns_empty_map() {
         let mut proj = new_empty_project();
         let url = Uri::from_str(FAKE_PATH).unwrap();
@@ -1474,11 +1502,14 @@ INVALID_SYNTAX"
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn semantic_all_when_two_files_each_have_errors_then_returns_diagnostics_for_each_uri() {
+        use super::UriKey;
+
         let mut proj = new_empty_project();
         let url_a = Uri::from_str(FAKE_PATH).unwrap();
         let url_b = Uri::from_str(FAKE_PATH_2).unwrap();
+        let key_a = UriKey::from_uri(&url_a);
+        let key_b = UriKey::from_uri(&url_b);
 
         // Both files contain unparseable garbage so each produces its
         // own parse-time diagnostics and the analyzer should attribute
@@ -1486,20 +1517,20 @@ INVALID_SYNTAX"
         proj.change_text_document(&url_a, "this is not valid IEC 61131-3".to_owned());
         proj.change_text_document(&url_b, "neither is this".to_owned());
 
-        let by_uri = proj.semantic_all();
+        let by_key = proj.semantic_all();
 
         assert!(
-            by_uri.contains_key(&url_a),
+            by_key.contains_key(&key_a),
             "expected diagnostics for {url_a:?}, got keys {:?}",
-            by_uri.keys().collect::<Vec<_>>()
+            by_key.keys().collect::<Vec<_>>()
         );
         assert!(
-            by_uri.contains_key(&url_b),
+            by_key.contains_key(&key_b),
             "expected diagnostics for {url_b:?}, got keys {:?}",
-            by_uri.keys().collect::<Vec<_>>()
+            by_key.keys().collect::<Vec<_>>()
         );
-        assert!(!by_uri[&url_a].is_empty());
-        assert!(!by_uri[&url_b].is_empty());
+        assert!(!by_key[&key_a].is_empty());
+        assert!(!by_key[&key_b].is_empty());
     }
 
     #[test]
@@ -1528,27 +1559,38 @@ INVALID_SYNTAX"
     }
 
     #[test]
-    fn file_id_to_uri_when_round_trip_from_uri_path_then_matches_original() {
-        use super::file_id_to_uri;
+    fn file_id_to_uri_key_when_round_trip_from_uri_path_then_matches_original() {
+        use super::file_id_to_uri_key;
         use ironplc_dsl::core::FileId;
 
         let original = Uri::from_str(FAKE_PATH).unwrap();
         let path = std::path::PathBuf::from(original.path().as_str());
         let file_id = FileId::from_path(&path);
 
-        let reconstructed = file_id_to_uri(&file_id).expect("file id should map back to a URI");
+        let reconstructed =
+            file_id_to_uri_key(&file_id).expect("file id should map back to a URI key");
         assert_eq!(
             reconstructed.as_str(),
             original.as_str(),
-            "expected URI round-trip via FileId to be lossless"
+            "expected URI key round-trip via FileId to match the original URI string"
         );
     }
 
     #[test]
-    fn file_id_to_uri_when_builtin_then_returns_none() {
-        use super::file_id_to_uri;
+    fn file_id_to_uri_key_when_builtin_then_returns_none() {
+        use super::file_id_to_uri_key;
         use ironplc_dsl::core::FileId;
 
-        assert!(file_id_to_uri(&FileId::builtin()).is_none());
+        assert!(file_id_to_uri_key(&FileId::builtin()).is_none());
+    }
+
+    #[test]
+    fn uri_key_when_to_uri_then_round_trips_back_to_original() {
+        use super::UriKey;
+
+        let original = Uri::from_str(FAKE_PATH).unwrap();
+        let key = UriKey::from_uri(&original);
+        let back = key.to_uri();
+        assert_eq!(back.as_str(), original.as_str());
     }
 }

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -1,5 +1,6 @@
 //! Adapts data types between what is required by the compiler
 //! and the language server protocol.
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -23,6 +24,34 @@ fn to_path_buf(uri: &Uri) -> Result<PathBuf, ()> {
     Ok(PathBuf::from(uri.path().as_str()))
 }
 
+/// Reconstruct an LSP `file:` URI from a `FileId` whose inner path was
+/// produced by `FileId::from_path`. Returns `None` for `FileId::BuiltIn`,
+/// for `FileId::File` with an empty path (which the analyzer uses as
+/// a placeholder for whole-project diagnostics like "no source files"),
+/// or when the path cannot be turned into a valid URI.
+fn file_id_to_uri(file_id: &FileId) -> Option<Uri> {
+    match file_id {
+        FileId::File(path) => {
+            let s = path.as_ref();
+            if s.is_empty() {
+                return None;
+            }
+            // Paths created from `FileId::from_path` use the OS path
+            // separators. On Linux/macOS they begin with `/`; on Windows
+            // they look like `C:/foo`. Normalise so the resulting URI
+            // is `file:///...`.
+            let normalised = s.replace('\\', "/");
+            let uri_str = if normalised.starts_with('/') {
+                format!("file://{normalised}")
+            } else {
+                format!("file:///{normalised}")
+            };
+            Uri::from_str(&uri_str).ok()
+        }
+        FileId::BuiltIn => None,
+    }
+}
+
 /// The LSP project provides a view onto a project that accepts
 /// and returns LSP types.
 pub struct LspProject {
@@ -31,6 +60,11 @@ pub struct LspProject {
     runner: Option<VmRunner>,
     /// Compiler options used for compilation (cached for runner).
     compiler_options: ironplc_parser::options::CompilerOptions,
+    /// URI of the most recently changed text document. Used as a
+    /// fallback so that diagnostics whose `FileId` cannot be mapped
+    /// back to a URI (e.g. `BuiltIn`) still surface in the editor
+    /// instead of being silently dropped.
+    last_changed_uri: Option<Uri>,
 }
 
 impl LspProject {
@@ -39,6 +73,7 @@ impl LspProject {
             wrapped: project,
             runner: None,
             compiler_options: ironplc_parser::options::CompilerOptions::default(),
+            last_changed_uri: None,
         }
     }
 
@@ -50,6 +85,7 @@ impl LspProject {
             wrapped: project,
             runner: None,
             compiler_options: options,
+            last_changed_uri: None,
         }
     }
 
@@ -70,6 +106,7 @@ impl LspProject {
         if let Ok(path) = path {
             let file_id = FileId::from_path(&path);
             self.wrapped.change_text_document(&file_id, content);
+            self.last_changed_uri = Some(uri.clone());
         } else {
             error!("URL must be convertible to a file path {}", uri.as_str());
         }
@@ -108,25 +145,73 @@ impl LspProject {
         Err(vec![])
     }
 
-    pub(crate) fn semantic(&mut self, uri: &Uri) -> Vec<lsp_types::Diagnostic> {
-        let path = to_path_buf(uri);
-        if let Ok(path) = path {
-            let file_id = FileId::from_path(&path);
-            let semantic_result = self.wrapped.semantic();
+    /// Run semantic analysis on the whole workspace and return all
+    /// resulting diagnostics grouped by the URI that should display
+    /// each one.
+    ///
+    /// Every diagnostic appears under each URI that its primary or
+    /// secondary labels reference, so a cross-file diagnostic shows
+    /// up in both files. Diagnostics whose `FileId` cannot be mapped
+    /// to a URI (e.g. `BuiltIn`) are attributed to the most recently
+    /// edited URI so they do not silently disappear.
+    ///
+    /// Callers are responsible for emitting `PublishDiagnostics`
+    /// notifications for every URI in the returned map and for
+    /// emitting empty notifications to clear URIs that previously
+    /// had diagnostics but no longer do.
+    // `lsp_types::Uri` wraps `fluent_uri::Uri`, which uses interior
+    // `Cell`s purely for parse-result caching — neither equality nor
+    // hashing reads them, so using `Uri` as a HashMap key is safe
+    // even though Clippy can't see that.
+    #[allow(clippy::mutable_key_type)]
+    pub(crate) fn semantic_all(&mut self) -> HashMap<Uri, Vec<lsp_types::Diagnostic>> {
+        let semantic_result = self.wrapped.semantic();
 
-            return match semantic_result {
-                Ok(_) => vec![],
-                Err(diagnostics) => diagnostics
-                    .into_iter()
-                    .filter(|d| d.file_ids().contains(&file_id))
-                    .map(|d| map_diagnostic(d, self.wrapped.as_ref()))
-                    .collect(),
-            };
-        } else {
-            error!("URL must be convertible to a file path {uri:?}");
+        let diagnostics = match semantic_result {
+            Ok(_) => return HashMap::new(),
+            Err(diagnostics) => diagnostics,
+        };
+
+        let mut by_uri: HashMap<Uri, Vec<lsp_types::Diagnostic>> = HashMap::new();
+        for diagnostic in diagnostics {
+            // Resolve every file id this diagnostic touches into a URI.
+            // De-duplicate so a diagnostic with primary and secondary
+            // labels in the same file is published once for that file.
+            let mut uris: Vec<Uri> = Vec::new();
+            for file_id in diagnostic.file_ids() {
+                if let Some(uri) = file_id_to_uri(file_id) {
+                    if !uris.contains(&uri) {
+                        uris.push(uri);
+                    }
+                }
+            }
+            if uris.is_empty() {
+                // No usable URI on the diagnostic itself — fall back to
+                // the last edited document so we never silently drop it.
+                if let Some(fallback) = self.last_changed_uri.clone() {
+                    uris.push(fallback);
+                } else {
+                    continue;
+                }
+            }
+
+            let mapped = map_diagnostic(diagnostic, self.wrapped.as_ref());
+            for uri in uris {
+                by_uri.entry(uri).or_default().push(mapped.clone());
+            }
         }
 
-        vec![]
+        by_uri
+    }
+
+    /// Run semantic analysis and return only the diagnostics that
+    /// should be shown for `uri`. Retained as a thin wrapper over
+    /// `semantic_all` for tests and callers that only need a single
+    /// file's diagnostics.
+    #[allow(dead_code, clippy::mutable_key_type)]
+    pub(crate) fn semantic(&mut self, uri: &Uri) -> Vec<lsp_types::Diagnostic> {
+        let mut by_uri = self.semantic_all();
+        by_uri.remove(uri).unwrap_or_default()
     }
 
     /// Returns the semantic context from the last successful analysis.
@@ -1358,5 +1443,112 @@ INVALID_SYNTAX"
             type_kind_to_symbol_kind(TypeSymbolKind::FunctionBlock),
             lsp_types::SymbolKind::CLASS
         );
+    }
+
+    #[cfg(target_os = "windows")]
+    static FAKE_PATH_2: &str = "file:///C:/second_steps.st";
+    #[cfg(not(target_os = "windows"))]
+    static FAKE_PATH_2: &str = "file:///localhost/second_steps.st";
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn semantic_all_when_no_errors_then_returns_empty_map() {
+        let mut proj = new_empty_project();
+        let url = Uri::from_str(FAKE_PATH).unwrap();
+        proj.change_text_document(
+            &url,
+            "PROGRAM Main\nVAR\n  x : BOOL;\nEND_VAR\nEND_PROGRAM".to_owned(),
+        );
+
+        let by_uri = proj.semantic_all();
+        // Empty project (no configuration with a program instance) still
+        // analyses cleanly when there are no parse errors. Either way,
+        // the contract is "no errors => no entries".
+        for (_, diags) in by_uri.iter() {
+            assert!(
+                diags.is_empty(),
+                "expected no diagnostics for clean project, got: {:?}",
+                diags
+            );
+        }
+    }
+
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn semantic_all_when_two_files_each_have_errors_then_returns_diagnostics_for_each_uri() {
+        let mut proj = new_empty_project();
+        let url_a = Uri::from_str(FAKE_PATH).unwrap();
+        let url_b = Uri::from_str(FAKE_PATH_2).unwrap();
+
+        // Both files contain unparseable garbage so each produces its
+        // own parse-time diagnostics and the analyzer should attribute
+        // them to their respective FileIds.
+        proj.change_text_document(&url_a, "this is not valid IEC 61131-3".to_owned());
+        proj.change_text_document(&url_b, "neither is this".to_owned());
+
+        let by_uri = proj.semantic_all();
+
+        assert!(
+            by_uri.contains_key(&url_a),
+            "expected diagnostics for {url_a:?}, got keys {:?}",
+            by_uri.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            by_uri.contains_key(&url_b),
+            "expected diagnostics for {url_b:?}, got keys {:?}",
+            by_uri.keys().collect::<Vec<_>>()
+        );
+        assert!(!by_uri[&url_a].is_empty());
+        assert!(!by_uri[&url_b].is_empty());
+    }
+
+    #[test]
+    fn semantic_when_back_compat_wrapper_then_returns_only_uris_diagnostics() {
+        // The single-URI `semantic` wrapper should still return only the
+        // diagnostics that the publisher would direct at that URI.
+        let mut proj = new_empty_project();
+        let url_a = Uri::from_str(FAKE_PATH).unwrap();
+        let url_b = Uri::from_str(FAKE_PATH_2).unwrap();
+
+        proj.change_text_document(&url_a, "this is not valid IEC 61131-3".to_owned());
+        proj.change_text_document(&url_b, "neither is this".to_owned());
+
+        let only_a = proj.semantic(&url_a);
+        assert!(
+            !only_a.is_empty(),
+            "expected diagnostics for url_a from back-compat wrapper"
+        );
+        // None of the diagnostics returned by `semantic(url_a)` should
+        // refer to url_b's range/source — the wrapper is a strict
+        // single-URI view.
+        // (Indirect check: `semantic_all` for url_b returns at least
+        // one diagnostic that does not appear in `only_a`.)
+        let only_b = proj.semantic(&url_b);
+        assert!(!only_b.is_empty());
+    }
+
+    #[test]
+    fn file_id_to_uri_when_round_trip_from_uri_path_then_matches_original() {
+        use super::file_id_to_uri;
+        use ironplc_dsl::core::FileId;
+
+        let original = Uri::from_str(FAKE_PATH).unwrap();
+        let path = std::path::PathBuf::from(original.path().as_str());
+        let file_id = FileId::from_path(&path);
+
+        let reconstructed = file_id_to_uri(&file_id).expect("file id should map back to a URI");
+        assert_eq!(
+            reconstructed.as_str(),
+            original.as_str(),
+            "expected URI round-trip via FileId to be lossless"
+        );
+    }
+
+    #[test]
+    fn file_id_to_uri_when_builtin_then_returns_none() {
+        use super::file_id_to_uri;
+        use ironplc_dsl::core::FileId;
+
+        assert!(file_id_to_uri(&FileId::builtin()).is_none());
     }
 }

--- a/specs/plans/2026-05-09-lsp-multi-file-diagnostics.md
+++ b/specs/plans/2026-05-09-lsp-multi-file-diagnostics.md
@@ -1,0 +1,108 @@
+# Plan: Publish LSP Diagnostics for Every File in the Workspace
+
+## Overview
+
+The IronPLC LSP server only publishes diagnostics for the file the user just edited, even though the compiler analyses the whole workspace and produces diagnostics for every file. When a project spans multiple files, errors in unedited files (including the ones causing analysis to fail) are silently dropped. This plan rewires the LSP layer to publish per-file diagnostics for every affected URI in the workspace and to clear stale diagnostics correctly.
+
+## Current State
+
+### What Exists
+
+- **`LspProject::semantic(uri)`** at `compiler/ironplc-cli/src/lsp_project.rs:111` — runs `Project::semantic()` (whole-workspace analysis) and then **filters** `diagnostics.filter(|d| d.file_ids().contains(&file_id))` so only diagnostics touching the requested URI survive.
+- **`did_open`/`did_change` handlers** at `compiler/ironplc-cli/src/lsp.rs:344` and `compiler/ironplc-cli/src/lsp.rs:370` — call `semantic(uri)` and emit a single `PublishDiagnostics` notification keyed to that URI.
+- **Compiler `Project::semantic()`** at `compiler/project/src/project.rs:194` — already analyses every source in the project and returns `Result<(), Vec<Diagnostic>>` containing diagnostics from any file.
+- **`Diagnostic::file_ids()`** at `compiler/dsl/src/diagnostic.rs:289` — returns the set of `FileId`s referenced by a diagnostic's primary plus secondary labels.
+- **`FileId`** is `File(Arc<str>)` where the inner string is the file system path; can be reconstructed to a URI via `file://{path}`.
+- **Test scaffolding (`TestServer`)** at `compiler/ironplc-cli/src/lsp.rs:462` — a self-contained in-process LSP harness that lets tests send notifications and consume `PublishDiagnostics` notifications synchronously.
+
+### What's Missing
+
+- No grouping of diagnostics by URI: the filter at `lsp_project.rs:121` drops every diagnostic that does not touch the edited URI.
+- No fan-out in the handlers: `did_open`/`did_change` only ever send one `PublishDiagnostics` notification per edit.
+- No tracking of which URIs have outstanding diagnostics, so when an error in `b.st` is fixed by editing `a.st` the squiggle in `b.st` would never be cleared even after fan-out.
+- No multi-file integration tests covering the publish/clear lifecycle.
+
+## Design
+
+The standard LSP convention (rust-analyzer, gopls, Pyright, tsserver) is:
+
+1. After any change, recompute project-wide diagnostics.
+2. Group them by file URI.
+3. Send one `publishDiagnostics` notification per file with current errors.
+4. For every URI that previously had diagnostics but no longer does, send `publishDiagnostics(uri, [])` to clear the stale squiggles.
+
+This plan adopts the same pattern.
+
+### New API on `LspProject`
+
+Replace the per-URI `semantic(&Uri) -> Vec<Diagnostic>` with a project-wide method:
+
+```rust
+pub(crate) fn semantic_all(&mut self) -> HashMap<Uri, Vec<lsp_types::Diagnostic>>;
+```
+
+It runs `self.wrapped.semantic()`, then for every diagnostic groups it by each `FileId` it touches (primary and secondary labels). Each `FileId::File(path)` is mapped to `Uri::from_str(&format!("file://{path}"))`. Diagnostics whose `FileId` is `BuiltIn` or whose path cannot be turned into a valid URI are attributed to the URI most recently provided to `change_text_document` (a fallback "primary" URI), so they never go missing in the diagnostics view.
+
+The existing `semantic(uri)` is kept as a thin wrapper for tests/back-compat (it returns `semantic_all().remove(uri).unwrap_or_default()`), but the LSP handlers stop using it.
+
+### Server-side fan-out and stale clearing
+
+Add to `LspServer`:
+
+```rust
+struct LspServer<'a> {
+    sender: &'a Sender<Message>,
+    project: LspProject,
+    /// URIs for which we have a non-empty PublishDiagnostics outstanding.
+    /// Used to send empty-diagnostics notifications when previously-failing
+    /// files no longer have errors.
+    published_uris: HashSet<Uri>,
+}
+```
+
+After the project state changes (`did_open`, `did_change`, future `did_save`/`did_close`), the server calls `project.semantic_all()`, then:
+
+1. For every `(uri, diags)` in the map: send `PublishDiagnostics{uri, diagnostics: diags, version: ...}`. The version field is `Some(version)` only when `uri` matches the request's `uri`; for other URIs, it's `None` (the LSP spec allows omitting it for files the editor has not opened or that we are publishing on behalf of the workspace).
+2. For every URI in `published_uris` that is NOT in the new map: send `PublishDiagnostics{uri, diagnostics: vec![], version: None}` to clear it.
+3. Replace `published_uris` with the set of URIs that received non-empty diagnostics.
+
+### Edge cases
+
+- **Empty results:** When `semantic_all()` returns an empty map (analysis succeeded), every previously-published URI must be cleared and `published_uris` reset to empty.
+- **Diagnostics with no resolvable file:** Always show on the editing URI to avoid silent loss. Already covered by the `BuiltIn`/fallback rule.
+- **Trait change risk:** `LspProject::semantic(uri)` is called by tests; we keep the wrapper to avoid breaking them.
+- **HashMap iteration order:** VS Code does not care, but tests must not assume order. The integration tests sort or look up by URI.
+
+## Implementation Steps
+
+1. **Add `semantic_all` to `LspProject`** (`compiler/ironplc-cli/src/lsp_project.rs`).
+   - Helper `file_id_to_uri(&FileId) -> Option<Uri>` that reconstructs `file://{path}`.
+   - Track `last_changed_uri: Option<Uri>` updated by `change_text_document` for the fallback.
+   - Group diagnostics across all `file_ids()`.
+   - Keep `semantic(&Uri)` as a back-compat wrapper.
+2. **Update `LspServer`** (`compiler/ironplc-cli/src/lsp.rs`).
+   - Add `published_uris: HashSet<Uri>` field, initialise empty.
+   - Add a helper method `publish_diagnostics(&mut self, edited_uri: &Uri, edited_version: Option<i32>)` that runs `semantic_all`, sends per-file notifications, sends empty-clear notifications, and updates `published_uris`.
+   - Replace the existing single-URI publish in `did_open` and `did_change` with this helper.
+3. **Unit tests in `lsp_project.rs`.**
+   - `semantic_all_when_two_files_each_have_errors_then_returns_diagnostics_for_each_uri`.
+   - `semantic_all_when_diagnostic_has_secondary_label_in_other_file_then_diagnostic_appears_for_both_uris` (verifies cross-file diagnostics surface in both files).
+   - `semantic_all_when_no_errors_then_empty_map`.
+4. **Integration tests in `lsp.rs`** using the existing `TestServer`.
+   - `multi_file_when_second_file_has_error_then_diagnostics_published_for_both_files` — open `a.st` (error-free) and `b.st` (parse error), assert two `PublishDiagnostics` notifications, one for each URI, with `b.st` containing the error.
+   - `multi_file_when_error_fixed_in_second_file_then_clearing_diagnostics_published` — start with `b.st` broken, then send a `did_change` that fixes `b.st`, assert a clear notification for `b.st`'s URI with `diagnostics == []`.
+   - `multi_file_when_unedited_file_starts_referencing_undefined_in_edited_file_then_diagnostic_published_for_unedited_file` — covers the "edit one file but error appears in another" scenario the user reported.
+   - `single_file_when_error_introduced_then_cleared_then_clearing_notification_emitted` — regression guard for stale clearing on the same file.
+
+## Acceptance Criteria
+
+- `semantic_all` returns a map keyed by `Uri` containing every diagnostic the compiler produced, regardless of the URI being edited.
+- `did_open`/`did_change` cause one `PublishDiagnostics` per affected URI plus one clearing `PublishDiagnostics` for each URI that no longer has diagnostics.
+- All new unit and integration tests pass.
+- `cd compiler && just` (compile, coverage, lint) passes locally before opening a PR.
+
+## Out of Scope
+
+- A workspace-vs-open-files setting toggle (the rust-analyzer/Pyright-style mode switch). IronPLC projects are typically small; default workspace-wide is fine. The toggle can be added later via `initializationOptions` without changing the architecture introduced here.
+- Incremental analysis / dependency tracking. The compiler still re-analyses everything on each edit; that is unchanged.
+- `did_save` / `did_close` handlers (none exist today; the same helper would slot in if they are added later).


### PR DESCRIPTION
## Summary

The LSP server now publishes diagnostics for every file in the workspace affected by compilation errors, rather than only the file being edited. It also correctly clears stale diagnostics when previously-failing files are fixed.

## Key Changes

- **New `LspProject::semantic_all()` method** that runs whole-workspace semantic analysis and returns diagnostics grouped by URI. Each diagnostic is attributed to every file it references (via primary and secondary labels), and diagnostics with unresolvable file IDs fall back to the most recently edited URI.

- **Server-side fan-out in `LspServer`** via new `publish_workspace_diagnostics()` method that:
  - Sends one `PublishDiagnostics` notification per affected file
  - Sends empty-diagnostics notifications to clear URIs that previously had errors but no longer do
  - Tracks published URIs in a `HashSet` to know which ones need clearing
  - Attaches version numbers only to the edited URI; other URIs receive `version: None`

- **Updated `did_open` and `did_change` handlers** to call `publish_workspace_diagnostics()` instead of publishing a single per-file notification.

- **Helper function `file_id_to_uri()`** that reconstructs LSP `file:` URIs from compiler `FileId` values, handling path normalization for cross-platform compatibility.

- **Backward-compatible `semantic(uri)` wrapper** retained for existing tests and callers; it delegates to `semantic_all()` and extracts a single URI's diagnostics.

## Implementation Details

- `LspProject` now tracks `last_changed_uri` to provide a fallback for diagnostics whose `FileId` cannot be mapped to a URI (e.g., `BuiltIn`), ensuring no diagnostics are silently dropped.

- Cross-file diagnostics (those with labels in multiple files) now appear in all affected files' diagnostic lists, improving visibility of inter-file errors.

- Comprehensive integration tests verify the publish/clear lifecycle across single and multi-file scenarios, including edge cases like fixing errors in unedited files and opening clean files after broken ones.

- Clippy `mutable_key_type` warnings are suppressed with documented justification: `lsp_types::Uri` uses interior `Cell`s only for parse caching, so equality and hashing are unaffected and using it as a HashMap/HashSet key is safe.

https://claude.ai/code/session_01FFKd77RoecT6kaWV9NGm1E