### PR TITLE
Codegen: emit per-statement line-map entries with file_id + BLAKE3 source file table

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
 name = "ironplc-codegen"
 version = "0.214.0"
 dependencies = [
+ "blake3",
  "ironplc-analyzer",
  "ironplc-container",
  "ironplc-dsl",

--- a/compiler/benchmarks/src/lib.rs
+++ b/compiler/benchmarks/src/lib.rs
@@ -20,5 +20,11 @@ pub fn compile_st(source: &str) -> Container {
         "Source has semantic diagnostics"
     );
     let codegen_options = ironplc_codegen::CodegenOptions::default();
-    compile(&analyzed, &context, &codegen_options).unwrap()
+    compile(
+        &analyzed,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
+    .unwrap()
 }

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -12,6 +12,7 @@ ironplc-dsl = { path = "../dsl", version = "0.214.0" }
 ironplc-container = { path = "../container", version = "0.214.0" }
 ironplc-problems = { path = "../problems", version = "0.214.0" }
 ironplc-analyzer = { path = "../analyzer", version = "0.214.0" }
+blake3 = "1"
 
 [build-dependencies]
 ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -242,10 +242,12 @@ pub fn compile(
     let enum_map = crate::compile_enum::build_enum_ordinal_map(library);
 
     let mut container = compile_program_with_functions(
-        program,
-        &func_decls,
-        &fb_decls,
-        global_vars,
+        ProgramInputs {
+            program,
+            func_decls: &func_decls,
+            fb_decls: &fb_decls,
+            global_vars,
+        },
         context.functions(),
         context.types(),
         enum_map,
@@ -371,6 +373,16 @@ pub(crate) fn finalize_function(emitter: &mut Emitter, ctx: &CompileContext) -> 
     }
 }
 
+/// The AST inputs that [`compile_program_with_functions`] operates on,
+/// all extracted from the same `Library` at the start of `compile()`.
+/// Grouped to keep the helper's argument count manageable.
+struct ProgramInputs<'a> {
+    program: &'a ProgramDeclaration,
+    func_decls: &'a [&'a FunctionDeclaration],
+    fb_decls: &'a [&'a FunctionBlockDeclaration],
+    global_vars: &'a [VarDecl],
+}
+
 /// Compiles a PROGRAM and its user-defined functions into a container.
 ///
 /// Always emits at least two functions:
@@ -380,19 +392,20 @@ pub(crate) fn finalize_function(emitter: &mut Emitter, ctx: &CompileContext) -> 
 ///
 /// When no initial values exist, the init function is a single RET_VOID.
 // Internal codegen helper split out from `compile()` purely for
-// readability of the public function; called from exactly one site, so
-// the argument count is the trade-off we accept to keep that boundary.
-#[allow(clippy::too_many_arguments)]
+// readability of the public function; called from exactly one site.
 fn compile_program_with_functions(
-    program: &ProgramDeclaration,
-    func_decls: &[&FunctionDeclaration],
-    fb_decls: &[&FunctionBlockDeclaration],
-    global_vars: &[VarDecl],
+    inputs: ProgramInputs<'_>,
     functions: &FunctionEnvironment,
     types: &TypeEnvironment,
     enum_map: crate::compile_enum::EnumOrdinalMap,
     sources: &dyn crate::source_lookup::SourceLookup,
 ) -> Result<Container, Diagnostic> {
+    let ProgramInputs {
+        program,
+        func_decls,
+        fb_decls,
+        global_vars,
+    } = inputs;
     let mut ctx = CompileContext::new();
     ctx.enum_map = enum_map;
     let mut builder = ContainerBuilder::new();

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -183,7 +183,16 @@ pub fn compile(
     library: &Library,
     context: &SemanticContext,
     options: &CodegenOptions,
+    sources: &dyn crate::source_lookup::SourceLookup,
 ) -> Result<Container, Diagnostic> {
+    // The `sources` parameter is scaffolding for source-map plumbing
+    // tracked in `specs/plans/2026-05-23-codegen-emit-line-map.md`. Commit A
+    // widens the signature so every call site declares its source-lookup
+    // intent; Commit B actually consumes the bytes (BLAKE3-hash them
+    // into the SOURCE_FILE_TABLE and pair each `LineMapEntry` with the
+    // file_id of the AST node that produced it). Until Commit B lands
+    // this parameter is unused.
+    let _ = sources;
     let program = find_program(library)?;
     let config = find_configuration(library);
     let user_globals: &[VarDecl] = config.map(|c| c.global_var.as_slice()).unwrap_or(&[]);
@@ -907,7 +916,13 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         assert_eq!(container.header.num_variables, 1);
         assert_eq!(container.header.num_functions, 2);
@@ -944,7 +959,12 @@ FUNCTION_BLOCK MyBlock
 END_FUNCTION_BLOCK
 ";
         let (library, context) = parse(source);
-        let result = compile(&library, &context, &CodegenOptions::default());
+        let result = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        );
 
         assert!(result.is_err());
         let diagnostic = result.unwrap_err();
@@ -961,7 +981,13 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         // Should have two functions (init + scan), both just RET_VOID
         assert_eq!(container.header.num_functions, 2);
@@ -990,7 +1016,13 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         // Should only have one constant (10 is deduplicated)
         assert_eq!(container.constant_pool.len(), 1);
@@ -1009,7 +1041,13 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         assert_eq!(container.header.num_variables, 2);
         assert_eq!(container.header.num_functions, 2);
@@ -1046,7 +1084,13 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         assert_eq!(
             container
@@ -1077,7 +1121,12 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let result = compile(&library, &context, &CodegenOptions::default());
+        let result = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        );
 
         assert!(result.is_ok());
     }
@@ -1094,7 +1143,12 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let result = compile(&library, &context, &CodegenOptions::default());
+        let result = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        );
 
         assert!(result.is_err());
         let diagnostic = result.unwrap_err();
@@ -1115,7 +1169,12 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let result = compile(&library, &context, &CodegenOptions::default());
+        let result = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        );
 
         assert!(result.is_err());
         let diagnostic = result.unwrap_err();
@@ -1133,7 +1192,13 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         assert_eq!(container.header.num_variables, 1);
         assert_eq!(
@@ -1156,7 +1221,13 @@ PROGRAM main
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         assert_eq!(container.header.num_variables, 1);
         assert_eq!(
@@ -1185,7 +1256,13 @@ END_VAR
 END_PROGRAM
 ";
         let (library, context) = parse(source);
-        let container = compile(&library, &context, &CodegenOptions::default()).unwrap();
+        let container = compile(
+            &library,
+            &context,
+            &CodegenOptions::default(),
+            &crate::EmptyLookup,
+        )
+        .unwrap();
 
         // Should have 3 functions: init, scan, SIGN_R
         assert_eq!(container.header.num_functions, 3);

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -185,14 +185,6 @@ pub fn compile(
     options: &CodegenOptions,
     sources: &dyn crate::source_lookup::SourceLookup,
 ) -> Result<Container, Diagnostic> {
-    // The `sources` parameter is scaffolding for source-map plumbing
-    // tracked in `specs/plans/2026-05-23-codegen-emit-line-map.md`. Commit A
-    // widens the signature so every call site declares its source-lookup
-    // intent; Commit B actually consumes the bytes (BLAKE3-hash them
-    // into the SOURCE_FILE_TABLE and pair each `LineMapEntry` with the
-    // file_id of the AST node that produced it). Until Commit B lands
-    // this parameter is unused.
-    let _ = sources;
     let program = find_program(library)?;
     let config = find_configuration(library);
     let user_globals: &[VarDecl] = config.map(|c| c.global_var.as_slice()).unwrap_or(&[]);
@@ -257,6 +249,7 @@ pub fn compile(
         context.functions(),
         context.types(),
         enum_map,
+        sources,
     )?;
 
     if options.system_uptime_global {
@@ -293,6 +286,41 @@ fn find_configuration(library: &Library) -> Option<&ConfigurationDeclaration> {
     })
 }
 
+/// Idempotently registers a POU's source file with the debug section's
+/// SOURCE_FILE_TABLE. Called from `compile_program_with_functions` for
+/// each top-level program / function / function-block declaration.
+fn register_pou_source_file(
+    ctx: &mut CompileContext,
+    file_id: &ironplc_dsl::core::FileId,
+    sources: &dyn crate::source_lookup::SourceLookup,
+) {
+    if ctx.debug_source_files.get(file_id).is_some() {
+        return;
+    }
+    let bytes = sources.source_bytes(file_id);
+    ctx.debug_source_files.register(file_id, bytes);
+}
+
+/// Pushes a function's line-map entries (already remapped through the
+/// optimizer) into the container builder, paired with the function's
+/// `FunctionId`.
+fn add_line_map_entries(
+    mut builder: ContainerBuilder,
+    function_id: FunctionId,
+    entries: &[crate::emit::EmittedLineMapEntry],
+) -> ContainerBuilder {
+    for entry in entries {
+        builder = builder.add_line_map_entry(ironplc_container::LineMapEntry {
+            function_id,
+            bytecode_offset: entry.bytecode_offset,
+            file_id: entry.file_id,
+            source_line: entry.source_line,
+            source_column: entry.source_column,
+        });
+    }
+    builder
+}
+
 /// Holds the compiled bytecode and metadata for a user-defined function.
 pub(crate) struct CompiledFunction {
     pub(crate) function_id: u16,
@@ -301,6 +329,11 @@ pub(crate) struct CompiledFunction {
     pub(crate) num_locals: u16,
     pub(crate) num_params: u16,
     pub(crate) name: String,
+    /// Per-statement line-map entries with `bytecode_offset` already
+    /// remapped through the optimizer. The codegen driver pairs each
+    /// entry with this function's `FunctionId` before pushing to the
+    /// container builder.
+    pub(crate) line_map: Vec<crate::emit::EmittedLineMapEntry>,
 }
 
 /// Holds the finalized bytecode and stack depth for a single emitted function.
@@ -313,6 +346,12 @@ pub(crate) struct CompiledFunction {
 pub(crate) struct FinalizedFunction {
     pub(crate) bytecode: Vec<u8>,
     pub(crate) max_stack_depth: u16,
+    /// Per-statement line-map entries with `bytecode_offset` already
+    /// remapped through the optimizer's old→new offset table. Entries
+    /// whose pre-optimization offset fell on an instruction that was
+    /// elided snap forward to the next surviving instruction; entries
+    /// past the new end-of-function are dropped.
+    pub(crate) line_map: Vec<crate::emit::EmittedLineMapEntry>,
 }
 
 /// Finalizes an emitter into ready-to-store bytecode plus stack depth.
@@ -320,11 +359,15 @@ pub(crate) struct FinalizedFunction {
 /// `emitter.bytecode()` must be called before `max_stack_depth()` because the
 /// peephole optimizer (run inside `bytecode()`) may increase max_stack_depth.
 pub(crate) fn finalize_function(emitter: &mut Emitter, ctx: &CompileContext) -> FinalizedFunction {
-    let (bytecode, _offset_map) = crate::optimize::optimize(emitter.bytecode(), &ctx.constants);
+    let raw_line_map = emitter.take_line_map();
+    let (bytecode, offset_map) = crate::optimize::optimize(emitter.bytecode(), &ctx.constants);
     let max_stack_depth = emitter.max_stack_depth();
+    let line_map =
+        crate::optimize::remap_line_map(raw_line_map, &offset_map, bytecode.len() as u16);
     FinalizedFunction {
         bytecode,
         max_stack_depth,
+        line_map,
     }
 }
 
@@ -344,10 +387,27 @@ fn compile_program_with_functions(
     functions: &FunctionEnvironment,
     types: &TypeEnvironment,
     enum_map: crate::compile_enum::EnumOrdinalMap,
+    sources: &dyn crate::source_lookup::SourceLookup,
 ) -> Result<Container, Diagnostic> {
     let mut ctx = CompileContext::new();
     ctx.enum_map = enum_map;
     let mut builder = ContainerBuilder::new();
+
+    // Register every top-level POU's source file with the debug
+    // section's SOURCE_FILE_TABLE. Each statement's `compile_statement`
+    // call later looks up the resulting `SourceFileId` via
+    // `ctx.debug_source_files.get(&span.file_id)` and pairs it with the
+    // statement's (line, column) for the LineMapEntry. The
+    // registration order (program first, then functions, then FB
+    // bodies) determines the `file_id` numbering, which appears in
+    // the on-disk container.
+    register_pou_source_file(&mut ctx, &program.name.span.file_id, sources);
+    for f in func_decls {
+        register_pou_source_file(&mut ctx, &f.name.span.file_id, sources);
+    }
+    for fb in fb_decls {
+        register_pou_source_file(&mut ctx, &fb.name.name.span.file_id, sources);
+    }
 
     // Assign global variable indices first (indices 0..G).
     assign_variables(&mut ctx, &mut builder, global_vars, types)?;
@@ -529,6 +589,7 @@ fn compile_program_with_functions(
         program_var_count,
         0,
     );
+    builder = add_line_map_entries(builder, FunctionId::INIT, &init.line_map);
 
     let scan = finalize_function(&mut scan_emitter, &ctx);
     builder = builder.add_function(
@@ -541,6 +602,7 @@ fn compile_program_with_functions(
         program_var_count,
         0,
     );
+    builder = add_line_map_entries(builder, FunctionId::SCAN, &scan.line_map);
 
     // Add user-defined function block bodies.
     for compiled in &compiled_fb_bodies {
@@ -550,6 +612,11 @@ fn compile_program_with_functions(
             compiled.max_stack_depth,
             compiled.num_locals,
             compiled.num_params,
+        );
+        builder = add_line_map_entries(
+            builder,
+            FunctionId::new(compiled.function_id),
+            &compiled.line_map,
         );
     }
 
@@ -572,6 +639,20 @@ fn compile_program_with_functions(
             compiled.num_locals,
             compiled.num_params,
         );
+        builder = add_line_map_entries(
+            builder,
+            FunctionId::new(compiled.function_id),
+            &compiled.line_map,
+        );
+    }
+
+    // Add the SOURCE_FILE_TABLE (tag 6). `ctx.debug_source_files`
+    // accumulated one entry per POU source file; insertion order is
+    // the file's SourceFileId, which the line-map entries above
+    // already reference.
+    let source_file_entries = std::mem::take(&mut ctx.debug_source_files).into_entries();
+    if !source_file_entries.is_empty() {
+        builder = builder.add_source_files(source_file_entries);
     }
 
     builder = builder
@@ -726,6 +807,10 @@ pub(crate) struct CompileContext {
     pub(crate) debug_var_names: Vec<VarNameEntry>,
     /// Debug info: STRING variable data-region layouts collected during assign_variables.
     pub(crate) debug_string_layouts: Vec<StringLayoutEntry>,
+    /// Debug info: registry mapping each referenced source `FileId` to its
+    /// `SourceFileId` (debug section SOURCE_FILE_TABLE index) plus cached
+    /// source bytes for (line, column) conversion in `compile_statement`.
+    pub(crate) debug_source_files: crate::source_lookup::SourceFileRegistry,
     /// Maps user-defined function name (lowercase) to compilation metadata.
     pub(crate) user_functions: HashMap<String, UserFunctionInfo>,
     /// Maps user-defined FB type name (uppercase) to compilation metadata.
@@ -767,6 +852,7 @@ impl CompileContext {
             num_temp_bufs: 0,
             debug_var_names: Vec::new(),
             debug_string_layouts: Vec::new(),
+            debug_source_files: crate::source_lookup::SourceFileRegistry::new(),
             user_functions: HashMap::new(),
             user_fb_types: HashMap::new(),
             next_user_fb_type_id: 0x1000,

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -379,6 +379,10 @@ pub(crate) fn finalize_function(emitter: &mut Emitter, ctx: &CompileContext) -> 
 /// - Functions 2+: user-defined functions
 ///
 /// When no initial values exist, the init function is a single RET_VOID.
+// Internal codegen helper split out from `compile()` purely for
+// readability of the public function; called from exactly one site, so
+// the argument count is the trade-off we accept to keep that boundary.
+#[allow(clippy::too_many_arguments)]
 fn compile_program_with_functions(
     program: &ProgramDeclaration,
     func_decls: &[&FunctionDeclaration],

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -428,6 +428,7 @@ pub(crate) fn compile_user_function(
         num_locals,
         num_params,
         name: func_name.to_string(),
+        line_map: finalized.line_map,
     })
 }
 
@@ -595,5 +596,6 @@ pub(crate) fn compile_user_function_block(
         num_locals,
         num_params: 0,
         name: fb_name,
+        line_map: finalized.line_map,
     })
 }

--- a/compiler/codegen/src/compile_stmt.rs
+++ b/compiler/codegen/src/compile_stmt.rs
@@ -57,12 +57,51 @@ pub(crate) fn compile_statements(
     Ok(())
 }
 
+/// Records the statement's source position on the emitter so the
+/// subsequent opcode(s) get a line-map entry pointing at this
+/// statement.
+///
+/// Looks up the statement's `FileId` in the SOURCE_FILE_TABLE
+/// registry built at the start of compilation. If the file isn't
+/// registered (synthetic ASTs, unknown spans) or the registry has no
+/// source bytes for it (the [`crate::EmptyLookup`] case), no entry is
+/// recorded — there's no useful (line, column) to surface, and a
+/// `file_id` without a position would only confuse a debugger.
+fn record_statement_position(
+    emitter: &mut crate::emit::Emitter,
+    ctx: &CompileContext,
+    stmt: &StmtKind,
+) {
+    let span = stmt.span();
+    let Some(file_id) = ctx.debug_source_files.get(&span.file_id) else {
+        return;
+    };
+    let Some(bytes) = ctx.debug_source_files.source_bytes(&span.file_id) else {
+        return;
+    };
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return;
+    };
+    let lc = ironplc_dsl::diagnostic::LineColumn::from_offset(text, span.start);
+    // 0-based → 1-based; clamp to u16 range (source files larger than
+    // ~64k lines are theoretical, but the saturating add keeps us out
+    // of UB territory either way).
+    let line = u16::try_from(lc.line.saturating_add(1)).unwrap_or(u16::MAX);
+    let column = u16::try_from(lc.column.saturating_add(1)).unwrap_or(u16::MAX);
+    emitter.set_source_position(
+        file_id,
+        ironplc_container::SourceLine::new(line),
+        ironplc_container::SourceColumn::new(column),
+    );
+}
+
 /// Compiles a single statement.
 fn compile_statement(
     emitter: &mut Emitter,
     ctx: &mut CompileContext,
     stmt: &StmtKind,
 ) -> Result<(), Diagnostic> {
+    record_statement_position(emitter, ctx, stmt);
     match stmt {
         StmtKind::Assignment(assignment) => {
             // Dereference assignment: myRef^ := expr

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -19,13 +19,13 @@
 //! # Example
 //!
 //! ```ignore
-//! use ironplc_codegen::compile;
+//! use ironplc_codegen::{compile, CodegenOptions, EmptyLookup};
 //! use ironplc_parser::parse_program;
 //!
 //! let source = "PROGRAM main VAR x : INT; END_VAR x := 42; END_PROGRAM";
 //! let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
 //! let (analyzed, ctx) = ironplc_analyzer::stages::resolve_types(&[&library]).unwrap();
-//! let container = compile(&analyzed, &ctx).unwrap();
+//! let container = compile(&analyzed, &ctx, &CodegenOptions::default(), &EmptyLookup).unwrap();
 //! ```
 
 mod compile;
@@ -40,8 +40,10 @@ mod compile_string;
 mod compile_struct;
 mod emit;
 mod optimize;
+mod source_lookup;
 
 pub use compile::{compile, CodegenOptions};
+pub use source_lookup::{EmptyLookup, SourceLookup};
 
 // Spec conformance testing infrastructure (test-only)
 #[cfg(test)]

--- a/compiler/codegen/src/optimize.rs
+++ b/compiler/codegen/src/optimize.rs
@@ -33,6 +33,47 @@ use crate::compile::PoolConstant;
 /// of the function can still be remapped.
 pub(crate) type OffsetMap = HashMap<usize, usize>;
 
+/// Remaps an emitter line map through the optimizer's old→new offset table.
+///
+/// For each entry the old `bytecode_offset` is looked up in `offset_map`,
+/// which by construction maps every instruction boundary — including
+/// removed instructions — to the position the next surviving instruction
+/// occupies in the optimized stream ("snap forward"). Entries whose
+/// remapped offset lands past the new end-of-function (`new_bytecode_len`)
+/// are dropped, and entries that map to the same remapped offset as the
+/// previous kept entry are deduplicated (the optimizer can collapse two
+/// pre-optimization positions onto one post-optimization position).
+///
+/// Entries whose old offset is not in the map are dropped silently; the
+/// emitter only records entries immediately before pushing an opcode,
+/// so this should never happen in practice. If it does, the resulting
+/// debug info would be wrong anyway, so silently dropping is safer than
+/// keeping a bad offset.
+pub(crate) fn remap_line_map(
+    raw: Vec<crate::emit::EmittedLineMapEntry>,
+    offset_map: &OffsetMap,
+    new_bytecode_len: u16,
+) -> Vec<crate::emit::EmittedLineMapEntry> {
+    let mut out: Vec<crate::emit::EmittedLineMapEntry> = Vec::with_capacity(raw.len());
+    for entry in raw {
+        let Some(&new_offset) = offset_map.get(&(entry.bytecode_offset as usize)) else {
+            continue;
+        };
+        if new_offset >= new_bytecode_len as usize {
+            continue;
+        }
+        let new_offset = new_offset as u16;
+        if out.last().is_some_and(|e| e.bytecode_offset == new_offset) {
+            continue;
+        }
+        out.push(crate::emit::EmittedLineMapEntry {
+            bytecode_offset: new_offset,
+            ..entry
+        });
+    }
+    out
+}
+
 /// A decoded instruction: its original byte offset and raw bytes.
 struct Instruction {
     offset: usize,

--- a/compiler/codegen/src/source_lookup.rs
+++ b/compiler/codegen/src/source_lookup.rs
@@ -1,0 +1,40 @@
+//! Bridge from the codegen driver to the source bytes the parser saw.
+//!
+//! Codegen needs the original source bytes for each [`FileId`] referenced
+//! by an AST node so it can hash them with BLAKE3 into the debug
+//! section's SOURCE_FILE_TABLE (tag 6). The bytes live in the driver
+//! (the CLI, LSP, playground, MCP, etc.) rather than in codegen, so the
+//! driver passes a [`SourceLookup`] adapter into [`super::compile`].
+//!
+//! When the driver doesn't have (or doesn't want to ship) the original
+//! bytes — common in unit tests and when compiling synthetic ASTs —
+//! it can pass [`EmptyLookup`]. Codegen still registers every seen
+//! [`FileId`] in the table, but with an all-zero `content_hash` that a
+//! debugger interprets as "drift check unavailable" rather than "hash
+//! mismatch" (per the spec entry on `SourceFileEntry`).
+
+use ironplc_dsl::core::FileId;
+
+/// Bridge from a [`FileId`] back to the source bytes the parser saw.
+///
+/// Implementations should return the **exact** bytes (no normalization,
+/// no trailing-newline fixup) so the BLAKE3 hash codegen records
+/// matches the hash a debugger computes by reading the file from disk.
+///
+/// Returning `None` is fine — codegen falls back to an all-zero hash
+/// that disables the drift check for that file.
+pub trait SourceLookup {
+    fn source_bytes(&self, file_id: &FileId) -> Option<&[u8]>;
+}
+
+/// A [`SourceLookup`] that has no source bytes for any file.
+///
+/// Convenient default for unit tests and synthetic-AST callers that
+/// don't want to track source bytes.
+pub struct EmptyLookup;
+
+impl SourceLookup for EmptyLookup {
+    fn source_bytes(&self, _file_id: &FileId) -> Option<&[u8]> {
+        None
+    }
+}

--- a/compiler/codegen/src/source_lookup.rs
+++ b/compiler/codegen/src/source_lookup.rs
@@ -13,6 +13,9 @@
 //! debugger interprets as "drift check unavailable" rather than "hash
 //! mismatch" (per the spec entry on `SourceFileEntry`).
 
+use std::collections::HashMap;
+
+use ironplc_container::{SourceFileEntry, SourceFileId, SOURCE_FILE_HASH_LEN};
 use ironplc_dsl::core::FileId;
 
 /// Bridge from a [`FileId`] back to the source bytes the parser saw.
@@ -36,5 +39,87 @@ pub struct EmptyLookup;
 impl SourceLookup for EmptyLookup {
     fn source_bytes(&self, _file_id: &FileId) -> Option<&[u8]> {
         None
+    }
+}
+
+/// Accumulator for the debug section's `SOURCE_FILE_TABLE` (tag 6).
+///
+/// `compile()` walks the library at the start of code generation,
+/// calling [`Self::register`] for every [`FileId`] referenced by a
+/// top-level POU. The codegen statement emitter then reads back two
+/// things per statement:
+///
+/// 1. The [`SourceFileId`] index, via [`Self::get`], used as
+///    `LineMapEntry.file_id`.
+/// 2. The cached source bytes, via [`Self::source_bytes`], used to
+///    convert a `SourceSpan.start` byte offset to a 1-based
+///    `(line, column)` for [`ironplc_container::LineMapEntry`].
+///
+/// `compile()` hands [`Self::into_entries`] to
+/// `ContainerBuilder::add_source_files` at the end of compilation.
+#[derive(Default)]
+pub(crate) struct SourceFileRegistry {
+    /// Index assigned to each known `FileId`. Insertion order is the
+    /// resulting `SourceFileId` value.
+    ids: HashMap<FileId, SourceFileId>,
+    /// Owned copy of each registered file's source bytes, used by the
+    /// statement emitter for (line, column) conversion. Files
+    /// registered without bytes (the [`EmptyLookup`] case) have no
+    /// entry here, so the emitter skips line-map recording for them.
+    bytes: HashMap<FileId, Vec<u8>>,
+    /// Entries to feed to `ContainerBuilder::add_source_files` at the
+    /// end of `compile()`. Index N is the entry for
+    /// `SourceFileId::new(N)`.
+    entries: Vec<SourceFileEntry>,
+}
+
+impl SourceFileRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a `FileId` (idempotent). Returns its `SourceFileId`.
+    ///
+    /// `bytes` is the source content the parser saw, or `None` when
+    /// the caller doesn't have it. The first form records a BLAKE3
+    /// hash; the second records an all-zero hash (per the spec,
+    /// "drift check unavailable") and disables line-map recording
+    /// for this file.
+    pub(crate) fn register(&mut self, file_id: &FileId, bytes: Option<&[u8]>) -> SourceFileId {
+        if let Some(&id) = self.ids.get(file_id) {
+            return id;
+        }
+        let content_hash: [u8; SOURCE_FILE_HASH_LEN] = match bytes {
+            Some(b) => *blake3::hash(b).as_bytes(),
+            None => [0u8; SOURCE_FILE_HASH_LEN],
+        };
+        let id = SourceFileId::new(self.entries.len() as u16);
+        self.entries.push(SourceFileEntry {
+            path: file_id.to_string(),
+            content_hash,
+        });
+        self.ids.insert(file_id.clone(), id);
+        if let Some(b) = bytes {
+            self.bytes.insert(file_id.clone(), b.to_vec());
+        }
+        id
+    }
+
+    /// Returns the previously-registered `SourceFileId` for `file_id`,
+    /// or `None` if `register` was never called for it.
+    pub(crate) fn get(&self, file_id: &FileId) -> Option<SourceFileId> {
+        self.ids.get(file_id).copied()
+    }
+
+    /// Returns the cached source bytes for `file_id`, or `None` if the
+    /// file was registered without bytes (or not at all).
+    pub(crate) fn source_bytes(&self, file_id: &FileId) -> Option<&[u8]> {
+        self.bytes.get(file_id).map(Vec::as_slice)
+    }
+
+    /// Consumes the registry and returns the entries to feed to
+    /// `ContainerBuilder::add_source_files`.
+    pub(crate) fn into_entries(self) -> Vec<SourceFileEntry> {
+        self.entries
     }
 }

--- a/compiler/codegen/src/spec_conformance.rs
+++ b/compiler/codegen/src/spec_conformance.rs
@@ -49,7 +49,7 @@ fn compile_and_run(source: &str) -> (ironplc_container::Container, VmBuffers) {
     let (analyzed, ctx) =
         ironplc_analyzer::stages::resolve_types(&[&library], &CompilerOptions::default()).unwrap();
     let codegen_options = crate::CodegenOptions::default();
-    let container = crate::compile(&analyzed, &ctx, &codegen_options).unwrap();
+    let container = crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
     let mut bufs = VmBuffers::from_container(&container);
     {
         let mut vm = load_and_start(&container, &mut bufs).unwrap();
@@ -64,7 +64,7 @@ fn compile_only(source: &str) -> ironplc_container::Container {
     let (analyzed, ctx) =
         ironplc_analyzer::stages::resolve_types(&[&library], &CompilerOptions::default()).unwrap();
     let codegen_options = crate::CodegenOptions::default();
-    crate::compile(&analyzed, &ctx, &codegen_options).unwrap()
+    crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap()
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/codegen/tests/it/common/mod.rs
+++ b/compiler/codegen/tests/it/common/mod.rs
@@ -579,7 +579,12 @@ pub fn try_parse_and_compile(
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
     };
-    compile(&library, &context, &codegen_options)
+    compile(
+        &library,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
 }
 
 /// Parses, analyzes, compiles, and runs one scan cycle.
@@ -600,7 +605,13 @@ pub fn parse_and_try_run(
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
     };
-    let container = compile(&library, &context, &codegen_options).unwrap();
+    let container = compile(
+        &library,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
+    .unwrap();
     let mut bufs = VmBuffers::from_container(&container);
     {
         let mut vm = load_and_start(&container, &mut bufs)?;
@@ -622,7 +633,13 @@ pub fn parse_and_run_rounds(
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
     };
-    let container = compile(&library, &context, &codegen_options).unwrap();
+    let container = compile(
+        &library,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
+    .unwrap();
     let mut bufs = VmBuffers::from_container(&container);
     let mut vm = load_and_start(&container, &mut bufs).unwrap();
     f(&mut vm);

--- a/compiler/codegen/tests/it/end_to_end_debug_line_map.rs
+++ b/compiler/codegen/tests/it/end_to_end_debug_line_map.rs
@@ -1,0 +1,183 @@
+//! End-to-end tests for the debug section's LINE_MAP (tag 1) +
+//! SOURCE_FILE_TABLE (tag 6).
+//!
+//! These tests parse a real `.st` source string, run the full
+//! codegen pipeline with a [`SourceLookup`] that returns the bytes,
+//! and assert on:
+//!
+//! - One `SourceFileEntry` per registered POU file, with a BLAKE3
+//!   hash matching `blake3::hash(source)`.
+//! - At least one `LineMapEntry` per statement, with
+//!   `(source_line, source_column)` matching the position of that
+//!   statement in the source, and `file_id` pointing at the right
+//!   `SourceFileEntry`.
+//! - Every `bytecode_offset` lands on an instruction boundary in the
+//!   optimized function bytecode (the optimizer offset-remap is wired
+//!   up correctly).
+
+use std::collections::HashMap;
+
+use ironplc_analyzer::stages::resolve_types;
+use ironplc_codegen::{compile, CodegenOptions, SourceLookup};
+use ironplc_container::opcode;
+use ironplc_container::{FunctionId, LineMapEntry, SourceFileId, SOURCE_FILE_HASH_LEN};
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_parser::parse_program;
+
+/// `SourceLookup` impl backed by an in-memory map. Mirrors the
+/// adapter the CLI uses.
+struct MapLookup(HashMap<FileId, Vec<u8>>);
+
+impl SourceLookup for MapLookup {
+    fn source_bytes(&self, file_id: &FileId) -> Option<&[u8]> {
+        self.0.get(file_id).map(Vec::as_slice)
+    }
+}
+
+/// Parses `source`, runs the analyzer, and compiles with a
+/// `SourceLookup` that returns the original bytes. Returns the
+/// container plus the FileId used for parsing so tests can assert
+/// against it.
+fn compile_with_source(source: &str) -> (ironplc_container::Container, FileId) {
+    let file_id = FileId::from_string("test.st");
+    let options = CompilerOptions::default();
+    let library = parse_program(source, &file_id, &options).unwrap();
+    let (analyzed, ctx) = resolve_types(&[&library], &options).unwrap();
+
+    let mut bytes_map = HashMap::new();
+    bytes_map.insert(file_id.clone(), source.as_bytes().to_vec());
+    let lookup = MapLookup(bytes_map);
+
+    let container = compile(&analyzed, &ctx, &CodegenOptions::default(), &lookup).unwrap();
+    (container, file_id)
+}
+
+#[test]
+fn line_map_when_program_has_assignment_statements_then_each_gets_an_entry() {
+    let source =
+        "PROGRAM main\n  VAR x : DINT; y : DINT; END_VAR\n  x := 10;\n  y := 20;\nEND_PROGRAM\n";
+    let (container, _) = compile_with_source(source);
+    let debug = container
+        .debug_section
+        .as_ref()
+        .expect("debug section present");
+
+    // SOURCE_FILE_TABLE: one entry for the program's file, BLAKE3
+    // hash matches the source bytes.
+    assert_eq!(debug.source_files.len(), 1);
+    let expected_hash: [u8; SOURCE_FILE_HASH_LEN] = *blake3::hash(source.as_bytes()).as_bytes();
+    assert_eq!(debug.source_files[0].content_hash, expected_hash);
+
+    // LINE_MAP: at least one entry per statement that emitted opcodes.
+    // The two assignments are on lines 3 and 4. The init function gets
+    // its own entries (variable initialization), so we filter to the
+    // scan function which contains the body statements.
+    let scan_entries: Vec<&LineMapEntry> = debug
+        .line_map
+        .iter()
+        .filter(|e| e.function_id == FunctionId::SCAN)
+        .collect();
+    let scan_lines: Vec<u16> = scan_entries.iter().map(|e| e.source_line.raw()).collect();
+    assert!(
+        scan_lines.contains(&3),
+        "expected SCAN line_map to cover line 3 (x := 10), got {scan_lines:?}",
+    );
+    assert!(
+        scan_lines.contains(&4),
+        "expected SCAN line_map to cover line 4 (y := 20), got {scan_lines:?}",
+    );
+
+    // Every line_map entry references file_id 0 (the only registered
+    // source file).
+    for entry in &debug.line_map {
+        assert_eq!(entry.file_id, SourceFileId::new(0));
+    }
+}
+
+#[test]
+fn line_map_when_empty_program_then_source_file_table_still_populated_with_zero_hash_for_no_bytes()
+{
+    // Compile with an empty lookup — no bytes mean an all-zero hash
+    // (the spec's "drift check unavailable" sentinel) and no
+    // line-map entries (the emitter skips set_source_position when
+    // no source bytes are cached).
+    let file_id = FileId::from_string("nobytes.st");
+    let source = "PROGRAM main\n  VAR x : DINT; END_VAR\n  x := 1;\nEND_PROGRAM\n";
+    let options = CompilerOptions::default();
+    let library = parse_program(source, &file_id, &options).unwrap();
+    let (analyzed, ctx) = resolve_types(&[&library], &options).unwrap();
+
+    let container = compile(
+        &analyzed,
+        &ctx,
+        &CodegenOptions::default(),
+        &ironplc_codegen::EmptyLookup,
+    )
+    .unwrap();
+    let debug = container.debug_section.as_ref().expect("debug section");
+
+    // Source file is still registered (so file_ids resolve) but the
+    // hash is all-zero.
+    assert_eq!(debug.source_files.len(), 1);
+    assert_eq!(
+        debug.source_files[0].content_hash,
+        [0u8; SOURCE_FILE_HASH_LEN]
+    );
+    // No line-map entries — without source bytes we can't compute
+    // (line, column), so we don't record anything.
+    assert!(
+        debug.line_map.is_empty(),
+        "expected empty line_map for EmptyLookup, got {:?}",
+        debug.line_map
+    );
+}
+
+#[test]
+fn line_map_when_optimizer_runs_then_bytecode_offsets_are_on_instruction_boundaries() {
+    // Use a program whose peephole optimizer will visibly fold
+    // instructions. `x := x` (self-assignment) is one of the
+    // patterns the optimizer collapses; verify any remaining line-map
+    // entries point at valid instruction starts in the optimized
+    // bytecode.
+    let source = "PROGRAM main\n  VAR x : DINT; END_VAR\n  x := 10;\n  x := x + 5;\nEND_PROGRAM\n";
+    let (container, _) = compile_with_source(source);
+    let debug = container
+        .debug_section
+        .as_ref()
+        .expect("debug section present");
+
+    for entry in &debug.line_map {
+        let bytecode = container
+            .code
+            .get_function_bytecode(entry.function_id)
+            .expect("function bytecode present");
+        let offset = entry.bytecode_offset as usize;
+        assert!(
+            offset < bytecode.len(),
+            "line_map offset {offset} is past end of function bytecode ({} bytes)",
+            bytecode.len(),
+        );
+        // Walk the bytecode from the start and confirm `offset` is
+        // one of the instruction starts. This is a coarse check —
+        // we just decode opcode arg-counts and skip — but it catches
+        // off-by-one remap bugs that would put offsets in the middle
+        // of multi-byte instructions.
+        let mut pc = 0usize;
+        let mut hit = false;
+        while pc < bytecode.len() {
+            if pc == offset {
+                hit = true;
+                break;
+            }
+            let op = bytecode[pc];
+            pc += opcode::instruction_size(op);
+        }
+        assert!(
+            hit,
+            "line_map offset {offset} (function {:?}) does not land on an instruction \
+             boundary in the optimized bytecode {:02X?}",
+            entry.function_id, bytecode,
+        );
+    }
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -74,6 +74,7 @@ mod end_to_end_conv_real_to_real;
 mod end_to_end_conv_string;
 mod end_to_end_conv_time_date;
 mod end_to_end_date;
+mod end_to_end_debug_line_map;
 mod end_to_end_delete;
 mod end_to_end_dialect;
 mod end_to_end_div;

--- a/compiler/ironplc-cli/src/cli.rs
+++ b/compiler/ironplc-cli/src/cli.rs
@@ -152,11 +152,16 @@ pub fn compile(
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: compiler_options.allow_system_uptime_global,
     };
-    let container =
-        ironplc_codegen::compile(&analyzed, &context, &codegen_options).map_err(|err| {
-            handle_diagnostics(&[err], Some(&project), suppress_output);
-            String::from("Error during code generation")
-        })?;
+    let container = ironplc_codegen::compile(
+        &analyzed,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
+    .map_err(|err| {
+        handle_diagnostics(&[err], Some(&project), suppress_output);
+        String::from("Error during code generation")
+    })?;
 
     // Write the container to the output file
     let mut out_file =

--- a/compiler/ironplc-cli/src/cli.rs
+++ b/compiler/ironplc-cli/src/cli.rs
@@ -152,16 +152,23 @@ pub fn compile(
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: compiler_options.allow_system_uptime_global,
     };
-    let container = ironplc_codegen::compile(
-        &analyzed,
-        &context,
-        &codegen_options,
-        &ironplc_codegen::EmptyLookup,
-    )
-    .map_err(|err| {
-        handle_diagnostics(&[err], Some(&project), suppress_output);
-        String::from("Error during code generation")
-    })?;
+    // Build a SourceLookup that hands codegen the exact bytes the
+    // parser saw for each FileId. The container's debug section
+    // SOURCE_FILE_TABLE (tag 6) records a BLAKE3 hash over these so a
+    // debugger can detect drift between the .iplc and the user's
+    // working copy.
+    let mut source_bytes: std::collections::HashMap<ironplc_dsl::core::FileId, Vec<u8>> =
+        std::collections::HashMap::new();
+    for src in project.sources() {
+        source_bytes.insert(src.file_id().clone(), src.as_string().as_bytes().to_vec());
+    }
+    let source_lookup = HashMapSourceLookup(source_bytes);
+
+    let container = ironplc_codegen::compile(&analyzed, &context, &codegen_options, &source_lookup)
+        .map_err(|err| {
+            handle_diagnostics(&[err], Some(&project), suppress_output);
+            String::from("Error during code generation")
+        })?;
 
     // Write the container to the output file
     let mut out_file =
@@ -171,6 +178,17 @@ pub fn compile(
         .map_err(|e| format!("Failed to write output file: {e}"))?;
 
     Ok(())
+}
+
+/// Codegen [`SourceLookup`](ironplc_codegen::SourceLookup) backed by an
+/// in-memory map populated from the project's loaded sources. The map
+/// owns the bytes so the lookup can outlive any borrow on the project.
+struct HashMapSourceLookup(std::collections::HashMap<ironplc_dsl::core::FileId, Vec<u8>>);
+
+impl ironplc_codegen::SourceLookup for HashMapSourceLookup {
+    fn source_bytes(&self, file_id: &ironplc_dsl::core::FileId) -> Option<&[u8]> {
+        self.0.get(file_id).map(Vec::as_slice)
+    }
 }
 
 fn create_project(

--- a/compiler/ironplc-cli/src/lsp_runner.rs
+++ b/compiler/ironplc-cli/src/lsp_runner.rs
@@ -250,13 +250,18 @@ fn compile_to_bytes(source: &str, options: &CompilerOptions) -> Result<Vec<u8>, 
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
     };
-    let container =
-        codegen_compile(&library, &context, &codegen_options).map_err(|diag| RunResult {
-            ok: false,
-            variables: vec![],
-            total_scans: 0,
-            error: Some(diag.description()),
-        })?;
+    let container = codegen_compile(
+        &library,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
+    .map_err(|diag| RunResult {
+        ok: false,
+        variables: vec![],
+        total_scans: 0,
+        error: Some(diag.description()),
+    })?;
 
     let mut buf = Vec::new();
     container.write_to(&mut buf).map_err(|e| RunResult {

--- a/compiler/mcp/src/tools/compile.rs
+++ b/compiler/mcp/src/tools/compile.rs
@@ -137,7 +137,12 @@ pub fn build_response(
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: compiler_options.allow_system_uptime_global,
     };
-    let container = match ironplc_codegen::compile(library, context, &codegen_options) {
+    let container = match ironplc_codegen::compile(
+        library,
+        context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    ) {
         Ok(c) => c,
         Err(err) => {
             diagnostics.push(serialize_diagnostic(&err));

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -484,7 +484,12 @@ fn compile_inner(source: &str, dialect: &str, allows: &str) -> CompileResult {
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
     };
-    let container = match codegen_compile(&library, &context, &codegen_options) {
+    let container = match codegen_compile(
+        &library,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    ) {
         Ok(c) => c,
         Err(diag) => {
             return CompileResult {

--- a/specs/plans/2026-05-23-codegen-emit-line-map.md
+++ b/specs/plans/2026-05-23-codegen-emit-line-map.md
@@ -1,0 +1,335 @@
+# Wire Codegen to Emit Line-Map Entries with file_id and BLAKE3 Source File Table
+
+## Goal
+
+Make `codegen::compile()` populate the debug section's `LINE_MAP`
+(tag 1) with real `(function_id, bytecode_offset, file_id, source_line,
+source_column)` entries derived from AST node spans, and register every
+referenced source file in the `SOURCE_FILE_TABLE` (tag 6) with a BLAKE3
+content hash. Today both tables are empty in production output — the
+container-format scaffolding landed in PR #1074, but no codegen call
+site uses it yet.
+
+When this lands, a debugger reading a freshly-compiled `.iplc` can:
+
+1. Look up `(function_id, bytecode_offset) → (file_id, line, column)`
+   to highlight the source statement currently executing.
+2. Resolve `file_id → (path, BLAKE3 hash)` to open the right file and
+   check that it hasn't drifted from what the compiler saw.
+
+## Context
+
+The SOURCE_FILE_TABLE and `file_id`-carrying `LineMapEntry` shipped in
+PR #1074. The Emitter's `set_source_position(SourceFileId, SourceLine,
+SourceColumn)` records entries; `take_line_map()` drains them; the
+`ContainerBuilder` accepts entries via `add_line_map_entry` and source
+files via `add_source_file`. **No production caller invokes any of
+this yet.**
+
+The pieces we need to assemble already exist in tree:
+
+- `ironplc_dsl::core::SourceSpan` (start, end, file_id) is attached to
+  every AST node via the `Located` trait, with concrete impls on
+  `StmtKind`, `Assignment`, `If`, `For`, `Case`, etc.
+  (`compiler/dsl/src/textual.rs:705-714` for the dispatcher).
+- `ironplc_dsl::diagnostic::LineColumn::from_offset(source: &str,
+  offset: usize)` already converts byte offsets to 0-indexed
+  (line, column) — straightforward to `+1` for our 1-based
+  `SourceLine`/`SourceColumn`.
+- `codegen::compile::finalize_function` (in `compile.rs`) is the
+  single chokepoint where every emitted function's bytecode is
+  optimized and finalized. Its doc comment explicitly anticipates
+  "future cross-cutting additions (e.g. source-map plumbing)". That's
+  where the per-function line map gets harvested.
+- `crate::optimize::optimize` already returns a (currently unused)
+  `_offset_map` parameter — the pre→post optimization offset
+  remap. We must apply it to the line map before storing entries,
+  otherwise `bytecode_offset` values point into pre-optimization
+  positions and don't land on real instruction boundaries.
+
+The production callers of `compile()` today are:
+
+- `ironplc-cli/src/cli.rs:156` (the build subcommand)
+- `ironplc-cli/src/lsp_runner.rs:12`
+- `playground/src/lib.rs:18`
+- `mcp/src/tools/compile.rs:140`
+- `benchmarks/src/lib.rs:6`
+- `codegen/tests/it/common/mod.rs:8`
+
+All of them have the original source bytes available at the call site
+(they had to, to parse). We just need a uniform way to hand those
+bytes to `compile()`.
+
+## Architecture
+
+### Source-bytes lookup
+
+Extend `codegen::compile()` to take a `&dyn SourceLookup` (or a closure
+— see Open Questions) that maps a `&FileId` to the source bytes the
+parser saw for that file:
+
+```rust
+pub trait SourceLookup {
+    fn source_bytes(&self, file_id: &FileId) -> Option<&[u8]>;
+}
+```
+
+Callers wrap their already-loaded source string per `FileId` in a small
+adapter. Tests that don't have source bytes pass an empty
+implementation that always returns `None` — codegen then registers any
+seen `FileId` with an all-zero hash (per the spec, "drift check
+unavailable"). This keeps test setup cheap.
+
+`compile()`'s new signature:
+
+```rust
+pub fn compile(
+    library: &Library,
+    context: &SemanticContext,
+    options: &CodegenOptions,
+    sources: &dyn SourceLookup,
+) -> Result<Container, Diagnostic>
+```
+
+### Per-function line map collection
+
+Extend `FinalizedFunction` (in `compile.rs`) with the per-function line
+map:
+
+```rust
+pub(crate) struct FinalizedFunction {
+    pub(crate) bytecode: Vec<u8>,
+    pub(crate) max_stack_depth: u16,
+    pub(crate) line_map: Vec<EmittedLineMapEntry>,
+}
+```
+
+`finalize_function` becomes:
+
+1. Drain `emitter.take_line_map()` → raw per-statement entries (offsets
+   in pre-optimization byte space).
+2. Call `optimize::optimize(...)` to get the optimized bytecode and the
+   `offset_map: Vec<(u32, u32)>` (or similar) mapping
+   pre→post offsets.
+3. **Remap each entry's `bytecode_offset` through `offset_map`.**
+   Entries whose pre-offsets fall on instructions removed by the
+   optimizer get snapped forward to the next surviving instruction.
+   Entries past the last surviving instruction are dropped.
+4. Store the remapped entries on `FinalizedFunction.line_map`.
+
+The remap is a correctness requirement, not an enhancement — without
+it, a breakpoint set on a line could resolve to an offset that's not
+the start of any instruction in the optimized stream, and the VM
+debug hook would never fire for it.
+
+### Plumbing into the container
+
+After `compile()` finalizes each function, it pairs the per-function
+`line_map` with the function's `FunctionId` and feeds each entry to the
+builder via `add_line_map_entry`. The builder's existing
+`sort_line_map` invariant (sorted by `(function_id, bytecode_offset)`)
+is maintained automatically by `ContainerBuilder::build`.
+
+### Source-file registration
+
+A small struct in `compile.rs` (or a sub-module — see Open Questions)
+owns the `FileId → SourceFileId` mapping:
+
+```rust
+struct SourceFileRegistry<'a> {
+    sources: &'a dyn SourceLookup,
+    seen: HashMap<FileId, SourceFileId>,
+    entries: Vec<SourceFileEntry>,
+}
+
+impl<'a> SourceFileRegistry<'a> {
+    fn intern(&mut self, file_id: &FileId) -> SourceFileId {
+        if let Some(id) = self.seen.get(file_id) { return *id; }
+        let bytes = self.sources.source_bytes(file_id);
+        let content_hash = match bytes {
+            Some(b) => *blake3::hash(b).as_bytes(),
+            None => [0u8; 32],
+        };
+        let entry = SourceFileEntry {
+            path: file_id.to_string(), // or whatever FileId::Display gives
+            content_hash,
+        };
+        let id = SourceFileId::new(self.entries.len() as u16);
+        self.entries.push(entry);
+        self.seen.insert(file_id.clone(), id);
+        id
+    }
+}
+```
+
+Each statement's `Located::span().file_id` is interned through this
+registry before `set_source_position` is called. The final
+`entries` vec is handed to the builder via `add_source_files`.
+
+### Where `set_source_position` is called
+
+Per-statement granularity: at the top of `compile_statement` (in
+`compile_stmt.rs`), grab the statement's span, convert
+`(start_offset, file_id)` to `(file_id, line, column)`, and call
+`emitter.set_source_position(...)`. Per-statement is the right
+granularity for v1 — IEC 61131-3 ST is "one statement per line"
+idiomatic, and finer granularity (per-expression) buys little for
+the cost of plumbing.
+
+`compile_stmts` (which iterates a slice) doesn't need to do anything
+itself; `compile_statement` handles each one.
+
+We do **not** call `clear_source_position`. The Emitter dedups on
+`(file_id, line, column)`, so leaving a stale position across
+statements is fine — the next statement just calls
+`set_source_position` again.
+
+### Byte-offset → (line, column) conversion
+
+For each statement that fires `set_source_position`, we need its
+1-based `(line, column)` derived from the byte offset in the source
+text. Two approaches:
+
+1. **Call `LineColumn::from_offset` directly.** O(offset) per call;
+   given hundreds of statements per file, this is O(n × stmt_count)
+   per file. For typical PLC programs (a few hundred lines, a few
+   dozen statements) it's noise. Adopt this first; profile later.
+2. **Precompute a line-start table per file.** O(file_len) once,
+   then O(log lines) per offset. Worth doing if (1) shows up in
+   profiling — it doesn't today.
+
+Plan: use (1). If a future profile of `cargo bench` shows codegen
+spending time in `from_offset`, add a small `LineOffsetTable` cache
+keyed by `FileId` inside `SourceFileRegistry`.
+
+## File Map
+
+Modified:
+
+- `compiler/codegen/Cargo.toml` — add `blake3 = "1"` (codegen calls
+  it to hash source bytes during compile).
+- `compiler/codegen/src/compile.rs` —
+  - Add `pub trait SourceLookup`.
+  - Add `SourceFileRegistry`.
+  - Extend `compile()` signature with `sources: &dyn SourceLookup`.
+  - Extend `FinalizedFunction` with `line_map`.
+  - Update `finalize_function` to drain the emitter line map and
+    apply the optimizer offset remap.
+  - At the end of `compile`, feed the registry's entries to the
+    builder via `add_source_files`, and feed each function's
+    `(function_id, [EmittedLineMapEntry])` pairs to
+    `add_line_map_entry`.
+- `compiler/codegen/src/compile_stmt.rs` — add the
+  `set_source_position` call at the top of `compile_statement`,
+  using `SourceFileRegistry` (threaded via `CompileContext` — see
+  Open Questions) to intern the file id and
+  `LineColumn::from_offset` to convert the byte offset.
+- `compiler/codegen/src/optimize.rs` — confirm the existing
+  `optimize()` return shape exposes the pre→post offset map in a
+  consumable form; tighten the type if it's currently opaque.
+  Update its tests if the public shape changes.
+- `compiler/ironplc-cli/src/cli.rs` — adopt a tiny `HashMap<FileId,
+  String>`-backed `SourceLookup` from the already-loaded sources.
+- `compiler/ironplc-cli/src/lsp_runner.rs` — same.
+- `compiler/playground/src/lib.rs` — same.
+- `compiler/mcp/src/tools/compile.rs` — same.
+- `compiler/benchmarks/src/lib.rs` — same.
+- `compiler/codegen/tests/it/common/mod.rs` — same; for tests that
+  don't care, hand in a no-op implementation.
+
+New:
+
+- (Possibly) `compiler/codegen/src/source_registry.rs` — house
+  `SourceLookup` and `SourceFileRegistry` if `compile.rs` is getting
+  crowded. See Open Questions.
+
+## Open Questions
+
+1. **Where does `SourceLookup` live?** Two options:
+   (a) `ironplc_codegen::SourceLookup` (the closest crate to the
+   consumer). (b) `ironplc_container::SourceLookup` (alongside
+   `SourceFileEntry` which it logically pairs with). Recommendation:
+   **(a)** — only codegen calls it, and the container crate shouldn't
+   pull in a trait used only at compile time.
+2. **Threading `SourceFileRegistry` into `CompileContext`?** The
+   registry is mutable state accumulated across many calls. Either
+   make it a `&mut SourceFileRegistry<'_>` parameter on every
+   compile-stmt function (intrusive) or stash it on `CompileContext`
+   (which is `&mut` everywhere already). Recommendation: **stash it
+   on `CompileContext`** — same pattern as `ctx.variables` and the
+   other accumulators.
+3. **Closure vs trait for `SourceLookup`?** A `&dyn Fn(&FileId) ->
+   Option<&[u8]>` is lighter but less greppable. A trait makes the
+   intent legible. Lean **trait**.
+4. **Per-statement offset choice — `start` or position of the
+   keyword?** A statement's `SourceSpan` covers the whole construct
+   (e.g., entire IF/END_IF block). For `set_source_position` at the
+   top of `compile_statement`, we want the *first* line of the
+   statement so the debugger lands at the head of an IF, not its
+   END_IF. `span.start` is correct.
+5. **Nested statements (IF body, FOR body)?** `compile_stmts`
+   recurses into bodies, and `compile_statement` is called for each.
+   So a `set_source_position` at the top of `compile_statement` runs
+   for both the outer IF and each inner statement. That's the right
+   behavior — every visible statement gets its own line-map entry.
+
+## Tasks
+
+Land in two commits on this branch so review can separate the
+threading from the actual emission:
+
+**Commit A — plumbing only (no behavioral change).**
+
+- [ ] Add `blake3` to `compiler/codegen/Cargo.toml`.
+- [ ] Define `SourceLookup` trait in `compiler/codegen/src/compile.rs`
+      (or `source_registry.rs`) with a no-op `EmptyLookup` for tests.
+- [ ] Extend `compile()` with `sources: &dyn SourceLookup`.
+- [ ] Update every caller of `compile()` to pass an empty/no-op lookup
+      (ironplc-cli, lsp_runner, playground, mcp, benchmarks, codegen
+      tests). Behavior unchanged; just the signature widens.
+- [ ] Run `cd compiler && just` — should pass with no behavioral
+      change.
+
+**Commit B — actual line-map and source-file-table emission.**
+
+- [ ] Add `SourceFileRegistry` on `CompileContext`; intern file_ids
+      on first use; hash bytes via BLAKE3.
+- [ ] Extend `FinalizedFunction` with `line_map`; have
+      `finalize_function` drain `emitter.take_line_map()` and apply
+      the optimizer offset remap. If `optimize()` doesn't expose the
+      remap usably yet, fix that first.
+- [ ] Call `emitter.set_source_position(...)` at the top of
+      `compile_statement` using the registry + `LineColumn::from_offset`.
+- [ ] After each function is finalized, pair its entries with their
+      `FunctionId` and call `builder.add_line_map_entry` per entry.
+- [ ] At the end of `compile`, call
+      `builder.add_source_files(registry.entries)`.
+- [ ] Update the real callers (`ironplc-cli`, `lsp_runner`,
+      `playground`, `mcp`, `benchmarks`) to hand in a real
+      `SourceLookup` backed by their already-loaded sources. Tests
+      that don't care keep the no-op lookup from Commit A.
+- [ ] End-to-end test in `codegen/tests/it/` or `vm-cli/tests/`:
+      compile a real multi-statement `.st` program with the real
+      driver, write the container, read it back, verify the line
+      map has one entry per statement at the expected `(file_id,
+      line, column)` and that the SOURCE_FILE_TABLE has one entry
+      with the expected BLAKE3 hash.
+- [ ] Offset-remap invariant test: compile a program whose optimizer
+      will visibly reorder/delete instructions, verify every
+      `bytecode_offset` in the line map lands on an instruction
+      boundary in the optimized stream (parse the bytecode and check
+      offset is at an opcode start).
+- [ ] Run `cd compiler && just` — compile, coverage, lint must all
+      pass.
+
+## Out of Scope
+
+- Per-expression source-position granularity. Per-statement is fine
+  for v1.
+- The DAP server / `DebugHook` integration. Those plans live in
+  `specs/design/debugger-support.md` and depend on this work but are
+  separate PRs.
+- Optimizer's "snap forward" handling of statements that get
+  entirely elided (e.g., `IF FALSE THEN ... END_IF`). The remap
+  drops entries past the end; per the existing 04-07 plan, snap-
+  forward is a follow-up with its own invariant test.


### PR DESCRIPTION
## Summary

Closes the codegen loop on the SOURCE_FILE_TABLE infrastructure that landed in #1074. Until now, `LINE_MAP` and `SOURCE_FILE_TABLE` were empty in production output — the on-disk format supported them but nothing in codegen populated them. After this PR, every `.iplc` written by `ironplcvm compile` carries:

- One `SOURCE_FILE_TABLE` entry per POU source file, with a real BLAKE3 hash of the parser's source bytes — a debugger can detect drift between the `.iplc` and the user's working copy on a per-file basis.
- One `LINE_MAP` entry per executed statement, with `(file_id, source_line, source_column)` resolved from each AST node's span and `bytecode_offset` correctly remapped through the peephole optimizer.

Plan: `specs/plans/2026-05-23-codegen-emit-line-map.md` (committed).

### How it fits together

- **`SourceLookup` trait** (Commit A) — pluggable bridge from the driver to the source bytes the parser saw. Drivers wrap their already-loaded sources in a small adapter. Drivers that don't have bytes (synthetic ASTs, tests, the WASM playground) pass `EmptyLookup` and get an all-zero `content_hash` per the spec's "drift check unavailable" sentinel.
- **`SourceFileRegistry`** (Commit B) — lives on `CompileContext`. At the start of `compile_program_with_functions` we walk top-level POU declarations and intern each `FileId` (hash with BLAKE3, cache bytes for line/column lookup).
- **`compile_statement`** (Commit B) — calls `Emitter::set_source_position` once per statement using `LineColumn::from_offset` to convert `span.start` to 1-based (line, column). Skipped when the file has no cached bytes — no useful position to record.
- **`FinalizedFunction` + `optimize::remap_line_map`** (Commit B) — the optimizer's pre→post offset map snaps line-map entries forward through elided instructions; entries past the new end-of-function are dropped; entries colliding on the same post-optimization offset dedup to the first. This is a correctness requirement, not a polish — without it `bytecode_offset` values would point into the middle of multi-byte instructions in the optimized stream.

### Drivers updated

- `ironplc-cli` — `compile` subcommand now wires real source bytes via `HashMapSourceLookup`.
- `lsp_runner`, `playground`, `mcp/tools/compile`, `benchmarks`, in-crate test helpers — still pass `EmptyLookup` for now. The line map / source table are empty in their output, same as today; switching them on is mechanical and can land independently.

## Test plan

- [x] `cd compiler && just` passes (compile + coverage + clippy + fmt + dupes + smoke)
- [x] New tests in `codegen/tests/it/end_to_end_debug_line_map.rs`:
  - Real program → `SOURCE_FILE_TABLE` has 1 entry with correct BLAKE3 hash; `LINE_MAP` has entries on the expected source lines; every entry's `file_id` resolves to the right table entry.
  - `EmptyLookup` → file registered with all-zero hash, line map empty (graceful degradation).
  - **Offset-remap invariant**: every `bytecode_offset` in the emitted line map lands on an instruction boundary in the optimized bytecode (decoded via `opcode::instruction_size`). Catches off-by-one remap bugs that would put offsets mid-instruction.
- [x] All 1047 existing codegen integration tests + 590 analyzer tests still pass — no behavior change for callers that don't care about line maps.

## Out of scope (for follow-up PRs)

- Per-expression line-map granularity. Per-statement is the right grain for v1 ST debugging.
- The DAP server / `DebuggerHook` integration (`specs/design/debugger-support.md`).
- Wiring real `SourceLookup` impls in lsp_runner / playground / mcp — straightforward but worth landing on its own so the change is reviewable per-driver.

https://claude.ai/code/session_017jnAenCns8PVjcU4rj66jN

---
_Generated by [Claude Code](https://claude.ai/code/session_017jnAenCns8PVjcU4rj66jN)_