### PR TITLE
Remove workflow-level permissions from reusable workflow

### DIFF
--- a/.github/workflows/partial_website.yaml
+++ b/.github/workflows/partial_website.yaml
@@ -11,12 +11,14 @@ on:
         type: string
         description: 'If not empty, then run for the specified branch name or tag'
 
-# Declares the maximum it may need: peaceiris/actions-gh-pages pushes the
-# gh-pages branch via GITHUB_TOKEN when publish is true. Callers that only
-# build (publish: false) cap this to read via their own job-level permissions.
+# No workflow-level permissions block: this reusable workflow inherits the
+# GITHUB_TOKEN permissions granted by each caller's job. A reusable workflow
+# cannot request more than the caller grants, so declaring contents: write here
+# would force every caller (including build-only ones) to grant write. Instead,
+# the publish caller (deployment.yaml's publish-website job) opts up to
+# contents: write, while build-only callers (integration.yaml, update.yaml)
+# inherit the default contents: read and skip the publish step (publish: false).
 # See specs/adrs/0032-ci-gating-and-secret-scoping.md.
-permissions:
-  contents: write
 
 jobs:
   docs:


### PR DESCRIPTION
## Summary
Remove the `permissions: contents: write` block from the reusable workflow definition in `.github/workflows/partial_website.yaml`. This allows the workflow to inherit permissions from each caller's job context rather than declaring a fixed permission level.

## Changes
- Removed the workflow-level `permissions: contents: write` declaration
- Updated the explanatory comment to clarify the permission inheritance model:
  - Reusable workflows inherit GITHUB_TOKEN permissions from their callers
  - Callers that need write access (e.g., `deployment.yaml`'s publish job) explicitly opt in via job-level `contents: write`
  - Build-only callers (e.g., `integration.yaml`, `update.yaml`) inherit the default `contents: read` and skip the publish step

## Implementation Details
This change implements the principle documented in `specs/adrs/0032-ci-gating-and-secret-scoping.md`: reusable workflows should not declare permissions that would force all callers to grant those permissions. Instead, callers that need elevated permissions should explicitly request them at the job level, while build-only jobs can use the default read-only permissions.

https://claude.ai/code/session_01MfSQn8MqjXTqV9Qv5YKEau