### PR TITLE
Fix Homebrew formula syntax: remove assignment operator from license

### DIFF
--- a/compiler/homebrew/Formula/ironplc.rb
+++ b/compiler/homebrew/Formula/ironplc.rb
@@ -17,7 +17,7 @@ class Ironplc < Formula
     version "${VERSION}"
     desc "IronPLC Compiler"
     homepage "https://www.ironplc.com"
-    license = "MIT"
+    license "MIT"
   
     if OS.mac?
         url "https://github.com/ironplc/ironplc/releases/download/v${VERSION}/${MACFILENAME}"


### PR DESCRIPTION
## Summary
Corrects a syntax error in the Homebrew formula for IronPLC by removing the assignment operator (`=`) from the `license` declaration.

## Changes
- Changed `license = "MIT"` to `license "MIT"` in `compiler/homebrew/Formula/ironplc.rb`

## Details
The Homebrew DSL uses method-style declarations for formula metadata. The `license` field should be declared as a method call with an argument, not as a variable assignment. This fix ensures the formula conforms to Homebrew's expected syntax and will be properly recognized by Homebrew's validation tools.

https://claude.ai/code/session_01UoPZFGaVQqg7yKNeDT6REb