### PR TITLE
Disable OpenCode E2E test in deployment pipeline

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -104,17 +104,20 @@ jobs:
     with:
       compiler-version: ${{ needs.release.outputs.version || inputs.dryrun-test-version-override }}
 
-  opencode-e2e-test:
-    name: OpenCode Integration E2E Test
-    # Install the just-published compiler and verify the ironplcmcp MCP server
-    # works with the OpenCode agent: a connectivity check plus a real-agent run
-    # against a local Ollama model.
-    needs: [release, publish-prerelease]
-    uses: ./.github/workflows/partial_opencode_e2e.yaml
-    if: ${{ !inputs.dryrun || inputs.dryrun-test-version-override }}
-    with:
-      compiler-version: ${{ needs.release.outputs.version || inputs.dryrun-test-version-override }}
-      model: "llama3.2:3b"
+  # TODO: Re-enable once OpenCode reliably passes in the release build.
+  # The reusable workflow (.github/workflows/partial_opencode_e2e.yaml) is
+  # retained but is no longer wired into the deployment pipeline.
+  # opencode-e2e-test:
+  #   name: OpenCode Integration E2E Test
+  #   # Install the just-published compiler and verify the ironplcmcp MCP server
+  #   # works with the OpenCode agent: a connectivity check plus a real-agent run
+  #   # against a local Ollama model.
+  #   needs: [release, publish-prerelease]
+  #   uses: ./.github/workflows/partial_opencode_e2e.yaml
+  #   if: ${{ !inputs.dryrun || inputs.dryrun-test-version-override }}
+  #   with:
+  #     compiler-version: ${{ needs.release.outputs.version || inputs.dryrun-test-version-override }}
+  #     model: "llama3.2:3b"
 
   playground-e2e-test:
     name: Playground E2E Test
@@ -128,7 +131,7 @@ jobs:
     # if those are failing so we depend on those. In particular,
     # install-script-smoke-test must pass before we publish the
     # docs site, because the site serves install.sh.
-    needs: [release, smoke-test, install-script-smoke-test, opencode-e2e-test, playground-e2e-test]
+    needs: [release, smoke-test, install-script-smoke-test, playground-e2e-test]
     uses: ./.github/workflows/partial_website.yaml
     with:
       publish: ${{ !inputs.dryrun }}


### PR DESCRIPTION
## Summary
Temporarily disables the OpenCode integration E2E test in the deployment workflow due to reliability issues in the release build environment.

## Changes
- Commented out the `opencode-e2e-test` job in `.github/workflows/deployment.yaml`
- Removed `opencode-e2e-test` from the `needs` dependency list of the `publish-website` job
- Retained the reusable workflow file (`.github/workflows/partial_opencode_e2e.yaml`) for future re-enablement
- Added TODO comment explaining the temporary disablement

## Details
The OpenCode E2E test was failing reliably in the release build pipeline. Rather than removing the test infrastructure entirely, it has been commented out with a clear TODO marker for re-enablement once the underlying reliability issues are resolved. The reusable workflow remains available for manual testing or future integration.

The `publish-website` job now only depends on `release`, `smoke-test`, `install-script-smoke-test`, and `playground-e2e-test`.

https://claude.ai/code/session_01XPqxUA3QGZXN8yvkeecJBW