### PR TITLE
Fix for Unneeded defensive code

### DIFF
--- a/integrations/vscode/src/extension.ts
+++ b/integrations/vscode/src/extension.ts
@@ -113,14 +113,9 @@ export function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration('ironplc');
   client = createClient(result.path, config);
 
-  if (client) {
-    client.start();
-    context.subscriptions.push(IplcEditorProvider.register(context, client));
-    console.debug('Extension "ironplc" is active!');
-  }
-  else {
-    console.error('Extension "ironplc" is NOT active!');
-  }
+  client.start();
+  context.subscriptions.push(IplcEditorProvider.register(context, client));
+  console.debug('Extension "ironplc" is active!');
 }
 
 function registerRunSupport(context: vscode.ExtensionContext) {


### PR DESCRIPTION
The best fix is to remove the always-true `if (client)` / `else` branch and execute the “true” branch unconditionally after `client` is created. This preserves behavior while eliminating unreachable code and the redundant guard.

In `integrations/vscode/src/extension.ts`, within `activate(...)` around lines 116–123:

- Keep `client = createClient(result.path, config);`
- Replace the conditional block with unconditional startup/registration:
  - `client.start();`
  - `context.subscriptions.push(IplcEditorProvider.register(context, client));`
  - `console.debug('Extension "ironplc" is active!');`
- Remove the unreachable `else` error log branch.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._