### PR TITLE
Emit WSTRING iec_type_tag for WSTRING variable declarations

### DIFF
--- a/compiler/codegen/src/compile_setup.rs
+++ b/compiler/codegen/src/compile_setup.rs
@@ -114,7 +114,11 @@ pub(crate) fn assign_variables(
                         data_offset,
                         max_length,
                     });
-                    (iec_type_tag::STRING, "STRING".into())
+                    if char_width.is_wide() {
+                        (iec_type_tag::WSTRING, "WSTRING".into())
+                    } else {
+                        (iec_type_tag::STRING, "STRING".into())
+                    }
                 }
                 InitialValueAssignmentKind::FunctionBlock(fb_init) => {
                     let fb_name = fb_init.type_name.to_string().to_uppercase();

--- a/compiler/codegen/tests/it/end_to_end_string.rs
+++ b/compiler/codegen/tests/it/end_to_end_string.rs
@@ -2,7 +2,8 @@
 
 use ironplc_parser::options::CompilerOptions;
 
-use crate::common::parse_and_run;
+use crate::common::{parse_and_compile, parse_and_run};
+use ironplc_container::debug_section::iec_type_tag;
 use ironplc_container::STRING_HEADER_BYTES;
 
 /// Reads a STRING value from the data region at the given byte offset.
@@ -177,4 +178,36 @@ END_PROGRAM
 
     let s = read_string(&bufs.data_region, 0);
     assert_eq!(s, "Hello");
+}
+
+#[test]
+fn end_to_end_when_string_declared_then_debug_tag_is_string() {
+    let source = "
+PROGRAM main
+  VAR
+    x : STRING;
+  END_VAR
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let debug = container.debug_section.as_ref().unwrap();
+    let var = debug.var_names.iter().find(|v| v.name == "x").unwrap();
+    assert_eq!(var.type_name, "STRING");
+    assert_eq!(var.iec_type_tag, iec_type_tag::STRING);
+}
+
+#[test]
+fn end_to_end_when_wstring_declared_then_debug_tag_is_wstring() {
+    let source = "
+PROGRAM main
+  VAR
+    x : WSTRING;
+  END_VAR
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let debug = container.debug_section.as_ref().unwrap();
+    let var = debug.var_names.iter().find(|v| v.name == "x").unwrap();
+    assert_eq!(var.type_name, "WSTRING");
+    assert_eq!(var.iec_type_tag, iec_type_tag::WSTRING);
 }


### PR DESCRIPTION
## Summary
- `InitialValueAssignmentKind::String` in `compile_setup.rs` previously hard-coded `iec_type_tag::STRING` (and the "STRING" display name) for every string variable, ignoring the encoding. With codegen now carrying the actual `CharWidth` (via #1075), branch on `char_width.is_wide()` and emit `iec_type_tag::WSTRING` / "WSTRING" for WSTRING declarations.
- Adds end-to-end tests verifying the debug-name tag round-trips for both STRING and WSTRING declarations.

No behavioral change for STRING. The fix is in debug metadata only; the runtime data region still treats every string as Latin-1 until the container format bump lands.

Carved out of #1050.

## Test plan
- [x] `cd compiler && just compile`
- [x] `cd compiler && just test` — new tests pass alongside existing STRING tests
- [x] `cd compiler && just coverage` (≥ 85%)
- [x] `cd compiler && just lint`
- [x] `cd compiler && just dupes`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BG78PFCpLogkubyscPWEiQ)_