### PR TITLE
Introduce CharWidth enum in container crate

### DIFF
--- a/compiler/container/src/char_width.rs
+++ b/compiler/container/src/char_width.rs
@@ -1,0 +1,103 @@
+//! Per-code-unit byte width for string types.
+//!
+//! Per ADR-0016 / ADR-0035, IEC 61131-3 string values have one of two
+//! encodings:
+//!
+//! - `STRING`  — Latin-1, one byte per character
+//! - `WSTRING` — UTF-16LE, two bytes per code unit
+//!
+//! The runtime carries the encoding as part of:
+//!
+//! 1. each string variable's data-region header
+//! 2. each constant-pool string entry
+//! 3. each temp-buffer slot in the VM
+//!
+//! Representing the width as an enum (rather than a `u8`) makes string
+//! operations exhaustively match on the two valid encodings and turns
+//! boundary reads (bytecode operand, constant-pool tag, data-region header
+//! byte) into a single validated conversion point.
+
+use crate::ContainerError;
+
+/// Per-code-unit byte width of a string value.
+///
+/// The discriminants match the on-disk encoding used by the string header,
+/// the constant-pool encoding tag, and the `char_width` operand of
+/// `STR_INIT` — so `width as u8` round-trips through the bytecode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CharWidth {
+    /// STRING: Latin-1, one byte per character.
+    Narrow = 1,
+    /// WSTRING: UTF-16LE, two bytes per code unit.
+    Wide = 2,
+}
+
+impl CharWidth {
+    /// Returns the byte width of one code unit.
+    #[inline]
+    pub const fn byte_width(self) -> u8 {
+        self as u8
+    }
+
+    /// Returns the byte width as `usize`, for index arithmetic.
+    #[inline]
+    pub const fn as_usize(self) -> usize {
+        self as u8 as usize
+    }
+
+    /// Returns `true` for [`CharWidth::Wide`] (UTF-16LE / WSTRING).
+    #[inline]
+    pub const fn is_wide(self) -> bool {
+        matches!(self, CharWidth::Wide)
+    }
+
+    /// Parses a `char_width` byte read from a bytecode operand, header field,
+    /// or constant-pool tag. Returns
+    /// [`ContainerError::InvalidCharWidth`] for any value other than
+    /// `1` or `2`.
+    pub fn from_u8(value: u8) -> Result<Self, ContainerError> {
+        match value {
+            1 => Ok(CharWidth::Narrow),
+            2 => Ok(CharWidth::Wide),
+            _ => Err(ContainerError::InvalidCharWidth(value)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_u8_when_valid_bytes_then_returns_variant() {
+        assert_eq!(CharWidth::from_u8(1).unwrap(), CharWidth::Narrow);
+        assert_eq!(CharWidth::from_u8(2).unwrap(), CharWidth::Wide);
+    }
+
+    #[test]
+    fn from_u8_when_invalid_byte_then_error() {
+        assert!(matches!(
+            CharWidth::from_u8(0),
+            Err(ContainerError::InvalidCharWidth(0))
+        ));
+        assert!(matches!(
+            CharWidth::from_u8(99),
+            Err(ContainerError::InvalidCharWidth(99))
+        ));
+    }
+
+    #[test]
+    fn byte_width_when_each_variant_then_matches_discriminant() {
+        assert_eq!(CharWidth::Narrow.byte_width(), 1);
+        assert_eq!(CharWidth::Wide.byte_width(), 2);
+        assert_eq!(CharWidth::Narrow.as_usize(), 1);
+        assert_eq!(CharWidth::Wide.as_usize(), 2);
+    }
+
+    #[test]
+    fn is_wide_when_each_variant_then_matches() {
+        assert!(!CharWidth::Narrow.is_wide());
+        assert!(CharWidth::Wide.is_wide());
+    }
+}

--- a/compiler/container/src/error.rs
+++ b/compiler/container/src/error.rs
@@ -25,6 +25,10 @@ pub enum ContainerError {
     InvalidDebugSection,
     /// A field entry has an unrecognized field type tag.
     InvalidFieldType(u8),
+    /// A `char_width` byte (string header, constant-pool tag, or bytecode
+    /// operand) is not a recognized [`crate::CharWidth`] discriminant
+    /// (1 = `Narrow`, 2 = `Wide`).
+    InvalidCharWidth(u8),
 }
 
 impl fmt::Display for ContainerError {
@@ -48,6 +52,9 @@ impl fmt::Display for ContainerError {
             ContainerError::InvalidDebugSection => write!(f, "invalid debug section"),
             ContainerError::InvalidFieldType(t) => {
                 write!(f, "invalid field type: {t}")
+            }
+            ContainerError::InvalidCharWidth(t) => {
+                write!(f, "invalid char_width: {t}")
             }
         }
     }
@@ -116,6 +123,13 @@ mod tests {
     fn container_error_display_when_invalid_field_type_then_contains_tag() {
         let msg = ContainerError::InvalidFieldType(5).to_string();
         assert!(msg.contains('5'), "got: {msg}");
+    }
+
+    #[test]
+    fn container_error_display_when_invalid_char_width_then_contains_tag() {
+        let msg = ContainerError::InvalidCharWidth(99).to_string();
+        assert!(msg.contains("99"), "got: {msg}");
+        assert!(msg.contains("char_width"), "got: {msg}");
     }
 
     #[test]

--- a/compiler/container/src/lib.rs
+++ b/compiler/container/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate std;
 
 // Always available (no_std)
+mod char_width;
 mod const_type;
 mod container_ref;
 mod error;
@@ -32,6 +33,7 @@ pub mod task_table;
 mod type_section;
 
 // Always-available re-exports
+pub use char_width::CharWidth;
 pub use const_type::ConstType;
 pub use container_ref::{ContainerRef, ProgramEntryRef, TaskEntryRef};
 pub use error::ContainerError;

--- a/specs/plans/2026-05-21-introduce-char-width-enum.md
+++ b/specs/plans/2026-05-21-introduce-char-width-enum.md
@@ -1,0 +1,46 @@
+# Introduce CharWidth Enum Implementation Plan
+
+**Goal:** Introduce a typed `CharWidth { Narrow = 1, Wide = 2 }` enum in `ironplc-container` as a standalone, inert addition. No on-disk format changes, no callers added in this PR — the enum sits in place ready for follow-up WSTRING work to consume it.
+
+**Architecture:** Pure additive. One new module (`compiler/container/src/char_width.rs`) defining the enum, one new variant on `ContainerError` for invalid byte values, and one re-export from `lib.rs`. The format version, header layout, and constant-pool wire format are all unchanged.
+
+**Context:** Carved out of PR #1050 (WSTRING support) to make that review tractable. PR #1050 lands the enum mid-stream as part of a later refactor; landing it standalone first lets follow-up PRs use it from the start instead of going through a `u8` interim.
+
+**Tech Stack:** Rust, `ironplc-container` crate (no_std-compatible)
+
+---
+
+### Task 1: Add the `CharWidth` enum module
+
+**Files:**
+- Add: `compiler/container/src/char_width.rs`
+
+The enum has two discriminants matching the eventual on-disk encoding tag (`Narrow = 1`, `Wide = 2`) so `width as u8` round-trips. Helpers: `byte_width()`, `as_usize()`, `is_wide()`, `from_u8(u8) -> Result<Self, ContainerError>`. Unit tests cover valid bytes, invalid bytes returning `InvalidCharWidth`, byte-width matching the discriminant, and `is_wide` discrimination.
+
+### Task 2: Add `ContainerError::InvalidCharWidth(u8)`
+
+**Files:**
+- Modify: `compiler/container/src/error.rs`
+
+Add the variant, the `Display` arm, and a test for the message. Place the variant alongside the other invalid-tag variants (`InvalidConstantType`, `InvalidTaskType`, `InvalidFieldType`).
+
+### Task 3: Wire up the module and re-export
+
+**Files:**
+- Modify: `compiler/container/src/lib.rs`
+
+Add `mod char_width;` to the always-available section (the enum is `no_std`-compatible), and `pub use char_width::CharWidth;` alongside the other always-available re-exports.
+
+---
+
+## Deliberately out of scope
+
+- `FORMAT_VERSION` bump (stays at 2)
+- `STRING_HEADER_BYTES` change (stays at 4)
+- `ConstType::WStr` variant
+- Any caller in container, VM, codegen, or analyzer
+- Problem code V9015 (`Trap::InvalidCharWidth`) — that's a VM-side concern landed with the runtime checks
+
+## Verification
+
+`cd compiler && just` must pass: compile, coverage ≥ 85%, clippy, fmt, dupes. The new module's own unit tests cover its surface; no integration tests are added because the enum has no callers yet.


### PR DESCRIPTION
Adds a typed `CharWidth { Narrow = 1, Wide = 2 }` enum to
`ironplc-container` with `from_u8` validation, `byte_width`, `as_usize`,
and `is_wide` helpers, plus a new `ContainerError::InvalidCharWidth(u8)`
variant for byte values outside the {1, 2} range.

The enum is purely additive: no callers in container, VM, codegen, or
analyzer; no on-disk format version or header layout change. It lands
ahead of the rest of WSTRING support (PR #1050) so follow-up patches
can consume the typed representation from the start instead of going
through a `u8` interim.