### PR TITLE
Design: unified variable inspection model

### DIFF
--- a/compiler/vm-cli/src/cli.rs
+++ b/compiler/vm-cli/src/cli.rs
@@ -9,7 +9,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use ironplc_container::debug_format::{build_var_debug_map, format_variable_value, VarDebugInfo};
-use ironplc_container::Container;
+use ironplc_container::debug_section::var_section;
+use ironplc_container::{Container, FunctionId};
 use ironplc_vm::{Vm, VmBuffers};
 use serde_json::json;
 
@@ -23,7 +24,12 @@ const BUILD_OPT_LEVEL: &str = env!("BUILD_OPT_LEVEL");
 /// When `scans` is `None`, runs continuously until Ctrl+C.
 /// When `dump_vars` is `Some(path)`, writes variable values after stopping.
 /// A path of "-" writes to stdout; any other path writes to a file.
-pub fn run(path: &Path, dump_vars: Option<&Path>, scans: Option<u64>) -> Result<(), VmError> {
+pub fn run(
+    path: &Path,
+    dump_vars: Option<&Path>,
+    scans: Option<u64>,
+    group_by_scope: bool,
+) -> Result<(), VmError> {
     let mut file = File::open(path).map_err(|e| {
         VmError::io(
             error::FILE_OPEN,
@@ -75,7 +81,7 @@ pub fn run(path: &Path, dump_vars: Option<&Path>, scans: Option<u64>) -> Result<
             let faulted = running.fault(ctx);
             let err = VmError::from_trap(faulted.trap(), faulted.task_id(), faulted.instance_id());
             if let Some(dump_path) = dump_vars {
-                dump_variables_faulted(&faulted, &container, dump_path)?;
+                dump_variables_faulted(&faulted, &container, dump_path, group_by_scope)?;
             }
             return Err(err);
         }
@@ -95,7 +101,7 @@ pub fn run(path: &Path, dump_vars: Option<&Path>, scans: Option<u64>) -> Result<
     let stopped = running.stop();
 
     if let Some(dump_path) = dump_vars {
-        dump_variables_stopped(&stopped, &container, dump_path)?;
+        dump_variables_stopped(&stopped, &container, dump_path, group_by_scope)?;
     }
 
     Ok(())
@@ -274,42 +280,203 @@ fn open_dump_output(dump_path: &Path) -> Result<Box<dyn Write>, VmError> {
     }
 }
 
+/// A variable row in the scoped dump: its slot metadata plus current value.
+struct ScopeRow {
+    var_index: u16,
+    name: String,
+    type_name: String,
+    iec_type_tag: u8,
+    var_section: u8,
+    raw: u64,
+}
+
+/// A group of variables in the scoped dump, owned by a single POU. The
+/// `[Globals]` group uses [`FunctionId::GLOBAL_SCOPE`].
+struct ScopeGroup {
+    function_id: FunctionId,
+    label: String,
+    rows: Vec<ScopeRow>,
+}
+
+/// Returns the IEC 61131-3 section name for a `var_section` code.
+fn var_section_name(section: u8) -> &'static str {
+    match section {
+        var_section::VAR => "VAR",
+        var_section::VAR_TEMP => "VAR_TEMP",
+        var_section::VAR_INPUT => "VAR_INPUT",
+        var_section::VAR_OUTPUT => "VAR_OUTPUT",
+        var_section::VAR_IN_OUT => "VAR_IN_OUT",
+        var_section::VAR_EXTERNAL => "VAR_EXTERNAL",
+        var_section::VAR_GLOBAL => "VAR_GLOBAL",
+        _ => "VAR",
+    }
+}
+
+/// Builds the scoped dump groups from the container's debug section and the
+/// per-index variable values. `values[i]` is the raw value of variable slot
+/// `i`. Returns an empty vector when the container carries no named
+/// variables (the caller then falls back to the flat dump).
+///
+/// Globals (`function_id == GLOBAL_SCOPE`) come first, then each owning POU
+/// in ascending `function_id` order. Within a group, rows are ordered by
+/// `var_index`, which matches declaration order (params, locals, return).
+fn build_scope_groups(container: &Container, values: &[u64]) -> Vec<ScopeGroup> {
+    let Some(debug) = &container.debug_section else {
+        return Vec::new();
+    };
+    if debug.var_names.is_empty() {
+        return Vec::new();
+    }
+
+    // function_id (raw) -> POU name, for group labels.
+    let mut func_names: HashMap<u16, &str> = HashMap::new();
+    for f in &debug.func_names {
+        func_names.insert(f.function_id.raw(), f.name.as_str());
+    }
+
+    // Collect rows per function_id (raw), skipping any entry whose slot is
+    // out of range for the values we read.
+    let mut by_function: HashMap<u16, Vec<ScopeRow>> = HashMap::new();
+    for entry in &debug.var_names {
+        let idx = entry.var_index.raw();
+        let Some(&raw) = values.get(idx as usize) else {
+            continue;
+        };
+        by_function
+            .entry(entry.function_id.raw())
+            .or_default()
+            .push(ScopeRow {
+                var_index: idx,
+                name: entry.name.clone(),
+                type_name: entry.type_name.clone(),
+                iec_type_tag: entry.iec_type_tag,
+                var_section: entry.var_section,
+                raw,
+            });
+    }
+
+    let global_raw = FunctionId::GLOBAL_SCOPE.raw();
+    let mut ordered_ids: Vec<u16> = by_function.keys().copied().collect();
+    // Globals first, then ascending by function id.
+    ordered_ids.sort_by_key(|&id| (id != global_raw, id));
+
+    let mut groups = Vec::with_capacity(ordered_ids.len());
+    for id in ordered_ids {
+        let mut rows = by_function.remove(&id).unwrap_or_default();
+        rows.sort_by_key(|r| r.var_index);
+        let label = if id == global_raw {
+            "Globals".to_string()
+        } else if let Some(name) = func_names.get(&id) {
+            (*name).to_string()
+        } else {
+            format!("function {id}")
+        };
+        groups.push(ScopeGroup {
+            function_id: FunctionId::new(id),
+            label,
+            rows,
+        });
+    }
+    groups
+}
+
+/// Writes one scoped group: a `[label]` header followed by one indented line
+/// per variable. Non-global variables carry an IEC section annotation;
+/// globals omit it (the group already implies global scope).
+fn write_scoped_group(out: &mut dyn Write, group: &ScopeGroup) -> Result<(), VmError> {
+    let is_global = group.function_id == FunctionId::GLOBAL_SCOPE;
+    let mut text = format!("[{}]\n", group.label);
+    for row in &group.rows {
+        let value = format_variable_value(row.raw, row.iec_type_tag);
+        let typed = if row.type_name.is_empty() {
+            row.name.clone()
+        } else {
+            format!("{} : {}", row.name, row.type_name)
+        };
+        if is_global {
+            text.push_str(&format!("  {typed} = {value}\n"));
+        } else {
+            text.push_str(&format!(
+                "  {typed} = {value}  ({})\n",
+                var_section_name(row.var_section)
+            ));
+        }
+    }
+    out.write_all(text.as_bytes()).map_err(|e| {
+        VmError::io(
+            error::DUMP_WRITE,
+            format!("Unable to write dump output: {e}"),
+        )
+    })
+}
+
+/// Writes the variable dump. When `group_by_scope` is set and the container
+/// has named variables, emits the scoped layout; otherwise emits the flat,
+/// one-line-per-variable format (REQ-VC-005/008/009).
+fn write_dump(
+    out: &mut dyn Write,
+    container: &Container,
+    values: &[u64],
+    group_by_scope: bool,
+) -> Result<(), VmError> {
+    if group_by_scope {
+        let groups = build_scope_groups(container, values);
+        if !groups.is_empty() {
+            for group in &groups {
+                write_scoped_group(out, group)?;
+            }
+            return Ok(());
+        }
+        // No debug info to group by — fall back to the flat dump.
+    }
+
+    let debug_map = build_var_debug_map(container);
+    for (i, &raw) in values.iter().enumerate() {
+        write_variable_line(out, i as u16, raw, &debug_map)?;
+    }
+    Ok(())
+}
+
 fn dump_variables_stopped(
     stopped: &ironplc_vm::VmStopped,
     container: &Container,
     dump_path: &Path,
+    group_by_scope: bool,
 ) -> Result<(), VmError> {
-    let debug_map = build_var_debug_map(container);
     let num_vars = stopped.num_variables();
-    let mut out = open_dump_output(dump_path)?;
+    let mut values = Vec::with_capacity(num_vars as usize);
     for i in 0..num_vars {
-        let raw = stopped
-            .read_variable_raw(ironplc_container::VarIndex::new(i))
-            .map_err(|e| {
-                VmError::io(error::VAR_READ, format!("Unable to read variable {i}: {e}"))
-            })?;
-        write_variable_line(&mut *out, i, raw, &debug_map)?;
+        values.push(
+            stopped
+                .read_variable_raw(ironplc_container::VarIndex::new(i))
+                .map_err(|e| {
+                    VmError::io(error::VAR_READ, format!("Unable to read variable {i}: {e}"))
+                })?,
+        );
     }
-    Ok(())
+    let mut out = open_dump_output(dump_path)?;
+    write_dump(&mut *out, container, &values, group_by_scope)
 }
 
 fn dump_variables_faulted(
     faulted: &ironplc_vm::VmFaulted,
     container: &Container,
     dump_path: &Path,
+    group_by_scope: bool,
 ) -> Result<(), VmError> {
-    let debug_map = build_var_debug_map(container);
     let num_vars = faulted.num_variables();
-    let mut out = open_dump_output(dump_path)?;
+    let mut values = Vec::with_capacity(num_vars as usize);
     for i in 0..num_vars {
-        let raw = faulted
-            .read_variable_raw(ironplc_container::VarIndex::new(i))
-            .map_err(|e| {
-                VmError::io(error::VAR_READ, format!("Unable to read variable {i}: {e}"))
-            })?;
-        write_variable_line(&mut *out, i, raw, &debug_map)?;
+        values.push(
+            faulted
+                .read_variable_raw(ironplc_container::VarIndex::new(i))
+                .map_err(|e| {
+                    VmError::io(error::VAR_READ, format!("Unable to read variable {i}: {e}"))
+                })?,
+        );
     }
-    Ok(())
+    let mut out = open_dump_output(dump_path)?;
+    write_dump(&mut *out, container, &values, group_by_scope)
 }
 
 #[cfg(test)]
@@ -501,6 +668,220 @@ mod tests {
         assert!(
             err.to_string().starts_with("V6006"),
             "expected V6006 (dump write), got {err}"
+        );
+    }
+
+    use ironplc_container::debug_section::{FuncNameEntry, VarNameEntry};
+    use ironplc_container::{ContainerBuilder, VarIndex};
+
+    fn var(
+        index: u16,
+        owner: FunctionId,
+        section: u8,
+        tag: u8,
+        name: &str,
+        type_name: &str,
+    ) -> VarNameEntry {
+        VarNameEntry {
+            var_index: VarIndex::new(index),
+            function_id: owner,
+            var_section: section,
+            iec_type_tag: tag,
+            name: name.into(),
+            type_name: type_name.into(),
+        }
+    }
+
+    fn container_with(vars: Vec<VarNameEntry>, funcs: Vec<FuncNameEntry>) -> Container {
+        let mut builder = ContainerBuilder::new();
+        for v in vars {
+            builder = builder.add_var_name(v);
+        }
+        for f in funcs {
+            builder = builder.add_func_name(f);
+        }
+        builder.build()
+    }
+
+    #[test]
+    fn var_section_name_when_known_section_then_returns_iec_name() {
+        assert_eq!(var_section_name(var_section::VAR), "VAR");
+        assert_eq!(var_section_name(var_section::VAR_INPUT), "VAR_INPUT");
+        assert_eq!(var_section_name(var_section::VAR_OUTPUT), "VAR_OUTPUT");
+        assert_eq!(var_section_name(var_section::VAR_IN_OUT), "VAR_IN_OUT");
+    }
+
+    /// REQ-VC-018: scoped dump groups variables, with the `[Globals]` group
+    /// first, then per-POU groups in ascending function-id order.
+    #[spec_test(REQ_VC_018)]
+    fn build_scope_groups_when_globals_and_functions_then_globals_first_then_by_function_id() {
+        let container = container_with(
+            vec![
+                var(
+                    0,
+                    FunctionId::GLOBAL_SCOPE,
+                    var_section::VAR,
+                    iec_type_tag::DINT,
+                    "g",
+                    "DINT",
+                ),
+                var(
+                    2,
+                    FunctionId::new(3),
+                    var_section::VAR_INPUT,
+                    iec_type_tag::DINT,
+                    "n3",
+                    "DINT",
+                ),
+                var(
+                    1,
+                    FunctionId::new(2),
+                    var_section::VAR_INPUT,
+                    iec_type_tag::DINT,
+                    "n2",
+                    "DINT",
+                ),
+            ],
+            vec![
+                FuncNameEntry {
+                    function_id: FunctionId::new(2),
+                    name: "alpha".into(),
+                },
+                FuncNameEntry {
+                    function_id: FunctionId::new(3),
+                    name: "beta".into(),
+                },
+            ],
+        );
+        let groups = build_scope_groups(&container, &[0, 0, 0]);
+        let labels: Vec<&str> = groups.iter().map(|g| g.label.as_str()).collect();
+        assert_eq!(labels, vec!["Globals", "alpha", "beta"]);
+    }
+
+    #[test]
+    fn build_scope_groups_when_rows_then_ordered_by_var_index_within_group() {
+        let container = container_with(
+            vec![
+                var(
+                    2,
+                    FunctionId::new(2),
+                    var_section::VAR,
+                    iec_type_tag::DINT,
+                    "c",
+                    "DINT",
+                ),
+                var(
+                    0,
+                    FunctionId::new(2),
+                    var_section::VAR_INPUT,
+                    iec_type_tag::DINT,
+                    "a",
+                    "DINT",
+                ),
+                var(
+                    1,
+                    FunctionId::new(2),
+                    var_section::VAR,
+                    iec_type_tag::DINT,
+                    "b",
+                    "DINT",
+                ),
+            ],
+            vec![FuncNameEntry {
+                function_id: FunctionId::new(2),
+                name: "f".into(),
+            }],
+        );
+        let groups = build_scope_groups(&container, &[0, 0, 0]);
+        assert_eq!(groups.len(), 1);
+        let names: Vec<&str> = groups[0].rows.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    /// REQ-VC-019: non-global lines carry an IEC section annotation; the
+    /// `[Globals]` group omits it.
+    #[spec_test(REQ_VC_019)]
+    fn write_scoped_group_when_function_local_then_includes_section_annotation() {
+        let global = ScopeGroup {
+            function_id: FunctionId::GLOBAL_SCOPE,
+            label: "Globals".into(),
+            rows: vec![ScopeRow {
+                var_index: 0,
+                name: "counter".into(),
+                type_name: "DINT".into(),
+                iec_type_tag: iec_type_tag::DINT,
+                var_section: var_section::VAR_GLOBAL,
+                raw: 3,
+            }],
+        };
+        let mut buf = Vec::new();
+        assert!(write_scoped_group(&mut buf, &global).is_ok());
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "[Globals]\n  counter : DINT = 3\n"
+        );
+
+        let func = ScopeGroup {
+            function_id: FunctionId::new(2),
+            label: "add_offset".into(),
+            rows: vec![ScopeRow {
+                var_index: 5,
+                name: "n".into(),
+                type_name: "DINT".into(),
+                iec_type_tag: iec_type_tag::DINT,
+                var_section: var_section::VAR_INPUT,
+                raw: 7,
+            }],
+        };
+        let mut buf = Vec::new();
+        assert!(write_scoped_group(&mut buf, &func).is_ok());
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "[add_offset]\n  n : DINT = 7  (VAR_INPUT)\n"
+        );
+    }
+
+    /// REQ-VC-020: with no debug section, `--group-by-scope` falls back to the
+    /// flat dump format.
+    #[spec_test(REQ_VC_020)]
+    fn write_dump_when_no_debug_section_then_falls_back_to_flat() {
+        let container = ContainerBuilder::new().build();
+        let mut buf = Vec::new();
+        assert!(write_dump(&mut buf, &container, &[10, 42], true).is_ok());
+        assert_eq!(String::from_utf8(buf).unwrap(), "var[0]: 10\nvar[1]: 42\n");
+    }
+
+    #[test]
+    fn write_dump_when_group_by_scope_and_debug_then_emits_grouped_layout() {
+        let container = container_with(
+            vec![
+                var(
+                    0,
+                    FunctionId::GLOBAL_SCOPE,
+                    var_section::VAR,
+                    iec_type_tag::DINT,
+                    "counter",
+                    "DINT",
+                ),
+                var(
+                    1,
+                    FunctionId::new(2),
+                    var_section::VAR_INPUT,
+                    iec_type_tag::DINT,
+                    "step",
+                    "DINT",
+                ),
+            ],
+            vec![FuncNameEntry {
+                function_id: FunctionId::new(2),
+                name: "acc".into(),
+            }],
+        );
+        let mut buf = Vec::new();
+        assert!(write_dump(&mut buf, &container, &[3, 9], true).is_ok());
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "[Globals]\n  counter : DINT = 3\n[acc]\n  step : DINT = 9  (VAR_INPUT)\n"
         );
     }
 }

--- a/compiler/vm-cli/src/main.rs
+++ b/compiler/vm-cli/src/main.rs
@@ -54,6 +54,12 @@ enum Action {
         /// Run N scheduling rounds then stop (default: continuous until Ctrl+C).
         #[arg(long)]
         scans: Option<u64>,
+
+        /// Group the variable dump by owning POU (frame) and annotate each
+        /// variable with its IEC section. Requires `--dump-vars`; falls back
+        /// to the flat dump when the container has no debug section.
+        #[arg(long)]
+        group_by_scope: bool,
     },
     /// Benchmarks a bytecode container by running it many times and reporting timing statistics.
     Benchmark {
@@ -80,7 +86,8 @@ pub fn main() -> ExitCode {
             file,
             dump_vars,
             scans,
-        } => cli::run(&file, dump_vars.as_deref(), scans),
+            group_by_scope,
+        } => cli::run(&file, dump_vars.as_deref(), scans, group_by_scope),
         Action::Benchmark {
             file,
             cycles,

--- a/specs/design/variable-inspection-model.md
+++ b/specs/design/variable-inspection-model.md
@@ -1,0 +1,384 @@
+# Spec: Variable Inspection Model
+
+## Overview
+
+This spec defines how IronPLC presents PLC variables for inspection — in
+the `ironplcvm` CLI dump today and in the DAP debugger's `variables` view
+later. It exists because the first cut (`ironplcvm run --dump-vars
+--group-by-scope`) grouped variables by **FUNCTION_BLOCK type**, which is
+the wrong unit: a FB type has no state; its **instances** do, and a program
+may have many of them.
+
+The model here is a single source of truth that both consumers render:
+
+- The **CLI dump** renders it as an indented text tree (with a flat list
+  as a fallback).
+- The **DAP server** renders it as the `variables` / `variablesReference`
+  lazy-expansion tree (`specs/design/debugger-support.md`).
+
+Keeping one model prevents the CLI and the debugger from drifting into two
+incompatible notions of "what a variable is."
+
+This spec builds on and amends:
+
+- **[Debugger Support](debugger-support.md)** — Layer 1 debug info and the
+  DAP `variables` request. This spec supersedes that document's Gaps #5/#6
+  (FB type/field tables) and corrects its debug-section tag registry (see
+  [Debug-section tag reconciliation](#debug-section-tag-reconciliation)).
+- **[Bytecode Container Format](bytecode-container-format.md)** — the debug
+  section and the type section (array descriptors).
+- **[Runtime Execution Model](runtime-execution-model.md)** — the data
+  region and FB copy-in/copy-out.
+
+## Problem statement
+
+### Two things called "scope" were conflated
+
+`--group-by-scope` produced output like:
+
+```
+[ACCUMULATOR]
+  step : DINT = 3  (VAR_INPUT)
+  total : DINT = 6  (VAR_OUTPUT)
+```
+
+Two defects:
+
+1. **Type, not instance.** `[ACCUMULATOR]` is a FB *type*. With
+   `m1, m2 : MotorController` there is no single thing to label, and both
+   instances' state would collapse under one header.
+2. **Scratch, not state.** A user FB's persistent fields live **per
+   instance in the data region**. On every `FB_CALL` the VM copies that
+   instance's fields into a **shared** set of variable-table slots (the FB
+   body's locals), runs the body, and copies them back
+   (`compiler/vm/src/vm.rs:2084` copy-in,
+   `compiler/vm/src/frame_stack.rs:43` copy-out). Those body slots are
+   reused across every instance, so after a scan they hold whatever the
+   last call left behind. The dump was showing leftover scratch, not any
+   instance's real state.
+
+### Ground truth of the data model
+
+(From a survey of `compiler/codegen/src/` and `compiler/vm/src/`.)
+
+- A composite variable — FB instance, STRUCT, or ARRAY — gets **one
+  variable-table slot that holds the byte offset of its region in the data
+  region** (`compile_setup.rs:474`, `compile_struct.rs:567`,
+  `compile_array.rs`). The real bytes live in the data region at that
+  offset.
+- FB instance fields are 8-byte slots laid out contiguously at the
+  instance's `data_offset`; each instance gets its own region; all
+  instances of a type share the body's var-table partition
+  (`compile_setup.rs:162`, `vm.rs:2085`).
+- The debug section records **none** of this composite layout today. An FB
+  instance variable emits a `VarNameEntry` with `iec_type_tag = OTHER` and
+  a `type_name` string (e.g. `"ACCUMULATOR"`) and nothing else
+  (`compile_setup.rs:283`). Structs are the same. Arrays additionally have
+  a runtime `ArrayDescriptor` in the **type section**
+  (`type_section.rs:80`) but no debug entry.
+- `StringLayoutEntry` (debug tag 4) already maps `var_index →
+  (data_offset, max_length)` (`debug_section.rs:137`). It is the precedent
+  for tying a variable to a data-region layout; the composite tables below
+  generalize it.
+
+So a faithful tree must (a) emit field-layout debug info we do not yet
+produce, and (b) walk the **data region** at each instance's offset. That
+is why this is a design doc, not a patch.
+
+## The two hierarchies
+
+A debugger surfaces two *orthogonal* trees. Conflating them is the original
+sin of `--group-by-scope`.
+
+### 1. The instance / data tree (static, always inspectable)
+
+Rooted at the program. Always meaningful — even on an idle VM between
+scans — because it reflects persistent state in the data region and globals
+in the variable table.
+
+```
+program (plc_main)
+├─ counter : DINT = 3                 (global / program VAR)
+├─ acc : accumulator                  (FB instance — expandable)
+│  ├─ step  : DINT = 3
+│  └─ total : DINT = 6
+├─ setpoints : ARRAY[0..2] OF INT     (array — expandable)
+│  ├─ [0] : INT = 10
+│  ├─ [1] : INT = 20
+│  └─ [2] : INT = 30
+└─ cfg : Settings                     (struct — expandable)
+   ├─ gain : REAL = 1.5
+   └─ timer : TON                     (nested FB instance — expandable)
+      ├─ IN : BOOL = TRUE
+      └─ ...
+```
+
+Composite nodes (FB instance, struct, array) expand into children;
+children may themselves be composite (nested FBs, struct-of-array, etc.).
+This is the tree the CLI dump renders and the DAP `variables` request
+serves for the program/global scope.
+
+### 2. The call-stack view (runtime, only while paused)
+
+Meaningful **only** when execution is paused inside a call. A FUNCTION's
+parameters and locals are transient per-call values with no instances;
+they exist on a frame of the call stack, not in the data tree. This view is
+`stackTrace` → `scopes` → `variables(frame)` in DAP, and has no CLI-dump
+representation (the dump runs on a *stopped* VM with an empty frame stack).
+
+This spec specifies tree #1 in full and defines where tree #2 plugs in; the
+mechanics of pausing and frame inspection belong to
+`debugger-support.md` Layer 2.
+
+## The node model
+
+One recursive abstraction both consumers build, independent of rendering:
+
+```
+VarNode {
+    name: String,            // "counter", "acc", "[0]", "gain"
+    type_name: String,       // "DINT", "accumulator", "ARRAY[0..2] OF INT"
+    value: Option<Value>,    // Some for scalars; None for composites (a header)
+    section: Option<VarSection>, // IEC section, for top-level frame/program vars
+    children: Children,      // Leaf | Fields(Vec<VarNode>) | Elements(Vec<VarNode>)
+}
+```
+
+- **Leaf** nodes are scalars: `value` is `Some`, formatted by
+  `format_variable_value(raw, iec_type_tag)`
+  (`compiler/container/src/debug_format.rs`).
+- **Composite** nodes (FB/struct) have `Fields`; **array** nodes have
+  `Elements` indexed `[i]`.
+- Building a node is *lazy-friendly*: a composite node can be produced
+  without expanding its children, so the DAP server hands back a
+  `variablesReference` and expands on demand, while the CLI expands eagerly
+  to a configurable depth.
+
+### Resolving a composite node's bytes
+
+To expand a composite node the inspector needs a **base offset** into the
+data region and a **field layout**:
+
+- **Base offset.** For a top-level composite variable, read the
+  variable-table slot — it already holds the `data_offset`
+  (`compile_setup.rs:474`). For a nested field, the base is computed from
+  the parent. *Open item:* confirm during implementation whether a nested
+  composite field stores an inline region (structs lay fields out
+  contiguously) or an offset pointer (as top-level FB instances do); the
+  layout table below carries a per-field flag to encode which.
+- **Field layout.** Comes from the new composite-type debug tables below.
+
+Expansion is then: for each field, `field_base = resolve(parent_base,
+field)`, read `data_region[field_base .. field_base + 8]` (or recurse for a
+composite field), and format per the field's type reference.
+
+## Required debug info
+
+The tree needs layout facts the compiler has at codegen time but currently
+discards. This section defines the additions. All are **new debug-section
+sub-tables** (the directory format already lets readers skip unknown tags,
+so old readers are unaffected).
+
+### Debug-section tag reconciliation
+
+`debugger-support.md`'s tag registry is **stale**: it lists tag 4 as
+`FB_TYPE_NAME` and tag 5 as `FB_FIELD_NAME`, but the implemented code uses
+tag 4 for `STRING_LAYOUT` (`debug_section.rs:13`). Implemented tags today:
+
+| Tag | Name | Status |
+|-----|------|--------|
+| 1 | LINE_MAP | implemented |
+| 2 | VAR_NAME | implemented |
+| 3 | FUNC_NAME | implemented |
+| 4 | STRING_LAYOUT | implemented |
+| 6 | SOURCE_FILE | implemented |
+| 9 | ENUM_DEF | implemented |
+
+This spec **keeps tag 4 = STRING_LAYOUT** and assigns fresh tags for
+composite layout, avoiding the collision. `debugger-support.md`'s registry
+must be updated to match (action item, not a format change).
+
+| Tag | Name | This spec |
+|-----|------|-----------|
+| 10 | COMPOSITE_TYPE | FB + struct type descriptors (name + fields) |
+| 11 | VAR_TYPE_REF | var_index → type reference (for composite/array vars) |
+| 12 | ARRAY_TYPE | array layout for debug (element type + dims) |
+
+Tags 5, 7, 8 (the stale FB_*/LD/FBD reservations) are left unused and
+re-marked reserved.
+
+### TypeRef encoding
+
+A 3-byte reference naming what a variable or field *is*, so the inspector
+knows how to expand it:
+
+| Offset | Field | Type | Meaning |
+|--------|-------|------|---------|
+| 0 | kind | u8 | 0 = scalar, 1 = composite, 2 = array |
+| 1 | id | u16 | scalar: `iec_type_tag`; composite: COMPOSITE_TYPE id; array: ARRAY_TYPE id |
+
+### Tag 10 — COMPOSITE_TYPE
+
+Unifies FB types and structs: both are "a named record of fields at
+offsets." One descriptor per user composite type.
+
+```
+CompositeTypeEntry {
+    type_id: u16,           // matches FbInstanceInfo.type_id for FBs
+    kind: u8,               // 0 = struct, 1 = function_block
+    name: String,           // "ACCUMULATOR", "Settings"
+    fields: Vec<FieldEntry>,
+}
+FieldEntry {
+    name: String,           // "step", "total", "gain"
+    byte_offset: u16,       // offset within the instance's data region
+    inline: u8,             // 1 = field bytes are inline; 0 = field slot holds a data_offset pointer
+    type_ref: TypeRef,      // scalar / nested composite / array
+}
+```
+
+`byte_offset` + `inline` + `type_ref` are exactly what
+`build_struct_fields` (`compile_struct.rs:629`) and the FB field map
+(`FbInstanceInfo.field_indices`, `compile.rs:786`) already compute
+internally — this table just persists them.
+
+### Tag 11 — VAR_TYPE_REF
+
+Links a named variable to its TypeRef without touching the existing
+`VarNameEntry` wire format (preserving the #1106 work and its conformance
+tests). Only emitted for non-scalar variables; scalars are fully described
+by `VarNameEntry.iec_type_tag` already.
+
+```
+VarTypeRefEntry {
+    function_id: FunctionId, // owner (GLOBAL_SCOPE for program/globals)
+    var_index: VarIndex,
+    type_ref: TypeRef,
+}
+```
+
+### Tag 12 — ARRAY_TYPE
+
+The type section already has a runtime `ArrayDescriptor` (element type,
+count, element_extra — `type_section.rs:80`). For source-level display the
+debug side adds dimension bounds and a nested `type_ref` for composite
+element types:
+
+```
+ArrayTypeEntry {
+    array_id: u16,
+    element_ref: TypeRef,    // element scalar tag or composite/array id
+    dims: Vec<Dim>,          // each: lower:i32, upper:i32 (IEC bounds)
+}
+```
+
+### Codegen emission
+
+All facts already exist at codegen time:
+
+- COMPOSITE_TYPE: emit one entry per registered user FB type
+  (`ctx.user_fb_types`) and per struct type, from the field maps already
+  built.
+- VAR_TYPE_REF: at each composite/array variable assignment
+  (`compile_setup.rs`, `compile_fn.rs`), emit the var's TypeRef alongside
+  the existing `VarNameEntry`.
+- ARRAY_TYPE: emit alongside the existing `add_array_descriptor`
+  (`compile_array.rs:617`), carrying source bounds.
+
+Built-in (stdlib) FB types (TON, CTU, …) get COMPOSITE_TYPE entries with
+their standard field names so `acc : TON` expands to `IN/PT/Q/ET` — this is
+the work `debugger-support.md` filed as Gaps #5/#6.
+
+## Consumer 1: CLI dump
+
+### Surface
+
+`--group-by-scope` is **removed** (it was never released — branch only).
+The dump grows one rendering mode:
+
+| Option | Behavior |
+|--------|----------|
+| `--dump-vars [PATH]` | Default flat, one-line-per-slot format. Unchanged; still spec-locked by REQ-VC-005/008/009. |
+| `--dump-vars [PATH] --tree` | Render the instance/data tree (this spec). Falls back to flat when no composite debug info is present. |
+
+The **flat list is the fallback**, per the project decision to demote the
+old grouping rather than make a misleading grouped view the default.
+
+### Tree rendering
+
+Walk tree #1 from program/global roots, depth-first, indenting two spaces
+per level. Scalars print `name : type = value`; composites print a header
+`name : type` then their expanded children; array elements print `[i] :
+type = value`. A `--tree-depth N` guard bounds recursion (default
+unbounded; cycles are impossible — IEC composites form a DAG).
+
+### Worked example
+
+```
+plc_main
+  counter : DINT = 3
+  acc : ACCUMULATOR
+    step : DINT = 3
+    total : DINT = 6
+  setpoints : ARRAY[0..2] OF INT
+    [0] : INT = 10
+    [1] : INT = 20
+    [2] : INT = 30
+```
+
+## Consumer 2: DAP `variables`
+
+The DAP server builds the same `VarNode` tree and maps it to the protocol:
+
+- `scopes` returns at least a **Program / Globals** scope (tree #1 root)
+  and, when paused, per-frame **Locals / Inputs / Outputs** scopes (tree
+  #2).
+- Each composite `VarNode` is returned as a DAP `Variable` with a non-zero
+  `variablesReference`; expanding it issues `variables(reference)`, which
+  lazily builds that node's children. Arrays use `indexedVariables` for
+  large arrays.
+- Leaf formatting reuses `format_variable_value`.
+
+Because both consumers build `VarNode` from the same debug tables and the
+same data-region walk, the CLI dump and the debugger cannot disagree about
+structure.
+
+## Phasing
+
+This is multi-PR. Each phase is independently useful and testable.
+
+1. **Debug info (codegen + container).** Add tags 10/11/12, emit them for
+   structs, user FBs, stdlib FBs, and arrays. Round-trip tests. No consumer
+   change yet — verifiable via container inspection.
+2. **`VarNode` builder (shared crate).** A pure function from
+   `(container debug tables, data-region bytes, variable-table values)` to
+   a `VarNode` tree. Unit-tested with hand-built containers; no I/O.
+3. **CLI `--tree`.** Render the builder's output; remove
+   `--group-by-scope`; keep flat as fallback. Update `vm-cli.md`.
+4. **DAP wiring.** Map `VarNode` to `variables`/`variablesReference` when
+   the debugger lands (depends on `debugger-support.md` Layer 2).
+
+## Out of scope
+
+- Pausing, stepping, breakpoints, the call-stack frame mechanics — those
+  are `debugger-support.md` Layer 2/3. This spec only defines what a frame
+  scope *contains* once it exists.
+- Writing/forcing variable values. Read-only inspection here.
+- Multi-instance *debugging semantics* (which instance a breakpoint fires
+  on) — the data tree shows all instances' state; firing rules are a later
+  debugger concern.
+- Pointer/REF_TO graph following beyond one hop; shown as the raw target
+  index for now.
+
+## Open questions
+
+1. **Nested composite base offset.** Confirm whether struct/FB fields that
+   are themselves composite store inline bytes or an offset pointer; the
+   `FieldEntry.inline` flag is provisioned for both, but emission must set
+   it correctly per codegen reality (`compile_struct.rs`).
+2. **Stdlib FB field tables.** Source the standard FBs' field names/offsets
+   from the existing intrinsic layout (`compiler/vm/src/builtin.rs`) vs. a
+   hand-authored table — decide during Phase 1.
+3. **`type_id` namespace.** Confirm FB `type_id`s and struct ids don't
+   collide in one COMPOSITE_TYPE table; if they can, add `kind` to the key
+   or partition the id space.

--- a/specs/design/vm-cli.md
+++ b/specs/design/vm-cli.md
@@ -51,6 +51,7 @@ ironplcvm run [OPTIONS] <FILE>
 |--------|-------------|
 | `--dump-vars [PATH]` | After the VM stops, write all variable values to `PATH`. If `PATH` is omitted or `-`, write to stdout. |
 | `--scans <N>` | Run exactly `N` scheduling rounds then stop. When omitted, runs continuously until SIGINT (Ctrl+C). |
+| `--group-by-scope` | Group the `--dump-vars` output by owning POU (frame) and annotate each variable with its IEC section. Falls back to the flat format when the container has no debug section. |
 
 **Behavior:**
 
@@ -154,6 +155,40 @@ For a program `x := 10; y := x + 32;` with two variables:
 var[0]: 10
 var[1]: 42
 ```
+
+## Scoped Variable Dump Format
+
+The `--group-by-scope` option is a debug-info-aware alternative layout for
+`--dump-vars`. It groups variables by the POU that declares them — using the
+`function_id` and `var_section` metadata in the debug section's VAR_NAME
+table — so the output mirrors the call structure a debugger would show.
+
+### Behavior
+
+- **REQ-VC-018** With `--group-by-scope`, variables are emitted in groups, each introduced by a `[<label>]` header line followed by one indented line per variable; program/global variables form a `[Globals]` group that is emitted first, before any per-POU group.
+- **REQ-VC-019** Within `--group-by-scope`, each non-global variable line is annotated with its IEC section name (`VAR`, `VAR_INPUT`, `VAR_OUTPUT`, `VAR_IN_OUT`, `VAR_TEMP`, `VAR_EXTERNAL`, `VAR_GLOBAL`); variables in the `[Globals]` group omit the annotation.
+- **REQ-VC-020** If the container has no debug section (or it names no variables), `--group-by-scope` falls back to the flat dump format (REQ-VC-005/008/009).
+
+### Format
+
+For a program with a global `counter : DINT`, a function `add_offset`
+(input `n`, local `bump`, return value), and a function block `accumulator`
+(input `step`, output `total`):
+
+```
+[Globals]
+  counter : DINT = 3
+[add_offset]
+  n : DINT = 3  (VAR_INPUT)
+  bump : DINT = 11  (VAR)
+  add_offset : DINT = 14  (VAR_OUTPUT)
+[accumulator]
+  step : DINT = 3  (VAR_INPUT)
+  total : DINT = 6  (VAR_OUTPUT)
+```
+
+The function's return value appears as a `VAR_OUTPUT`-annotated line named
+after the function (matching the debug section's encoding).
 
 ## Exit Codes
 

--- a/specs/plans/2026-06-15-scoped-variable-dump.md
+++ b/specs/plans/2026-06-15-scoped-variable-dump.md
@@ -1,0 +1,189 @@
+# Scoped Variable Dump for `ironplcvm`
+
+## Goal
+
+Add an opt-in `--group-by-scope` flag to `ironplcvm run` that renders the
+`--dump-vars` output grouped by owning POU (frame) and annotated with each
+variable's IEC section, using the `function_id` + `var_section` metadata
+now present in the debug section (shipped in #1106). The default
+`--dump-vars` output is unchanged — the flat, spec-locked format stays as
+is.
+
+Today's flat dump:
+
+```
+acc: 0
+counter: 3
+result: 6
+n: 3
+bump: 11
+add_offset: 14
+step: 3
+total: 6
+```
+
+With `--group-by-scope`:
+
+```
+[Globals]
+  counter : DINT = 3
+  result : DINT = 6
+  acc : ACCUMULATOR = 0
+[add_offset]
+  n : DINT = 3  (VAR_INPUT)
+  bump : DINT = 11  (VAR)
+  add_offset : DINT = 14  (VAR_OUTPUT)
+[accumulator]
+  step : DINT = 3  (VAR_INPUT)
+  total : DINT = 6  (VAR_OUTPUT)
+```
+
+## Why now
+
+The user wants to *try out* the debug-info work. #1106 added per-function
+`VarNameEntry`s (owner `function_id` + `var_section`), but the only tool
+that reads variables — `ironplcvm run --dump-vars` — still prints a flat,
+index-ordered list that ignores both fields. Surfacing the scope metadata
+in the dump makes the merged work directly visible and gives a concrete
+artifact to exercise, without waiting for the DAP/VS Code stack.
+
+It is also a natural rehearsal for the DAP `scopes` request, which groups
+variables by the same `var_section` → scope mapping
+(`specs/design/debugger-support.md`).
+
+## Constraints (must not break)
+
+- **REQ-VC-005 / REQ-VC-008 / REQ-VC-009** in `specs/design/vm-cli.md`
+  pin the *flat* dump format: one variable per line, ascending by index,
+  `<name>: <value>` (or `var[<index>]: <raw_i32>`). These have `spec_test`
+  conformance tests. The grouped output is therefore a **new, opt-in
+  mode**, not a change to the default. The default path stays byte-for-byte
+  identical.
+- `VarDebugInfo` / `build_var_debug_map` (in `compiler/container/src/
+  debug_format.rs`) are shared by `vm-cli`, `ironplc-cli` (lsp_runner),
+  and `playground`, and are constructed in their tests. To avoid a
+  cross-crate blast radius, the scoped renderer reads
+  `container.debug_section` (`var_names`, `func_names`) **directly** in
+  `vm-cli` rather than extending the shared struct.
+
+## Scope
+
+In:
+
+- `compiler/vm-cli/src/main.rs`: add `--group-by-scope` bool to the `Run`
+  subcommand; thread it into `cli::run`.
+- `compiler/vm-cli/src/cli.rs`: thread the flag through
+  `dump_variables_stopped` / `dump_variables_faulted`; add a
+  `dump_variables_scoped` renderer and supporting helpers
+  (`var_section_name`, group building).
+- `specs/design/vm-cli.md`: document `--group-by-scope` and add new REQ
+  IDs for the grouped format (the flat REQs are untouched).
+- Tests: unit tests for the scoped renderer + grouping/ordering.
+
+Out (deferred):
+
+- Changing or replacing the default flat dump.
+- Showing FB *instance* sub-fields (needs FB field-name tables, Phase 5).
+- Live per-frame inspection (that is the DAP debugger, later phases).
+- Reading the *call stack* at the dump point — the dump reflects the
+  variable table after the VM stops at a scan boundary, where no frames
+  are live. Grouping is by *declaring* POU, not a runtime frame snapshot.
+
+## Architecture
+
+### Flag plumbing
+
+`Action::Run` gains `#[arg(long)] group_by_scope: bool`. `main` passes it
+to `cli::run(path, dump_vars, scans, group_by_scope)`. `run` forwards it to
+the two dump functions. When `false`, behavior is exactly as today.
+
+### Grouping
+
+A scoped group is `(function_id, label, Vec<VarRow>)` where `VarRow` holds
+`var_index`, `name`, `type_name`, `iec_type_tag`, `var_section`, and the
+raw value read from the stopped/faulted VM.
+
+Build order:
+
+1. **Globals** first: all `var_names` whose `function_id ==
+   FunctionId::GLOBAL_SCOPE`, labeled `[Globals]`.
+2. Then each distinct non-global `function_id` that appears in
+   `var_names`, in ascending id order, labeled with its `func_names` entry
+   (fallback `[function <id>]` if absent).
+
+Within a group, rows are ordered by `var_index` (which matches
+declaration order: params, locals, return).
+
+Each row: `  <name> : <type_name> = <value>` with the value formatted via
+the existing `format_variable_value(raw, iec_type_tag)`. For non-global
+sections, append `  (<SECTION>)`; globals omit the annotation (it is
+implied by the group). The section name comes from a small
+`var_section_name(u8) -> &str` map (VAR, VAR_TEMP, VAR_INPUT, …).
+
+### Fallback when no debug info
+
+If the container has no debug section, or `var_names` is empty,
+`--group-by-scope` falls back to the existing flat renderer (so the flag
+is always safe to pass). A variable index present in the VM but absent
+from `var_names` is not expected in a debug build; if it occurs, it is
+appended under an `[Unmapped]` group using the flat `var[i]` form so no
+value is silently dropped.
+
+### Value reads
+
+Unchanged: `stopped.read_variable_raw(VarIndex)` /
+`faulted.read_variable_raw(...)`. The scoped renderer reads the same
+slots; it only changes layout, not which bytes are read.
+
+## File map
+
+Modified:
+
+- `compiler/vm-cli/src/main.rs` — `--group-by-scope` arg + call wiring.
+- `compiler/vm-cli/src/cli.rs` — flag param on `run` and the two dump
+  helpers; new `dump_variables_scoped`, `build_scope_groups`,
+  `var_section_name`, `write_scoped_group`.
+- `specs/design/vm-cli.md` — `--group-by-scope` option row + new REQ-VC
+  IDs for the grouped layout.
+
+Not modified:
+
+- `compiler/container/src/debug_format.rs` — shared helpers untouched.
+- Flat dump path / its REQ-VC conformance tests.
+- VM crate.
+
+## Tests
+
+`vm-cli` unit tests (alongside the existing `write_variable_line` tests):
+
+- `var_section_name_when_known_section_then_returns_iec_name`
+- `build_scope_groups_when_globals_and_functions_then_globals_first_then_by_function_id`
+- `build_scope_groups_when_rows_then_ordered_by_var_index_within_group`
+- `write_scoped_group_when_global_then_omits_section_annotation`
+- `write_scoped_group_when_function_local_then_includes_section_annotation`
+- `dump_scoped_when_no_debug_section_then_falls_back_to_flat`
+
+Spec conformance:
+
+- New REQ IDs (e.g. REQ-VC-014..016) for: grouped layout shape, globals
+  group first, section annotation on non-globals. Bound with `spec_test`.
+- The existing REQ-VC-005/008/009 flat-format tests remain and must still
+  pass (default path unchanged).
+
+Manual end-to-end (recorded in the PR description, not a test):
+
+```
+ironplcc compile demo.st --output demo.iplc
+ironplcvm run demo.iplc --dump-vars - --scans 3 --group-by-scope
+```
+
+against a program with a user FUNCTION and FUNCTION_BLOCK.
+
+## Out of scope
+
+- A separate `inspect` subcommand for static debug-section dumps (the
+  alternative considered; can come later if useful).
+- Trace/step execution modes (a different debugger increment).
+- Grouping by DAP scope buckets (Inputs/Outputs/Locals) rather than by
+  IEC section annotation — the per-section annotation already conveys the
+  same information and maps cleanly when the DAP server lands.


### PR DESCRIPTION
Closed in favor of #1115, which contains only the design doc. The `--group-by-scope` CLI work remains on the `claude/nifty-volta-xgfouh` branch and can get its own PR if wanted.

---

(Original description retained below for history.)

Adds a design doc, `specs/design/variable-inspection-model.md`, plus the earlier `--group-by-scope` CLI work. Superseded by #1115 (docs-only).