### PR TITLE
Distinguish WSTRING from STRING in MCP types_all rendering

### DIFF
--- a/compiler/mcp/src/tools/types_all.rs
+++ b/compiler/mcp/src/tools/types_all.rs
@@ -270,7 +270,13 @@ fn render_type(ty: &IntermediateType) -> String {
             ByteSized::B64 => "LDT".into(),
             _ => "DATE_AND_TIME".into(),
         },
-        IntermediateType::String { .. } => "STRING".into(),
+        IntermediateType::String { char_width, .. } => {
+            if char_width.is_wide() {
+                "WSTRING".into()
+            } else {
+                "STRING".into()
+            }
+        }
         IntermediateType::Enumeration { .. } => "ENUM".into(),
         IntermediateType::Structure { .. } => "STRUCT".into(),
         IntermediateType::Array { element_type, .. } => {
@@ -372,6 +378,25 @@ mod tests {
         assert_eq!(entry.low, Some(0));
         assert_eq!(entry.high, Some(100));
         assert_eq!(entry.base_type.as_deref(), Some("INT"));
+    }
+
+    #[test]
+    fn build_response_when_struct_has_string_and_wstring_fields_then_each_field_type_distinguishes_encoding(
+    ) {
+        let resp = build(
+            "TYPE MyRec : STRUCT s : STRING; w : WSTRING; END_STRUCT; END_TYPE\nPROGRAM p\nEND_PROGRAM",
+        );
+        assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
+        let entry = resp
+            .types
+            .iter()
+            .find(|t| t.name == "MyRec")
+            .expect("MyRec not found");
+        let fields = entry.fields.clone().expect("struct fields missing");
+        let s = fields.iter().find(|f| f.name == "s").unwrap();
+        assert_eq!(s.type_name, "STRING");
+        let w = fields.iter().find(|f| f.name == "w").unwrap();
+        assert_eq!(w.type_name, "WSTRING");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `render_type` in `mcp/tools/types_all.rs`, used to format the type name of nested type references (struct fields, array elements), collapsed every `IntermediateType::String` to "STRING" regardless of encoding. With analyzer-side width tracking in place, branch on `char_width.is_wide()` and render "WSTRING" for WSTRING elements.
- Adds a struct-field round-trip test (`s : STRING; w : WSTRING;`) that asserts each field's `type_name` reflects the declared encoding.

The `kind` arm in `collect_types` is left as `"string"` for all string aliases — `iter_user_defined` filters out elementary types, so top-level STRING/WSTRING type aliases never reach that arm today. Choosing not to add a dead-code branch there.

Carved out of #1050. Independent of the container format work — only depends on the analyzer's `char_width` tracking (already on main).

## Test plan
- [x] `cd compiler && just compile`
- [x] `cd compiler && just test` — new struct-field test passes
- [x] `cd compiler && just coverage` (≥ 85%)
- [x] `cd compiler && just lint`
- [x] `cd compiler && just dupes`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BG78PFCpLogkubyscPWEiQ)_