### PR TITLE
Thread CharWidth through codegen string metadata

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -45,12 +45,12 @@ use ironplc_container::debug_section::{
     EnumDefEntry, FuncNameEntry, StringLayoutEntry, VarNameEntry,
 };
 use ironplc_container::{
-    Container, ContainerBuilder, FbTypeId, FunctionId, UserFbDescriptor, VarIndex,
+    CharWidth, Container, ContainerBuilder, FbTypeId, FunctionId, UserFbDescriptor, VarIndex,
     STRING_HEADER_BYTES,
 };
 use ironplc_dsl::common::{
     FunctionBlockDeclaration, FunctionDeclaration, InitialValueAssignmentKind, Library,
-    LibraryElementKind, ProgramDeclaration, VarDecl, VariableType,
+    LibraryElementKind, ProgramDeclaration, StringType, VarDecl, VariableType,
 };
 use ironplc_dsl::configuration::ConfigurationDeclaration;
 use ironplc_dsl::core::{FileId, Id, Located};
@@ -118,35 +118,47 @@ pub(crate) enum PoolConstant {
 /// The IEC 61131-3 default maximum length for STRING (254 characters).
 pub(crate) const DEFAULT_STRING_MAX_LENGTH_U16: u16 = 254;
 
-/// Metadata for a STRING variable allocated in the data region.
+/// Metadata for a STRING/WSTRING variable allocated in the data region.
 #[derive(Clone)]
 pub(crate) struct StringVarInfo {
     /// Byte offset into the data region where this string starts.
     pub(crate) data_offset: u32,
-    /// Maximum number of characters this string can hold.
+    /// Maximum number of code units this string can hold.
     pub(crate) max_length: u16,
-    /// Bytes per character: 1 for STRING, 2 for WSTRING (not yet supported).
-    pub(crate) char_width: u16,
+    /// Per-code-unit byte width: `Narrow` for STRING, `Wide` for WSTRING.
+    pub(crate) char_width: CharWidth,
 }
 
-/// Bytes per character for STRING. WSTRING (when supported) will use 2.
-pub(crate) const STRING_CHAR_WIDTH: u16 = 1;
+/// Per-code-unit byte width for STRING (Latin-1 per ADR-0016).
+pub(crate) const NARROW_CHAR_WIDTH: CharWidth = CharWidth::Narrow;
+/// Per-code-unit byte width for WSTRING (UTF-16LE per ADR-0016).
+pub(crate) const WIDE_CHAR_WIDTH: CharWidth = CharWidth::Wide;
 
-/// Total bytes needed in the data region for a STRING value with the given
-/// maximum length: header plus per-character storage.
-pub(crate) fn string_region_size(max_length: u16) -> u32 {
-    STRING_HEADER_BYTES as u32 + (max_length as u32) * (STRING_CHAR_WIDTH as u32)
+/// Returns the per-code-unit byte width for an IEC string type:
+/// `Narrow` for STRING, `Wide` for WSTRING (ADR-0016).
+pub(crate) fn char_width_for_string_type(width: &StringType) -> CharWidth {
+    match width {
+        StringType::String => NARROW_CHAR_WIDTH,
+        StringType::WString => WIDE_CHAR_WIDTH,
+    }
+}
+
+/// Total bytes needed in the data region for a STRING/WSTRING value with the
+/// given maximum length (in code units) and `char_width`: header plus
+/// `max_length * char_width` payload bytes.
+pub(crate) fn string_region_size(max_length: u16, char_width: CharWidth) -> u32 {
+    STRING_HEADER_BYTES as u32 + (max_length as u32) * (char_width.byte_width() as u32)
 }
 
 /// Encode a character-string literal into bytes for the constant pool.
 ///
-/// `char_width` selects the encoding: 1 for STRING (Latin-1 per ADR-0016).
-/// WSTRING (`char_width = 2`) is not yet supported and will panic; the
+/// `char_width` selects the encoding: `Narrow` for STRING (Latin-1 per
+/// ADR-0016). `Wide` (UTF-16LE) is not yet supported and will panic; the
 /// parameter exists so call sites already pass the value.
-pub(crate) fn encode_string_literal(chars: &[char], char_width: u16) -> Vec<u8> {
+pub(crate) fn encode_string_literal(chars: &[char], char_width: CharWidth) -> Vec<u8> {
     match char_width {
-        STRING_CHAR_WIDTH => chars.iter().map(|&ch| ch as u8).collect(),
-        _ => unreachable!("WSTRING literal encoding is not yet supported"),
+        CharWidth::Narrow => chars.iter().map(|&ch| ch as u8).collect(),
+        CharWidth::Wide => unreachable!("WSTRING literal encoding is not yet supported"),
     }
 }
 
@@ -469,9 +481,13 @@ fn compile_program_with_functions(
     if ctx.data_region_offset > 0 {
         builder = builder.data_region_bytes(ctx.data_region_offset);
         if ctx.num_temp_bufs > 0 {
-            builder = builder
-                .num_temp_bufs(ctx.num_temp_bufs)
-                .max_temp_buf_bytes(string_region_size(ctx.max_string_capacity));
+            builder =
+                builder
+                    .num_temp_bufs(ctx.num_temp_bufs)
+                    .max_temp_buf_bytes(string_region_size(
+                        ctx.max_string_capacity,
+                        NARROW_CHAR_WIDTH,
+                    ));
         }
     }
 
@@ -598,14 +614,14 @@ fn compile_program_with_functions(
 pub(crate) struct StringParamInfo {
     /// Byte offset in the data region where this parameter's string is stored.
     pub(crate) data_offset: u32,
-    /// Maximum number of characters this parameter can hold.
+    /// Maximum number of code units this parameter can hold.
     pub(crate) max_length: u16,
-    /// Bytes per character: 1 for STRING, 2 for WSTRING (not yet supported).
+    /// Per-code-unit byte width: `Narrow` for STRING, `Wide` for WSTRING.
     #[allow(dead_code)]
-    pub(crate) char_width: u16,
+    pub(crate) char_width: CharWidth,
 }
 
-/// Metadata for a STRING return value in a user-defined function.
+/// Metadata for a STRING/WSTRING return value in a user-defined function.
 ///
 /// When a function returns STRING/WSTRING, the return value lives in the
 /// data region rather than on the operand stack.
@@ -613,11 +629,11 @@ pub(crate) struct StringParamInfo {
 pub(crate) struct StringReturnInfo {
     /// Byte offset in the data region where the return string is stored.
     pub(crate) data_offset: u32,
-    /// Maximum number of characters the return string can hold.
+    /// Maximum number of code units the return string can hold.
     pub(crate) max_length: u16,
-    /// Bytes per character: 1 for STRING, 2 for WSTRING (not yet supported).
+    /// Per-code-unit byte width: `Narrow` for STRING, `Wide` for WSTRING.
     #[allow(dead_code)]
-    pub(crate) char_width: u16,
+    pub(crate) char_width: CharWidth,
 }
 
 /// Metadata for a compiled user-defined function.

--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -13,7 +13,7 @@ use ironplc_dsl::textual::{Expr, ExprKind, SymbolicVariableKind, UnaryOp, Variab
 use ironplc_problems::Problem;
 
 use ironplc_analyzer::intermediate_type::{ArrayDimension, ByteSized, IntermediateType};
-use ironplc_container::{ContainerBuilder, SlotIndex, VarIndex};
+use ironplc_container::{CharWidth, ContainerBuilder, SlotIndex, VarIndex};
 
 use super::compile::{CompileContext, OpType, OpWidth, Signedness, VarTypeInfo};
 use super::compile_expr::compile_expr;
@@ -29,9 +29,13 @@ pub(crate) struct ArraySpec {
     pub element_type_name: Id,
     /// Whether each element is a REF_TO the named type.
     pub ref_to: bool,
-    /// For STRING arrays, the maximum string length per element.
-    /// `None` for non-string element types.
+    /// For STRING/WSTRING arrays, the maximum string length per element
+    /// (in code units). `None` for non-string element types.
     pub string_max_len: Option<u16>,
+    /// For STRING/WSTRING arrays, the per-code-unit byte width:
+    /// `Narrow` for STRING, `Wide` for WSTRING. `None` for non-string
+    /// element types.
+    pub string_char_width: Option<CharWidth>,
 }
 
 /// Metadata for a single dimension of an array, used for index computation.
@@ -350,23 +354,31 @@ pub(crate) fn array_spec_from_inline(
             Ok((lower, upper))
         })
         .collect::<Result<Vec<_>, Diagnostic>>()?;
-    let string_max_len = match &subranges.type_name {
-        ironplc_dsl::common::ArrayElementType::String(spec)
-        | ironplc_dsl::common::ArrayElementType::WString(spec) => {
+    let (string_max_len, string_char_width) = match &subranges.type_name {
+        ironplc_dsl::common::ArrayElementType::String(spec) => {
             let len = spec
                 .length
                 .as_ref()
                 .and_then(|l| l.as_integer().map(|i| i.value as u16))
                 .unwrap_or(super::compile::DEFAULT_STRING_MAX_LENGTH_U16);
-            Some(len)
+            (Some(len), Some(CharWidth::Narrow))
         }
-        _ => None,
+        ironplc_dsl::common::ArrayElementType::WString(spec) => {
+            let len = spec
+                .length
+                .as_ref()
+                .and_then(|l| l.as_integer().map(|i| i.value as u16))
+                .unwrap_or(super::compile::DEFAULT_STRING_MAX_LENGTH_U16);
+            (Some(len), Some(CharWidth::Wide))
+        }
+        _ => (None, None),
     };
     Ok(ArraySpec {
         dimensions,
         element_type_name: Id::from(&subranges.type_name.to_type_name().to_string()),
         ref_to: subranges.ref_to,
         string_max_len,
+        string_char_width,
     })
 }
 
@@ -383,20 +395,24 @@ pub(crate) fn array_spec_from_named(
         element_type
     };
     let element_type_name = intermediate_type_to_name(inner_type)?;
-    let string_max_len = match inner_type {
-        IntermediateType::String { max_len, .. } => {
+    let (string_max_len, string_char_width) = match inner_type {
+        IntermediateType::String {
+            max_len,
+            char_width,
+        } => {
             let len = max_len
                 .map(|v| v as u16)
                 .unwrap_or(super::compile::DEFAULT_STRING_MAX_LENGTH_U16);
-            Some(len)
+            (Some(len), Some(*char_width))
         }
-        _ => None,
+        _ => (None, None),
     };
     Ok(ArraySpec {
         dimensions: dims,
         element_type_name,
         ref_to,
         string_max_len,
+        string_char_width,
     })
 }
 
@@ -494,6 +510,7 @@ pub(crate) fn register_array_variable(
 ) -> Result<(u8, String), Diagnostic> {
     let is_string = spec.string_max_len.is_some();
     let string_max_len = spec.string_max_len.unwrap_or(0);
+    let string_char_width = spec.string_char_width.unwrap_or(CharWidth::Narrow);
 
     // 1. Resolve element type
     let element_vti = if spec.ref_to {
@@ -557,8 +574,8 @@ pub(crate) fn register_array_variable(
     // 5. Allocate data region space
     let data_offset = ctx.data_region_offset;
     let total_bytes = if is_string {
-        // STRING elements: each element is [max_len:u16][cur_len:u16][data:max_len bytes]
-        let element_stride = super::compile::string_region_size(string_max_len);
+        // STRING/WSTRING elements: each element is [max_len:u16][cur_len:u16][data]
+        let element_stride = super::compile::string_region_size(string_max_len, string_char_width);
         total_elements.checked_mul(element_stride).ok_or_else(|| {
             Diagnostic::problem(
                 Problem::NotImplemented,

--- a/compiler/codegen/src/compile_expr.rs
+++ b/compiler/codegen/src/compile_expr.rs
@@ -18,7 +18,7 @@ use ironplc_problems::Problem;
 
 use super::compile::{
     encode_string_literal, CompileContext, OpType, OpWidth, Signedness, VarTypeInfo,
-    DEFAULT_OP_TYPE, STRING_CHAR_WIDTH,
+    DEFAULT_OP_TYPE, NARROW_CHAR_WIDTH,
 };
 use super::compile_call::compile_function_call;
 use super::compile_setup::resolve_type_name;
@@ -377,7 +377,7 @@ pub(crate) fn compile_constant(
             // Load the string literal into a temp buffer, leaving buf_idx on the stack.
             // The caller (e.g., string assignment path) will consume the buf_idx via
             // emit_str_store_var to copy the value into the target data region.
-            let bytes = encode_string_literal(&lit.value, STRING_CHAR_WIDTH);
+            let bytes = encode_string_literal(&lit.value, NARROW_CHAR_WIDTH);
             let pool_index = ctx.add_str_constant(bytes);
             ctx.num_temp_bufs += 1;
             emitter.emit_load_const_str(pool_index);

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -16,9 +16,10 @@ use ironplc_problems::Problem;
 use ironplc_analyzer::{FunctionEnvironment, TypeEnvironment};
 
 use super::compile::{
-    finalize_function, string_region_size, CompileContext, CompiledFunction, CurrentFunctionReturn,
-    OpType, OpWidth, Signedness, StringParamInfo, StringReturnInfo, StringVarInfo,
-    UserFunctionInfo, VarTypeInfo, DEFAULT_OP_TYPE, STRING_CHAR_WIDTH,
+    char_width_for_string_type, finalize_function, string_region_size, CompileContext,
+    CompiledFunction, CurrentFunctionReturn, OpType, OpWidth, Signedness, StringParamInfo,
+    StringReturnInfo, StringVarInfo, UserFunctionInfo, VarTypeInfo, DEFAULT_OP_TYPE,
+    NARROW_CHAR_WIDTH, WIDE_CHAR_WIDTH,
 };
 use super::compile_expr::emit_load_var;
 use super::compile_setup::{emit_function_local_prologue, resolve_type_name};
@@ -107,9 +108,10 @@ pub(crate) fn compile_user_function(
                 }
                 InitialValueAssignmentKind::String(string_init) => {
                     let max_length = resolve_string_max_length(string_init)?;
+                    let char_width = char_width_for_string_type(&string_init.width);
 
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = string_region_size(max_length);
+                    let total_bytes = string_region_size(max_length, char_width);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -129,7 +131,7 @@ pub(crate) fn compile_user_function(
                         StringVarInfo {
                             data_offset,
                             max_length,
-                            char_width: STRING_CHAR_WIDTH,
+                            char_width,
                         },
                     );
                 }
@@ -172,9 +174,10 @@ pub(crate) fn compile_user_function(
                 }
                 InitialValueAssignmentKind::String(string_init) => {
                     let max_length = resolve_string_max_length(string_init)?;
+                    let char_width = char_width_for_string_type(&string_init.width);
 
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = string_region_size(max_length);
+                    let total_bytes = string_region_size(max_length, char_width);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -194,7 +197,7 @@ pub(crate) fn compile_user_function(
                         StringVarInfo {
                             data_offset,
                             max_length,
-                            char_width: STRING_CHAR_WIDTH,
+                            char_width,
                         },
                     );
                 }
@@ -230,9 +233,13 @@ pub(crate) fn compile_user_function(
     let return_string_info = match &func_decl.return_type {
         FunctionReturnType::String(spec) | FunctionReturnType::WString(spec) => {
             let max_length = resolve_string_spec_max_length(spec)?;
+            let char_width = match &func_decl.return_type {
+                FunctionReturnType::WString(_) => WIDE_CHAR_WIDTH,
+                _ => NARROW_CHAR_WIDTH,
+            };
 
             let data_offset = ctx.data_region_offset;
-            let total_bytes = string_region_size(max_length);
+            let total_bytes = string_region_size(max_length, char_width);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
@@ -247,13 +254,13 @@ pub(crate) fn compile_user_function(
                 StringVarInfo {
                     data_offset,
                     max_length,
-                    char_width: STRING_CHAR_WIDTH,
+                    char_width,
                 },
             );
             Some(StringReturnInfo {
                 data_offset,
                 max_length,
-                char_width: STRING_CHAR_WIDTH,
+                char_width,
             })
         }
         FunctionReturnType::Named(_) => {
@@ -531,9 +538,10 @@ pub(crate) fn compile_user_function_block(
                 }
                 InitialValueAssignmentKind::String(string_init) => {
                     let max_length = resolve_string_max_length(string_init)?;
+                    let char_width = char_width_for_string_type(&string_init.width);
 
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = string_region_size(max_length);
+                    let total_bytes = string_region_size(max_length, char_width);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -553,7 +561,7 @@ pub(crate) fn compile_user_function_block(
                         StringVarInfo {
                             data_offset,
                             max_length,
-                            char_width: STRING_CHAR_WIDTH,
+                            char_width,
                         },
                     );
                 }

--- a/compiler/codegen/src/compile_setup.rs
+++ b/compiler/codegen/src/compile_setup.rs
@@ -20,8 +20,9 @@ use ironplc_analyzer::intermediate_type::IntermediateType;
 use ironplc_analyzer::TypeEnvironment;
 
 use super::compile::{
-    encode_string_literal, string_region_size, CompileContext, FbInstanceInfo, OpType, OpWidth,
-    Signedness, StringVarInfo, VarTypeInfo, DEFAULT_OP_TYPE, STRING_CHAR_WIDTH,
+    char_width_for_string_type, encode_string_literal, string_region_size, CompileContext,
+    FbInstanceInfo, OpType, OpWidth, Signedness, StringVarInfo, VarTypeInfo, DEFAULT_OP_TYPE,
+    NARROW_CHAR_WIDTH,
 };
 use super::compile_call::resolve_fb_type;
 use super::compile_expr::{compile_constant, emit_store_var, emit_truncation, resolve_variable};
@@ -81,10 +82,11 @@ pub(crate) fn assign_variables(
                 }
                 InitialValueAssignmentKind::String(string_init) => {
                     let max_length = resolve_string_max_length(string_init)?;
+                    let char_width = char_width_for_string_type(&string_init.width);
 
                     // Allocate space in the data region: [max_length: u16][cur_length: u16][data]
                     let data_offset = ctx.data_region_offset;
-                    let total_bytes = string_region_size(max_length);
+                    let total_bytes = string_region_size(max_length, char_width);
                     ctx.data_region_offset = ctx
                         .data_region_offset
                         .checked_add(total_bytes)
@@ -104,7 +106,7 @@ pub(crate) fn assign_variables(
                         StringVarInfo {
                             data_offset,
                             max_length,
-                            char_width: STRING_CHAR_WIDTH,
+                            char_width,
                         },
                     );
                     ctx.debug_string_layouts.push(StringLayoutEntry {
@@ -411,7 +413,7 @@ pub(crate) fn emit_initial_values(
 
                         // If there's an initial value, load and store it.
                         if let Some(chars) = &string_init.initial_value {
-                            let bytes = encode_string_literal(chars, STRING_CHAR_WIDTH);
+                            let bytes = encode_string_literal(chars, NARROW_CHAR_WIDTH);
                             let pool_index = ctx.add_str_constant(bytes);
                             ctx.num_temp_bufs += 1;
                             emitter.emit_load_const_str(pool_index);
@@ -661,7 +663,7 @@ pub(crate) fn emit_function_local_prologue(
                         emitter.emit_str_init(data_offset, max_length);
 
                         if let Some(chars) = &string_init.initial_value {
-                            let bytes = encode_string_literal(chars, STRING_CHAR_WIDTH);
+                            let bytes = encode_string_literal(chars, NARROW_CHAR_WIDTH);
                             let pool_index = ctx.add_str_constant(bytes);
                             ctx.num_temp_bufs += 1;
                             emitter.emit_load_const_str(pool_index);

--- a/compiler/codegen/src/compile_string.rs
+++ b/compiler/codegen/src/compile_string.rs
@@ -12,7 +12,7 @@ use ironplc_dsl::textual::{CompareExpr, CompareOp, Expr, ExprKind, Function, Par
 
 use super::compile::{
     encode_string_literal, string_region_size, CompileContext, DEFAULT_OP_TYPE,
-    DEFAULT_STRING_MAX_LENGTH_U16, STRING_CHAR_WIDTH,
+    DEFAULT_STRING_MAX_LENGTH_U16, NARROW_CHAR_WIDTH,
 };
 use super::compile_expr::{compile_expr, resolve_variable_name};
 use crate::emit::Emitter;
@@ -124,7 +124,7 @@ pub(crate) fn resolve_string_arg(
             // through to the general expression path below.
             let max_length = DEFAULT_STRING_MAX_LENGTH_U16;
             let data_offset = ctx.data_region_offset;
-            let total_bytes = string_region_size(max_length);
+            let total_bytes = string_region_size(max_length, NARROW_CHAR_WIDTH);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
@@ -144,10 +144,10 @@ pub(crate) fn resolve_string_arg(
         }
         ExprKind::Const(ConstantKind::CharacterString(lit)) => {
             // Allocate space in the data region for this string literal.
-            let bytes = encode_string_literal(&lit.value, STRING_CHAR_WIDTH);
+            let bytes = encode_string_literal(&lit.value, NARROW_CHAR_WIDTH);
             let max_length = DEFAULT_STRING_MAX_LENGTH_U16;
             let data_offset = ctx.data_region_offset;
-            let total_bytes = string_region_size(max_length);
+            let total_bytes = string_region_size(max_length, NARROW_CHAR_WIDTH);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
@@ -173,7 +173,7 @@ pub(crate) fn resolve_string_arg(
             // temporary data region slot so the caller gets a data_offset.
             let max_length = DEFAULT_STRING_MAX_LENGTH_U16;
             let data_offset = ctx.data_region_offset;
-            let total_bytes = string_region_size(max_length);
+            let total_bytes = string_region_size(max_length, NARROW_CHAR_WIDTH);
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)

--- a/compiler/codegen/src/compile_struct.rs
+++ b/compiler/codegen/src/compile_struct.rs
@@ -527,13 +527,17 @@ pub(crate) fn initialize_struct_fields(
             dimensions: array_dims,
         } = &field_info.field_type
         {
-            if let IntermediateType::String { max_len, .. } = element_type.as_ref() {
-                // STRING array field — initialize headers for each string element.
+            if let IntermediateType::String {
+                max_len,
+                char_width,
+            } = element_type.as_ref()
+            {
+                // STRING/WSTRING array field — initialize headers for each string element.
                 let max_length = max_len.unwrap_or(254) as u16;
                 let total_elements = array_dims
                     .iter()
                     .fold(1u32, |acc, d| acc * (d.upper - d.lower + 1) as u32);
-                let stride = super::compile::string_region_size(max_length);
+                let stride = super::compile::string_region_size(max_length, *char_width);
                 let field_byte_offset = struct_data_offset + slot_idx.raw() * 8;
                 for i in 0..total_elements {
                     let elem_byte_offset = field_byte_offset + i * stride;

--- a/specs/plans/2026-05-21-codegen-wstring-width.md
+++ b/specs/plans/2026-05-21-codegen-wstring-width.md
@@ -1,0 +1,62 @@
+# Codegen WSTRING Width Plumbing Implementation Plan
+
+**Goal:** Replace codegen's raw `u16` / `STRING_CHAR_WIDTH = 1` representation with a typed `CharWidth` carried on `StringVarInfo`, `StringParamInfo`, `StringReturnInfo`, and `ArraySpec`. Source the actual encoding from `StringDeclaration` / `StringInitializer` / `FunctionReturnType` / `ArrayElementType` so WSTRING declarations now flow through codegen with `CharWidth::Wide` instead of being silently collapsed to STRING. The container format is unchanged; the runtime data-region layout grows for WSTRING (header still 4 bytes, payload doubled) — safe because there are no WSTRING tests on main.
+
+**Architecture:** Typed surface change in `compiler/codegen/`. The four metadata structs gain typed `CharWidth` fields (or change existing `u16` fields to `CharWidth`). A new `char_width_for_string_type(&StringType) -> CharWidth` helper maps DSL widths to the container enum. Construction sites in `compile_fn.rs`, `compile_setup.rs`, `compile_struct.rs`, and `compile_array.rs` read the width from the AST at declaration time. `encode_string_literal` retains its panic on `Wide` — string literals can't yet be encoded as UTF-16LE because the constant pool wire format doesn't carry the per-entry encoding tag.
+
+**Context:** Third slice of PR #1050 (WSTRING support). Builds on the `CharWidth` enum (#1070) and the analyzer-side width tracking (#1073). Codegen now knows when a variable/return/parameter/array element is WSTRING vs STRING, but the bytecode it emits still uses STRING-shaped headers and Latin-1 payload — that flip happens with the container format bump.
+
+**Tech Stack:** Rust, `ironplc-codegen` crate (already depends on `ironplc-container`)
+
+---
+
+### Task 1: Type up the char_width constants and helper
+
+**Files:**
+- Modify: `compiler/codegen/src/compile.rs`
+
+Replace `pub(crate) const STRING_CHAR_WIDTH: u16 = 1` with two typed constants `NARROW_CHAR_WIDTH: CharWidth = CharWidth::Narrow` and `WIDE_CHAR_WIDTH: CharWidth = CharWidth::Wide`. Add a `pub(crate) fn char_width_for_string_type(width: &StringType) -> CharWidth` helper that maps `StringType::String` → `Narrow`, `StringType::WString` → `Wide`.
+
+### Task 2: Change `char_width` field types to `CharWidth`
+
+**Files:**
+- Modify: `compiler/codegen/src/compile.rs`
+
+`StringVarInfo`, `StringParamInfo`, and `StringReturnInfo` change `char_width: u16` to `char_width: CharWidth`. `encode_string_literal(chars, char_width: u16)` → `CharWidth` (kept panicking on `Wide` via match exhaustion). `string_region_size(max_length, char_width: u8)` → `CharWidth`; the body uses `char_width.as_usize() as u32`.
+
+### Task 3: Source widths from declarations at construction sites
+
+**Files:**
+- Modify: `compiler/codegen/src/compile_fn.rs`
+- Modify: `compiler/codegen/src/compile_setup.rs`
+
+At each `InitialValueAssignmentKind::String(string_init)` arm, compute `let char_width = char_width_for_string_type(&string_init.width);` and pass it into `string_region_size` and the `StringVarInfo` / `StringParamInfo` it constructs. For function returns, match on `FunctionReturnType::String` → Narrow vs `WString` → Wide.
+
+### Task 4: Add `string_char_width` to `ArraySpec` and populate it
+
+**Files:**
+- Modify: `compiler/codegen/src/compile_array.rs`
+
+`ArraySpec` gains a `pub string_char_width: Option<CharWidth>` field next to the existing `string_max_len`. Populate it from `ArrayElementType::String → Some(Narrow)`, `ArrayElementType::WString → Some(Wide)`, `_ => None`. All construction sites updated.
+
+### Task 5: Update remaining destructuring/construction sites
+
+**Files:**
+- Modify: `compiler/codegen/src/compile_struct.rs`
+
+Test construction sites that currently pass `char_width: CharWidth::Narrow` may also need touching if they use the renamed constants. Verify all `STRING_CHAR_WIDTH` references compile.
+
+---
+
+## Deliberately out of scope
+
+- `FORMAT_VERSION` bump, header layout change, `STRING_HEADER_BYTES` 4→6
+- `encode_string_literal` actually producing UTF-16LE bytes for `Wide`
+- Per-constant-pool-entry encoding tag in the container wire format
+- VM-side encoding-mismatch traps (V9014/V9015)
+- `iec_type_tag::WSTRING` in debug names being set from the new field
+- End-to-end WSTRING tests
+
+## Verification
+
+`cd compiler && just` must pass: compile, coverage ≥ 85%, clippy, fmt, dupes. Existing STRING tests continue to work because their declarations resolve to `CharWidth::Narrow`, identical to the prior `STRING_CHAR_WIDTH = 1` value. There are no WSTRING tests on main, so the new behavior (WSTRING variables sized for 2-byte code units) doesn't trip any assertions.


### PR DESCRIPTION
## Summary
- Replaces codegen's raw `u16` / `STRING_CHAR_WIDTH = 1` representation with a typed `CharWidth` on `StringVarInfo`, `StringParamInfo`, `StringReturnInfo`, and `ArraySpec`. Adds typed `NARROW_CHAR_WIDTH` / `WIDE_CHAR_WIDTH` constants and a `char_width_for_string_type(&StringType) -> CharWidth` helper.
- Construction sites in `compile_fn.rs`, `compile_setup.rs`, `compile_struct.rs`, and `compile_array.rs` now read the actual encoding from the declaration's `StringType` (or from `IntermediateType::String.char_width` for array elements typed via the analyzer) rather than hard-coding Latin-1.
- `string_region_size` and `encode_string_literal` take `CharWidth`. The encoder still panics on `Wide` — UTF-16LE literal encoding needs the constant-pool wire format to carry a per-entry encoding tag, which lands with the format bump.
- `ArraySpec` gains a `string_char_width: Option<CharWidth>` field next to the existing `string_max_len`, populated from `ArrayElementType::String` (Narrow) vs `WString` (Wide).

No behavioral change for STRING — Narrow yields the same byte layout as the prior `STRING_CHAR_WIDTH = 1`. WSTRING declarations now flow through with `Wide` and the data region grows for the doubled payload, but no test on `main` exercises WSTRING end-to-end. Carved out of #1050 to keep the WSTRING split-up reviewable. Builds on #1070 (CharWidth enum) and #1073 (analyzer width tracking).

## Test plan
- [x] `cd compiler && just compile`
- [x] `cd compiler && just test`
- [x] `cd compiler && just coverage` (≥ 85%)
- [x] `cd compiler && just lint` (clippy + fmt clean)
- [x] `cd compiler && just dupes` (within thresholds)
- [x] Existing STRING tests pass unchanged — STRING declarations resolve to `CharWidth::Narrow`, byte-identical to the prior `STRING_CHAR_WIDTH = 1`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BG78PFCpLogkubyscPWEiQ)_