### PR TITLE
Codegen: emit max_call_depth; VM rejects over-deep containers

### DIFF
--- a/compiler/codegen/src/call_graph.rs
+++ b/compiler/codegen/src/call_graph.rs
@@ -1,0 +1,203 @@
+//! Static call-graph analysis for the codegen.
+//!
+//! As bytecode is emitted, the codegen records one edge per `CALL` /
+//! user-`FB_CALL` it produces. After all function bodies are compiled
+//! this module walks the resulting directed graph from the entry
+//! function and returns the longest path — the program's worst-case
+//! PLC call depth.
+//!
+//! That number is written to `FileHeader.max_call_depth` so the VM can
+//! reject containers that wouldn't fit in the embedder's frame buffer
+//! before any init code runs (`Trap::ProgramExceedsCallDepth`).
+//!
+//! Cycles are forbidden by IEC 61131-3 and rejected earlier by semantic
+//! analysis (`Problem::RecursiveCycle`). This module's 3-color DFS is
+//! a defensive backstop: if a cycle ever slips through, the longest-path
+//! walk would otherwise loop forever, so we detect cycles and return an
+//! `InternalError` diagnostic instead.
+
+use std::collections::{HashMap, HashSet};
+
+use ironplc_container::FunctionId;
+use ironplc_dsl::core::FileId;
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
+use ironplc_problems::Problem;
+
+/// Compute the longest path from `entry` through `graph`, counting
+/// the entry node itself.
+///
+/// Returns the depth as a `u16` (depth 1 = entry only, no calls).
+/// Returns `InternalError` on cycle — the recursion ban in semantic
+/// analysis means we should never see one in practice; this is a
+/// fail-loud backstop against analyzer regressions.
+pub(crate) fn compute_max_call_depth(
+    graph: &HashMap<FunctionId, HashSet<FunctionId>>,
+    entry: FunctionId,
+) -> Result<u16, Diagnostic> {
+    // 3-color DFS: White (not visited), Gray (on current path),
+    // Black (fully explored).
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+
+    /// Per-node DFS frame: the node, its enumerated children, the
+    /// next-child cursor, and the deepest depth seen so far among
+    /// children already finalized.
+    struct Frame {
+        node: FunctionId,
+        children: Vec<FunctionId>,
+        next_child: usize,
+        max_child_depth: u16,
+    }
+
+    let mut color: HashMap<FunctionId, Color> = HashMap::new();
+    let mut depth: HashMap<FunctionId, u16> = HashMap::new();
+    // Iterative DFS with an explicit work stack so a deep call graph
+    // doesn't blow the Rust thread stack.
+    let mut stack: Vec<Frame> = Vec::new();
+    color.insert(entry, Color::Gray);
+    stack.push(Frame {
+        node: entry,
+        children: graph
+            .get(&entry)
+            .map(|s| s.iter().copied().collect())
+            .unwrap_or_default(),
+        next_child: 0,
+        max_child_depth: 0,
+    });
+
+    while let Some(top) = stack.last_mut() {
+        if top.next_child < top.children.len() {
+            let child = top.children[top.next_child];
+            top.next_child += 1;
+            match color.get(&child).copied().unwrap_or(Color::White) {
+                Color::Gray => {
+                    // Back edge — cycle detected. Static analysis
+                    // should have rejected this earlier; surface as
+                    // an internal error so the bug is visible.
+                    return Err(Diagnostic::problem(
+                        Problem::InternalError,
+                        Label::file(
+                            FileId::default(),
+                            format!(
+                                "codegen call-graph cycle detected involving function {child}; \
+                                 semantic analysis should have rejected this program with \
+                                 Problem::RecursiveCycle"
+                            ),
+                        ),
+                    ));
+                }
+                Color::Black => {
+                    let d = depth[&child];
+                    if d > top.max_child_depth {
+                        top.max_child_depth = d;
+                    }
+                }
+                Color::White => {
+                    color.insert(child, Color::Gray);
+                    let next_children: Vec<FunctionId> = graph
+                        .get(&child)
+                        .map(|s| s.iter().copied().collect())
+                        .unwrap_or_default();
+                    stack.push(Frame {
+                        node: child,
+                        children: next_children,
+                        next_child: 0,
+                        max_child_depth: 0,
+                    });
+                }
+            }
+        } else {
+            // All children explored; finalize this node.
+            let d = top.max_child_depth.saturating_add(1);
+            let node = top.node;
+            depth.insert(node, d);
+            color.insert(node, Color::Black);
+            stack.pop();
+            if let Some(parent) = stack.last_mut() {
+                if d > parent.max_child_depth {
+                    parent.max_child_depth = d;
+                }
+            }
+        }
+    }
+
+    Ok(*depth.get(&entry).unwrap_or(&1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph(edges: &[(u16, u16)]) -> HashMap<FunctionId, HashSet<FunctionId>> {
+        let mut g: HashMap<FunctionId, HashSet<FunctionId>> = HashMap::new();
+        for &(from, to) in edges {
+            g.entry(FunctionId::new(from))
+                .or_default()
+                .insert(FunctionId::new(to));
+        }
+        g
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_entry_has_no_callees_then_one() {
+        let g = graph(&[]);
+        assert_eq!(compute_max_call_depth(&g, FunctionId::new(1)).unwrap(), 1);
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_entry_calls_one_callee_then_two() {
+        let g = graph(&[(1, 2)]);
+        assert_eq!(compute_max_call_depth(&g, FunctionId::new(1)).unwrap(), 2);
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_chain_three_deep_then_four() {
+        // 1 -> 2 -> 3 -> 4 (depth = 4 frames)
+        let g = graph(&[(1, 2), (2, 3), (3, 4)]);
+        assert_eq!(compute_max_call_depth(&g, FunctionId::new(1)).unwrap(), 4);
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_diamond_then_longest_path_wins() {
+        // 1 -> {2, 3}
+        // 2 -> 4
+        // 3 -> 4 -> 5
+        let g = graph(&[(1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+        assert_eq!(compute_max_call_depth(&g, FunctionId::new(1)).unwrap(), 4);
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_two_chains_then_longer_wins() {
+        // 1 -> 2 -> 3        (depth 3 via this branch)
+        // 1 -> 4 -> 5 -> 6   (depth 4 via this branch)
+        let g = graph(&[(1, 2), (2, 3), (1, 4), (4, 5), (5, 6)]);
+        assert_eq!(compute_max_call_depth(&g, FunctionId::new(1)).unwrap(), 4);
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_shared_subtree_then_memoized() {
+        // Both 2 and 3 call 4; 4 calls 5. Sharing should not double-count.
+        let g = graph(&[(1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+        assert_eq!(compute_max_call_depth(&g, FunctionId::new(1)).unwrap(), 4);
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_self_cycle_then_internal_error() {
+        // 1 -> 1
+        let g = graph(&[(1, 1)]);
+        let err = compute_max_call_depth(&g, FunctionId::new(1)).unwrap_err();
+        assert_eq!(err.code, Problem::InternalError.code());
+    }
+
+    #[test]
+    fn compute_max_call_depth_when_indirect_cycle_then_internal_error() {
+        // 1 -> 2 -> 3 -> 1
+        let g = graph(&[(1, 2), (2, 3), (3, 1)]);
+        let err = compute_max_call_depth(&g, FunctionId::new(1)).unwrap_err();
+        assert_eq!(err.code, Problem::InternalError.code());
+    }
+}

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -39,7 +39,7 @@
 //! After arithmetic at native width, narrow types (SINT, INT, USINT, UINT)
 //! are truncated back to their declared range before storing.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use ironplc_container::debug_section::{
     EnumDefEntry, FuncNameEntry, StringLayoutEntry, VarNameEntry,
@@ -516,7 +516,13 @@ fn compile_program_with_functions(
     // register themselves at the end of `compile_user_function`). Per
     // IEC 61131-3 functions cannot instantiate FBs, so they don't require FB
     // bodies to have been compiled first.
-    for (next_function_id, func_decl) in (2_u16..).zip(func_decls.iter()) {
+    //
+    // Function IDs are POSITIONAL in the container (`get_function`
+    // indexes the `functions` Vec). FB bodies are inserted at positions
+    // 2..(2 + N_fb), so user functions must start at the next free
+    // position so each callable POU has a unique runtime id.
+    let user_fn_id_base = 2u16 + fb_decls.len() as u16;
+    for (next_function_id, func_decl) in (user_fn_id_base..).zip(func_decls.iter()) {
         let compiled = compile_user_function(
             func_decl,
             next_function_id,
@@ -559,9 +565,13 @@ fn compile_program_with_functions(
     emit_initial_values(&mut init_emitter, &mut ctx, &local_vars, types)?;
     init_emitter.emit_ret_void();
 
-    // Compile the program body into the scan emitter.
+    // Compile the program body into the scan emitter. Mark
+    // FunctionId::SCAN as the current caller so any CALL / user FB_CALL
+    // emitted from inside the body records a call-graph edge.
     let mut scan_emitter = Emitter::new();
+    ctx.current_function_id = Some(FunctionId::SCAN);
     compile_body(&mut scan_emitter, &mut ctx, &program.body)?;
+    ctx.current_function_id = None;
     scan_emitter.emit_ret_void();
 
     // Build the container.
@@ -676,10 +686,20 @@ fn compile_program_with_functions(
         builder = builder.add_source_files(source_file_entries);
     }
 
+    // Compute the worst-case PLC call depth from the static call graph
+    // and stamp it on the header so `VmReady::start` can reject
+    // containers that wouldn't fit in the embedder's frame buffer
+    // (Trap::ProgramExceedsCallDepth). Cycles should already be
+    // rejected by semantic analysis (Problem::RecursiveCycle); the DFS
+    // is a defensive backstop that surfaces an internal error.
+    let max_call_depth =
+        crate::call_graph::compute_max_call_depth(&ctx.call_graph, FunctionId::SCAN)?;
+
     builder = builder
         .init_function_id(FunctionId::INIT)
         .entry_function_id(FunctionId::SCAN)
-        .shared_globals_size(program_var_count);
+        .shared_globals_size(program_var_count)
+        .max_call_depth(max_call_depth);
 
     // Add debug info.
     let program_name = program.name.to_string();
@@ -842,6 +862,22 @@ pub(crate) struct CompileContext {
     /// early `RETURN` statement should produce the return value before the
     /// `RET` opcode. `None` for programs and FBs (RETURN emits `RET_VOID`).
     pub(crate) current_function_return: Option<CurrentFunctionReturn>,
+    /// Function whose body is currently being emitted; `None` outside any
+    /// body. Set by the body-compilation entry points (SCAN, user
+    /// functions, user-FB bodies) so [`record_call_edge`] knows who the
+    /// caller is. Edges are aggregated into [`call_graph`] for the
+    /// post-emission `max_call_depth` computation.
+    ///
+    /// [`record_call_edge`]: CompileContext::record_call_edge
+    /// [`call_graph`]: CompileContext::call_graph
+    pub(crate) current_function_id: Option<FunctionId>,
+    /// Adjacency map: caller `FunctionId` → set of callees. Populated by
+    /// [`record_call_edge`] from inside `compile_call.rs` (user CALL)
+    /// and `compile_stmt.rs` (user `FB_CALL`). Empty for intrinsic
+    /// FBs, which have no PLC body.
+    ///
+    /// [`record_call_edge`]: CompileContext::record_call_edge
+    pub(crate) call_graph: HashMap<FunctionId, HashSet<FunctionId>>,
 }
 
 /// Describes how a `RETURN` statement should yield the function's value.
@@ -879,12 +915,26 @@ impl CompileContext {
             next_user_fb_type_id: 0x1000,
             enum_map: crate::compile_enum::EnumOrdinalMap::default(),
             current_function_return: None,
+            current_function_id: None,
+            call_graph: HashMap::new(),
         }
     }
 
     /// Returns the exit label for the innermost enclosing loop, if any.
     pub(crate) fn current_loop_exit(&self) -> Option<crate::emit::Label> {
         self.loop_exit_labels.last().copied()
+    }
+
+    /// Records a static call-graph edge from the function whose body is
+    /// currently being emitted to `callee`.
+    ///
+    /// No-op when no body is being emitted (e.g. during INIT, which
+    /// only stores constants and never CALLs) — `current_function_id`
+    /// is `None` outside body-compilation entry points.
+    pub(crate) fn record_call_edge(&mut self, callee: FunctionId) {
+        if let Some(caller) = self.current_function_id {
+            self.call_graph.entry(caller).or_default().insert(callee);
+        }
     }
 
     /// Looks up a variable index by identifier, using the provided span for error reporting.

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -319,6 +319,7 @@ fn compile_user_function_call(
         func_info.var_offset,
         func_info.max_stack_depth,
     );
+    ctx.record_call_edge(ironplc_container::FunctionId::new(func_info.function_id));
     // For STRING-returning functions, the CALL leaves a buf_idx on the stack
     // (from emit_str_load_var in the function epilogue). The caller's
     // assignment path will consume it via emit_str_store_var.

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -4,7 +4,7 @@
 //! including variable setup, body compilation, and metadata registration.
 //! Separated from compile.rs to keep module sizes within the 1000-line guideline.
 
-use ironplc_container::{ContainerBuilder, VarIndex};
+use ironplc_container::{ContainerBuilder, FunctionId, VarIndex};
 use ironplc_dsl::common::{
     FunctionBlockDeclaration, FunctionDeclaration, FunctionReturnType, InitialValueAssignmentKind,
     VarDecl, VariableType,
@@ -329,8 +329,14 @@ pub(crate) fn compile_user_function(
         }
     });
 
+    // Mark this function as the current caller so nested CALL / FB_CALL
+    // emissions record edges into ctx.call_graph.
+    let saved_current_fn = ctx.current_function_id.take();
+    ctx.current_function_id = Some(FunctionId::new(function_id));
+
     compile_statements(&mut func_emitter, ctx, &body)?;
 
+    ctx.current_function_id = saved_current_fn;
     ctx.current_function_return = saved_return_ctx;
 
     // Load the return value and emit RET.
@@ -575,9 +581,17 @@ pub(crate) fn compile_user_function_block(
     let num_locals = current_index.raw() - var_offset;
 
     // Compile the FB body.
+    // Mark this FB's body as the current caller so nested CALL / FB_CALL
+    // emissions record edges into ctx.call_graph (mirrors the same setup
+    // in compile_user_function and the SCAN-body site).
+    let saved_current_fn = ctx.current_function_id.take();
+    ctx.current_function_id = Some(FunctionId::new(function_id));
+
     let mut fb_emitter = Emitter::new();
     compile_body(&mut fb_emitter, ctx, &fb_decl.body)?;
     fb_emitter.emit_ret_void();
+
+    ctx.current_function_id = saved_current_fn;
 
     let finalized = finalize_function(&mut fb_emitter, ctx);
 

--- a/compiler/codegen/src/compile_stmt.rs
+++ b/compiler/codegen/src/compile_stmt.rs
@@ -497,8 +497,17 @@ fn compile_fb_call(
         }
     }
 
-    // Call the function block.
+    // Call the function block. Record a call-graph edge for user-defined
+    // FBs (intrinsic FBs have no PLC body and never recurse into the
+    // dispatch loop, so they contribute no frames).
     emitter.emit_fb_call(type_id);
+    if let Some(user_fb) = ctx
+        .user_fb_types
+        .values()
+        .find(|info| info.type_id == type_id)
+    {
+        ctx.record_call_edge(ironplc_container::FunctionId::new(user_fb.function_id));
+    }
 
     // Read output parameters.
     for param in &fb_call.params {

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -28,6 +28,7 @@
 //! let container = compile(&analyzed, &ctx, &CodegenOptions::default(), &EmptyLookup).unwrap();
 //! ```
 
+mod call_graph;
 mod compile;
 mod compile_array;
 mod compile_call;

--- a/compiler/codegen/tests/it/codegen_max_call_depth.rs
+++ b/compiler/codegen/tests/it/codegen_max_call_depth.rs
@@ -1,0 +1,162 @@
+//! End-to-end codegen tests for `header.max_call_depth` computation.
+//!
+//! Each test compiles a small IEC 61131-3 program and asserts the
+//! resulting container header carries the call depth the codegen
+//! analysis is supposed to produce.
+
+use ironplc_codegen::CodegenOptions;
+use ironplc_parser::options::CompilerOptions;
+
+use crate::common::try_parse_and_compile;
+
+fn compile_for_depth(source: &str) -> u16 {
+    let container =
+        try_parse_and_compile(source, &CompilerOptions::default()).expect("source should compile");
+    container.header.max_call_depth
+}
+
+#[test]
+fn compile_when_program_has_no_calls_then_max_call_depth_is_one() {
+    // SCAN does arithmetic only — no CALL, no FB_CALL. Only the
+    // entry frame is on the stack at any point, so depth = 1.
+    let source = "
+PROGRAM main
+  VAR x : INT; END_VAR
+  x := 1 + 2;
+END_PROGRAM
+";
+    assert_eq!(compile_for_depth(source), 1);
+}
+
+#[test]
+fn compile_when_program_calls_one_function_then_max_call_depth_is_two() {
+    // SCAN -> ADD_ONE. Two frames: SCAN, then ADD_ONE.
+    let source = "
+FUNCTION ADD_ONE : INT
+  VAR_INPUT x : INT; END_VAR
+  ADD_ONE := x + 1;
+END_FUNCTION
+
+PROGRAM main
+  VAR y : INT; END_VAR
+  y := ADD_ONE(x := 5);
+END_PROGRAM
+";
+    assert_eq!(compile_for_depth(source), 2);
+}
+
+#[test]
+fn compile_when_call_chain_three_deep_then_max_call_depth_is_four() {
+    // SCAN -> A -> B -> C. Four frames at the deepest point.
+    let source = "
+FUNCTION C : INT
+  VAR_INPUT n : INT; END_VAR
+  C := n;
+END_FUNCTION
+
+FUNCTION B : INT
+  VAR_INPUT n : INT; END_VAR
+  B := C(n := n);
+END_FUNCTION
+
+FUNCTION A : INT
+  VAR_INPUT n : INT; END_VAR
+  A := B(n := n);
+END_FUNCTION
+
+PROGRAM main
+  VAR y : INT; END_VAR
+  y := A(n := 7);
+END_PROGRAM
+";
+    assert_eq!(compile_for_depth(source), 4);
+}
+
+#[test]
+fn compile_when_diamond_call_graph_then_max_call_depth_takes_longest() {
+    // SCAN -> {SHORT, LONG_A}
+    // SHORT returns directly                 (path length 2)
+    // LONG_A -> LONG_B -> LEAF               (path length 4)
+    // Verifies the longest path wins, not the average / first / etc.
+    let source = "
+FUNCTION SHORT : INT
+  VAR_INPUT n : INT; END_VAR
+  SHORT := n;
+END_FUNCTION
+
+FUNCTION LEAF : INT
+  VAR_INPUT n : INT; END_VAR
+  LEAF := n;
+END_FUNCTION
+
+FUNCTION LONG_B : INT
+  VAR_INPUT n : INT; END_VAR
+  LONG_B := LEAF(n := n);
+END_FUNCTION
+
+FUNCTION LONG_A : INT
+  VAR_INPUT n : INT; END_VAR
+  LONG_A := LONG_B(n := n);
+END_FUNCTION
+
+PROGRAM main
+  VAR a : INT; b : INT; END_VAR
+  a := SHORT(n := 1);
+  b := LONG_A(n := 2);
+END_PROGRAM
+";
+    assert_eq!(compile_for_depth(source), 4);
+}
+
+#[test]
+fn compile_when_program_calls_user_fb_then_fb_body_counted() {
+    // SCAN -> CTR.body. Two frames.
+    let source = "
+FUNCTION_BLOCK CTR
+  VAR n : INT; END_VAR
+  n := n + 1;
+END_FUNCTION_BLOCK
+
+PROGRAM main
+  VAR c : CTR; END_VAR
+  c();
+END_PROGRAM
+";
+    assert_eq!(compile_for_depth(source), 2);
+}
+
+#[test]
+fn compile_when_user_fb_body_calls_user_function_then_both_counted() {
+    // SCAN -> CTR.body -> ADD_ONE. Three frames at the deepest point.
+    let source = "
+FUNCTION ADD_ONE : INT
+  VAR_INPUT x : INT; END_VAR
+  ADD_ONE := x + 1;
+END_FUNCTION
+
+FUNCTION_BLOCK CTR
+  VAR n : INT; END_VAR
+  n := ADD_ONE(x := n);
+END_FUNCTION_BLOCK
+
+PROGRAM main
+  VAR c : CTR; END_VAR
+  c();
+END_PROGRAM
+";
+    assert_eq!(compile_for_depth(source), 3);
+}
+
+#[test]
+fn compile_when_codegen_options_default_then_header_has_max_call_depth_set() {
+    // Smoke-test the wiring: regardless of options, every compiled
+    // program ends up with a populated `max_call_depth` (>= 1).
+    let _ = CodegenOptions::default();
+    let source = "
+PROGRAM main
+  VAR x : INT; END_VAR
+  x := 0;
+END_PROGRAM
+";
+    assert!(compile_for_depth(source) >= 1);
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -12,6 +12,7 @@
 #[macro_use]
 mod common;
 
+mod codegen_max_call_depth;
 mod compile_abs;
 mod compile_abs_float;
 mod compile_add;

--- a/compiler/container/src/builder.rs
+++ b/compiler/container/src/builder.rs
@@ -20,6 +20,7 @@ use crate::type_section::{ArrayDescriptor, FbTypeDescriptor, TypeSection, UserFb
 pub struct ContainerBuilder {
     num_variables: u16,
     max_stack_depth: u16,
+    max_call_depth: u16,
     data_region_bytes: u32,
     num_temp_bufs: u16,
     max_temp_buf_bytes: u32,
@@ -48,6 +49,7 @@ impl ContainerBuilder {
         ContainerBuilder {
             num_variables: 0,
             max_stack_depth: 0,
+            max_call_depth: 0,
             data_region_bytes: 0,
             num_temp_bufs: 0,
             max_temp_buf_bytes: 0,
@@ -179,6 +181,22 @@ impl ContainerBuilder {
     /// Sets the shared globals size in the task table.
     pub fn shared_globals_size(mut self, size: u16) -> Self {
         self.shared_globals_size = size;
+        self
+    }
+
+    /// Sets the worst-case call depth (longest path through the static
+    /// call graph, counting the entry frame).
+    ///
+    /// Codegen computes this from the program's CALL / user-FB_CALL
+    /// edges and passes the result here so `VmReady::start` can
+    /// reject containers that exceed the embedder's frame buffer
+    /// before any init code runs.
+    ///
+    /// Default `0` means "not computed" — `VmReady::start` skips the
+    /// check, preserving backward compatibility with hand-built test
+    /// containers.
+    pub fn max_call_depth(mut self, depth: u16) -> Self {
+        self.max_call_depth = depth;
         self
     }
 
@@ -365,6 +383,7 @@ impl ContainerBuilder {
         let header = FileHeader {
             num_variables: self.num_variables,
             max_stack_depth: self.max_stack_depth,
+            max_call_depth: self.max_call_depth,
             data_region_bytes: self.data_region_bytes,
             num_temp_bufs: self.num_temp_bufs,
             max_temp_buf_bytes: self.max_temp_buf_bytes,
@@ -477,6 +496,21 @@ mod tests {
 
         // No type section when no FB types or array descriptors added
         assert!(container.type_section.is_none());
+    }
+
+    #[test]
+    fn builder_when_max_call_depth_set_then_propagates_to_header() {
+        let container = ContainerBuilder::new()
+            .num_variables(0)
+            .max_call_depth(17)
+            .build();
+        assert_eq!(container.header.max_call_depth, 17);
+    }
+
+    #[test]
+    fn builder_when_max_call_depth_unset_then_header_default_is_zero() {
+        let container = ContainerBuilder::new().num_variables(0).build();
+        assert_eq!(container.header.max_call_depth, 0);
     }
 
     #[test]

--- a/compiler/vm/resources/problem-codes.csv
+++ b/compiler/vm/resources/problem-codes.csv
@@ -19,3 +19,4 @@ V9012,CallStackOverflow,VM call frame stack exceeded maximum depth,none
 V9013,InvalidCmpOp,Unknown comparison operator code in CMP_BR instruction,tuple
 V9014,EncodingMismatch,String operation operand encoding does not match expected encoding,struct
 V9015,InvalidCharWidth,String header or constant pool entry has an invalid char_width byte,tuple
+V9016,ProgramExceedsCallDepth,Container declares a call depth that exceeds the VM frame-stack buffer,struct

--- a/compiler/vm/src/error.rs
+++ b/compiler/vm/src/error.rs
@@ -39,6 +39,18 @@ pub enum Trap {
     /// constant-pool entry, or bytecode operand was neither `1` (STRING) nor
     /// `2` (WSTRING). The bytecode is malformed or has been tampered with.
     InvalidCharWidth(u8),
+    /// The container's `header.max_call_depth` exceeds the frame-stack
+    /// buffer provided by the embedder. The container was rejected at
+    /// `VmReady::start` before any init code executed.
+    ///
+    /// `required` is the depth codegen declared the program needs;
+    /// `capacity` is the size of the embedder's frame buffer. The
+    /// embedder either grows the buffer or the program is recompiled
+    /// with a shallower call chain.
+    ProgramExceedsCallDepth {
+        required: u16,
+        capacity: u16,
+    },
 }
 
 // v_code() and exit_code() are generated from resources/problem-codes.csv
@@ -86,6 +98,12 @@ impl fmt::Display for Trap {
             ),
             Trap::InvalidCharWidth(value) => {
                 write!(f, "invalid char_width byte: {value} (expected 1 or 2)")
+            }
+            Trap::ProgramExceedsCallDepth { required, capacity } => {
+                write!(
+                    f,
+                    "program declares call depth {required} but VM frame buffer holds at most {capacity}"
+                )
             }
         }
     }
@@ -387,6 +405,32 @@ mod tests {
     }
 
     #[test]
+    fn trap_display_when_program_exceeds_call_depth_then_includes_required_and_capacity() {
+        assert_eq!(
+            format!(
+                "{}",
+                Trap::ProgramExceedsCallDepth {
+                    required: 64,
+                    capacity: 32,
+                }
+            ),
+            "program declares call depth 64 but VM frame buffer holds at most 32"
+        );
+    }
+
+    #[test]
+    fn v_code_when_program_exceeds_call_depth_then_v9016() {
+        assert_eq!(
+            Trap::ProgramExceedsCallDepth {
+                required: 64,
+                capacity: 32,
+            }
+            .v_code(),
+            "V9016"
+        );
+    }
+
+    #[test]
     fn exit_code_when_internal_error_then_3() {
         assert_eq!(Trap::StackOverflow.exit_code(), 3);
         assert_eq!(Trap::StackUnderflow.exit_code(), 3);
@@ -413,5 +457,13 @@ mod tests {
             3
         );
         assert_eq!(Trap::InvalidCharWidth(7).exit_code(), 3);
+        assert_eq!(
+            Trap::ProgramExceedsCallDepth {
+                required: 64,
+                capacity: 32,
+            }
+            .exit_code(),
+            3
+        );
     }
 }

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -147,6 +147,25 @@ impl<'a> VmReady<'a> {
     pub fn start(mut self) -> Result<VmRunning<'a>, FaultContext> {
         let shared_globals_size = self.container.task_table.shared_globals_size;
 
+        // Reject containers whose declared call depth would not fit in
+        // the embedder's frame buffer. Codegen populates
+        // `max_call_depth` from the static call graph; a value of 0
+        // means "not computed" (legacy or hand-built test containers)
+        // and disables the check, preserving the prior behavior where
+        // the runtime `Trap::CallStackOverflow` is the only signal.
+        let declared = self.container.header.max_call_depth;
+        let capacity = self.frames.len();
+        if declared != 0 && declared as usize > capacity {
+            return Err(FaultContext {
+                trap: Trap::ProgramExceedsCallDepth {
+                    required: declared,
+                    capacity: capacity.min(u16::MAX as usize) as u16,
+                },
+                task_id: TaskId::DEFAULT,
+                instance_id: InstanceId::DEFAULT,
+            });
+        }
+
         // Execute init functions once before entering scan mode.
         for pi in 0..self.program_instances.len() {
             let init_fn = self.program_instances[pi].init_function_id;

--- a/compiler/vm/tests/it/load_max_call_depth.rs
+++ b/compiler/vm/tests/it/load_max_call_depth.rs
@@ -1,0 +1,77 @@
+//! Integration tests for the `header.max_call_depth` validation
+//! performed by `VmReady::start`.
+//!
+//! The validation lets a container declare its worst-case PLC call
+//! depth so the VM can reject a program that would not fit in the
+//! embedder's frame buffer *before* any init bytecode runs.
+
+use ironplc_container::{opcode, ContainerBuilder, FunctionId};
+use ironplc_vm::error::Trap;
+use ironplc_vm::Vm;
+
+use crate::common::VmBuffers;
+
+fn empty_init_container_with_depth(max_call_depth: u16) -> ironplc_container::Container {
+    let init_bytecode: Vec<u8> = vec![opcode::RET_VOID];
+    let scan_bytecode: Vec<u8> = vec![opcode::RET_VOID];
+    ContainerBuilder::new()
+        .num_variables(1)
+        .max_call_depth(max_call_depth)
+        .add_function(FunctionId::INIT, &init_bytecode, 0, 1, 0)
+        .add_function(FunctionId::SCAN, &scan_bytecode, 0, 1, 0)
+        .init_function_id(FunctionId::INIT)
+        .entry_function_id(FunctionId::SCAN)
+        .build()
+}
+
+#[test]
+fn start_when_container_declares_call_depth_exceeding_buffer_then_returns_program_exceeds_call_depth(
+) {
+    // `VmBuffers::from_container` allocates `MAX_CALL_DEPTH = 32` frames
+    // (the embedder default). Declaring 64 must be rejected up-front.
+    let c = empty_init_container_with_depth(64);
+    let mut b = VmBuffers::from_container(&c);
+    let fault = match Vm::new().load(&c, &mut b).start() {
+        Ok(_) => panic!("start should reject over-deep container"),
+        Err(f) => f,
+    };
+    assert_eq!(
+        fault.trap,
+        Trap::ProgramExceedsCallDepth {
+            required: 64,
+            capacity: 32,
+        }
+    );
+}
+
+#[test]
+fn start_when_container_declares_zero_call_depth_then_no_validation_runs() {
+    // Default / hand-built / legacy containers leave `max_call_depth = 0`.
+    // The validation must skip in that case (back-compat).
+    let c = empty_init_container_with_depth(0);
+    let mut b = VmBuffers::from_container(&c);
+    let ok = Vm::new().load(&c, &mut b).start().is_ok();
+    assert!(
+        ok,
+        "start should succeed when max_call_depth is 0 (not computed)"
+    );
+}
+
+#[test]
+fn start_when_container_declares_call_depth_within_buffer_then_succeeds() {
+    let c = empty_init_container_with_depth(16);
+    let mut b = VmBuffers::from_container(&c);
+    let ok = Vm::new().load(&c, &mut b).start().is_ok();
+    assert!(ok, "start should succeed when max_call_depth fits");
+}
+
+#[test]
+fn start_when_container_declares_call_depth_equal_to_buffer_then_succeeds() {
+    // Equality is the boundary case — the buffer holds exactly the
+    // declared depth, so it should be accepted (the rejection check
+    // is strict greater-than).
+    let c = empty_init_container_with_depth(32);
+    let mut b = VmBuffers::from_container(&c);
+    let ok = Vm::new().load(&c, &mut b).start().is_ok();
+    assert!(ok, "start should succeed at exact-fit boundary");
+}

--- a/compiler/vm/tests/it/main.rs
+++ b/compiler/vm/tests/it/main.rs
@@ -39,6 +39,7 @@ mod execute_neg_i32;
 mod execute_stack_overflow;
 mod execute_string_ops;
 mod execute_sub_i32;
+mod load_max_call_depth;
 mod profiling;
 mod proptest_robustness;
 mod scenarios;

--- a/docs/reference/runtime/problems/V9016.rst
+++ b/docs/reference/runtime/problems/V9016.rst
@@ -1,0 +1,26 @@
+=====
+V9016
+=====
+
+.. problem-summary:: V9016
+
+The container's declared worst-case call depth
+(``FileHeader.max_call_depth``) is larger than the call-frame buffer
+the embedder provided to the VM. ``VmReady::start`` rejects the
+container before any init code runs, so no PLC instructions execute.
+
+Codegen computes ``max_call_depth`` from the program's static call
+graph (longest path through ``CALL`` and user-``FB_CALL`` edges,
+counting the entry frame). The VM compares that number against
+``VmBuffers.frames.len()``.
+
+To resolve:
+
+* Grow the embedder's frame buffer if the program legitimately needs
+  the declared depth, then reload.
+* Recompile with a shallower call chain.
+
+The trap message reports both numbers (``required`` and ``capacity``).
+A ``required`` of ``0`` means the container was built without
+populating the field (legacy or hand-built containers); in that case
+no comparison runs and this trap is not raised.

--- a/specs/plans/2026-06-08-codegen-max-call-depth.md
+++ b/specs/plans/2026-06-08-codegen-max-call-depth.md
@@ -1,0 +1,357 @@
+# Compute `max_call_depth` in Codegen and Validate at VM Load
+
+## Goal
+
+Tighten the artificial `MAX_CALL_DEPTH = 32` bound landed in
+`compiler/vm/src/vm.rs` to each program's actual worst case:
+
+1. Codegen builds the static call graph during emission, runs a
+   3-color DFS to detect cycles, and writes the longest path to
+   the already-reserved `FileHeader.max_call_depth` field (bytes
+   194–195, currently always 0 — see `header.rs:67`, `header.rs:153`).
+2. `Vm::load` rejects containers whose `header.max_call_depth`
+   exceeds the embedder's frame-stack capacity, returning a typed
+   load error rather than waiting for runtime `CallStackOverflow`.
+
+Both halves are small. The PR ships a real safety improvement
+(fail-fast on a buggy container, plus codegen-side cycle detection
+as a backstop) and closes the loose end the Phase 2 plan explicitly
+deferred.
+
+## Why now
+
+The Phase 2 PR (`specs/plans/2026-05-25-iterative-vm-dispatch.md`)
+deferred this work intentionally: it would have inflated the
+dispatch rewrite. With the rewrite landed, the field is reserved
+in the header and unused; computing and validating it is now a
+self-contained follow-up.
+
+It also unblocks Phase 3 (DAP debugger): every paused VM needs a
+trustworthy upper bound on how many frames `stackTrace` can be
+asked to walk.
+
+## Scope
+
+In:
+
+- `compiler/codegen/src/`: collect call-graph edges during emission;
+  compute longest path; emit error on cycles; pass depth to builder.
+- `compiler/container/src/builder.rs`: opt-in `.max_call_depth(u16)`
+  setter that propagates to `FileHeader.max_call_depth`.
+- `compiler/vm/src/vm.rs`: validate `header.max_call_depth ≤
+  frames.len()` in `Vm::load`, returning a typed error.
+
+Out (deferred):
+
+- Sizing `VmBuffers.frames` from `header.max_call_depth`. The buffer
+  stays at fixed `MAX_CALL_DEPTH = 32` so this PR doesn't break
+  embedder-side memory budgeting. Tightening the buffer is a
+  follow-up that depends on `VmBuffers::from_container` reading
+  the header field.
+- Any container-format change. The `max_call_depth` field is
+  already reserved (`header.rs:67`); no version bump.
+- Updating hand-built test containers in `compiler/vm/tests/it/` to
+  set `max_call_depth`. They keep the default (0), which means "not
+  computed" and disables the load-time check. This preserves all
+  existing VM tests — including the
+  `execute_when_call_recursion_exceeds_max_depth_then_traps_call_stack_overflow`
+  test, which depends on the runtime `Trap::CallStackOverflow`
+  firing at frame 33.
+
+## Architecture
+
+### `ContainerBuilder::max_call_depth(u16)`
+
+Trivial pass-through. The existing `max_stack_depth` setter
+(`builder.rs:161`) is the precedent. Default stays 0.
+
+```rust
+pub fn max_call_depth(mut self, n: u16) -> Self {
+    self.max_call_depth = n;
+    self
+}
+```
+
+`build()` writes the value into the `FileHeader` it constructs at
+`builder.rs:365`.
+
+### Call-graph collection during emission
+
+The two emission sites are:
+
+- `compile_call.rs:316` — user function `CALL` (has `function_id`).
+- `compile_stmt.rs:495–530` — user-FB `FB_CALL` (has `type_id`; the
+  callee's `function_id` is in `ctx.user_fb_types[name].function_id`,
+  available at the same site).
+
+Both sites already run inside `CompileContext`. Add:
+
+```rust
+pub struct CompileContext {
+    // ... existing fields ...
+
+    /// Adjacency: caller function id -> set of callee function ids.
+    /// Populated by `emit_call` and the FB_CALL emission site.
+    pub call_graph: HashMap<FunctionId, HashSet<FunctionId>>,
+
+    /// Function currently being emitted. Pushed by `compile_function`
+    /// (and the FB-body equivalent), popped after the body emits.
+    pub current_function: Option<FunctionId>,
+}
+```
+
+Edge insertion is a one-liner at each emit site:
+
+```rust
+if let Some(caller) = ctx.current_function {
+    ctx.call_graph
+       .entry(caller)
+       .or_default()
+       .insert(callee);
+}
+```
+
+### Longest-path + cycle detection
+
+After every function/FB body is emitted, run a 3-color DFS from the
+entry function id (`FunctionId::SCAN`):
+
+```rust
+fn longest_path_or_cycle(
+    graph: &HashMap<FunctionId, HashSet<FunctionId>>,
+    entry: FunctionId,
+) -> Result<u16, FunctionId /* node in the cycle */> {
+    // Color: 0 = white, 1 = gray (on stack), 2 = black (done).
+    let mut color: HashMap<FunctionId, u8> = HashMap::new();
+    let mut depth: HashMap<FunctionId, u16> = HashMap::new();
+
+    fn dfs(
+        node: FunctionId,
+        graph: &HashMap<FunctionId, HashSet<FunctionId>>,
+        color: &mut HashMap<FunctionId, u8>,
+        depth: &mut HashMap<FunctionId, u16>,
+    ) -> Result<u16, FunctionId> {
+        match color.get(&node).copied().unwrap_or(0) {
+            1 => return Err(node),        // back edge -> cycle
+            2 => return Ok(depth[&node]), // memoized
+            _ => {}
+        }
+        color.insert(node, 1);
+        let mut max_child = 0u16;
+        if let Some(callees) = graph.get(&node) {
+            for &c in callees {
+                max_child = max_child.max(dfs(c, graph, color, depth)?);
+            }
+        }
+        let d = max_child + 1;
+        depth.insert(node, d);
+        color.insert(node, 2);
+        Ok(d)
+    }
+
+    dfs(entry, graph, &mut color, &mut depth)
+}
+```
+
+Depth semantics: `dfs(entry)` returns the number of stack frames at
+the deepest point, counting the entry frame. A leaf returns 1; a
+chain of N calls returns N+1.
+
+The recursion ban in semantic analysis already rejects cyclic
+programs, so the codegen check is a backstop. If a cycle ever
+slips through, emit a `Diagnostic` with code `P0XYZ` (new) and
+position pointing at the function declaration whose body
+introduced the back edge. Failing closed is correct — a cyclic
+program would loop forever in this DFS otherwise.
+
+### Codegen integration point
+
+Right before `ContainerBuilder::build()` is called in
+`compile.rs:244–255`:
+
+```rust
+let depth = longest_path_or_cycle(&ctx.call_graph, FunctionId::SCAN)
+    .map_err(|cycle_node| {
+        Diagnostic::new(
+            "P0XYZ",
+            format!("call graph contains a cycle at function {}", cycle_node),
+            // ... source position ...
+        )
+    })?;
+builder.max_call_depth(depth);
+let mut container = builder.build();
+```
+
+The exact `builder.build()` call site is inside
+`compile_program_with_functions`. Wiring the depth call has to
+happen wherever the builder is finalized.
+
+### `Vm::load` validation
+
+Today `Vm::load` is infallible:
+
+```rust
+pub fn load<'a>(self, container: &'a Container, bufs: &'a mut VmBuffers) -> VmReady<'a>
+```
+
+The cheapest change is to **leave the signature alone** and add the
+validation to `VmReady::start()`, which already returns
+`Result<VmRunning<'a>, FaultContext>` (`vm.rs:147`). The check runs
+before any init bytecode executes:
+
+```rust
+pub fn start(mut self) -> Result<VmRunning<'a>, FaultContext> {
+    let declared = self.container.header.max_call_depth as usize;
+    if declared > 0 && declared > self.frames.len() {
+        return Err(FaultContext {
+            trap: Trap::ProgramExceedsCallDepth {
+                required: self.container.header.max_call_depth,
+                capacity: self.frames.len() as u16,
+            },
+            task_id: TaskId::DEFAULT,
+            instance_id: InstanceId::DEFAULT,
+        });
+    }
+    // ... existing init-execution loop ...
+}
+```
+
+The `declared > 0` guard preserves backward compatibility with
+hand-built test containers that don't populate the field.
+
+Adds one Trap variant:
+
+```rust
+// in compiler/vm/src/error.rs
+ProgramExceedsCallDepth { required: u16, capacity: u16 },
+```
+
+with a `Display` impl mentioning both numbers so the embedder
+knows whether to upgrade the buffer or recompile with fewer calls.
+
+### `FunctionId::SCAN` and entry resolution
+
+`FunctionId::SCAN` is the entry by convention. The depth computation
+uses it directly. If a future container ever changes the entry,
+read it from `task_table.programs[0].entry_function_id` instead —
+mention this in a code comment so the future move is obvious.
+
+## File map
+
+Modified:
+
+- `compiler/codegen/src/compile.rs` — add `call_graph` /
+  `current_function` to `CompileContext`; wire depth computation
+  into the `compile_program_with_functions` finalization path.
+- `compiler/codegen/src/compile_call.rs` — record edge on `emit_call`.
+- `compiler/codegen/src/compile_stmt.rs` — record edge on user-FB
+  `FB_CALL` emission.
+- `compiler/codegen/src/lib.rs` — re-export new helper if extracted
+  to its own module (see below).
+- `compiler/container/src/builder.rs` — add `max_call_depth` field
+  + setter + propagation in `build()`.
+- `compiler/vm/src/vm.rs` — add `max_call_depth` validation in
+  `VmReady::start()`.
+- `compiler/vm/src/error.rs` — add `ProgramExceedsCallDepth` Trap
+  variant with `Display` impl.
+- `docs/compiler/problems/` — new problem doc for the cycle
+  diagnostic (per CLAUDE.md problem-code policy).
+
+New (optional, only if the helper grows past ~30 lines):
+
+- `compiler/codegen/src/call_graph.rs` — `longest_path_or_cycle` and
+  any related types kept out of `compile.rs` to manage module size.
+
+Not modified:
+
+- Container format / wire encoding. The header field already exists.
+- `compiler/vm/src/buffers.rs`. `VmBuffers::from_container` still
+  sizes frames at `MAX_CALL_DEPTH`. Tightening the buffer to the
+  header value is a follow-up.
+- `compiler/vm/src/frame_stack.rs`. Phase 2's FrameStack works as-is.
+- VM trap behavior on runtime overflow. `Trap::CallStackOverflow`
+  still fires from `FrameStack::push` if (against the header's
+  declaration) a program tries to push past the buffer.
+
+## Migration
+
+Single commit. The work is mechanical:
+
+1. Add `Trap::ProgramExceedsCallDepth` and its `Display`.
+2. Add `ContainerBuilder::max_call_depth` setter.
+3. Add `CompileContext.call_graph` and `current_function`; push/pop
+   `current_function` around each body emission.
+4. Insert one-line edge records at the two emit sites.
+5. Implement `longest_path_or_cycle`.
+6. Wire it into the builder finalization.
+7. Add `VmReady::start()` validation.
+8. Add tests (below).
+9. `cd compiler && just`.
+
+If any existing test fails, that's the signal to investigate — most
+likely a hand-built test container that does set `max_call_depth`
+but has bytecode going deeper. Resolve by either fixing the test's
+declared depth or fixing the bytecode.
+
+## Tests
+
+Codegen (`compiler/codegen/tests/it/`):
+
+- `compile_when_program_has_no_calls_then_max_call_depth_is_one`
+  — a program whose `SCAN` only does arithmetic. Depth = 1.
+- `compile_when_program_calls_one_function_then_max_call_depth_is_two`
+  — `SCAN → FOO`. Depth = 2.
+- `compile_when_call_chain_three_deep_then_max_call_depth_is_four`
+  — `SCAN → A → B → C`. Depth = 4.
+- `compile_when_diamond_call_graph_then_max_call_depth_takes_longest`
+  — `SCAN → {A, B}; A → C; B → D → E`. Depth = 4 (SCAN→B→D→E).
+- `compile_when_program_calls_user_fb_then_fb_body_counted`
+  — `SCAN → FB.body`. Depth = 2.
+- `compile_when_user_fb_calls_user_fb_then_both_counted`
+  — `SCAN → outerFB.body → innerFB.body`. Depth = 3.
+- `compile_when_call_graph_has_cycle_then_codegen_returns_diagnostic`
+  — synthesized cycle (semantic analysis is bypassed via a unit
+  test that injects a fake edge into the graph, since real cycles
+  are rejected earlier).
+
+VM (`compiler/vm/tests/it/`):
+
+- `start_when_container_declares_call_depth_exceeding_buffer_then_returns_program_exceeds_call_depth`
+  — build a container with `max_call_depth = 64` via the builder
+  setter, default `VmBuffers` (frames = 32). `start()` returns the
+  new Trap variant with `required = 64, capacity = 32`.
+- `start_when_container_declares_zero_call_depth_then_no_validation_runs`
+  — legacy container path: no `.max_call_depth` set → default 0 →
+  start succeeds (back-compat).
+- `start_when_container_declares_call_depth_within_buffer_then_succeeds`
+  — `.max_call_depth(16)` with default 32-cap buffer → start
+  succeeds.
+
+Container (`compiler/container/`):
+
+- `builder_when_max_call_depth_set_then_propagates_to_header` — the
+  setter end-to-end.
+
+Conformance (`compiler/container/src/spec_conformance.rs`): no
+changes — the existing field-offset test already covers bytes
+194–195.
+
+Problem doc (`docs/compiler/problems/`):
+
+- New `P0XYZ.rst` for the cycle diagnostic. Title, description,
+  example, "how to fix" sections per the CLAUDE.md template.
+
+## Out of scope
+
+- Resizing `VmBuffers.frames` from the container header. Stays
+  fixed at `MAX_CALL_DEPTH = 32`. Tightening the buffer to the
+  header value is a follow-up and unlocks per-program memory
+  budgeting on embedded targets.
+- Reporting depth in a CLI or debug-info dump. Useful but not
+  required.
+- Adding the depth check to `VmReady::resume()` (a separate
+  start-from-saved-state path). `resume()` doesn't run init and
+  the validation can move into it later if/when its use grows.
+- Tracking which FB/function declaration introduced the deepest
+  path for diagnostic purposes. Today the trap reports numbers,
+  not call paths.


### PR DESCRIPTION
Closes the loose end the iterative-dispatch PR (#1094) explicitly deferred: the call-frame buffer's artificial `MAX_CALL_DEPTH = 32` is now backed by a real per-program declaration that the VM checks before any init code runs.

**Depends on #1094** — the FrameStack infrastructure must land first, so this PR targets that branch as its base. Once #1094 merges to main, I'll retarget this PR.

## Summary

- **Codegen**: records one edge per `CALL` / user `FB_CALL` during emission. After all bodies are compiled, an iterative 3-color DFS from `FunctionId::SCAN` returns the longest path (depth 1 = entry only). Result is stamped on the already-reserved `FileHeader.max_call_depth` field via a new `ContainerBuilder::max_call_depth(u16)` setter.
- **VM**: `VmReady::start` rejects containers whose declared depth exceeds the frame buffer with `Trap::ProgramExceedsCallDepth { required, capacity }` (V9016). The check is skipped when `declared == 0` so hand-built test containers keep working.
- **Bug fix** the call-graph DFS surfaced: FB types and user functions both allocated function IDs starting at 2, so a function and an FB could share a runtime id. User functions now start at `2 + N_fb` so each POU has a unique id.
- **Cycle backstop**: if the DFS ever finds a cycle, codegen returns `Problem::InternalError` rather than looping forever. Semantic analysis (`Problem::RecursiveCycle`) should reject these earlier; this is defense-in-depth.

## Out of scope

Sizing `VmBuffers.frames` from `header.max_call_depth`. The buffer stays at fixed `MAX_CALL_DEPTH = 32`; tightening it requires threading an embedder-supplied frame budget through `VmBuffers::from_container` and is a follow-up.

## Test plan

- [x] `compiler/codegen/src/call_graph.rs` — 8 unit tests for the DFS (empty graph, chain, diamond, shared subtree, self-cycle, indirect cycle).
- [x] `compiler/codegen/tests/it/codegen_max_call_depth.rs` — 7 end-to-end tests compiling small IEC 61131-3 programs and asserting `header.max_call_depth`.
- [x] `compiler/vm/tests/it/load_max_call_depth.rs` — 4 tests covering the boundary cases (exceeds, equal, fits, zero-skip).
- [x] `compiler/vm/src/error.rs` — Display / `v_code` / `exit_code` tests for the new trap variant.
- [x] `compiler/container/src/builder.rs` — setter propagation tests.
- [x] `cd compiler && just` exits 0 (compile + coverage + clippy + fmt + dupes).
- [x] Full workspace `cargo test --workspace` passes including the previously failing `end_to_end_when_user_fb_body_calls_user_function_then_compiles` (now passes because the ID collision is fixed).

https://claude.ai/code/session_01MYbAUdSrAJyFz7BwKpZWaT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYbAUdSrAJyFz7BwKpZWaT)_