### PR TITLE
Emit FieldType::WString for top-level ARRAY OF WSTRING descriptors

### DIFF
--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -605,7 +605,12 @@ pub(crate) fn register_array_variable(
 
     // 7. Register descriptor in the container and get its index
     let (element_type_byte, element_extra) = if is_string {
-        (ironplc_container::FieldType::String as u8, string_max_len)
+        let element_field_type = if string_char_width.is_wide() {
+            ironplc_container::FieldType::WString
+        } else {
+            ironplc_container::FieldType::String
+        };
+        (element_field_type as u8, string_max_len)
     } else {
         (var_type_info_to_type_byte(&element_vti), 0)
     };

--- a/compiler/codegen/tests/it/compile_array.rs
+++ b/compiler/codegen/tests/it/compile_array.rs
@@ -380,3 +380,55 @@ fn flat_index_arithmetic_when_worst_case_subscript_then_fits_i64() {
     let result = max_range.checked_mul(max_stride);
     assert!(result.is_some(), "flat index must fit in i64");
 }
+
+#[test]
+fn compile_when_var_array_of_string_then_descriptor_uses_string_field_type() {
+    // FieldType::String = 6 per container/src/type_section.rs.
+    let source = "
+PROGRAM main
+  VAR
+    names : ARRAY[1..3] OF STRING[10];
+  END_VAR
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let type_section = container.type_section.as_ref().unwrap();
+    let str_desc = type_section
+        .array_descriptors
+        .iter()
+        .find(|d| d.element_type == 6);
+    assert!(
+        str_desc.is_some(),
+        "Expected ARRAY OF STRING descriptor with element_type=6 (String), got: {:?}",
+        type_section.array_descriptors
+    );
+    let desc = str_desc.unwrap();
+    assert_eq!(desc.total_elements, 3);
+    assert_eq!(desc.element_extra, 10);
+}
+
+#[test]
+fn compile_when_var_array_of_wstring_then_descriptor_uses_wstring_field_type() {
+    // FieldType::WString = 7 per container/src/type_section.rs.
+    let source = "
+PROGRAM main
+  VAR
+    names : ARRAY[1..3] OF WSTRING[10];
+  END_VAR
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let type_section = container.type_section.as_ref().unwrap();
+    let wstr_desc = type_section
+        .array_descriptors
+        .iter()
+        .find(|d| d.element_type == 7);
+    assert!(
+        wstr_desc.is_some(),
+        "Expected ARRAY OF WSTRING descriptor with element_type=7 (WString), got: {:?}",
+        type_section.array_descriptors
+    );
+    let desc = wstr_desc.unwrap();
+    assert_eq!(desc.total_elements, 3);
+    assert_eq!(desc.element_extra, 10);
+}


### PR DESCRIPTION
## Summary
- `compile_array.rs::register_array_var` hard-coded `FieldType::String` (= 6) for the array descriptor of every STRING/WSTRING array variable, regardless of element encoding. With `string_char_width` flowing through `ArraySpec` (#1075), branch on `string_char_width.is_wide()` and emit `FieldType::WString` (= 7) for top-level WSTRING arrays.
- Mirror of #1079, which fixed the same bug for ARRAY fields nested inside a STRUCT. After this lands, every site that writes the element-type discriminant for a string array honors the encoding.
- Adds two `compile_array.rs` integration tests verifying the descriptor's `element_type` for `VAR names : ARRAY[1..3] OF STRING[10]` and `... OF WSTRING[10]`.

No VM code consumes the distinction at runtime yet — that's Phase 2 of #1050, which depends on the container format bump.

Carved out of #1050.

## Test plan
- [x] `cd compiler && just compile`
- [x] `cd compiler && just test` — both new tests pass
- [x] `cd compiler && just coverage` (≥ 85%)
- [x] `cd compiler && just lint`
- [x] `cd compiler && just dupes`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BG78PFCpLogkubyscPWEiQ)_