### PR TITLE
Fix OpenCode E2E by restarting Ollama with the intended context window

### DIFF
--- a/justfile
+++ b/justfile
@@ -309,7 +309,17 @@ opencode-e2e compiler-version="" model="llama3.2:3b":
   npm run smoke
 
   # Layer 2: real-agent end-to-end against a local Ollama model. A larger
-  # context window improves small models' tool-calling reliability.
+  # context window improves small models' tool-calling reliability: OpenCode's
+  # system prompt plus the ironplc_check tool schema overflow the default
+  # window, truncating the instructions so the model never calls the tool.
+  #
+  # OLLAMA_CONTEXT_LENGTH only takes effect when the server starts, and the CI
+  # environment (ai-action/setup-ollama) has already started `ollama serve` with
+  # the default window. A second `ollama serve` would just fail to bind with
+  # "address already in use" and leave that default window in place, so stop any
+  # running server first, then start our own with the larger window.
+  pkill -x ollama 2>/dev/null || true
+  timeout 30 sh -c 'while curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; do sleep 1; done' || true
   OLLAMA_CONTEXT_LENGTH=16384 ollama serve >/tmp/ollama-serve.log 2>&1 &
   timeout 60 sh -c 'until curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; do sleep 1; done'
   ollama pull "{{model}}"


### PR DESCRIPTION
## Problem

The OpenCode agent end-to-end test fails: the agent never invokes `ironplc_check` across all retry attempts (`tool invoked: false, compiler responded: false`) and OpenCode's stdout is empty. The Ollama serve log shows:

```
Error: listen tcp 127.0.0.1:11434: bind: address already in use
```

## Root cause

This is an environment conflict in the `opencode-e2e` recipe, not a bug in IronPLC's MCP server or in OpenCode.

- CI's `ai-action/setup-ollama` already starts `ollama serve` on port 11434 with Ollama's **default** context window.
- The recipe then started a **second** `ollama serve` with `OLLAMA_CONTEXT_LENGTH=16384`. That second server failed to bind (the `address already in use` error), so the intended larger window never took effect.
- `OLLAMA_CONTEXT_LENGTH` only applies when the server starts; it can't be changed on a running server.

With the default window, OpenCode's system prompt + the `ironplc_check` tool schema + the directive prompt overflow the context, truncating the instructions, so `llama3.2:3b` never emits a tool call. The tiny `ping` pre-flight fits and succeeds — which is why only the real agent run failed and the failure looked ambiguous.

## Fix

Stop any already-running Ollama server and wait for the port to free before starting our own, so `OLLAMA_CONTEXT_LENGTH=16384` actually applies. The `|| true` guards keep the recipe safe under `set -eu` when no prior server exists (e.g. local runs).

## Testing

This only manifests in the CI environment where `setup-ollama` pre-starts a server, so the meaningful validation is this workflow run. After the fix, the Ollama serve log should no longer show `address already in use`, and the agent run should invoke `ironplc_check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)