### PR TITLE
Reject unsafe Rust code at compile time

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -28,6 +28,15 @@ authors = [ "Garret Fick" ]
 license = "MIT"
 repository = "https://github.com/ironplc/ironplc"
 
+# IronPLC must remain free of `unsafe` Rust. `deny` makes the compiler
+# reject any `unsafe` block, fn, trait, or impl in our code. `deny`
+# (rather than `forbid`) is required so that proc-macros which wrap
+# unsafe internally — e.g. `ctor::ctor`, whose expansion includes
+# `#[allow(unsafe_code)]` — continue to work. Per development standards,
+# IronPLC code must not add `#[allow(unsafe_code)]` to bypass this.
+[workspace.lints.rust]
+unsafe_code = "deny"
+
 # Reduce per-binary debug-info size. `line-tables-only` retains the file/line
 # tables that `cargo llvm-cov` needs to map coverage hits to source, but drops
 # the type-, variable-, and inline-scope DWARF sections that dominate target/

--- a/compiler/analyzer/Cargo.toml
+++ b/compiler/analyzer/Cargo.toml
@@ -25,3 +25,6 @@ ironplc-parser = { path = "../parser", version = "0.213.0" }
 ctor = "0.11"
 env_logger = "0.11"
 rstest = "0.26"
+
+[lints]
+workspace = true

--- a/compiler/benchmarks/Cargo.toml
+++ b/compiler/benchmarks/Cargo.toml
@@ -23,3 +23,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "st_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -31,3 +31,6 @@ rstest = "0.26"
 [[test]]
 name = "it"
 path = "tests/it/main.rs"
+
+[lints]
+workspace = true

--- a/compiler/container/Cargo.toml
+++ b/compiler/container/Cargo.toml
@@ -16,3 +16,6 @@ ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
 
 [dev-dependencies]
 spec_test_macro = { path = "../spec_test_macro" }
+
+[lints]
+workspace = true

--- a/compiler/dsl/Cargo.toml
+++ b/compiler/dsl/Cargo.toml
@@ -18,3 +18,6 @@ paste = "1.0"
 logos = "0.16.1"
 regex = "1.12.3"
 lazy_static = "1.5.0"
+
+[lints]
+workspace = true

--- a/compiler/dsl_macro_derive/Cargo.toml
+++ b/compiler/dsl_macro_derive/Cargo.toml
@@ -22,3 +22,6 @@ syn = { version = "2.0", features = ["extra-traits", "derive"]}
 quote = "1.0"
 proc-macro2 = "1.0"
 convert_case = "0.11.0"
+
+[lints]
+workspace = true

--- a/compiler/ironplc-cli/Cargo.toml
+++ b/compiler/ironplc-cli/Cargo.toml
@@ -47,3 +47,6 @@ ctor = "0.11"
 [[bin]]
 name = "ironplcc"
 path = "bin/main.rs"
+
+[lints]
+workspace = true

--- a/compiler/mcp/Cargo.toml
+++ b/compiler/mcp/Cargo.toml
@@ -42,3 +42,6 @@ assert_cmd = { version = "2.2" }
 predicates = { version = "3.1" }
 rstest = "0.26"
 spec_test_macro = { path = "../spec_test_macro" }
+
+[lints]
+workspace = true

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -25,3 +25,6 @@ peg = "0.8.5"
 
 [dev-dependencies]
 rstest = "0.26"
+
+[lints]
+workspace = true

--- a/compiler/playground/Cargo.toml
+++ b/compiler/playground/Cargo.toml
@@ -26,3 +26,6 @@ base64 = "0.22"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+
+[lints]
+workspace = true

--- a/compiler/plc2plc/Cargo.toml
+++ b/compiler/plc2plc/Cargo.toml
@@ -18,3 +18,6 @@ paste = "1.0"
 
 [dev-dependencies]
 ironplc-parser = { path = "../parser", version = "0.213.0" }
+
+[lints]
+workspace = true

--- a/compiler/problems/Cargo.toml
+++ b/compiler/problems/Cargo.toml
@@ -12,3 +12,6 @@ maintenance = { status = "experimental" }
 
 [build-dependencies]
 csv = "1.4"
+
+[lints]
+workspace = true

--- a/compiler/project/Cargo.toml
+++ b/compiler/project/Cargo.toml
@@ -27,3 +27,6 @@ serde_json = "1.0"
 tempfile = "3"
 ctor = "0.11"
 env_logger = "0.11"
+
+[lints]
+workspace = true

--- a/compiler/sources/Cargo.toml
+++ b/compiler/sources/Cargo.toml
@@ -22,3 +22,6 @@ ironplc-test = { path = "../test", version = "0.213.0" }
 tempfile = "3.27"
 ctor = "0.11"
 env_logger = "0.11"
+
+[lints]
+workspace = true

--- a/compiler/spec_requirements_gen/Cargo.toml
+++ b/compiler/spec_requirements_gen/Cargo.toml
@@ -6,3 +6,6 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[lints]
+workspace = true

--- a/compiler/spec_test_macro/Cargo.toml
+++ b/compiler/spec_test_macro/Cargo.toml
@@ -14,3 +14,6 @@ proc-macro = true
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/compiler/test/Cargo.toml
+++ b/compiler/test/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 
 [badges]
 maintenance = { status = "experimental" }
+
+[lints]
+workspace = true

--- a/compiler/vm-cli/Cargo.toml
+++ b/compiler/vm-cli/Cargo.toml
@@ -32,3 +32,6 @@ predicates = { version = "3.1" }
 tempfile = "3"
 ctor = "0.11"
 spec_test_macro = { path = "../spec_test_macro" }
+
+[lints]
+workspace = true

--- a/compiler/vm/Cargo.toml
+++ b/compiler/vm/Cargo.toml
@@ -28,3 +28,6 @@ csv = "1"
 [[test]]
 name = "it"
 path = "tests/it/main.rs"
+
+[lints]
+workspace = true

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -468,7 +468,8 @@ The build system enforces synchronization between components:
 
 ### Safety
 - Leverage Rust's safety guarantees
-- Avoid `unsafe` code unless absolutely necessary
+- **`unsafe` code is rejected at compile time.** The workspace sets `unsafe_code = "deny"` in `[workspace.lints.rust]` (root `compiler/Cargo.toml`), and every member crate inherits it via `[lints] workspace = true`. Any `unsafe` block, function, trait, or impl in IronPLC code fails the build
+- **Do not bypass the check with `#[allow(unsafe_code)]`.** The standards already forbid `#[allow(...)]` suppressions (see [Code Quality](#code-quality)); `unsafe_code` is no exception. `deny` (rather than `forbid`) is the chosen level only so that proc-macros which wrap unsafe internally — e.g. `ctor::ctor`, whose expansion includes `#[allow(unsafe_code)]` — keep working. If a feature appears to require `unsafe`, raise it for discussion
 - Use strong typing to prevent logic errors (e.g., `TypeName` vs `String`)
 
 ### Dependencies


### PR DESCRIPTION
Adds `unsafe_code = "deny"` as a workspace lint in the root
Cargo.toml and wires every member crate to inherit it via
`[lints] workspace = true`. Any `unsafe` block, function, trait,
or impl in IronPLC code now fails the build with `-D unsafe-code`.

`deny` (rather than `forbid`) is required so proc-macros that wrap
unsafe internally — notably `ctor::ctor` used in test-logger init —
can still compile via the `#[allow(unsafe_code)]` in their own
expansion. The existing development-standards rule against
`#[allow(...)]` suppressions already prohibits IronPLC code from
adding such an attribute to bypass the check.