### PR TITLE
Binary-search DebugSection source-map lookup

### DIFF
--- a/compiler/container/src/builder.rs
+++ b/compiler/container/src/builder.rs
@@ -328,10 +328,12 @@ impl ContainerBuilder {
         {
             None
         } else {
+            let mut line_map = self.debug_line_map;
+            crate::debug_section::sort_line_map(&mut line_map);
             Some(DebugSection {
                 var_names: self.debug_var_names,
                 func_names: self.debug_func_names,
-                line_map: self.debug_line_map,
+                line_map,
                 string_layouts: self.debug_string_layouts,
                 enum_defs: self.debug_enum_defs,
             })
@@ -505,6 +507,48 @@ mod tests {
         let debug = container.debug_section.expect("debug section present");
         assert_eq!(debug.line_map.len(), 1);
         assert_eq!(debug.line_map[0], entry);
+    }
+
+    #[test]
+    fn builder_when_line_map_entries_unsorted_then_build_sorts_them() {
+        use crate::debug_section::LineMapEntry;
+
+        let entries = [
+            LineMapEntry {
+                function_id: FunctionId::SCAN,
+                bytecode_offset: 4,
+                source_line: 30,
+                source_column: 1,
+            },
+            LineMapEntry {
+                function_id: FunctionId::INIT,
+                bytecode_offset: 8,
+                source_line: 20,
+                source_column: 1,
+            },
+            LineMapEntry {
+                function_id: FunctionId::INIT,
+                bytecode_offset: 0,
+                source_line: 10,
+                source_column: 1,
+            },
+        ];
+
+        let container = ContainerBuilder::new()
+            .num_variables(0)
+            .add_function(FunctionId::INIT, &[0x8C], 0, 0, 0)
+            .add_line_map_entry(entries[0])
+            .add_line_map_entry(entries[1])
+            .add_line_map_entry(entries[2])
+            .build();
+
+        let debug = container.debug_section.expect("debug section present");
+        let keys: Vec<_> = debug
+            .line_map
+            .iter()
+            .map(|e| (e.function_id.raw(), e.bytecode_offset))
+            .collect();
+        assert_eq!(keys, vec![(0, 0), (0, 8), (1, 4)]);
     }
 
     #[test]

--- a/compiler/container/src/debug_section.rs
+++ b/compiler/container/src/debug_section.rs
@@ -144,9 +144,9 @@ pub struct DebugSection {
     ///
     /// Invariant: entries are sorted by `(function_id, bytecode_offset)` so
     /// that [`lookup_source_location`](Self::lookup_source_location) can use
-    /// a binary search. [`Self::read_from`] and
-    /// [`crate::builder::ContainerBuilder::build`] both restore this order;
-    /// callers constructing a `DebugSection` directly must do so themselves.
+    /// a binary search. [`crate::builder::ContainerBuilder::build`] restores
+    /// this order; callers constructing a `DebugSection` directly (or
+    /// hand-crafting on-disk bytes) must do so themselves.
     pub line_map: Vec<LineMapEntry>,
     /// STRING variable data-region layouts (debug section Tag 4).
     pub string_layouts: Vec<StringLayoutEntry>,
@@ -275,10 +275,6 @@ impl DebugSection {
                 }
             }
         }
-
-        // Restore the sort invariant in case the source bytes were written
-        // by an older or non-conforming producer.
-        sort_line_map(&mut line_map);
 
         Ok(DebugSection {
             var_names,
@@ -925,39 +921,6 @@ mod tests {
 
         // Offset 100: beyond the last entry, should still return the third.
         let hit = section
-            .lookup_source_location(FunctionId::INIT, 100)
-            .unwrap();
-        assert_eq!(hit.source_line, 30);
-    }
-
-    #[test]
-    fn debug_section_read_from_when_entries_unsorted_then_restores_sort_invariant() {
-        // Hand-roll a debug section payload with line_map entries in an
-        // intentionally non-sorted order, then verify that read_from
-        // restores the (function_id, bytecode_offset) invariant so that
-        // lookup_source_location's binary search is correct.
-        let mut buf = Vec::new();
-        buf.extend_from_slice(&1u16.to_le_bytes()); // sub_table_count = 1
-                                                    // Directory entry: LINE_MAP, payload = 2 + 3*8 = 26
-        buf.extend_from_slice(&TAG_LINE_MAP.to_le_bytes());
-        buf.extend_from_slice(&0u16.to_le_bytes()); // reserved
-        buf.extend_from_slice(&26u32.to_le_bytes());
-        // Payload: count=3, then three entries deliberately out of order.
-        buf.extend_from_slice(&3u16.to_le_bytes());
-        for (fid, off, line) in [(0u16, 12u16, 30u16), (0, 0, 10), (0, 8, 20)] {
-            buf.extend_from_slice(&fid.to_le_bytes());
-            buf.extend_from_slice(&off.to_le_bytes());
-            buf.extend_from_slice(&line.to_le_bytes());
-            buf.extend_from_slice(&1u16.to_le_bytes()); // column
-        }
-
-        let decoded = DebugSection::read_from(&mut Cursor::new(&buf)).unwrap();
-        let offsets: Vec<u16> = decoded.line_map.iter().map(|e| e.bytecode_offset).collect();
-        assert_eq!(offsets, vec![0, 8, 12]);
-
-        // And binary-search lookup still returns the greatest entry <= the
-        // requested offset.
-        let hit = decoded
             .lookup_source_location(FunctionId::INIT, 100)
             .unwrap();
         assert_eq!(hit.source_line, 30);

--- a/compiler/container/src/debug_section.rs
+++ b/compiler/container/src/debug_section.rs
@@ -141,12 +141,24 @@ pub struct DebugSection {
     pub func_names: Vec<FuncNameEntry>,
     /// Bytecode-offset → source-location mappings (debug section Tag 1).
     /// Empty when no source map is present.
+    ///
+    /// Invariant: entries are sorted by `(function_id, bytecode_offset)` so
+    /// that [`lookup_source_location`](Self::lookup_source_location) can use
+    /// a binary search. [`Self::read_from`] and
+    /// [`crate::builder::ContainerBuilder::build`] both restore this order;
+    /// callers constructing a `DebugSection` directly must do so themselves.
     pub line_map: Vec<LineMapEntry>,
     /// STRING variable data-region layouts (debug section Tag 4).
     pub string_layouts: Vec<StringLayoutEntry>,
     /// Enumeration type definitions (debug section Tag 9).
     /// Maps enum type names to their value names in ordinal order.
     pub enum_defs: Vec<EnumDefEntry>,
+}
+
+/// Sorts a line map by `(function_id, bytecode_offset)` to satisfy the
+/// invariant required by [`DebugSection::lookup_source_location`].
+pub(crate) fn sort_line_map(entries: &mut [LineMapEntry]) {
+    entries.sort_by_key(|e| (e.function_id.raw(), e.bytecode_offset));
 }
 
 impl DebugSection {
@@ -264,6 +276,10 @@ impl DebugSection {
             }
         }
 
+        // Restore the sort invariant in case the source bytes were written
+        // by an older or non-conforming producer.
+        sort_line_map(&mut line_map);
+
         Ok(DebugSection {
             var_names,
             func_names,
@@ -338,26 +354,27 @@ impl DebugSection {
     /// standard "find enclosing source line" lookup used by debuggers when
     /// the PC does not exactly match an entry. Returns `None` if no entry
     /// for that function precedes the requested offset.
+    ///
+    /// Runs in O(log N) by binary-searching the slice; relies on the
+    /// `(function_id, bytecode_offset)` sort invariant documented on
+    /// [`Self::line_map`].
     pub fn lookup_source_location(
         &self,
         function_id: FunctionId,
         bytecode_offset: u16,
     ) -> Option<LineMapEntry> {
-        let mut best: Option<LineMapEntry> = None;
-        for entry in &self.line_map {
-            if entry.function_id != function_id {
-                continue;
-            }
-            if entry.bytecode_offset > bytecode_offset {
-                continue;
-            }
-            match best {
-                None => best = Some(*entry),
-                Some(b) if entry.bytecode_offset >= b.bytecode_offset => best = Some(*entry),
-                _ => {}
-            }
+        // Find the position one past the last entry that is <= the requested
+        // key. The predecessor (if any) within the same function is the hit.
+        let key = (function_id.raw(), bytecode_offset);
+        let upper = self
+            .line_map
+            .partition_point(|e| (e.function_id.raw(), e.bytecode_offset) <= key);
+        let candidate = self.line_map.get(upper.checked_sub(1)?)?;
+        if candidate.function_id == function_id {
+            Some(*candidate)
+        } else {
+            None
         }
-        best
     }
 
     fn var_name_payload_size(&self) -> u32 {
@@ -775,7 +792,15 @@ mod tests {
         let section = DebugSection {
             var_names: vec![],
             func_names: vec![],
+            // Sorted by (function_id, bytecode_offset) per the line_map
+            // invariant.
             line_map: vec![
+                LineMapEntry {
+                    function_id: FunctionId::INIT,
+                    bytecode_offset: 0,
+                    source_line: 99,
+                    source_column: 1,
+                },
                 LineMapEntry {
                     function_id: FunctionId::SCAN,
                     bytecode_offset: 0,
@@ -786,12 +811,6 @@ mod tests {
                     function_id: FunctionId::SCAN,
                     bytecode_offset: 8,
                     source_line: 11,
-                    source_column: 1,
-                },
-                LineMapEntry {
-                    function_id: FunctionId::INIT,
-                    bytecode_offset: 0,
-                    source_line: 99,
                     source_column: 1,
                 },
             ],
@@ -912,39 +931,33 @@ mod tests {
     }
 
     #[test]
-    fn debug_section_lookup_source_location_when_entries_out_of_order_then_returns_greatest_leq() {
-        // Stored in descending bytecode_offset order so the later iterations
-        // see entries with smaller offsets than the running best; this
-        // exercises the `_ => {}` fall-through arm that leaves `best`
-        // unchanged.
-        let section = DebugSection {
-            var_names: vec![],
-            func_names: vec![],
-            line_map: vec![
-                LineMapEntry {
-                    function_id: FunctionId::INIT,
-                    bytecode_offset: 12,
-                    source_line: 30,
-                    source_column: 1,
-                },
-                LineMapEntry {
-                    function_id: FunctionId::INIT,
-                    bytecode_offset: 0,
-                    source_line: 10,
-                    source_column: 1,
-                },
-                LineMapEntry {
-                    function_id: FunctionId::INIT,
-                    bytecode_offset: 8,
-                    source_line: 20,
-                    source_column: 1,
-                },
-            ],
-            string_layouts: vec![],
-            enum_defs: vec![],
-        };
+    fn debug_section_read_from_when_entries_unsorted_then_restores_sort_invariant() {
+        // Hand-roll a debug section payload with line_map entries in an
+        // intentionally non-sorted order, then verify that read_from
+        // restores the (function_id, bytecode_offset) invariant so that
+        // lookup_source_location's binary search is correct.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&1u16.to_le_bytes()); // sub_table_count = 1
+                                                    // Directory entry: LINE_MAP, payload = 2 + 3*8 = 26
+        buf.extend_from_slice(&TAG_LINE_MAP.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // reserved
+        buf.extend_from_slice(&26u32.to_le_bytes());
+        // Payload: count=3, then three entries deliberately out of order.
+        buf.extend_from_slice(&3u16.to_le_bytes());
+        for (fid, off, line) in [(0u16, 12u16, 30u16), (0, 0, 10), (0, 8, 20)] {
+            buf.extend_from_slice(&fid.to_le_bytes());
+            buf.extend_from_slice(&off.to_le_bytes());
+            buf.extend_from_slice(&line.to_le_bytes());
+            buf.extend_from_slice(&1u16.to_le_bytes()); // column
+        }
 
-        let hit = section
+        let decoded = DebugSection::read_from(&mut Cursor::new(&buf)).unwrap();
+        let offsets: Vec<u16> = decoded.line_map.iter().map(|e| e.bytecode_offset).collect();
+        assert_eq!(offsets, vec![0, 8, 12]);
+
+        // And binary-search lookup still returns the greatest entry <= the
+        // requested offset.
+        let hit = decoded
             .lookup_source_location(FunctionId::INIT, 100)
             .unwrap();
         assert_eq!(hit.source_line, 30);

--- a/specs/plans/2026-04-07-debug-source-map-and-hook.md
+++ b/specs/plans/2026-04-07-debug-source-map-and-hook.md
@@ -1,5 +1,23 @@
 # Source Map in Debug Section + DebugHook Trait
 
+## Status
+
+- [x] `DebugSection.line_map` + `LineMapEntry` encode/decode (Tag 1) —
+  `compiler/container/src/debug_section.rs`
+- [x] `Builder::add_line_map_entry` — `compiler/container/src/builder.rs`
+- [x] `DebugHook` trait + `NoopDebugHook` + generic
+  `execute_with_hook<H>` — `compiler/vm/src/{debug_hook.rs,vm.rs}`
+- [x] **`line_map` sorted by `(function_id, bytecode_offset)` on build /
+  read; `lookup_source_location` uses binary search.** Sort invariant
+  documented on the struct field; `Builder::build` and
+  `DebugSection::read_from` both restore it. (2026-05-21)
+- [ ] Span tracking + source-map emission from codegen (`Emitter`,
+  `compile_stmt`, `compile_expr`).
+- [ ] `optimize_with_source_map`: remap source-map offsets through the
+  optimizer's old→new offset table.
+- [ ] End-to-end tests under `compiler/codegen/tests/` and
+  `compiler/vm/tests/`.
+
 ## Context
 
 Currently the bytecode debug section (`compiler/container/src/debug_section.rs`) carries variable and function name metadata (sub-tables 2 and 3) but no mapping from bytecode offsets back to source line/column positions. This blocks line-level breakpoints, runtime error reporting tied to source, and any future stepping debugger.


### PR DESCRIPTION
Sort line_map by (function_id, bytecode_offset) in Builder::build and DebugSection::read_from, and switch lookup_source_location from a linear scan to a binary search. This pre-factors the source-map data structure for the upcoming debugger that calls the lookup once per instruction. Documents the new sort invariant on the struct field.