### PR TITLE
Fix for Unused variable when looking for MCP

### DIFF
--- a/integrations/vscode/src/screenshots/run.ts
+++ b/integrations/vscode/src/screenshots/run.ts
@@ -73,7 +73,6 @@ async function main(): Promise<void> {
 
   const opts = { vscodePath, extensionPath, userDataDir };
   const ironplccAvailable = hasIronplcc();
-  const ironplcmcpAvailable = hasIronplcmcp();
 
   try {
     console.log('\n--- Syntax Highlighting ---');


### PR DESCRIPTION
To fix this, remove the unused local variable declaration in `main()`:

- File: `integrations/vscode/src/screenshots/run.ts`
- Region: around lines 74–77
- Change: delete `const ironplcmcpAvailable = hasIronplcmcp();`

This resolves the CodeQL warning directly and does not alter runtime behavior, because the variable was never used. No imports, method signatures, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._