### PR TITLE
VmBuffers: size frame stack from header.max_call_depth

### DIFF
--- a/compiler/vm/src/buffers.rs
+++ b/compiler/vm/src/buffers.rs
@@ -53,7 +53,21 @@ impl VmBuffers {
             tasks: vec![TaskState::default(); task_count],
             programs: vec![ProgramInstanceState::default(); program_count],
             ready: vec![0usize; task_count.max(1)],
-            frames: vec![zero_frame; MAX_CALL_DEPTH as usize],
+            // Size the call-frame stack from the container's declared
+            // worst-case depth. Codegen writes that depth from the
+            // static call graph; hand-built containers leave it at 0
+            // ("not computed"), in which case we fall back to
+            // `MAX_CALL_DEPTH` to preserve back-compat (the same
+            // sentinel `VmReady::start` uses to skip its
+            // `Trap::ProgramExceedsCallDepth` check).
+            frames: vec![
+                zero_frame;
+                if h.max_call_depth == 0 {
+                    MAX_CALL_DEPTH as usize
+                } else {
+                    h.max_call_depth as usize
+                }
+            ],
         }
     }
 }

--- a/compiler/vm/tests/it/load_max_call_depth.rs
+++ b/compiler/vm/tests/it/load_max_call_depth.rs
@@ -27,11 +27,16 @@ fn empty_init_container_with_depth(max_call_depth: u16) -> ironplc_container::Co
 #[test]
 fn start_when_container_declares_call_depth_exceeding_buffer_then_returns_program_exceeds_call_depth(
 ) {
-    // `VmBuffers::from_container` allocates `MAX_CALL_DEPTH = 32` frames
-    // (the embedder default). Declaring 64 must be rejected up-front.
-    let c = empty_init_container_with_depth(64);
-    let mut b = VmBuffers::from_container(&c);
-    let fault = match Vm::new().load(&c, &mut b).start() {
+    // Construct the frame buffer from a small container, then load a
+    // deeper container into it. This mirrors the embedded scenario the
+    // check is for: a fixed-size buffer allocated up front (or shared
+    // across loads) that can't grow to fit a freshly loaded program.
+    let small = empty_init_container_with_depth(8);
+    let mut b = VmBuffers::from_container(&small);
+    assert_eq!(b.frames.len(), 8, "buffer sized from the small container");
+
+    let deep = empty_init_container_with_depth(64);
+    let fault = match Vm::new().load(&deep, &mut b).start() {
         Ok(_) => panic!("start should reject over-deep container"),
         Err(f) => f,
     };
@@ -39,9 +44,26 @@ fn start_when_container_declares_call_depth_exceeding_buffer_then_returns_progra
         fault.trap,
         Trap::ProgramExceedsCallDepth {
             required: 64,
-            capacity: 32,
+            capacity: 8,
         }
     );
+}
+
+#[test]
+fn from_container_when_max_call_depth_set_then_buffer_sized_to_declared_depth() {
+    let c = empty_init_container_with_depth(7);
+    let b = VmBuffers::from_container(&c);
+    assert_eq!(b.frames.len(), 7);
+}
+
+#[test]
+fn from_container_when_max_call_depth_zero_then_buffer_falls_back_to_max_call_depth() {
+    // Hand-built / legacy containers leave the field unset. The buffer
+    // must still allocate the default `MAX_CALL_DEPTH = 32` so those
+    // tests keep working with their existing assumptions.
+    let c = empty_init_container_with_depth(0);
+    let b = VmBuffers::from_container(&c);
+    assert_eq!(b.frames.len(), 32);
 }
 
 #[test]


### PR DESCRIPTION
Builds on the codegen `max_call_depth` work (PR #1099). `VmBuffers::from_container` now sizes the frame stack from `header.max_call_depth` instead of a hardcoded `MAX_CALL_DEPTH = 32`. Codegen-built containers shrink to what the static call graph actually needs, which matters on memory-constrained embedded targets.

## Summary

- `VmBuffers::from_container` reads `header.max_call_depth`. Field == 0 → fall back to `MAX_CALL_DEPTH` (same "not computed" sentinel `VmReady::start` already uses to skip its capacity check). No hand-built / legacy test container has to change.
- One test rewrite: the "declared depth exceeds buffer" case used to build the buffer from the same over-deep container, which now sizes the buffer to fit. Updated to allocate the buffer from a small container first, then `load()` a deeper one into it — mirrors the real embedded scenario (fixed buffer allocated up front, possibly shared across loads).
- Two new unit tests for the sizing logic itself.

## Test plan

- [x] `cargo test --workspace` passes — no other test broke from the buffer size change.
- [x] `cd compiler && just` exits 0.
- [x] New: `from_container_when_max_call_depth_set_then_buffer_sized_to_declared_depth` (declared 7 → 7-frame buffer).
- [x] New: `from_container_when_max_call_depth_zero_then_buffer_falls_back_to_max_call_depth` (declared 0 → 32-frame buffer).
- [x] Updated: `start_when_container_declares_call_depth_exceeding_buffer_then_returns_program_exceeds_call_depth` (small buffer + deep container → `Trap::ProgramExceedsCallDepth { required: 64, capacity: 8 }`).

https://claude.ai/code/session_01MYbAUdSrAJyFz7BwKpZWaT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYbAUdSrAJyFz7BwKpZWaT)_