### PR TITLE
Pause Marketplace publish; install docs use VSIX from GitHub releases

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -154,11 +154,17 @@ jobs:
       # Execute build recipes
       - name: Install dependencies
         run: just setup
-      - name: Publish VS Code Extension to Marketplace
-        if: ${{ !inputs.dryrun }}
-        run: just publish ironplc-vscode-extension.vsix
-        env:
-          VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+      # TODO: Restore once the ironplc publisher and ironplc.ironplc
+      # extension are reinstated on the Visual Studio Marketplace.
+      # The publisher was blocked and the extension removed by Microsoft;
+      # publish attempts return RequestBlockedException (VSID/Concurrency)
+      # until the listing is restored. Users install via the GitHub
+      # release VSIX in the meantime (see docs/quickstart/installation.rst).
+      # - name: Publish VS Code Extension to Marketplace
+      #   if: ${{ !inputs.dryrun }}
+      #   run: just publish ironplc-vscode-extension.vsix
+      #   env:
+      #     VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
       - name: Publish VS Code Extension to Open VSX
         if: ${{ !inputs.dryrun }}
         run: just publish-openvsx ironplc-vscode-extension.vsix

--- a/docs/how-to-guides/troubleshoot-editor.rst
+++ b/docs/how-to-guides/troubleshoot-editor.rst
@@ -122,4 +122,8 @@ If all else fails, try a clean reset:
    * macOS/Linux: ``~/.vscode/extensions/ironplc.*`` (or ``~/.cursor/extensions/ironplc.*`` for Cursor)
 
 3. Reload the development environment
-4. Reinstall the extension from the marketplace
+4. Reinstall the extension by downloading the latest
+   ``ironplc-vscode-extension.vsix`` from the
+   `IronPLC GitHub releases <https://github.com/ironplc/ironplc/releases/>`_
+   and using :menuselection:`... (View and More Actions) --> Install from VSIX...`
+   in the Extensions view

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -4,6 +4,19 @@
 Installation
 ============
 
+.. note::
+
+   The IronPLC VS Code extension is currently unavailable on the Visual
+   Studio Marketplace. Install via:
+
+   - `Open VSX <https://open-vsx.org/extension/ironplc/ironplc>`_ (Cursor,
+     Windsurf, VSCodium)
+   - Direct VSIX from `IronPLC GitHub releases`_
+
+   Existing installs continue to work; automatic updates from the
+   Marketplace are paused. We are working with Microsoft to restore the
+   listing.
+
 IronPLC supports the following platforms:
 
 - Windows (x64, arm64)

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -45,13 +45,17 @@ Follow the steps below to install IronPLC.
 
    .. rubric:: Install IronPLC Extension
 
+   #. Download the latest IronPLC extension
+      :download_artifact:`ironplc-vscode-extension.vsix` from
+      `IronPLC GitHub releases`_.
+
    Run your development environment, then:
 
    #. Go to the Extensions view by clicking on the Extensions icon in
       :guilabel:`Activity Bar` on the side of the window or using the
       View: Extensions command (:kbd:`Ctrl+Shift+X`).
-   #. In the Extensions view, enter :samp:`IronPLC` in the search box.
-   #. In the Extensions view for the IronPLC item, choose :guilabel:`Install`.
+   #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
+   #. In the :guilabel:`Install from VSIX` dialog, select the VSIX file you downloaded earlier.
 
 .. tab:: macOS
 
@@ -82,13 +86,17 @@ Follow the steps below to install IronPLC.
 
    .. rubric:: Install IronPLC Extension
 
+   #. Download the latest IronPLC extension
+      :download_artifact:`ironplc-vscode-extension.vsix` from
+      `IronPLC GitHub releases`_.
+
    Run your development environment, then:
 
    #. Go to the Extensions view by clicking on the Extensions icon in
       :guilabel:`Activity Bar` on the side of the window or using the
       View: Extensions command (:kbd:`⌘+Shift+X`).
-   #. In the Extensions view, enter :samp:`IronPLC` in the search box.
-   #. In the Extensions view for the IronPLC item, choose :guilabel:`Install`.
+   #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
+   #. In the :guilabel:`Install from VSIX` dialog, select the VSIX file you downloaded earlier.
 
 .. tab:: Linux
 
@@ -114,13 +122,17 @@ Follow the steps below to install IronPLC.
 
    .. rubric:: Install IronPLC Extension
 
+   #. Download the latest IronPLC extension
+      :download_artifact:`ironplc-vscode-extension.vsix` from
+      `IronPLC GitHub releases`_.
+
    Run your development environment, then:
 
    #. Go to the Extensions view by clicking on the Extensions icon in
       :guilabel:`Activity Bar` on the side of the window or using the
       View: Extensions command (:kbd:`Ctrl+Shift+X`).
-   #. In the Extensions view, enter :samp:`IronPLC` in the search box.
-   #. In the Extensions view for the IronPLC item, choose :guilabel:`Install`.
+   #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
+   #. In the :guilabel:`Install from VSIX` dialog, select the VSIX file you downloaded earlier.
 
 --------------------------------------
 Next Steps

--- a/integrations/vscode/README.md
+++ b/integrations/vscode/README.md
@@ -1,5 +1,15 @@
 # IronPLC
 
+> **Note:** The IronPLC VS Code extension is currently unavailable on the
+> Visual Studio Marketplace. Install via:
+>
+> - [Open VSX](https://open-vsx.org/extension/ironplc/ironplc) (Cursor, Windsurf, VSCodium)
+> - [Direct VSIX from GitHub Releases](https://github.com/ironplc/ironplc/releases/latest)
+>
+> Existing installs continue to work; automatic updates from the
+> Marketplace are paused. We are working with Microsoft to restore the
+> listing.
+
 IronPLC provides IEC 61131-3 Structured Text language support for VS Code.
 Get real-time error checking, syntax highlighting, and build tools for PLC
 programs — no proprietary IDE required.


### PR DESCRIPTION
The ironplc.ironplc extension was removed and the publisher blocked
on the Visual Studio Marketplace; Microsoft has not disclosed the
specific reason. Comment out the Marketplace publish step (Open VSX
continues) and update the install and troubleshoot docs so users have
a working install path via the VSIX attached to each GitHub release.

https://claude.ai/code/session_01WbMqwMAmgiceEborEdmrcJ