### PR TITLE
Add PostHog pageview analytics to the website

### DIFF
--- a/docs/_static/posthog-init.js
+++ b/docs/_static/posthog-init.js
@@ -1,0 +1,25 @@
+// PostHog browser SDK loader for the IronPLC website.
+//
+// Registered via `html_js_files` in conf.py, so Sphinx emits a
+// `<script src="_static/posthog-init.js">` tag in the <head> of every page.
+//
+// The minified function below is the official browser snippet from
+// https://posthog.com/docs/libraries/js. It does two things:
+//
+//   1. Inserts a <script> tag for /static/array.js (the real PostHog SDK)
+//      and starts downloading it asynchronously.
+//   2. Sets up a stub `window.posthog` with the SDK's method names so any
+//      calls made before array.js finishes loading get queued and replayed
+//      once it does.
+//
+// Unlike the playground, the website only needs pageview analytics, so
+// `capture_pageview` is enabled and autocapture / session recording are off.
+!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+
+posthog.init('phc_xQV6wYsbu5FuF5AuCkwXgZqcdtcURBi5BoLrPu9Mar7L', {
+  api_host: 'https://us.i.posthog.com',
+  person_profiles: 'identified_only',
+  capture_pageview: true,
+  autocapture: false,
+  disable_session_recording: true,
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ html_title = "IronPLC - Open-Source IEC 61131-3 Toolchain"
 html_static_path = ['_static']
 html_extra_path = ['robots.txt']
 html_css_files = ["overrides.css"]
-html_js_files = ["version-check.js"]
+html_js_files = ["version-check.js", "posthog-init.js"]
 
 html_theme_options = {
     "light_css_variables": {

--- a/specs/plans/2026-06-03-website-posthog-analytics.md
+++ b/specs/plans/2026-06-03-website-posthog-analytics.md
@@ -1,0 +1,66 @@
+# Plan: Add PostHog pageview analytics to the website
+
+## Goal
+
+Add PostHog to the main marketing/documentation website (`docs/`, the Sphinx +
+furo site published to https://www.ironplc.com/) so that ordinary visitor
+traffic generates a steady stream of pageview events. The website receives
+regular visitors (unlike the playground, which is published on the same weekly
+cadence but sees far less traffic), so this gives a continuous signal that the
+PostHog ingestion pipeline works end-to-end.
+
+## Scope
+
+In scope:
+- New `docs/_static/posthog-init.js` — the official PostHog browser loader
+  snippet plus an `init` call, configured for pageview capture.
+- Register the loader in `docs/conf.py` via `html_js_files`.
+
+Out of scope:
+- The playground integration (already present in `playground/posthog-init.js`).
+- Removing or changing the existing Clicky tracker (kept as-is).
+- A reverse proxy for PostHog (noted as a future improvement; ad/tracker
+  blockers will drop some events without it).
+- Any cookie-consent banner. The site already ships Clicky with no consent
+  banner, so adding PostHog follows the established privacy posture.
+
+## Decisions
+
+- **Project:** reuse the same PostHog project key/host as the playground
+  (`phc_xQV6wYsbu5FuF5AuCkwXgZqcdtcURBi5BoLrPu9Mar7L`,
+  `https://us.i.posthog.com`). Website and playground data share one project.
+- **Capture scope:** pageviews only. `capture_pageview: true`,
+  `autocapture: false`, `disable_session_recording: true`,
+  `person_profiles: 'identified_only'`. This yields visitors / pageviews /
+  referrers without click-level autocapture or recordings.
+
+## Architecture
+
+The furo theme already injects custom static JavaScript through Sphinx's
+`html_js_files` (e.g. `version-check.js`). PostHog's loader is shipped as a
+static file and registered the same way; Sphinx emits a
+`<script src="_static/posthog-init.js">` tag in every page's `<head>`. This is
+the clean alternative to the existing Clicky hack (which is embedded inside a
+`footer_icons` HTML blob because it loads a third-party CDN URL rather than a
+local file).
+
+The loader uses PostHog's official async snippet: it defines a stubbed
+`window.posthog` that queues calls, asynchronously loads the real SDK
+(`array.js`), then replays the queue. `posthog.init(...)` with
+`capture_pageview: true` records a `$pageview` on load.
+
+## Deployment
+
+The website is published by the `publish-website` job in `deployment.yaml`,
+which runs on the weekly Monday release (or a manual `workflow_dispatch` with
+`dryrun` unchecked). The change therefore goes live with the next release, not
+on merge to `main`.
+
+## Testing
+
+- `cd docs && just ci` must pass (Sphinx build with `-W -n`, warnings as
+  errors). Adding a static asset and an `html_js_files` entry must not
+  introduce build warnings.
+- Manual verification after deploy: load https://www.ironplc.com/, confirm a
+  request to `https://us.i.posthog.com/...` fires and a `$pageview` appears in
+  PostHog.


### PR DESCRIPTION
Register a PostHog browser loader (docs/_static/posthog-init.js) via
html_js_files so every website page captures a pageview. The marketing/
docs site at www.ironplc.com receives steady traffic, providing a
continuous signal that the PostHog ingestion pipeline works end to end.

Reuses the playground PostHog project key/host. Captures pageviews only:
autocapture and session recording are disabled.

https://claude.ai/code/session_019pabbCetVfZRoi8GUsrvPD