### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/partial_opencode_e2e.yaml
+++ b/.github/workflows/partial_opencode_e2e.yaml
@@ -26,6 +26,9 @@ on:
         default: "llama3.2:3b"
         description: 'Ollama model used for the real-agent end-to-end test'
 
+permissions:
+  contents: read
+
 jobs:
   opencode-e2e:
     name: OpenCode Integration E2E Job


### PR DESCRIPTION
Potential fix for [https://github.com/ironplc/ironplc/security/code-scanning/9](https://github.com/ironplc/ironplc/security/code-scanning/9)

Add an explicit `permissions` block to the workflow so all jobs default to least privilege.  
Best fix here: define workflow-level permissions directly under `on:`/before `jobs:` with:

- `contents: read`

This preserves functionality (checkout and read access still work) while constraining token capabilities.  
Edit only `.github/workflows/partial_opencode_e2e.yaml`, inserting the block between the trigger definitions and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
