### PR TITLE
Potential fix for code scanning alert no. 5: Missing origin verification in `postMessage` handler

### DIFF
--- a/playground/worker.js
+++ b/playground/worker.js
@@ -25,6 +25,16 @@ init()
   });
 
 self.onmessage = (e) => {
+  if (e.source && e.source !== self) {
+    self.postMessage({ type: "error", error: "Untrusted message source" });
+    return;
+  }
+
+  if (!e.data || typeof e.data !== "object" || typeof e.data.command !== "string") {
+    self.postMessage({ type: "error", error: "Invalid message payload" });
+    return;
+  }
+
   const { id, command, source, bytecodeBase64, scans, cycleTimeUs, dialect, allows } = e.data;
 
   if (!ready) {


### PR DESCRIPTION
Potential fix for [https://github.com/ironplc/ironplc/security/code-scanning/5](https://github.com/ironplc/ironplc/security/code-scanning/5)

To fix this safely without changing intended functionality, add a strict validation guard at the top of `self.onmessage`:

- Ensure the message source is the same worker context (`e.source === self`) when present.
- Validate that `e.data` is an object and that `command` is a string before destructuring/dispatch.
- Reject invalid messages with an error response and return early.

For this file (`playground/worker.js`), update the `self.onmessage` block around line 27. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
