### PR TITLE
ci: bump E2E setup-node from Node 20 to Node 22

### DIFF
--- a/.github/workflows/partial_opencode_e2e.yaml
+++ b/.github/workflows/partial_opencode_e2e.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: taiki-e/install-action@01159adff8f38113be7211e869405f6f6abf02d7 # just
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Set up Ollama
         uses: ai-action/setup-ollama@d0eb66d576e0880178be72b68b77b2dbbf5a884f # v2.0.53
 

--- a/.github/workflows/partial_playground_e2e.yaml
+++ b/.github/workflows/partial_playground_e2e.yaml
@@ -22,7 +22,7 @@ jobs:
       # Configure the execution environment
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Node 20 reached end-of-life, so setup-node steps pinning node-version: '20'
emit deprecation warnings. Bump the OpenCode and playground E2E workflows to
Node 22, matching the VS Code extension's declared engines floor (>=22.0.0).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WuwihGkSAsqoP2uPJtaq7b