### PR TITLE
Improve OpenCode E2E test diagnostics and logging

### DIFF
--- a/integrations/opencode/test/agent.mjs
+++ b/integrations/opencode/test/agent.mjs
@@ -164,8 +164,6 @@ for (let attempt = 1; attempt <= attempts; attempt++) {
   }
 }
 
-const lastResult = attemptResults[attemptResults.length - 1] || { stdout: "", stderr: "" };
-
 console.error(
   "FAIL: the agent did not invoke the IronPLC check tool within the attempt budget.",
 );

--- a/integrations/opencode/test/agent.mjs
+++ b/integrations/opencode/test/agent.mjs
@@ -20,7 +20,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { ironplcmcpBin, makeWorkspace, runOpencode, testDir } from "./lib.mjs";
+import {
+  ironplcmcpBin,
+  makeWorkspace,
+  readOrPlaceholder,
+  readRecentOpencodeLogs,
+  runOpencode,
+  testDir,
+} from "./lib.mjs";
 
 const model = process.env.OPENCODE_E2E_MODEL || "ollama/llama3.2:3b";
 const [providerId, ...modelParts] = model.split("/");
@@ -99,15 +106,27 @@ function resetLogs() {
 
 console.log(`Model: ${model}  Ollama: ${ollamaBaseUrl}  ironplcmcp: ${bin}`);
 
-let lastOutput = "";
+let lastResult = { stdout: "", stderr: "" };
 for (let attempt = 1; attempt <= attempts; attempt++) {
   resetLogs();
   console.log(`Attempt ${attempt}/${attempts}: asking the agent to call ironplc_check...`);
+  // `--print-logs` and `--log-level DEBUG` route OpenCode's own server logs to
+  // stderr. Without them, a server-side failure surfaces only as an opaque
+  // "Unexpected server error. Check server logs for details." message.
   const result = runOpencode(
-    ["run", "--model", model, "--dangerously-skip-permissions", prompt],
+    [
+      "run",
+      "--model",
+      model,
+      "--log-level",
+      "DEBUG",
+      "--print-logs",
+      "--dangerously-skip-permissions",
+      prompt,
+    ],
     { cwd: workspace, timeoutMs: 300000 },
   );
-  lastOutput = `${result.stdout || ""}\n${result.stderr || ""}`;
+  lastResult = result;
 
   const invoked = toolWasInvoked();
   const responded = compilerResponded();
@@ -124,6 +143,27 @@ for (let attempt = 1; attempt <= attempts; attempt++) {
 console.error(
   "FAIL: the agent did not invoke the IronPLC check tool within the attempt budget.",
 );
-console.error("---- last OpenCode output (tail) ----");
-console.error(lastOutput.slice(-4000));
+
+// Dump every diagnostic channel so the failure can be understood from CI logs
+// alone, without re-running locally.
+console.error("\n==== last OpenCode stdout ====");
+console.error(lastResult.stdout || "(empty)");
+console.error("\n==== last OpenCode stderr ====");
+console.error(lastResult.stderr || "(empty)");
+if (lastResult.error) {
+  console.error("\n==== OpenCode spawn error ====");
+  console.error(`${lastResult.error.message} (signal: ${lastResult.signal ?? "none"})`);
+}
+
+console.error("\n==== MCP traffic: OpenCode -> server (.in) ====");
+console.error(readOrPlaceholder(`${recordLog}.in`));
+console.error("\n==== MCP traffic: server -> OpenCode (.out) ====");
+console.error(readOrPlaceholder(`${recordLog}.out`));
+console.error("\n==== ironplcmcp stderr (.err) ====");
+console.error(readOrPlaceholder(`${recordLog}.err`));
+
+const serverLogs = readRecentOpencodeLogs();
+console.error("\n==== OpenCode server logs ====");
+console.error(serverLogs || "(no OpenCode log directory found)");
+
 process.exit(1);

--- a/integrations/opencode/test/agent.mjs
+++ b/integrations/opencode/test/agent.mjs
@@ -106,7 +106,31 @@ function resetLogs() {
 
 console.log(`Model: ${model}  Ollama: ${ollamaBaseUrl}  ironplcmcp: ${bin}`);
 
-let lastResult = { stdout: "", stderr: "" };
+// Pre-flight: assert OpenCode's resolved model catalog actually contains the
+// configured `provider/model`. If it does not, the inline provider config in
+// opencode.json failed to load — and the subsequent `opencode run` failure
+// would otherwise surface as the same opaque "Unexpected server error" that
+// any other server-side problem produces, leaving the cause ambiguous.
+const modelsListing = runOpencode(["models"], { cwd: workspace, timeoutMs: 60000 });
+const modelsOutput = `${modelsListing.stdout || ""}\n${modelsListing.stderr || ""}`;
+const modelIsListed = modelsOutput
+  .split("\n")
+  .some((line) => line.trim() === model);
+if (!modelIsListed) {
+  console.error(
+    `FAIL (pre-flight): OpenCode did not list "${model}" in \`opencode models\`. ` +
+      "The inline provider config in opencode.json was not loaded — `opencode run` " +
+      "would fail at model resolution.",
+  );
+  console.error("\n==== opencode models ====");
+  console.error(modelsOutput.trim() || "(empty)");
+  process.exit(1);
+}
+console.log(`Pre-flight: OpenCode resolves "${model}".`);
+
+// Keep every attempt's output so the first informative failure is not lost
+// when later attempts fail differently or hang.
+const attemptResults = [];
 for (let attempt = 1; attempt <= attempts; attempt++) {
   resetLogs();
   console.log(`Attempt ${attempt}/${attempts}: asking the agent to call ironplc_check...`);
@@ -126,7 +150,7 @@ for (let attempt = 1; attempt <= attempts; attempt++) {
     ],
     { cwd: workspace, timeoutMs: 300000 },
   );
-  lastResult = result;
+  attemptResults.push(result);
 
   const invoked = toolWasInvoked();
   const responded = compilerResponded();
@@ -140,20 +164,29 @@ for (let attempt = 1; attempt <= attempts; attempt++) {
   }
 }
 
+const lastResult = attemptResults[attemptResults.length - 1] || { stdout: "", stderr: "" };
+
 console.error(
   "FAIL: the agent did not invoke the IronPLC check tool within the attempt budget.",
 );
 
 // Dump every diagnostic channel so the failure can be understood from CI logs
 // alone, without re-running locally.
-console.error("\n==== last OpenCode stdout ====");
-console.error(lastResult.stdout || "(empty)");
-console.error("\n==== last OpenCode stderr ====");
-console.error(lastResult.stderr || "(empty)");
-if (lastResult.error) {
-  console.error("\n==== OpenCode spawn error ====");
-  console.error(`${lastResult.error.message} (signal: ${lastResult.signal ?? "none"})`);
-}
+
+// Every attempt's stdout/stderr. The first attempt's error is often the most
+// informative — later attempts may fail differently, time out, or hang after
+// the underlying problem has already been triggered.
+attemptResults.forEach((result, index) => {
+  const n = index + 1;
+  console.error(`\n==== attempt ${n}/${attempts} OpenCode stdout ====`);
+  console.error(result.stdout || "(empty)");
+  console.error(`\n==== attempt ${n}/${attempts} OpenCode stderr ====`);
+  console.error(result.stderr || "(empty)");
+  if (result.error) {
+    console.error(`\n==== attempt ${n}/${attempts} OpenCode spawn error ====`);
+    console.error(`${result.error.message} (signal: ${result.signal ?? "none"})`);
+  }
+});
 
 console.error("\n==== MCP traffic: OpenCode -> server (.in) ====");
 console.error(readOrPlaceholder(`${recordLog}.in`));
@@ -162,8 +195,34 @@ console.error(readOrPlaceholder(`${recordLog}.out`));
 console.error("\n==== ironplcmcp stderr (.err) ====");
 console.error(readOrPlaceholder(`${recordLog}.err`));
 
+// OpenCode's view of the resolved config: what providers/models it actually
+// loaded from opencode.json. Distinguishes "config not parsed" from
+// "request to model failed."
+const debugConfig = runOpencode(["debug", "config"], { cwd: workspace, timeoutMs: 60000 });
+console.error("\n==== opencode debug config ====");
+console.error((debugConfig.stdout || "").trim() || (debugConfig.stderr || "(empty)").trim());
+
+const debugV2 = runOpencode(["debug", "v2"], { cwd: workspace, timeoutMs: 60000 });
+console.error("\n==== opencode debug v2 (providers only) ====");
+console.error(extractProvidersFromV2(debugV2.stdout || ""));
+
 const serverLogs = readRecentOpencodeLogs();
 console.error("\n==== OpenCode server logs ====");
 console.error(serverLogs || "(no OpenCode log directory found)");
 
 process.exit(1);
+
+/// `opencode debug v2` dumps the full provider catalog (hundreds of entries).
+/// We only care about the `providers` array — which is the part affected by
+/// our inline config — so strip the rest to keep the failure dump readable.
+function extractProvidersFromV2(text) {
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && Array.isArray(parsed.providers)) {
+      return JSON.stringify({ providers: parsed.providers }, null, 2);
+    }
+  } catch {
+    /* fall through */
+  }
+  return text.trim() || "(empty)";
+}

--- a/integrations/opencode/test/lib.mjs
+++ b/integrations/opencode/test/lib.mjs
@@ -50,5 +50,53 @@ export function runOpencode(args, { cwd, timeoutMs = 120000, env = {} } = {}) {
 /// Strip ANSI escape sequences so we can match against OpenCode's TUI output.
 export function stripAnsi(text) {
   // eslint-disable-next-line no-control-regex
-  return (text || "").replace(/\[[0-9;]*m/g, "");
+  return (text || "").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/// Locate OpenCode's own server log directory. OpenCode writes detailed logs
+/// (the ones referenced by "Check server logs for details") under its XDG data
+/// dir. Honor an explicit override, then try the usual locations.
+export function opencodeLogDir() {
+  if (process.env.OPENCODE_LOG_DIR) return process.env.OPENCODE_LOG_DIR;
+  const dataHome =
+    process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  const candidates = [
+    path.join(dataHome, "opencode", "log"),
+    path.join(os.homedir(), ".opencode", "log"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/// Return the contents of the most recently modified OpenCode server log files,
+/// newest first, capped to `maxFiles`. Returns "" when no log dir is found.
+export function readRecentOpencodeLogs(maxFiles = 2) {
+  const dir = opencodeLogDir();
+  if (!dir) return "";
+  let entries;
+  try {
+    entries = fs
+      .readdirSync(dir)
+      .map((name) => path.join(dir, name))
+      .filter((file) => fs.statSync(file).isFile())
+      .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)
+      .slice(0, maxFiles);
+  } catch {
+    return "";
+  }
+  return entries
+    .map((file) => `==== ${file} ====\n${fs.readFileSync(file, "utf8")}`)
+    .join("\n\n");
+}
+
+/// Read a file, returning a placeholder string when it is missing or empty.
+export function readOrPlaceholder(file) {
+  try {
+    const text = fs.readFileSync(file, "utf8");
+    return text.length ? text : "(empty)";
+  } catch {
+    return "(missing)";
+  }
 }

--- a/integrations/opencode/test/record-mcp.mjs
+++ b/integrations/opencode/test/record-mcp.mjs
@@ -8,7 +8,8 @@
 //
 // Configuration (environment variables):
 //   IRONPLCMCP_BIN          path to the ironplcmcp binary (required)
-//   IRONPLCMCP_RECORD_LOG   log prefix; writes "<prefix>.in" and "<prefix>.out"
+//   IRONPLCMCP_RECORD_LOG   log prefix; writes "<prefix>.in", "<prefix>.out"
+//                           and "<prefix>.err"
 
 import { spawn } from "node:child_process";
 import fs from "node:fs";
@@ -21,10 +22,14 @@ if (!bin) {
   process.exit(2);
 }
 
-const child = spawn(bin, [], { stdio: ["pipe", "pipe", "inherit"] });
+// Pipe (rather than inherit) the child's stderr so we can tee it to a log file.
+// Inheriting would send the compiler's diagnostics to OpenCode, where the test
+// harness never sees them; capturing them is essential for diagnosing failures.
+const child = spawn(bin, [], { stdio: ["pipe", "pipe", "pipe"] });
 
 const inLog = logPrefix ? fs.createWriteStream(`${logPrefix}.in`, { flags: "a" }) : null;
 const outLog = logPrefix ? fs.createWriteStream(`${logPrefix}.out`, { flags: "a" }) : null;
+const errLog = logPrefix ? fs.createWriteStream(`${logPrefix}.err`, { flags: "a" }) : null;
 
 // OpenCode -> server: record and forward.
 process.stdin.on("data", (chunk) => {
@@ -37,6 +42,12 @@ process.stdin.on("end", () => child.stdin.end());
 child.stdout.on("data", (chunk) => {
   if (outLog) outLog.write(chunk);
   process.stdout.write(chunk);
+});
+
+// server stderr: record and forward to our own stderr.
+child.stderr.on("data", (chunk) => {
+  if (errLog) errLog.write(chunk);
+  process.stderr.write(chunk);
 });
 
 child.on("error", (err) => {

--- a/justfile
+++ b/justfile
@@ -313,6 +313,40 @@ opencode-e2e compiler-version="" model="llama3.2:3b":
   OLLAMA_CONTEXT_LENGTH=16384 ollama serve >/tmp/ollama-serve.log 2>&1 &
   timeout 60 sh -c 'until curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; do sleep 1; done'
   ollama pull "{{model}}"
+
+  # On any failure below, surface the Ollama server log. The agent failure mode
+  # we are guarding against ("Unexpected server error") originates in the model
+  # provider, so this log is the other half of the picture alongside OpenCode's
+  # own logs (which the agent test now prints on failure).
+  dump_ollama_log() {
+    status=$?
+    if [ "$status" -ne 0 ]; then
+      echo "==== ollama serve log (tail) ====" >&2
+      tail -n 200 /tmp/ollama-serve.log >&2 || true
+    fi
+  }
+  trap dump_ollama_log EXIT
+
+  # Pre-flight: prove the model can do an OpenAI-compatible tool call directly,
+  # independent of OpenCode. This isolates "the model/provider is broken" from
+  # "the agent chose not to call the tool" — the ambiguity that makes a bare
+  # agent-test failure hard to diagnose.
+  echo "Pre-flight: probing {{model}} for OpenAI-compatible tool calling..."
+  PROBE=$(curl -sf http://localhost:11434/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "model": "{{model}}",
+      "messages": [{"role": "user", "content": "Call the ping tool now."}],
+      "tools": [{"type": "function", "function": {
+        "name": "ping",
+        "description": "Replies to a ping.",
+        "parameters": {"type": "object", "properties": {}}
+      }}],
+      "tool_choice": "auto"
+    }') || { echo "Pre-flight: the model did not respond to a tool-calling request." >&2; echo "$PROBE" >&2; exit 1; }
+  echo "Pre-flight response (truncated):"
+  printf '%s\n' "$PROBE" | head -c 2000; echo
+
   OPENCODE_E2E_MODEL="ollama/{{model}}" npm run agent-e2e
 
 [windows]


### PR DESCRIPTION
## Summary

Enhanced the OpenCode end-to-end test to capture and surface comprehensive diagnostic information on failure, making it easier to diagnose agent and model issues from CI logs alone without requiring local reproduction.

## Key Changes

- **Enhanced failure diagnostics in agent test**: Changed from truncating the last 4000 characters of combined output to dumping all diagnostic channels separately (stdout, stderr, spawn errors) with clear section headers
- **Added MCP traffic logging**: Now captures and displays OpenCode↔server MCP protocol traffic (.in/.out files) and ironplcmcp stderr (.err file) on failure
- **Added OpenCode server log capture**: Implemented `readRecentOpencodeLogs()` to locate and dump OpenCode's own server logs (the detailed logs referenced by "Check server logs for details" messages)
- **Improved ANSI stripping**: Fixed regex in `stripAnsi()` to use explicit `\x1b` escape sequence instead of control character
- **Enhanced MCP recording**: Modified `record-mcp.mjs` to capture ironplcmcp's stderr to a log file (`.err`) instead of inheriting it, ensuring compiler diagnostics are visible in test failure output
- **Added model pre-flight check**: Added a direct OpenAI-compatible tool-calling probe to the `opencode-e2e` justfile recipe to isolate "model is broken" from "agent chose not to call tool" failure modes
- **Improved Ollama diagnostics**: Added trap to dump Ollama server log on test failure, providing visibility into model provider issues

## Implementation Details

- New helper functions in `lib.mjs`:
  - `opencodeLogDir()`: Locates OpenCode's XDG data directory with fallbacks
  - `readRecentOpencodeLogs(maxFiles)`: Reads the N most recently modified server log files
  - `readOrPlaceholder(file)`: Safely reads files with graceful fallback messages
- The pre-flight model probe uses the Ollama OpenAI-compatible API to verify tool-calling capability before running the full agent test
- All diagnostic output is clearly labeled with section headers for easy parsing from CI logs

https://claude.ai/code/session_017XbPjzfdny5wo9R63cJHHF