### PR TITLE
Allow OpenCode E2E workflow to be run manually

### DIFF
--- a/.github/workflows/partial_opencode_e2e.yaml
+++ b/.github/workflows/partial_opencode_e2e.yaml
@@ -11,6 +11,20 @@ on:
         type: string
         default: "llama3.2:3b"
         description: 'Ollama model used for the real-agent end-to-end test'
+  # Allow running manually against any branch from the Actions tab. The bulk of
+  # the test lives in the justfile, so this exercises branch changes directly.
+  workflow_dispatch:
+    inputs:
+      compiler-version:
+        required: false
+        type: string
+        default: ""
+        description: 'The version number to test with (without the "v" prefix). Empty string uses the latest release.'
+      model:
+        required: false
+        type: string
+        default: "llama3.2:3b"
+        description: 'Ollama model used for the real-agent end-to-end test'
 
 jobs:
   opencode-e2e:


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to `partial_opencode_e2e.yaml` so the OpenCode integration E2E can be launched manually against any branch from the Actions tab. Since most of the test logic lives in the justfile (`just opencode-e2e`) and the checkout step uses the triggering ref, manual runs exercise branch changes directly.

The existing `workflow_call` trigger (used by `deployment.yaml`) is unchanged. The `workflow_dispatch` inputs mirror it, except `compiler-version` is optional and defaults to empty (latest release) for convenient manual runs.

## Notes

- GitHub only shows the "Run workflow" button once `workflow_dispatch` is present on the default branch, so this needs to merge to `main` before it can be triggered. After that, pick any branch from the ref dropdown (or `gh workflow run partial_opencode_e2e.yaml --ref <branch>`).

## Test plan

- [ ] After merge, trigger manually against a branch and confirm it runs `just opencode-e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)