### PR TITLE
Upgrade ctor dependency to 1.0 and use unsafe attribute

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -471,20 +471,13 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.11.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
+checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
  "link-section",
+ "linktime-proc-macro",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "ctrlc"
@@ -597,21 +590,6 @@ dependencies = [
  "syn",
  "trybuild",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb86b441d67a711e6e76b410de7135385fec1b8cd304e99d11c56ae542e2fc"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "dyn-clone"
@@ -1247,9 +1225,15 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "link-section"
-version = "0.11.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acde40189b7f4b102f876f43a98ec1f5899f96e9a144945d36d9ce0be7f99c7"
+checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"

--- a/compiler/analyzer/Cargo.toml
+++ b/compiler/analyzer/Cargo.toml
@@ -23,7 +23,7 @@ fixedbitset = { version = "0.5" }
 
 [dev-dependencies]
 ironplc-parser = { path = "../parser", version = "0.226.0" }
-ctor = "0.11"
+ctor = "1.0"
 env_logger = "0.11"
 rstest = "0.26"
 

--- a/compiler/analyzer/src/lib.rs
+++ b/compiler/analyzer/src/lib.rs
@@ -5,7 +5,7 @@ extern crate ironplc_dsl;
 extern crate ironplc_parser;
 
 #[cfg(test)]
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init_test_logger() {
     let _ = env_logger::builder()
         .is_test(true)

--- a/compiler/ironplc-cli/Cargo.toml
+++ b/compiler/ironplc-cli/Cargo.toml
@@ -42,7 +42,7 @@ encoding_rs = "0.8"
 assert_cmd = { version = "2.2" }
 predicates = { version = "3.1" }
 tempfile = "3"
-ctor = "0.11"
+ctor = "1.0"
 
 [[bin]]
 name = "ironplcc"

--- a/compiler/ironplc-cli/src/lib.rs
+++ b/compiler/ironplc-cli/src/lib.rs
@@ -14,7 +14,7 @@ pub mod lsp_runner;
 mod test_helpers;
 
 #[cfg(test)]
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init_test_logger() {
     let _ = env_logger::builder()
         .is_test(true)

--- a/compiler/project/Cargo.toml
+++ b/compiler/project/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 tempfile = "3"
-ctor = "0.11"
+ctor = "1.0"
 env_logger = "0.11"
 
 [lints]

--- a/compiler/project/src/lib.rs
+++ b/compiler/project/src/lib.rs
@@ -8,7 +8,7 @@ pub mod tokenizer;
 pub use project::{FileBackedProject, MemoryBackedProject, Project};
 
 #[cfg(test)]
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init_test_logger() {
     let _ = env_logger::builder()
         .is_test(true)

--- a/compiler/sources/Cargo.toml
+++ b/compiler/sources/Cargo.toml
@@ -20,7 +20,7 @@ time = "0.3.47"
 [dev-dependencies]
 ironplc-test = { path = "../test", version = "0.226.0" }
 tempfile = "3.27"
-ctor = "0.11"
+ctor = "1.0"
 env_logger = "0.11"
 
 [lints]

--- a/compiler/sources/src/lib.rs
+++ b/compiler/sources/src/lib.rs
@@ -62,7 +62,7 @@ pub use project::SourceProject;
 pub use source::Source;
 
 #[cfg(test)]
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init_test_logger() {
     let _ = env_logger::builder()
         .is_test(true)

--- a/compiler/vm-cli/Cargo.toml
+++ b/compiler/vm-cli/Cargo.toml
@@ -31,7 +31,7 @@ ironplc-container = { path = "../container", version = "0.226.0" }
 blake3 = "1"
 predicates = { version = "3.1" }
 tempfile = "3"
-ctor = "0.11"
+ctor = "1.0"
 spec_test_macro = { path = "../spec_test_macro" }
 
 [lints]

--- a/compiler/vm-cli/src/main.rs
+++ b/compiler/vm-cli/src/main.rs
@@ -13,7 +13,7 @@ mod spec_requirements {
 }
 
 #[cfg(test)]
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init_test_logger() {
     let _ = env_logger::builder()
         .is_test(true)


### PR DESCRIPTION
## Summary
Upgrades the `ctor` crate dependency from 0.11 to 1.0 across all compiler crates and updates test logger initialization functions to use the new `unsafe` attribute syntax required by the newer version.

## Changes
- **Dependency upgrades**: Updated `ctor` from 0.11 to 1.0 in Cargo.toml files for:
  - `compiler/analyzer`
  - `compiler/ironplc-cli`
  - `compiler/project`
  - `compiler/sources`
  - `compiler/vm-cli`

- **API migration**: Updated all `#[ctor::ctor]` attributes to `#[ctor::ctor(unsafe)]` in:
  - `compiler/analyzer/src/lib.rs`
  - `compiler/ironplc-cli/src/lib.rs`
  - `compiler/project/src/lib.rs`
  - `compiler/sources/src/lib.rs`
  - `compiler/vm-cli/src/main.rs`

## Implementation Details
The ctor 1.0 release introduced a breaking change requiring explicit `unsafe` annotation on constructor functions. This is a mechanical upgrade with no functional changes—all test logger initialization functions remain unchanged in behavior, only the attribute syntax is updated to comply with the new API.

https://claude.ai/code/session_01SDiiRdMYJTNnLYhS3R9QE8