### PR TITLE
Use FunctionId newtype for function IDs in codegen

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -329,7 +329,7 @@ fn add_line_map_entries(
 
 /// Holds the compiled bytecode and metadata for a user-defined function.
 pub(crate) struct CompiledFunction {
-    pub(crate) function_id: u16,
+    pub(crate) function_id: FunctionId,
     pub(crate) bytecode: Vec<u8>,
     pub(crate) max_stack_depth: u16,
     pub(crate) num_locals: u16,
@@ -486,7 +486,7 @@ fn compile_program_with_functions(
                 type_id,
                 num_fields: field_decls_tmp.len(),
                 field_indices,
-                function_id: next_function_id,
+                function_id: FunctionId::new(next_function_id),
                 var_offset: 0, // updated after program vars are assigned
                 field_op_types,
             },
@@ -525,7 +525,7 @@ fn compile_program_with_functions(
     for (next_function_id, func_decl) in (user_fn_id_base..).zip(func_decls.iter()) {
         let compiled = compile_user_function(
             func_decl,
-            next_function_id,
+            FunctionId::new(next_function_id),
             var_offset,
             &mut ctx,
             functions,
@@ -638,24 +638,20 @@ fn compile_program_with_functions(
     // Add user-defined function block bodies.
     for compiled in &compiled_fb_bodies {
         builder = builder.add_function(
-            FunctionId::new(compiled.function_id),
+            compiled.function_id,
             &compiled.bytecode,
             compiled.max_stack_depth,
             compiled.num_locals,
             compiled.num_params,
         );
-        builder = add_line_map_entries(
-            builder,
-            FunctionId::new(compiled.function_id),
-            &compiled.line_map,
-        );
+        builder = add_line_map_entries(builder, compiled.function_id, &compiled.line_map);
     }
 
     // Add user FB type descriptors to the container.
     for fb_info in ctx.user_fb_types.values() {
         builder = builder.add_user_fb_type(UserFbDescriptor {
             type_id: FbTypeId::new(fb_info.type_id),
-            function_id: FunctionId::new(fb_info.function_id),
+            function_id: fb_info.function_id,
             var_offset: fb_info.var_offset,
             num_fields: fb_info.num_fields as u8,
         });
@@ -664,17 +660,13 @@ fn compile_program_with_functions(
     // Add user-defined functions.
     for compiled in &compiled_functions {
         builder = builder.add_function(
-            FunctionId::new(compiled.function_id),
+            compiled.function_id,
             &compiled.bytecode,
             compiled.max_stack_depth,
             compiled.num_locals,
             compiled.num_params,
         );
-        builder = add_line_map_entries(
-            builder,
-            FunctionId::new(compiled.function_id),
-            &compiled.line_map,
-        );
+        builder = add_line_map_entries(builder, compiled.function_id, &compiled.line_map);
     }
 
     // Add the SOURCE_FILE_TABLE (tag 6). `ctx.debug_source_files`
@@ -715,13 +707,13 @@ fn compile_program_with_functions(
 
     for compiled in &compiled_fb_bodies {
         builder = builder.add_func_name(FuncNameEntry {
-            function_id: FunctionId::new(compiled.function_id),
+            function_id: compiled.function_id,
             name: compiled.name.clone(),
         });
     }
     for compiled in &compiled_functions {
         builder = builder.add_func_name(FuncNameEntry {
-            function_id: FunctionId::new(compiled.function_id),
+            function_id: compiled.function_id,
             name: compiled.name.clone(),
         });
     }
@@ -771,7 +763,7 @@ pub(crate) struct StringReturnInfo {
 #[derive(Clone)]
 pub(crate) struct UserFunctionInfo {
     /// The function ID assigned in the container.
-    pub(crate) function_id: u16,
+    pub(crate) function_id: FunctionId,
     /// The absolute variable table offset where this function's parameters start.
     pub(crate) var_offset: VarIndex,
     /// Number of input parameters.
@@ -811,7 +803,7 @@ pub(crate) struct UserFbTypeInfo {
     /// Maps field name (lowercase) to field index (ordinal position).
     pub(crate) field_indices: HashMap<String, u8>,
     /// Function ID of the compiled FB body in the container.
-    pub(crate) function_id: u16,
+    pub(crate) function_id: FunctionId,
     /// Variable table offset where the FB body's slots start.
     pub(crate) var_offset: u16,
     /// Maps field name (lowercase) to its op type for codegen at call sites.

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -319,7 +319,7 @@ fn compile_user_function_call(
         func_info.var_offset,
         func_info.max_stack_depth,
     );
-    ctx.record_call_edge(ironplc_container::FunctionId::new(func_info.function_id));
+    ctx.record_call_edge(func_info.function_id);
     // For STRING-returning functions, the CALL leaves a buf_idx on the stack
     // (from emit_str_load_var in the function epilogue). The caller's
     // assignment path will consume it via emit_str_store_var.

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -40,7 +40,7 @@ use crate::emit::Emitter;
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn compile_user_function(
     func_decl: &FunctionDeclaration,
-    function_id: u16,
+    function_id: FunctionId,
     var_offset: VarIndex,
     ctx: &mut CompileContext,
     functions: &FunctionEnvironment,
@@ -332,7 +332,7 @@ pub(crate) fn compile_user_function(
     // Mark this function as the current caller so nested CALL / FB_CALL
     // emissions record edges into ctx.call_graph.
     let saved_current_fn = ctx.current_function_id.take();
-    ctx.current_function_id = Some(FunctionId::new(function_id));
+    ctx.current_function_id = Some(function_id);
 
     compile_statements(&mut func_emitter, ctx, &body)?;
 
@@ -448,7 +448,7 @@ pub(crate) fn compile_user_function(
 /// The VM's copy-in/copy-out logic mirrors this ordering.
 pub(crate) fn compile_user_function_block(
     fb_decl: &FunctionBlockDeclaration,
-    function_id: u16,
+    function_id: FunctionId,
     var_offset: u16,
     ctx: &mut CompileContext,
     builder: &mut ContainerBuilder,
@@ -585,7 +585,7 @@ pub(crate) fn compile_user_function_block(
     // emissions record edges into ctx.call_graph (mirrors the same setup
     // in compile_user_function and the SCAN-body site).
     let saved_current_fn = ctx.current_function_id.take();
-    ctx.current_function_id = Some(FunctionId::new(function_id));
+    ctx.current_function_id = Some(function_id);
 
     let mut fb_emitter = Emitter::new();
     compile_body(&mut fb_emitter, ctx, &fb_decl.body)?;

--- a/compiler/codegen/src/compile_stmt.rs
+++ b/compiler/codegen/src/compile_stmt.rs
@@ -506,7 +506,7 @@ fn compile_fb_call(
         .values()
         .find(|info| info.type_id == type_id)
     {
-        ctx.record_call_edge(ironplc_container::FunctionId::new(user_fb.function_id));
+        ctx.record_call_edge(user_fb.function_id);
     }
 
     // Read output parameters.

--- a/compiler/codegen/src/emit.rs
+++ b/compiler/codegen/src/emit.rs
@@ -3,7 +3,7 @@
 //! Provides a builder that appends opcodes and operands to a byte buffer.
 
 use ironplc_container::opcode;
-use ironplc_container::{SourceColumn, SourceFileId, SourceLine, VarIndex};
+use ironplc_container::{FunctionId, SourceColumn, SourceFileId, SourceLine, VarIndex};
 
 /// A bytecode-offset → source-location entry recorded by the [`Emitter`].
 ///
@@ -807,7 +807,7 @@ impl Emitter {
     /// function's parameters start.
     pub fn emit_call(
         &mut self,
-        function_id: u16,
+        function_id: FunctionId,
         num_params: u16,
         var_offset: VarIndex,
         callee_max_stack: u16,
@@ -1607,7 +1607,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_load_const_i32(0); // arg 1
         em.emit_load_const_i32(1); // arg 2
-        em.emit_call(2, 2, VarIndex::new(5), 0); // CALL function 2, 2 params, var_offset=5
+        em.emit_call(FunctionId::new(2), 2, VarIndex::new(5), 0); // CALL function 2, 2 params, var_offset=5
 
         // LOAD_CONST pool:0, LOAD_CONST pool:1, CALL func:2 var_offset:5
         assert_eq!(
@@ -1633,7 +1633,7 @@ mod tests {
         let mut em = Emitter::new();
         em.emit_load_const_i32(0); // stack: 1
         em.emit_load_const_i32(1); // stack: 2
-        em.emit_call(2, 2, VarIndex::new(5), 0); // pop 2 args, push 1 result = stack: 1
+        em.emit_call(FunctionId::new(2), 2, VarIndex::new(5), 0); // pop 2 args, push 1 result = stack: 1
         em.emit_store_var_i32(VarIndex::new(0)); // stack: 0
 
         assert_eq!(em.max_stack_depth(), 2);


### PR DESCRIPTION
Codegen threaded raw u16 values for function IDs through its internal
structs and helpers, wrapping them in the FunctionId newtype only at the
container-builder boundary. This left several u16 fields and parameters
that could be confused with other u16 values (var offsets, param counts,
type IDs).

Thread the existing ironplc_container::FunctionId newtype through codegen
instead: CompiledFunction, UserFunctionInfo, and UserFbTypeInfo now store
FunctionId, the compile_user_function(_block) and Emitter::emit_call
signatures take FunctionId, and the redundant FunctionId::new wrapping at
internal call sites is removed. Construction from a raw u16 now happens
only where IDs originate (sequential range counters and tests).