### PR TITLE
Update VS Code extension documentation and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,15 @@ Contributions are very welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for detai
 * [msr](https://github.com/slowtec/msr) - A Rust library for industrial automation.
 * [ethercat-rs](https://github.com/birkenfeld/ethercat-rs) - An experimental Rust automation toolbox using the IgH (Etherlab) EtherCAT master.
 * [rustmatic](https://github.com/NOP0/rustmatic) - Rustmatic is a thought experiment on creating a PLC-like environment in Rust.
+
+## Trademarks
+
+IronPLC is an independent open-source project. It is not affiliated with,
+endorsed by, or sponsored by any third party. TwinCAT is a trademark of
+Beckhoff Automation GmbH & Co. KG. CODESYS is a trademark of CODESYS GmbH.
+Beremiz is a trademark of its respective owner. PLCopen is a trademark of
+PLCopen. EtherCAT is a registered trademark of Beckhoff Automation. All
+other trademarks are the property of their respective owners. References
+to these names in IronPLC and its documentation are descriptive
+(nominative) only — they identify file formats, compatibility modes, and
+related projects, and do not imply endorsement.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,3 +78,4 @@ macOS and Linux.
    How-to guides <how-to-guides/index>
    Explanation <explanation/index>
    Reference <reference/index>
+   Trademarks <trademarks>

--- a/docs/trademarks.rst
+++ b/docs/trademarks.rst
@@ -1,0 +1,49 @@
+==========
+Trademarks
+==========
+
+IronPLC is an independent open-source project. It is not affiliated with,
+endorsed by, or sponsored by any third party. The names of other products
+and companies referenced in IronPLC and its documentation are used only to
+identify file formats, compatibility modes, and related projects, and do
+not imply endorsement.
+
+Third-party marks
+=================
+
+The following third-party trademarks may appear in IronPLC, its
+documentation, or its source code. All trademarks are the property of
+their respective owners.
+
+* **TwinCAT** is a trademark of Beckhoff Automation GmbH & Co. KG.
+  IronPLC reads ``.TcPOU``, ``.TcGVL``, and ``.TcDUT`` files, which are
+  PLCopen XML payloads produced by TwinCAT. IronPLC is not a product of,
+  affiliated with, or endorsed by Beckhoff Automation.
+* **CODESYS** is a trademark of CODESYS GmbH. IronPLC provides a
+  ``codesys`` dialect preset to read code written for CODESYS-based
+  environments. IronPLC is not a product of, affiliated with, or endorsed
+  by CODESYS GmbH.
+* **PLCopen** is a trademark of PLCopen. IronPLC reads files conforming
+  to the publicly published PLCopen XML (TC6) schema.
+* **EtherCAT** is a registered trademark of Beckhoff Automation
+  GmbH & Co. KG.
+* **Beremiz** is a trademark of its respective owner. IronPLC documents
+  a workflow for users migrating Beremiz projects but is unaffiliated.
+* **Visual Studio Code** and **Visual Studio** are trademarks of
+  Microsoft Corporation.
+
+All other trademarks are the property of their respective owners.
+
+Nominative use
+==============
+
+References to third-party trademarks in IronPLC and its documentation
+are made for the sole purpose of identifying compatible products,
+file formats, or related projects. Such use is intended to be
+nominative fair use and does not constitute or imply any endorsement,
+sponsorship, partnership, or other relationship between IronPLC and the
+trademark owners.
+
+If you believe IronPLC uses a mark in a way that infringes your rights,
+please open an `issue <https://github.com/ironplc/ironplc/issues>`_
+or contact the project maintainers so we can address it.

--- a/integrations/vscode/README.md
+++ b/integrations/vscode/README.md
@@ -17,13 +17,12 @@ to write your first PLC program.
 ## Capabilities
 
 * [**Real-time diagnostics**](https://www.ironplc.com/reference/editor/overview.html) — syntax and semantic errors reported as you type
-* [**Syntax highlighting**](https://www.ironplc.com/reference/compiler/source-formats/index.html) — Structured Text, PLCopen XML, and TwinCAT files
+* [**Syntax highlighting**](https://www.ironplc.com/reference/compiler/source-formats/index.html) — Structured Text and PLCopen XML files
 * [**Build and run**](https://www.ironplc.com/reference/editor/build-tasks.html) — compile and execute programs from the editor
 * [**Bytecode viewer**](https://www.ironplc.com/reference/editor/bytecode-viewer.html) — inspect compiled programs
-* [**AI agent support**](https://www.ironplc.com/how-to-guides/ai-agents/index.html) — use with MCP-compatible tools like Claude
 
-Works with Structured Text (`.st`, `.iec`), PLCopen XML, and
-TwinCAT (`.TcPOU`, `.TcGVL`, `.TcDUT`) files.
+Works with Structured Text (`.st`, `.iec`) and PLCopen XML files,
+including the PLCopen XML-based `.TcPOU`, `.TcGVL`, and `.TcDUT` formats.
 
 ## Learn More
 
@@ -31,3 +30,13 @@ TwinCAT (`.TcPOU`, `.TcGVL`, `.TcDUT`) files.
 * [Playground](https://playground.ironplc.com)
 * [Troubleshooting](https://www.ironplc.com/how-to-guides/troubleshoot-editor.html)
 * [Source](https://github.com/ironplc/ironplc)
+
+## Trademarks
+
+IronPLC is an independent open-source project. It is not affiliated with,
+endorsed by, or sponsored by any third party. TwinCAT is a trademark of
+Beckhoff Automation GmbH & Co. KG. CODESYS is a trademark of CODESYS GmbH.
+PLCopen is a trademark of PLCopen. All other trademarks are the property
+of their respective owners. References to these names in this extension
+are descriptive only — they indicate file formats and compatibility modes
+that the extension can read.

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -19,9 +19,13 @@
   "homepage": "https://www.ironplc.com",
   "repository": {
     "type": "git",
-    "url": "http://github.com/ironplc/ironplc.git",
+    "url": "https://github.com/ironplc/ironplc.git",
     "directory": "integrations/vscode"
   },
+  "bugs": {
+    "url": "https://github.com/ironplc/ironplc/issues"
+  },
+  "qna": "https://github.com/ironplc/ironplc/issues",
   "activationEvents": [
     "onCustomEditor:ironplc.iplcViewer",
     "onLanguage:61131-3-st",
@@ -135,6 +139,7 @@
       {
         "id": "twincat-pou",
         "aliases": [
+          "PLCopen POU (.TcPOU)",
           "TwinCAT POU"
         ],
         "extensions": [
@@ -145,6 +150,7 @@
       {
         "id": "twincat-gvl",
         "aliases": [
+          "PLCopen GVL (.TcGVL)",
           "TwinCAT GVL"
         ],
         "extensions": [
@@ -155,6 +161,7 @@
       {
         "id": "twincat-dut",
         "aliases": [
+          "PLCopen DUT (.TcDUT)",
           "TwinCAT DUT"
         ],
         "extensions": [


### PR DESCRIPTION
## Summary
Updated the VS Code extension README and package.json to clarify file format support, remove outdated AI agent capability, add trademark notices, and improve package metadata.

## Key Changes

- **Documentation clarity**: Updated capabilities list to remove TwinCAT from the syntax highlighting bullet point, clarifying that `.TcPOU`, `.TcGVL`, and `.TcDUT` are PLCopen XML-based formats rather than a separate format category
- **Removed AI agent support**: Deleted the AI agent support capability line as it is no longer applicable
- **Added trademark section**: New "Trademarks" section in README documenting that IronPLC is independent and clarifying trademark ownership (Beckhoff, CODESYS, PLCopen)
- **Package metadata improvements**:
  - Fixed repository URL from `http://` to `https://`
  - Added `bugs` field pointing to GitHub issues
  - Added `qna` field for community support
- **Language aliases**: Added descriptive PLCopen XML-based aliases to TwinCAT file type definitions (`.TcPOU`, `.TcGVL`, `.TcDUT`) to better reflect their actual format

## Implementation Details

The changes maintain backward compatibility while improving clarity around file format support. The trademark section follows standard open-source practices for acknowledging third-party trademarks used in documentation and file format references.

https://claude.ai/code/session_01Q9UyVXU8NnEYrANZGg9ZUE