### PR TITLE
feat(vm): VM debug engine — breakpoints, stepping, re-entrant driver (Phase 3)

### DIFF
--- a/compiler/benchmarks/benches/st_benchmark.rs
+++ b/compiler/benchmarks/benches/st_benchmark.rs
@@ -10,7 +10,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use ironplc_benchmarks::compile_st;
 use ironplc_vm::test_support::load_and_start;
-use ironplc_vm::{Slot, VmBuffers};
+use ironplc_vm::{NoopDebugHook, Slot, VmBuffers};
 use std::hint::black_box;
 
 /// Runs one benchmark iteration: creates `VmBuffers`, applies `$setup`,
@@ -425,8 +425,69 @@ fn bench_counter_up(c: &mut Criterion) {
     group.finish();
 }
 
+/// Debug-mode scan cost: runs an identical counter loop through the
+/// production `run_round` and through the re-entrant `run_round_debug`
+/// driver with the zero-cost [`NoopDebugHook`]. This tracks the cost a
+/// debugger's "run to next breakpoint" pays while streaming through code at
+/// full speed (interactive single-stepping is unaffected by per-scan cost).
+///
+/// The two arms are NOT expected to match: `run_round` inlines and
+/// specialises `execute_with_hook` at its single call site, while
+/// `run_round_debug` calls the out-of-line generic copy. The gap here is
+/// that driver difference, not a hot-path regression — the production
+/// `run_round` path itself is guarded against regression by the other
+/// `run_round` benches in this file (compare a branch to a `main` baseline
+/// with `--save-baseline` / `--baseline`).
+fn bench_debug_scan_cost(c: &mut Criterion) {
+    let mut group = c.benchmark_group("st_debug_scan_cost");
+    let container = compile_st(
+        "PROGRAM main
+  VAR counter : DINT; END_VAR
+  WHILE counter > 0 DO
+    counter := counter - 1;
+  END_WHILE;
+END_PROGRAM",
+    );
+
+    let count = 10_000;
+    group.throughput(Throughput::Elements(count as u64));
+
+    // Production path — reuses the shared macro (run_round).
+    bench_run!(
+        group,
+        BenchmarkId::new("run_round", count),
+        &container,
+        |bufs| {
+            bufs.vars[0] = Slot::from_i32(count);
+        }
+    );
+
+    // Debug driver path — run_round_debug with the zero-cost hook.
+    group.bench_with_input(
+        BenchmarkId::new("run_round_debug_noop", count),
+        &(),
+        |b, _| {
+            b.iter_batched(
+                || {
+                    let mut bufs = VmBuffers::from_container(&container);
+                    bufs.vars[0] = Slot::from_i32(count);
+                    bufs
+                },
+                |mut bufs| {
+                    let mut vm = load_and_start(&container, &mut bufs).unwrap();
+                    let mut hook = NoopDebugHook;
+                    black_box(vm.run_round_debug(0, &mut hook).unwrap());
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+    group.finish();
+}
+
 criterion_group!(
     benches,
+    bench_debug_scan_cost,
     bench_counter_loop,
     bench_arithmetic_i32,
     bench_arithmetic_f64,

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -11,6 +11,10 @@
 //!
 //! [`DebugHook`]: crate::debug_hook::DebugHook
 
+use ironplc_container::FunctionId;
+
+use crate::debug_hook::{DebugHook, HookAction};
+
 /// Stable identifier for a breakpoint, handed out by [`BreakpointTable`].
 ///
 /// The value is opaque; callers use it to disable or remove a specific
@@ -31,4 +35,206 @@ pub enum PauseReason {
     Step,
     /// Stopped on entry, before executing the first instruction.
     Entry,
+}
+
+/// One breakpoint: a `(function_id, offset)` location plus an enabled flag.
+#[derive(Clone, Copy, Debug)]
+struct BreakpointEntry {
+    id: BreakpointId,
+    function_id: FunctionId,
+    offset: usize,
+    enabled: bool,
+}
+
+impl BreakpointEntry {
+    /// Sort/search key: function first (by raw id), then bytecode offset.
+    fn key(&self) -> (u16, usize) {
+        (self.function_id.raw(), self.offset)
+    }
+}
+
+/// Set of pause-only breakpoints, keyed by `(function_id, bytecode_offset)`.
+///
+/// Entries are kept sorted so a per-instruction lookup is a binary search.
+/// This is deliberately a plain `Vec` with no atomics or `ArcSwap`: the
+/// single-threaded debug loop owns and mutates it directly.
+#[derive(Debug, Default)]
+pub struct BreakpointTable {
+    entries: Vec<BreakpointEntry>,
+    next_id: u32,
+}
+
+impl BreakpointTable {
+    /// Create an empty table.
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Number of breakpoints (enabled or not).
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the table holds no breakpoints.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Add an enabled breakpoint at `(function_id, offset)`, returning its id.
+    ///
+    /// Duplicate locations are allowed; [`lookup`](Self::lookup) reports the
+    /// first enabled breakpoint at a location.
+    pub fn add(&mut self, function_id: FunctionId, offset: usize) -> BreakpointId {
+        let id = BreakpointId(self.next_id);
+        self.next_id += 1;
+        let entry = BreakpointEntry {
+            id,
+            function_id,
+            offset,
+            enabled: true,
+        };
+        let pos = self.entries.partition_point(|e| e.key() < entry.key());
+        self.entries.insert(pos, entry);
+        id
+    }
+
+    /// Remove the breakpoint with `id`. Returns whether it existed.
+    pub fn remove(&mut self, id: BreakpointId) -> bool {
+        if let Some(pos) = self.entries.iter().position(|e| e.id == id) {
+            self.entries.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Enable or disable the breakpoint with `id`. Returns whether it existed.
+    pub fn set_enabled(&mut self, id: BreakpointId, enabled: bool) -> bool {
+        if let Some(e) = self.entries.iter_mut().find(|e| e.id == id) {
+            e.enabled = enabled;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Remove every breakpoint (ids are not reused).
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// The id of the first enabled breakpoint at `(function_id, offset)`, or
+    /// `None`.
+    pub fn lookup(&self, function_id: FunctionId, offset: usize) -> Option<BreakpointId> {
+        let key = (function_id.raw(), offset);
+        // Binary search to any entry at this key, then scan the equal run for
+        // an enabled one (duplicates at a location are permitted).
+        let mut idx = self.entries.partition_point(|e| e.key() < key);
+        while idx < self.entries.len() && self.entries[idx].key() == key {
+            if self.entries[idx].enabled {
+                return Some(self.entries[idx].id);
+            }
+            idx += 1;
+        }
+        None
+    }
+}
+
+/// The debugger's [`DebugHook`]: pauses at enabled breakpoints and leaves
+/// the frame stack intact for inspection.
+///
+/// Borrows the [`BreakpointTable`] so the owning (single-threaded) loop can
+/// consult and mutate it between rounds. After the hook reports a pause it
+/// suppresses that exact breakpoint for the immediately-following
+/// instruction, so a `continue`/resume steps off the current location rather
+/// than re-triggering the same breakpoint in place.
+pub struct DebuggerHook<'a> {
+    breakpoints: &'a BreakpointTable,
+    /// When set, the next instruction skips the breakpoint check exactly
+    /// once. Set on every pause so resume makes forward progress.
+    skip_breakpoint_once: bool,
+}
+
+impl<'a> DebuggerHook<'a> {
+    /// Create a debugger hook over `breakpoints` for a fresh debug session.
+    pub fn new(breakpoints: &'a BreakpointTable) -> Self {
+        Self {
+            breakpoints,
+            skip_breakpoint_once: false,
+        }
+    }
+}
+
+impl DebugHook for DebuggerHook<'_> {
+    fn before_instruction(&mut self, function_id: FunctionId, pc: usize, _op: u8) -> HookAction {
+        let skip = self.skip_breakpoint_once;
+        self.skip_breakpoint_once = false;
+        if !skip {
+            if let Some(id) = self.breakpoints.lookup(function_id, pc) {
+                // Suppress this breakpoint for the resume instruction.
+                self.skip_breakpoint_once = true;
+                return HookAction::Pause(PauseReason::Breakpoint(id));
+            }
+        }
+        HookAction::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn breakpoint_table_when_empty_then_lookup_misses() {
+        let table = BreakpointTable::new();
+        assert!(table.is_empty());
+        assert_eq!(table.lookup(FunctionId::SCAN, 0), None);
+    }
+
+    #[test]
+    fn breakpoint_table_when_added_then_lookup_hits_exact_location() {
+        let mut table = BreakpointTable::new();
+        let id = table.add(FunctionId::SCAN, 6);
+        assert_eq!(table.lookup(FunctionId::SCAN, 6), Some(id));
+        // Different offset / function does not match.
+        assert_eq!(table.lookup(FunctionId::SCAN, 5), None);
+        assert_eq!(table.lookup(FunctionId::new(2), 6), None);
+    }
+
+    #[test]
+    fn breakpoint_table_when_disabled_then_lookup_misses() {
+        let mut table = BreakpointTable::new();
+        let id = table.add(FunctionId::SCAN, 3);
+        assert!(table.set_enabled(id, false));
+        assert_eq!(table.lookup(FunctionId::SCAN, 3), None);
+        assert!(table.set_enabled(id, true));
+        assert_eq!(table.lookup(FunctionId::SCAN, 3), Some(id));
+    }
+
+    #[test]
+    fn breakpoint_table_when_removed_then_lookup_misses() {
+        let mut table = BreakpointTable::new();
+        let id = table.add(FunctionId::new(2), 9);
+        assert!(table.remove(id));
+        assert!(!table.remove(id));
+        assert_eq!(table.lookup(FunctionId::new(2), 9), None);
+    }
+
+    #[test]
+    fn breakpoint_table_when_many_functions_then_sorted_lookup_works() {
+        let mut table = BreakpointTable::new();
+        // Insert out of order across functions and offsets.
+        let a = table.add(FunctionId::new(5), 10);
+        let b = table.add(FunctionId::SCAN, 2);
+        let c = table.add(FunctionId::new(2), 100);
+        let d = table.add(FunctionId::SCAN, 0);
+        assert_eq!(table.lookup(FunctionId::new(5), 10), Some(a));
+        assert_eq!(table.lookup(FunctionId::SCAN, 2), Some(b));
+        assert_eq!(table.lookup(FunctionId::new(2), 100), Some(c));
+        assert_eq!(table.lookup(FunctionId::SCAN, 0), Some(d));
+        assert_eq!(table.len(), 4);
+    }
 }

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -1,0 +1,34 @@
+//! Debugger engine: breakpoints, stepping, and the pause/resume driver.
+//!
+//! This module turns the VM's instruction-level [`DebugHook`] into a
+//! debugger-grade engine that can pause at breakpoints, single-step, and
+//! leave the frame stack intact for inspection — all in `(FunctionId,
+//! bytecode_offset)` space, with no dependency on source-line debug info.
+//!
+//! It is deliberately single-threaded: the [`BreakpointTable`] is a plain
+//! sorted `Vec` owned and mutated directly by the caller (the Phase 4 DAP
+//! loop). There are no atomics, no `ArcSwap`, and no cross-thread pause.
+//!
+//! [`DebugHook`]: crate::debug_hook::DebugHook
+
+/// Stable identifier for a breakpoint, handed out by [`BreakpointTable`].
+///
+/// The value is opaque; callers use it to disable or remove a specific
+/// breakpoint and to recognise which breakpoint a [`PauseReason::Breakpoint`]
+/// refers to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BreakpointId(pub u32);
+
+/// Why the VM stopped before executing the next instruction.
+///
+/// A trap is *not* a pause reason: traps continue to surface through the
+/// existing fault path ([`FaultContext`](crate::FaultContext)), not here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PauseReason {
+    /// Stopped because execution reached an enabled breakpoint.
+    Breakpoint(BreakpointId),
+    /// Stopped because a single-step (`over` / `in` / `out`) landed.
+    Step,
+    /// Stopped on entry, before executing the first instruction.
+    Entry,
+}

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -330,6 +330,25 @@ mod tests {
     }
 
     #[test]
+    fn breakpoint_table_when_cleared_then_empty_and_lookups_miss() {
+        let mut table = BreakpointTable::new();
+        table.add(FunctionId::SCAN, 0);
+        table.add(FunctionId::SCAN, 6);
+        assert_eq!(table.len(), 2);
+        table.clear();
+        assert!(table.is_empty());
+        assert_eq!(table.lookup(FunctionId::SCAN, 0), None);
+    }
+
+    #[test]
+    fn breakpoint_table_when_id_absent_then_mutators_report_false() {
+        let mut table = BreakpointTable::new();
+        let ghost = BreakpointId(999);
+        assert!(!table.set_enabled(ghost, false));
+        assert!(!table.remove(ghost));
+    }
+
+    #[test]
     fn breakpoint_table_when_many_functions_then_sorted_lookup_works() {
         let mut table = BreakpointTable::new();
         // Insert out of order across functions and offsets.

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -143,19 +143,80 @@ impl BreakpointTable {
     }
 }
 
-/// The debugger's [`DebugHook`]: pauses at enabled breakpoints and leaves
-/// the frame stack intact for inspection.
+/// Single-step mode requested of the [`DebuggerHook`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StepMode {
+    /// Not stepping.
+    None,
+    /// Step to the next instruction at the same (or a shallower) call depth,
+    /// running any called functions to completion.
+    Over,
+    /// Step to the very next instruction executed, descending into calls.
+    In,
+    /// Run until the current function returns, then stop in the caller.
+    Out,
+}
+
+/// Remembers where a step started so the hook can tell when it has "landed".
+///
+/// Depth is the debugger's own mirror of the call depth (relative to scan
+/// entry), tracked via `before_call` / `after_return` — it never reaches
+/// into the VM's frame stack.
+#[derive(Clone, Copy, Debug)]
+struct StepController {
+    mode: StepMode,
+    origin_depth: usize,
+    origin_offset: usize,
+}
+
+impl StepController {
+    fn idle() -> Self {
+        Self {
+            mode: StepMode::None,
+            origin_depth: 0,
+            origin_offset: 0,
+        }
+    }
+
+    /// Whether a step in progress has landed at `(depth, offset)`.
+    fn landed(&self, depth: usize, offset: usize) -> bool {
+        // The origin instruction itself is never a landing — a step must
+        // make forward progress.
+        let at_origin = depth == self.origin_depth && offset == self.origin_offset;
+        match self.mode {
+            StepMode::None => false,
+            // Same or shallower depth (calls stepped over), but not the
+            // origin instruction.
+            StepMode::Over => depth <= self.origin_depth && !at_origin,
+            // Any next instruction, including the first of a callee.
+            StepMode::In => !at_origin,
+            // Only once control has unwound past the origin frame.
+            StepMode::Out => depth < self.origin_depth,
+        }
+    }
+}
+
+/// The debugger's [`DebugHook`]: pauses at enabled breakpoints, single-steps
+/// (over / in / out), and leaves the frame stack intact for inspection.
 ///
 /// Borrows the [`BreakpointTable`] so the owning (single-threaded) loop can
 /// consult and mutate it between rounds. After the hook reports a pause it
 /// suppresses that exact breakpoint for the immediately-following
-/// instruction, so a `continue`/resume steps off the current location rather
-/// than re-triggering the same breakpoint in place.
+/// instruction, so a `continue`/resume or the first step off the current
+/// location does not re-trigger the same breakpoint in place.
 pub struct DebuggerHook<'a> {
     breakpoints: &'a BreakpointTable,
     /// When set, the next instruction skips the breakpoint check exactly
     /// once. Set on every pause so resume makes forward progress.
     skip_breakpoint_once: bool,
+    /// Call depth relative to scan entry: `+1` per call, `-1` per return.
+    /// Self-heals to 0 at each scan boundary (the entry-frame return uses a
+    /// saturating decrement).
+    depth: usize,
+    /// Location observed at the most recent `before_instruction`, used as a
+    /// step's origin when one is armed while paused.
+    last_offset: usize,
+    step: StepController,
 }
 
 impl<'a> DebuggerHook<'a> {
@@ -164,12 +225,42 @@ impl<'a> DebuggerHook<'a> {
         Self {
             breakpoints,
             skip_breakpoint_once: false,
+            depth: 0,
+            last_offset: 0,
+            step: StepController::idle(),
         }
+    }
+
+    /// Arm a step-over from the current (paused) location: run to the next
+    /// instruction at the same or a shallower call depth.
+    pub fn step_over(&mut self) {
+        self.arm(StepMode::Over);
+    }
+
+    /// Arm a step-in from the current (paused) location: stop at the very
+    /// next instruction, descending into any call.
+    pub fn step_in(&mut self) {
+        self.arm(StepMode::In);
+    }
+
+    /// Arm a step-out from the current (paused) location: run until the
+    /// current function returns, then stop in the caller.
+    pub fn step_out(&mut self) {
+        self.arm(StepMode::Out);
+    }
+
+    fn arm(&mut self, mode: StepMode) {
+        self.step = StepController {
+            mode,
+            origin_depth: self.depth,
+            origin_offset: self.last_offset,
+        };
     }
 }
 
 impl DebugHook for DebuggerHook<'_> {
     fn before_instruction(&mut self, function_id: FunctionId, pc: usize, _op: u8) -> HookAction {
+        self.last_offset = pc;
         let skip = self.skip_breakpoint_once;
         self.skip_breakpoint_once = false;
         if !skip {
@@ -179,7 +270,22 @@ impl DebugHook for DebuggerHook<'_> {
                 return HookAction::Pause(PauseReason::Breakpoint(id));
             }
         }
+        if self.step.landed(self.depth, pc) {
+            // A step lands only once; disarm and suppress a co-located
+            // breakpoint on the resume instruction.
+            self.step.mode = StepMode::None;
+            self.skip_breakpoint_once = true;
+            return HookAction::Pause(PauseReason::Step);
+        }
         HookAction::Continue
+    }
+
+    fn before_call(&mut self, _callee: FunctionId) {
+        self.depth += 1;
+    }
+
+    fn after_return(&mut self, _returning_to: Option<FunctionId>) {
+        self.depth = self.depth.saturating_sub(1);
     }
 }
 

--- a/compiler/vm/src/debug_hook.rs
+++ b/compiler/vm/src/debug_hook.rs
@@ -112,7 +112,12 @@ mod tests {
             events: Vec<(FunctionId, usize, u8)>,
         }
         impl DebugHook for RecordingHook {
-            fn before_instruction(&mut self, function_id: FunctionId, pc: usize, op: u8) -> HookAction {
+            fn before_instruction(
+                &mut self,
+                function_id: FunctionId,
+                pc: usize,
+                op: u8,
+            ) -> HookAction {
                 self.events.push((function_id, pc, op));
                 HookAction::Continue
             }

--- a/compiler/vm/src/debug_hook.rs
+++ b/compiler/vm/src/debug_hook.rs
@@ -20,7 +20,25 @@
 
 use ironplc_container::FunctionId;
 
-/// A trait invoked by the VM before executing each instruction.
+use crate::debug::PauseReason;
+
+/// What the VM should do after the hook has inspected the upcoming
+/// instruction.
+///
+/// Returned from [`DebugHook::before_instruction`] on every opcode.
+/// [`NoopDebugHook`] always returns [`HookAction::Continue`] from an
+/// `#[inline(always)]` body so the monomorphised hot path stays branch-free.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HookAction {
+    /// Execute the instruction normally.
+    Continue,
+    /// Stop *before* executing the instruction at `(function_id, pc)`.
+    /// The frame stack is left intact so execution can resume from here.
+    Pause(PauseReason),
+}
+
+/// A trait invoked by the VM before executing each instruction and around
+/// each call/return.
 ///
 /// Implementations may inspect or react to the upcoming instruction —
 /// for example, by checking a breakpoint table, recording a trace, or
@@ -38,7 +56,24 @@ pub trait DebugHook {
     /// pair uniquely identifies the instruction across nested CALL /
     /// FB_CALL frames, so a consumer can perform e.g.
     /// `DebugSection::lookup_source_location(function_id, pc)`.
-    fn before_instruction(&mut self, function_id: FunctionId, pc: usize, op: u8);
+    ///
+    /// Returning [`HookAction::Pause`] stops the VM *before* the
+    /// instruction executes; `pc` is written back to the top frame so
+    /// the same instruction re-executes when the VM is resumed.
+    fn before_instruction(&mut self, function_id: FunctionId, pc: usize, op: u8) -> HookAction;
+
+    /// Called after the hook approves a `CALL` / `FB_CALL` instruction and
+    /// just before the callee frame is pushed. Default: no-op.
+    ///
+    /// Lets a hook track call depth without reaching into the VM's frame
+    /// stack.
+    fn before_call(&mut self, _callee: FunctionId) {}
+
+    /// Called just after a frame is popped (`RET` / `RET_VOID` /
+    /// fall-off-the-end). `returning_to` is the function the VM is
+    /// resuming in, or `None` if the outermost frame just returned.
+    /// Default: no-op.
+    fn after_return(&mut self, _returning_to: Option<FunctionId>) {}
 }
 
 /// A no-op [`DebugHook`] used by default. Zero-sized; the empty
@@ -48,7 +83,9 @@ pub struct NoopDebugHook;
 
 impl DebugHook for NoopDebugHook {
     #[inline(always)]
-    fn before_instruction(&mut self, _function_id: FunctionId, _pc: usize, _op: u8) {}
+    fn before_instruction(&mut self, _function_id: FunctionId, _pc: usize, _op: u8) -> HookAction {
+        HookAction::Continue
+    }
 }
 
 #[cfg(test)]
@@ -57,11 +94,16 @@ mod tests {
     use std::vec::Vec;
 
     #[test]
-    fn noop_debug_hook_when_called_then_does_nothing() {
+    fn noop_debug_hook_when_called_then_continues() {
         let mut hook = NoopDebugHook;
-        hook.before_instruction(FunctionId::INIT, 0, 1);
-        hook.before_instruction(FunctionId::SCAN, usize::MAX, u8::MAX);
-        // No assertion needed: hook has no observable state.
+        assert_eq!(
+            hook.before_instruction(FunctionId::INIT, 0, 1),
+            HookAction::Continue
+        );
+        assert_eq!(
+            hook.before_instruction(FunctionId::SCAN, usize::MAX, u8::MAX),
+            HookAction::Continue
+        );
     }
 
     #[test]
@@ -70,8 +112,9 @@ mod tests {
             events: Vec<(FunctionId, usize, u8)>,
         }
         impl DebugHook for RecordingHook {
-            fn before_instruction(&mut self, function_id: FunctionId, pc: usize, op: u8) {
+            fn before_instruction(&mut self, function_id: FunctionId, pc: usize, op: u8) -> HookAction {
                 self.events.push((function_id, pc, op));
+                HookAction::Continue
             }
         }
         let mut hook = RecordingHook { events: Vec::new() };
@@ -80,6 +123,22 @@ mod tests {
         assert_eq!(
             hook.events,
             vec![(FunctionId::SCAN, 0, 0x10), (FunctionId::new(2), 2, 0x11),]
+        );
+    }
+
+    #[test]
+    fn custom_debug_hook_when_pausing_then_returns_pause_action() {
+        use crate::debug::{BreakpointId, PauseReason};
+        struct PausingHook;
+        impl DebugHook for PausingHook {
+            fn before_instruction(&mut self, _f: FunctionId, _pc: usize, _op: u8) -> HookAction {
+                HookAction::Pause(PauseReason::Breakpoint(BreakpointId(7)))
+            }
+        }
+        let mut hook = PausingHook;
+        assert_eq!(
+            hook.before_instruction(FunctionId::SCAN, 0, 0x10),
+            HookAction::Pause(PauseReason::Breakpoint(BreakpointId(7)))
         );
     }
 }

--- a/compiler/vm/src/frame_stack.rs
+++ b/compiler/vm/src/frame_stack.rs
@@ -96,6 +96,17 @@ impl<'a> FrameStack<'a> {
         }
     }
 
+    /// Rebuild a frame stack over `backing` with `len` frames already live.
+    ///
+    /// Used by the re-entrant debug driver to resume a paused instance: the
+    /// frame contents survive in the embedder's backing slice across a
+    /// pause, and this restores the logical length so the dispatch loop
+    /// continues from the preserved top frame.
+    pub fn resume(backing: &'a mut [Frame], len: usize) -> Self {
+        debug_assert!(len <= backing.len(), "resume len exceeds frame capacity");
+        FrameStack { slots: backing, len }
+    }
+
     /// Number of frames currently on the stack.
     pub fn len(&self) -> usize {
         self.len

--- a/compiler/vm/src/frame_stack.rs
+++ b/compiler/vm/src/frame_stack.rs
@@ -104,7 +104,10 @@ impl<'a> FrameStack<'a> {
     /// continues from the preserved top frame.
     pub fn resume(backing: &'a mut [Frame], len: usize) -> Self {
         debug_assert!(len <= backing.len(), "resume len exceeds frame capacity");
-        FrameStack { slots: backing, len }
+        FrameStack {
+            slots: backing,
+            len,
+        }
     }
 
     /// Number of frames currently on the stack.

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -17,7 +17,7 @@ pub(crate) mod variable_table;
 mod vm;
 
 pub use buffers::VmBuffers;
-pub use debug::{BreakpointId, PauseReason};
+pub use debug::{BreakpointId, BreakpointTable, DebuggerHook, PauseReason};
 pub use debug_hook::{DebugHook, HookAction, NoopDebugHook};
 pub use frame_stack::{FbCallReturn, Frame, FrameStack};
 #[cfg(feature = "profiling")]

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -1,5 +1,6 @@
 mod buffers;
 pub(crate) mod builtin;
+pub mod debug;
 pub mod debug_hook;
 pub mod error;
 pub(crate) mod frame_stack;
@@ -16,7 +17,8 @@ pub(crate) mod variable_table;
 mod vm;
 
 pub use buffers::VmBuffers;
-pub use debug_hook::{DebugHook, NoopDebugHook};
+pub use debug::{BreakpointId, PauseReason};
+pub use debug_hook::{DebugHook, HookAction, NoopDebugHook};
 pub use frame_stack::{FbCallReturn, Frame, FrameStack};
 #[cfg(feature = "profiling")]
 pub use profile::InstructionProfile;

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -24,4 +24,6 @@ pub use frame_stack::{FbCallReturn, Frame, FrameStack};
 pub use profile::InstructionProfile;
 pub use scheduler::{ProgramInstanceState, TaskState};
 pub use value::Slot;
-pub use vm::{FaultContext, Vm, VmFaulted, VmReady, VmRunning, VmStopped};
+pub use vm::{
+    ExecuteOutcome, FaultContext, Phase, RoundOutcome, Vm, VmFaulted, VmReady, VmRunning, VmStopped,
+};

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -17,7 +17,7 @@ pub(crate) mod variable_table;
 mod vm;
 
 pub use buffers::VmBuffers;
-pub use debug::{BreakpointId, BreakpointTable, DebuggerHook, PauseReason};
+pub use debug::{BreakpointId, BreakpointTable, DebuggerHook, PauseReason, StepMode};
 pub use debug_hook::{DebugHook, HookAction, NoopDebugHook};
 pub use frame_stack::{FbCallReturn, Frame, FrameStack};
 #[cfg(feature = "profiling")]

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -914,7 +914,13 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
         if pc >= bytecode.len() {
             // Fell off the end of a function body without an explicit
             // RET — treat as RET_VOID.
-            handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables, hook)?;
+            handle_frame_return(
+                &mut temp_alloc,
+                &mut frame_stack,
+                data_region,
+                variables,
+                hook,
+            )?;
             continue;
         }
 
@@ -1390,7 +1396,13 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                 // Return value is already on the operand stack; just unwind
                 // this frame and let the caller frame (or outer-loop exit)
                 // resume.
-                handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables, hook)?;
+                handle_frame_return(
+                    &mut temp_alloc,
+                    &mut frame_stack,
+                    data_region,
+                    variables,
+                    hook,
+                )?;
                 advance_pc = false;
             }
             // --- String opcodes ---
@@ -2507,7 +2519,13 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     .copy_from_slice(&value_slot.as_i64().to_le_bytes());
             }
             opcode::RET_VOID => {
-                handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables, hook)?;
+                handle_frame_return(
+                    &mut temp_alloc,
+                    &mut frame_stack,
+                    data_region,
+                    variables,
+                    hook,
+                )?;
                 advance_pc = false;
             }
             _ => {

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -356,17 +356,7 @@ impl<'a> VmRunning<'a> {
         }
 
         // System variable injection: write monotonic uptime before task execution.
-        if self.container.header.flags & ironplc_container::FLAG_HAS_SYSTEM_UPTIME != 0 {
-            let time_ms = (current_time_us / 1000) as i64;
-            // __SYSTEM_UP_TIME at VarIndex(0): i32 milliseconds (wrapping)
-            self.variables
-                .store(VarIndex::new(0), Slot::from_i32(time_ms as i32))
-                .expect("system uptime variable must exist at index 0");
-            // __SYSTEM_UP_LTIME at VarIndex(1): i64 milliseconds (non-wrapping)
-            self.variables
-                .store(VarIndex::new(1), Slot::from_i64(time_ms))
-                .expect("system uptime variable must exist at index 1");
-        }
+        self.inject_system_uptime(current_time_us);
 
         // Stub: INPUT_FREEZE (no-op)
 
@@ -379,42 +369,26 @@ impl<'a> VmRunning<'a> {
             let mut last_instance_id = InstanceId::DEFAULT;
 
             // Iterate over program instances for this task.
-            // Copy fields to locals before calling execute() to satisfy borrow checker.
             for pi in 0..self.program_instances.len() {
                 if self.program_instances[pi].task_id != task_id {
                     continue;
                 }
                 let instance_id = self.program_instances[pi].instance_id;
                 last_instance_id = instance_id;
-                let entry_function_id = self.program_instances[pi].entry_function_id;
-                let var_table_offset = self.program_instances[pi].var_table_offset;
-                let var_table_count = self.program_instances[pi].var_table_count;
 
-                let scope = VariableScope {
-                    shared_globals_size: self.shared_globals_size,
-                    instance_offset: var_table_offset,
-                    instance_count: var_table_count,
-                };
-
-                execute(
-                    self.container,
-                    &mut self.stack,
-                    &mut self.variables,
-                    self.data_region,
-                    self.temp_buf,
-                    self.max_temp_buf_bytes,
-                    self.frames,
-                    &scope,
-                    current_time_us,
-                    entry_function_id,
-                    #[cfg(feature = "profiling")]
-                    &mut self.profile,
-                )
-                .map_err(|trap| FaultContext {
-                    trap,
-                    task_id,
-                    instance_id,
-                })?;
+                // Production scan: run the instance to completion with the
+                // zero-cost hook and fresh (non-resumable) frame state.
+                let (outcome, _, _) = self
+                    .run_instance(pi, current_time_us, 0, 0, &mut NoopDebugHook)
+                    .map_err(|trap| FaultContext {
+                        trap,
+                        task_id,
+                        instance_id,
+                    })?;
+                debug_assert!(
+                    matches!(outcome, ExecuteOutcome::Completed),
+                    "NoopDebugHook can never pause a scan"
+                );
             }
 
             #[cfg(not(target_arch = "wasm32"))]
@@ -456,6 +430,16 @@ impl<'a> VmRunning<'a> {
     /// A trap still surfaces through the fault path: the method returns
     /// `Err(FaultContext)` and sets the phase to [`Phase::Faulted`], exactly
     /// as `run_round` does.
+    ///
+    /// **Intentionally bypasses the scheduler and watchdog.** `run_round`
+    /// consults the [`TaskScheduler`] to pick ready tasks, records execution
+    /// time to re-arm cyclic timers, and traps on watchdog overrun. This
+    /// method does none of that: it runs instance 0 unconditionally and never
+    /// times the scan. That is deliberate — while a human controls the clock
+    /// at a breakpoint, cyclic re-arming is meaningless and a watchdog would
+    /// fire the moment execution paused. The shared per-instance execution
+    /// core lives in [`run_instance`](Self::run_instance); only the
+    /// scheduling/lifecycle policy around it differs between the two drivers.
     pub fn run_round_debug<H: DebugHook>(
         &mut self,
         current_time_us: u64,
@@ -469,63 +453,36 @@ impl<'a> VmRunning<'a> {
 
         let resuming = matches!(self.phase, Phase::PausedAt(_));
 
-        // Instance 0 is the single debuggee.
+        // Instance 0 is the single debuggee (v1 is single-instance).
         let instance_id = self.program_instances[0].instance_id;
         let task_id = self.program_instances[0].task_id;
-        let entry_function_id = self.program_instances[0].entry_function_id;
-        let var_table_offset = self.program_instances[0].var_table_offset;
-        let var_table_count = self.program_instances[0].var_table_count;
-
-        let scope = VariableScope {
-            shared_globals_size: self.shared_globals_size,
-            instance_offset: var_table_offset,
-            instance_count: var_table_count,
-        };
 
         if !resuming {
-            // Fresh scan: inject system uptime before running, mirroring
-            // run_round, then start with an empty frame stack so
-            // execute_with_hook pushes the entry frame.
-            if self.container.header.flags & ironplc_container::FLAG_HAS_SYSTEM_UPTIME != 0 {
-                let time_ms = (current_time_us / 1000) as i64;
-                self.variables
-                    .store(VarIndex::new(0), Slot::from_i32(time_ms as i32))
-                    .expect("system uptime variable must exist at index 0");
-                self.variables
-                    .store(VarIndex::new(1), Slot::from_i64(time_ms))
-                    .expect("system uptime variable must exist at index 1");
-            }
+            // Fresh scan: inject system uptime, then reset the resume state so
+            // run_instance starts with an empty frame stack (the dispatch loop
+            // pushes the entry frame). When resuming, the preserved frame count
+            // is non-zero and the paused frames survive in place.
+            self.inject_system_uptime(current_time_us);
             self.debug_frame_count = 0;
             self.debug_temp_alloc_next = 0;
         }
 
         self.phase = Phase::Running;
 
-        let outcome = execute_with_hook(
-            self.container,
-            &mut self.stack,
-            &mut self.variables,
-            self.data_region,
-            self.temp_buf,
-            self.max_temp_buf_bytes,
-            self.frames,
-            &scope,
-            current_time_us,
-            entry_function_id,
-            &mut self.debug_frame_count,
-            &mut self.debug_temp_alloc_next,
-            #[cfg(feature = "profiling")]
-            &mut self.profile,
-            hook,
-        )
-        .map_err(|trap| {
-            self.phase = Phase::Faulted;
-            FaultContext {
-                trap,
-                task_id,
-                instance_id,
-            }
-        })?;
+        let frame_count_in = self.debug_frame_count;
+        let temp_alloc_next_in = self.debug_temp_alloc_next;
+        let (outcome, frame_count, temp_alloc_next) = self
+            .run_instance(0, current_time_us, frame_count_in, temp_alloc_next_in, hook)
+            .map_err(|trap| {
+                self.phase = Phase::Faulted;
+                FaultContext {
+                    trap,
+                    task_id,
+                    instance_id,
+                }
+            })?;
+        self.debug_frame_count = frame_count;
+        self.debug_temp_alloc_next = temp_alloc_next;
 
         match outcome {
             ExecuteOutcome::Paused(reason) => {
@@ -538,6 +495,80 @@ impl<'a> VmRunning<'a> {
                 Ok(RoundOutcome::Completed)
             }
         }
+    }
+
+    /// Writes the monotonic uptime system variables before task execution,
+    /// if the loaded container declares them. Shared by [`run_round`] and
+    /// [`run_round_debug`] so the injection lives in exactly one place.
+    fn inject_system_uptime(&mut self, current_time_us: u64) {
+        if self.container.header.flags & ironplc_container::FLAG_HAS_SYSTEM_UPTIME == 0 {
+            return;
+        }
+        let time_ms = (current_time_us / 1000) as i64;
+        // __SYSTEM_UP_TIME at VarIndex(0): i32 milliseconds (wrapping)
+        self.variables
+            .store(VarIndex::new(0), Slot::from_i32(time_ms as i32))
+            .expect("system uptime variable must exist at index 0");
+        // __SYSTEM_UP_LTIME at VarIndex(1): i64 milliseconds (non-wrapping)
+        self.variables
+            .store(VarIndex::new(1), Slot::from_i64(time_ms))
+            .expect("system uptime variable must exist at index 1");
+    }
+
+    /// Runs one program instance's entry function through the shared dispatch
+    /// loop until it returns (`Completed`) or the hook pauses it (`Paused`).
+    ///
+    /// This is the single execution core behind both drivers:
+    /// - [`run_round`](Self::run_round) calls it per ready instance with
+    ///   [`NoopDebugHook`] and fresh `0` resume state (a production scan is
+    ///   never resumable, so the returned frame state is discarded);
+    /// - [`run_round_debug`](Self::run_round_debug) calls it once with a real
+    ///   hook and the *persisted* resume state, so a paused instance can
+    ///   continue on the next call.
+    ///
+    /// The caller owns all scheduling, watchdog, and instance-selection
+    /// policy; this method only builds the instance's [`VariableScope`] and
+    /// runs it. `frame_count` / `temp_alloc_next` are the resume state on
+    /// entry; the returned pair is the state after this run (advanced only
+    /// when the run paused mid-instance).
+    fn run_instance<H: DebugHook>(
+        &mut self,
+        instance_index: usize,
+        current_time_us: u64,
+        frame_count: usize,
+        temp_alloc_next: u16,
+        hook: &mut H,
+    ) -> Result<(ExecuteOutcome, usize, u16), Trap> {
+        let entry_function_id = self.program_instances[instance_index].entry_function_id;
+        let var_table_offset = self.program_instances[instance_index].var_table_offset;
+        let var_table_count = self.program_instances[instance_index].var_table_count;
+
+        let scope = VariableScope {
+            shared_globals_size: self.shared_globals_size,
+            instance_offset: var_table_offset,
+            instance_count: var_table_count,
+        };
+
+        let mut frame_count = frame_count;
+        let mut temp_alloc_next = temp_alloc_next;
+        let outcome = execute_with_hook(
+            self.container,
+            &mut self.stack,
+            &mut self.variables,
+            self.data_region,
+            self.temp_buf,
+            self.max_temp_buf_bytes,
+            self.frames,
+            &scope,
+            current_time_us,
+            entry_function_id,
+            &mut frame_count,
+            &mut temp_alloc_next,
+            #[cfg(feature = "profiling")]
+            &mut self.profile,
+            hook,
+        )?;
+        Ok((outcome, frame_count, temp_alloc_next))
     }
 
     /// Current debug-driver phase (see [`Phase`]).

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -5,7 +5,8 @@ use ironplc_container::{
 
 use crate::buffers::VmBuffers;
 use crate::builtin;
-use crate::debug_hook::{DebugHook, NoopDebugHook};
+use crate::debug::PauseReason;
+use crate::debug_hook::{DebugHook, HookAction, NoopDebugHook};
 use crate::error::Trap;
 use crate::frame_stack::{FbCallReturn, Frame, FrameStack};
 #[cfg(feature = "profiling")]
@@ -642,7 +643,12 @@ fn execute(
     #[cfg(feature = "profiling")] profile: &mut InstructionProfile,
 ) -> Result<(), Trap> {
     let mut hook = NoopDebugHook;
-    execute_with_hook(
+    // Fresh, non-resumable run: the frame stack starts empty (so the entry
+    // frame is pushed) and no temp-buffer allocations carry over. The noop
+    // hook can never pause, so `Completed` is the only reachable outcome.
+    let mut frame_count = 0usize;
+    let mut temp_alloc_next = 0u16;
+    match execute_with_hook(
         container,
         stack,
         variables,
@@ -653,10 +659,31 @@ fn execute(
         entry_scope,
         current_time_us,
         entry_function_id,
+        &mut frame_count,
+        &mut temp_alloc_next,
         #[cfg(feature = "profiling")]
         profile,
         &mut hook,
-    )
+    )? {
+        ExecuteOutcome::Completed => Ok(()),
+        ExecuteOutcome::Paused(_) => {
+            unreachable!("NoopDebugHook always returns HookAction::Continue")
+        }
+    }
+}
+
+/// Outcome of an [`execute_with_hook`] invocation.
+///
+/// `Completed` means the entry function's frame stack drained (the program
+/// returned). `Paused` means the debug hook requested a stop before an
+/// instruction executed; the frame stack, operand stack, and temp-buffer
+/// allocator position are all preserved so a later call can resume.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecuteOutcome {
+    /// The program returned normally.
+    Completed,
+    /// The hook paused execution before an instruction.
+    Paused(PauseReason),
 }
 
 /// Executes the entry function until its frame stack drains (program
@@ -688,18 +715,28 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
     entry_scope: &VariableScope,
     current_time_us: u64,
     entry_function_id: FunctionId,
+    frame_count: &mut usize,
+    temp_alloc_next: &mut u16,
     #[cfg(feature = "profiling")] profile: &mut InstructionProfile,
     hook: &mut H,
-) -> Result<(), Trap> {
+) -> Result<ExecuteOutcome, Trap> {
     let mut temp_alloc = string_ops::TempBufAllocator::new(max_temp_buf_bytes);
-    let mut frame_stack = FrameStack::new(frames);
-    frame_stack.push(Frame {
-        function_id: entry_function_id,
-        pc: 0,
-        scope: *entry_scope,
-        temp_alloc_mark: 0,
-        fb_return: None,
-    })?;
+    // Restore the temp-buffer bump position captured at the last pause. On a
+    // fresh run this is 0 (nothing allocated yet).
+    temp_alloc.rewind_to(*temp_alloc_next);
+    let mut frame_stack = FrameStack::resume(frames, *frame_count);
+    if frame_stack.is_empty() {
+        // Fresh run: push the entry frame. When resuming a paused instance
+        // the frame stack is non-empty and the entry frame (plus any deeper
+        // frames) already survive in the backing slice.
+        frame_stack.push(Frame {
+            function_id: entry_function_id,
+            pc: 0,
+            scope: *entry_scope,
+            temp_alloc_mark: 0,
+            fb_return: None,
+        })?;
+    }
 
     while !frame_stack.is_empty() {
         // Snapshot the top frame's mutable state for this iteration.
@@ -727,7 +764,22 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
         // Notify the debug hook before advancing pc so the hook sees the
         // offset of the opcode itself, not its operand bytes. With
         // NoopDebugHook this call is inlined away to nothing.
-        hook.before_instruction(current_function_id, pc, op);
+        match hook.before_instruction(current_function_id, pc, op) {
+            HookAction::Continue => {}
+            HookAction::Pause(reason) => {
+                // Write pc back to the top frame WITHOUT advancing, so the
+                // paused instruction re-executes on resume. The frame stack
+                // and temp-allocator position are preserved so the caller
+                // can resume this instance later.
+                frame_stack
+                    .top_mut()
+                    .expect("non-empty by loop condition")
+                    .pc = pc;
+                *frame_count = frame_stack.len();
+                *temp_alloc_next = temp_alloc.next();
+                return Ok(ExecuteOutcome::Paused(reason));
+            }
+        }
         pc += 1;
 
         #[cfg(feature = "profiling")]
@@ -2316,7 +2368,12 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
         }
     }
 
-    Ok(())
+    // The frame stack drained: the program returned. Record the (empty)
+    // frame count and temp-allocator position so a subsequent fresh scan
+    // starts from a clean slate.
+    *frame_count = frame_stack.len();
+    *temp_alloc_next = temp_alloc.next();
+    Ok(ExecuteOutcome::Completed)
 }
 
 /// Pops the topmost frame, rewinds the temp-buffer allocator to the

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -985,10 +985,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                 // not yet run `pc += 1`), so the paused opcode re-executes on
                 // resume. The frame stack and temp-allocator position are
                 // preserved so the caller can resume this instance later.
-                frame_stack
-                    .top_mut()
-                    .expect("non-empty by loop condition")
-                    .pc = pc;
+                commit_pc(&mut frame_stack, pc);
                 *frame_count = frame_stack.len();
                 *temp_alloc_next = temp_alloc.next();
                 return Ok(ExecuteOutcome::Paused(reason));
@@ -1430,10 +1427,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                 // `FrameStack::push` returns Trap::CallStackOverflow on
                 // capacity overflow — same trap as the old depth-counter
                 // check.
-                frame_stack
-                    .top_mut()
-                    .expect("non-empty: caller frame is still on stack")
-                    .pc = pc;
+                commit_pc(&mut frame_stack, pc);
                 hook.before_call(func_id);
                 frame_stack.push(Frame {
                     function_id: func_id,
@@ -2384,10 +2378,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                         // `fb_return` records what `handle_frame_return`
                         // needs to copy variable slots back to the data
                         // region after the FB body returns.
-                        frame_stack
-                            .top_mut()
-                            .expect("non-empty: caller frame is still on stack")
-                            .pc = pc;
+                        commit_pc(&mut frame_stack, pc);
                         hook.before_call(func_id);
                         frame_stack.push(Frame {
                             function_id: func_id,
@@ -2598,10 +2589,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
             // the frame we snapshotted at the top of the iteration. Push/pop
             // arms cleared `pc_dirty`, so this never clobbers a newly-pushed
             // callee's `pc: 0` or a freshly-popped caller's already-correct pc.
-            frame_stack
-                .top_mut()
-                .expect("non-empty: pc_dirty means no push/pop happened")
-                .pc = pc;
+            commit_pc(&mut frame_stack, pc);
         }
     }
 
@@ -2611,6 +2599,23 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
     *frame_count = frame_stack.len();
     *temp_alloc_next = temp_alloc.next();
     Ok(ExecuteOutcome::Completed)
+}
+
+/// Commit the dispatch loop's working `pc` back onto the topmost frame.
+///
+/// This is the single "store pc to the frame" operation behind every
+/// reconcile point in [`execute_with_hook`] (the normal end-of-iteration
+/// writeback, the CALL / FB_CALL caller-save, and the pause path). Folding
+/// them here keeps all four spellings identical and greppable.
+///
+/// Panics if the frame stack is empty; every caller holds the loop invariant
+/// that a frame is live at the commit point.
+#[inline(always)]
+fn commit_pc(frame_stack: &mut FrameStack, pc: usize) {
+    frame_stack
+        .top_mut()
+        .expect("commit_pc requires a non-empty frame stack")
+        .pc = pc;
 }
 
 /// Pops the topmost frame, rewinds the temp-buffer allocator to the

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -927,12 +927,31 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
         })?;
     }
 
+    // Dispatch loop invariant
+    // ------------------------
+    // At the TOP of every iteration, the top frame's `pc` field is
+    // authoritative: it points at the next opcode to execute. Inside the
+    // iteration we copy it into the local `pc` and treat that local as the
+    // working position — it advances past the opcode (line `pc += 1`) and
+    // over any operand bytes (`read_u16_le(bytecode, &mut pc)`), while the
+    // frame's `pc` stays stale. `pc_dirty` tracks that gap: while it is true,
+    // the local `pc` is ahead of `frame.pc` and still needs committing.
+    //
+    // Exactly ONE of these reconciles the local `pc` back into the frame
+    // before the next iteration (or before returning), restoring the
+    // invariant:
+    //   1. Normal opcodes: `pc_dirty` stays true, so the end-of-iteration
+    //      writeback stores `pc` into the (unchanged) top frame.
+    //   2. CALL / FB_CALL: manually store the caller's advanced `pc`, push the
+    //      callee frame with `pc: 0`, then clear `pc_dirty` — the top frame is
+    //      no longer the one we snapshotted, so the default writeback must not
+    //      run.
+    //   3. RET / RET_VOID / fall-off-end: pop via `handle_frame_return` (the
+    //      revealed caller's `pc` is already correct), then clear `pc_dirty`.
+    //   4. Pause: store the *un-advanced* `pc` so the paused opcode re-executes
+    //      on resume, then return `Paused` without reaching the writeback.
     while !frame_stack.is_empty() {
-        // Snapshot the top frame's mutable state for this iteration.
-        // `pc` is the local working copy; we write it back to the frame
-        // at the end of the iteration unless dispatch pushed or popped
-        // a frame (in which case the frame stack top changed mid-arm
-        // and `pc` is not relevant to the new top).
+        // Snapshot the top frame's authoritative `pc` into the working copy.
         let (current_function_id, scope, mut pc) = {
             let top = frame_stack.top().expect("non-empty by loop condition");
             (top.function_id, top.scope, top.pc)
@@ -962,10 +981,10 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
         match hook.before_instruction(current_function_id, pc, op) {
             HookAction::Continue => {}
             HookAction::Pause(reason) => {
-                // Write pc back to the top frame WITHOUT advancing, so the
-                // paused instruction re-executes on resume. The frame stack
-                // and temp-allocator position are preserved so the caller
-                // can resume this instance later.
+                // Invariant reconcile #4: store the *un-advanced* pc (we have
+                // not yet run `pc += 1`), so the paused opcode re-executes on
+                // resume. The frame stack and temp-allocator position are
+                // preserved so the caller can resume this instance later.
                 frame_stack
                     .top_mut()
                     .expect("non-empty by loop condition")
@@ -980,11 +999,13 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
         #[cfg(feature = "profiling")]
         profile.record(op);
 
-        // Set to false in arms that push or pop a frame; the post-match
-        // pc write-back is skipped in those cases so we never clobber a
-        // newly-pushed callee's `pc: 0` or a freshly-popped caller's
-        // already-correct `pc`.
-        let mut advance_pc = true;
+        // True while the local `pc` is ahead of the top frame's `pc` and still
+        // needs committing (see the dispatch-loop invariant above). Arms that
+        // push or pop a frame reconcile the stack themselves and set this to
+        // false, so the end-of-iteration writeback is skipped — otherwise it
+        // would clobber a newly-pushed callee's `pc: 0` or a freshly-popped
+        // caller's already-correct `pc`.
+        let mut pc_dirty = true;
 
         match op {
             // --- Load constants ---
@@ -1421,7 +1442,9 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     temp_alloc_mark: temp_alloc.next(),
                     fb_return: None,
                 })?;
-                advance_pc = false;
+                // Reconcile #2: caller pc stored above, callee pushed with
+                // pc: 0 — the snapshotted frame is no longer on top.
+                pc_dirty = false;
             }
             opcode::RET => {
                 // Return value is already on the operand stack; just unwind
@@ -1434,7 +1457,9 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     variables,
                     hook,
                 )?;
-                advance_pc = false;
+                // Reconcile #3: frame popped; the revealed caller's pc is
+                // already correct.
+                pc_dirty = false;
             }
             // --- String opcodes ---
             //
@@ -2375,7 +2400,9 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                                 num_fields,
                             }),
                         })?;
-                        advance_pc = false;
+                        // Reconcile #2: caller pc stored above, FB frame
+                        // pushed with pc: 0 — snapshotted frame no longer top.
+                        pc_dirty = false;
                     }
                 }
             }
@@ -2557,22 +2584,23 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     variables,
                     hook,
                 )?;
-                advance_pc = false;
+                // Reconcile #3: frame popped; the revealed caller's pc is
+                // already correct.
+                pc_dirty = false;
             }
             _ => {
                 return Err(Trap::InvalidInstruction(op));
             }
         }
 
-        if advance_pc {
-            // Write the working `pc` back to the frame we entered this
-            // iteration with. CALL / RET / FB_CALL-user-branch arms set
-            // `advance_pc = false` because they have already updated
-            // the stack and the top frame is no longer the one we
-            // started with.
+        if pc_dirty {
+            // Reconcile #1 (the common case): commit the working `pc` back to
+            // the frame we snapshotted at the top of the iteration. Push/pop
+            // arms cleared `pc_dirty`, so this never clobbers a newly-pushed
+            // callee's `pc: 0` or a freshly-popped caller's already-correct pc.
             frame_stack
                 .top_mut()
-                .expect("non-empty: advance_pc=true means no push/pop happened")
+                .expect("non-empty: pc_dirty means no push/pop happened")
                 .pc = pc;
         }
     }

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -216,6 +216,9 @@ impl<'a> VmReady<'a> {
             shared_globals_size,
             scan_count: 0,
             stop_requested: false,
+            phase: Phase::Ready,
+            debug_frame_count: 0,
+            debug_temp_alloc_next: 0,
             #[cfg(feature = "profiling")]
             profile: self.profile,
         })
@@ -243,6 +246,9 @@ impl<'a> VmReady<'a> {
             shared_globals_size,
             scan_count: initial_scan_count,
             stop_requested: false,
+            phase: Phase::Ready,
+            debug_frame_count: 0,
+            debug_temp_alloc_next: 0,
             #[cfg(feature = "profiling")]
             profile: self.profile,
         }
@@ -259,6 +265,41 @@ impl<'a> VmReady<'a> {
         let slot = self.variables.load(index)?;
         Ok(slot.as_u64())
     }
+}
+
+/// Execution phase of the re-entrant debug driver
+/// ([`run_round_debug`](VmRunning::run_round_debug)).
+///
+/// The non-debug [`run_round`](VmRunning::run_round) path never leaves
+/// [`Phase::Ready`]; only the debug driver moves through the paused
+/// sub-states.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Phase {
+    /// No scan in flight; the next debug round starts fresh.
+    Ready,
+    /// A scan is in flight (transient; observed only mid-round).
+    Running,
+    /// Paused before an instruction with the frame stack preserved; the
+    /// next debug round resumes the in-flight instance.
+    PausedAt(PauseReason),
+    /// A scan finished under the debug driver.
+    CompletedScan,
+    /// A trap ended the round; the VM should transition to [`VmFaulted`].
+    Faulted,
+}
+
+/// Outcome of one [`run_round_debug`](VmRunning::run_round_debug) call.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RoundOutcome {
+    /// The scan completed; call again to run the next scan.
+    Completed,
+    /// A step spanned the scan boundary and stopped at the start of the
+    /// next scan. Reserved for scan-stepping; not produced in the first
+    /// debug phase (intra-scan steps report [`RoundOutcome::Paused`]).
+    PausedAfterScan,
+    /// The VM paused mid-scan; the frame stack is preserved for inspection
+    /// and a later resume.
+    Paused(PauseReason),
 }
 
 /// A VM that is actively executing scan cycles.
@@ -279,6 +320,12 @@ pub struct VmRunning<'a> {
     shared_globals_size: u16,
     scan_count: u64,
     stop_requested: bool,
+    /// Debug driver phase. `Ready` for the non-debug path.
+    phase: Phase,
+    /// Live frame count preserved across a debug pause (0 when not mid-scan).
+    debug_frame_count: usize,
+    /// Temp-buffer allocator bump position preserved across a debug pause.
+    debug_temp_alloc_next: u16,
     #[cfg(feature = "profiling")]
     profile: InstructionProfile,
 }
@@ -394,6 +441,117 @@ impl<'a> VmRunning<'a> {
 
         self.scan_count += 1;
         Ok(())
+    }
+
+    /// Re-entrant debug variant of [`run_round`](Self::run_round).
+    ///
+    /// Runs the single program instance (v1 is single-instance; the Phase 4
+    /// DAP launch enforces exactly one instance) with `hook` observing every
+    /// instruction and call/return. Unlike `run_round`, this can stop
+    /// mid-scan: when the hook returns [`HookAction::Pause`], the frame
+    /// stack, operand stack, and temp-buffer position are preserved and the
+    /// method returns [`RoundOutcome::Paused`]. Calling it again resumes the
+    /// paused instance from exactly where it stopped.
+    ///
+    /// A trap still surfaces through the fault path: the method returns
+    /// `Err(FaultContext)` and sets the phase to [`Phase::Faulted`], exactly
+    /// as `run_round` does.
+    pub fn run_round_debug<H: DebugHook>(
+        &mut self,
+        current_time_us: u64,
+        hook: &mut H,
+    ) -> Result<RoundOutcome, FaultContext> {
+        // No program instance → nothing to debug; the scan is a no-op.
+        if self.program_instances.is_empty() {
+            self.phase = Phase::CompletedScan;
+            return Ok(RoundOutcome::Completed);
+        }
+
+        let resuming = matches!(self.phase, Phase::PausedAt(_));
+
+        // Instance 0 is the single debuggee.
+        let instance_id = self.program_instances[0].instance_id;
+        let task_id = self.program_instances[0].task_id;
+        let entry_function_id = self.program_instances[0].entry_function_id;
+        let var_table_offset = self.program_instances[0].var_table_offset;
+        let var_table_count = self.program_instances[0].var_table_count;
+
+        let scope = VariableScope {
+            shared_globals_size: self.shared_globals_size,
+            instance_offset: var_table_offset,
+            instance_count: var_table_count,
+        };
+
+        if !resuming {
+            // Fresh scan: inject system uptime before running, mirroring
+            // run_round, then start with an empty frame stack so
+            // execute_with_hook pushes the entry frame.
+            if self.container.header.flags & ironplc_container::FLAG_HAS_SYSTEM_UPTIME != 0 {
+                let time_ms = (current_time_us / 1000) as i64;
+                self.variables
+                    .store(VarIndex::new(0), Slot::from_i32(time_ms as i32))
+                    .expect("system uptime variable must exist at index 0");
+                self.variables
+                    .store(VarIndex::new(1), Slot::from_i64(time_ms))
+                    .expect("system uptime variable must exist at index 1");
+            }
+            self.debug_frame_count = 0;
+            self.debug_temp_alloc_next = 0;
+        }
+
+        self.phase = Phase::Running;
+
+        let outcome = execute_with_hook(
+            self.container,
+            &mut self.stack,
+            &mut self.variables,
+            self.data_region,
+            self.temp_buf,
+            self.max_temp_buf_bytes,
+            self.frames,
+            &scope,
+            current_time_us,
+            entry_function_id,
+            &mut self.debug_frame_count,
+            &mut self.debug_temp_alloc_next,
+            #[cfg(feature = "profiling")]
+            &mut self.profile,
+            hook,
+        )
+        .map_err(|trap| {
+            self.phase = Phase::Faulted;
+            FaultContext {
+                trap,
+                task_id,
+                instance_id,
+            }
+        })?;
+
+        match outcome {
+            ExecuteOutcome::Paused(reason) => {
+                self.phase = Phase::PausedAt(reason);
+                Ok(RoundOutcome::Paused(reason))
+            }
+            ExecuteOutcome::Completed => {
+                self.scan_count += 1;
+                self.phase = Phase::CompletedScan;
+                Ok(RoundOutcome::Completed)
+            }
+        }
+    }
+
+    /// Current debug-driver phase (see [`Phase`]).
+    pub fn phase(&self) -> Phase {
+        self.phase
+    }
+
+    /// The live call frames of a paused instance, outermost first.
+    ///
+    /// Empty unless the VM is paused ([`Phase::PausedAt`]). Lets a debugger
+    /// walk the stack — each [`Frame`] carries its `function_id` and `pc`
+    /// so `(function_id, pc)` pairs can be resolved against debug info.
+    pub fn debug_frames(&self) -> &[Frame] {
+        &self.frames[..self.debug_frame_count]
     }
 
     /// Reads a variable value as an i32.
@@ -756,7 +914,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
         if pc >= bytecode.len() {
             // Fell off the end of a function body without an explicit
             // RET — treat as RET_VOID.
-            handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables)?;
+            handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables, hook)?;
             continue;
         }
 
@@ -1218,6 +1376,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     .top_mut()
                     .expect("non-empty: caller frame is still on stack")
                     .pc = pc;
+                hook.before_call(func_id);
                 frame_stack.push(Frame {
                     function_id: func_id,
                     pc: 0,
@@ -1231,7 +1390,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                 // Return value is already on the operand stack; just unwind
                 // this frame and let the caller frame (or outer-loop exit)
                 // resume.
-                handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables)?;
+                handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables, hook)?;
                 advance_pc = false;
             }
             // --- String opcodes ---
@@ -2161,6 +2320,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                             .top_mut()
                             .expect("non-empty: caller frame is still on stack")
                             .pc = pc;
+                        hook.before_call(func_id);
                         frame_stack.push(Frame {
                             function_id: func_id,
                             pc: 0,
@@ -2347,7 +2507,7 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     .copy_from_slice(&value_slot.as_i64().to_le_bytes());
             }
             opcode::RET_VOID => {
-                handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables)?;
+                handle_frame_return(&mut temp_alloc, &mut frame_stack, data_region, variables, hook)?;
                 advance_pc = false;
             }
             _ => {
@@ -2381,12 +2541,16 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
 /// into the FB instance's data-region fields.
 ///
 /// Used by `RET`, `RET_VOID`, and the implicit-return path (running off
-/// the end of a function body) inside the iterative dispatch loop.
-fn handle_frame_return(
+/// the end of a function body) inside the iterative dispatch loop. This is
+/// the single choke point for frame pops, so [`DebugHook::after_return`]
+/// fires here exactly once per pop — keeping a hook's depth counter in
+/// lock-step with `frame_stack.len()`.
+fn handle_frame_return<H: DebugHook>(
     temp_alloc: &mut string_ops::TempBufAllocator,
     frame_stack: &mut FrameStack,
     data_region: &mut [u8],
     variables: &mut VariableTable,
+    hook: &mut H,
 ) -> Result<(), Trap> {
     let popped = frame_stack
         .pop()
@@ -2396,6 +2560,11 @@ fn handle_frame_return(
     if let Some(fbr) = popped.fb_return {
         fbr.copy_out(variables, data_region)?;
     }
+
+    // Notify the hook after the pop, passing the function control returns
+    // to — or `None` when the outermost frame just returned.
+    let returning_to = frame_stack.top().map(|f| f.function_id);
+    hook.after_return(returning_to);
 
     Ok(())
 }

--- a/compiler/vm/tests/it/debug_engine.rs
+++ b/compiler/vm/tests/it/debug_engine.rs
@@ -1,0 +1,146 @@
+//! Integration tests for the VM debug engine (Phase 3): the pause-capable
+//! [`DebugHook`], call/return depth callbacks, and the re-entrant
+//! `run_round_debug` driver.
+
+use crate::common::VmBuffers;
+use ironplc_container::{opcode, ContainerBuilder, FunctionId, VarIndex};
+use ironplc_vm::{DebugHook, HookAction, RoundOutcome};
+
+/// Builds a container with init (RET_VOID), a scan entry function, and
+/// additional user functions starting at function id 2.
+fn call_container(
+    scan_bytecode: &[u8],
+    user_functions: &[(&[u8], u16, u16, u16)],
+    num_vars: u16,
+    i32_constants: &[i32],
+) -> ironplc_container::Container {
+    let init_bytecode = [opcode::RET_VOID];
+    let mut builder = ContainerBuilder::new().num_variables(num_vars);
+    for &c in i32_constants {
+        builder = builder.add_i32_constant(c);
+    }
+    builder = builder
+        .add_function(FunctionId::INIT, &init_bytecode, 0, num_vars, 0)
+        .add_function(FunctionId::SCAN, scan_bytecode, 16, num_vars, 0);
+    for (i, (bytecode, max_stack, num_locals, num_params)) in user_functions.iter().enumerate() {
+        builder = builder.add_function(
+            FunctionId::new((i + 2) as u16),
+            bytecode,
+            *max_stack,
+            *num_locals,
+            *num_params,
+        );
+    }
+    builder
+        .init_function_id(FunctionId::INIT)
+        .entry_function_id(FunctionId::SCAN)
+        .build()
+}
+
+/// A hook that records the sequence of instruction / call / return events
+/// and never pauses.
+#[derive(Default)]
+struct RecordingHook {
+    events: Vec<Event>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Event {
+    Instr(FunctionId, usize),
+    Call(FunctionId),
+    Return(Option<FunctionId>),
+}
+
+impl DebugHook for RecordingHook {
+    fn before_instruction(&mut self, function_id: FunctionId, pc: usize, _op: u8) -> HookAction {
+        self.events.push(Event::Instr(function_id, pc));
+        HookAction::Continue
+    }
+    fn before_call(&mut self, callee: FunctionId) {
+        self.events.push(Event::Call(callee));
+    }
+    fn after_return(&mut self, returning_to: Option<FunctionId>) {
+        self.events.push(Event::Return(returning_to));
+    }
+}
+
+/// Scan calls a doubling function, so the debug driver should observe a
+/// `before_call` bracketing the callee's instructions and `after_return`
+/// callbacks that mirror each frame pop.
+#[test]
+fn run_round_debug_when_call_then_call_and_return_callbacks_bracket_callee() {
+    // Function 2 (var_offset=2, one param at var[2]): doubles its argument.
+    #[rustfmt::skip]
+    let func_body: Vec<u8> = vec![
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::ADD_I32,
+        opcode::RET,
+    ];
+    // Scan: push 21, call func 2, store result to var[0], return.
+    #[rustfmt::skip]
+    let scan_bytecode: Vec<u8> = vec![
+        opcode::LOAD_CONST_I32, 0x00, 0x00,
+        opcode::CALL, 0x02, 0x00, 0x02, 0x00,
+        opcode::STORE_VAR_I32, 0x00, 0x00,
+        opcode::RET_VOID,
+    ];
+
+    let c = call_container(&scan_bytecode, &[(&func_body, 4, 1, 1)], 3, &[21]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let mut hook = RecordingHook::default();
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Completed);
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 42);
+
+    let func2 = FunctionId::new(2);
+
+    // Exactly one call, to func 2.
+    let calls: Vec<FunctionId> = hook
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            Event::Call(f) => Some(*f),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(calls, vec![func2]);
+
+    // Two returns: func2 -> SCAN, then SCAN -> None (outermost).
+    let returns: Vec<Option<FunctionId>> = hook
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            Event::Return(r) => Some(*r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(returns, vec![Some(FunctionId::SCAN), None]);
+
+    // The call event precedes every func2 instruction, and the first return
+    // (to SCAN) follows them — the callee's instructions are bracketed.
+    let call_idx = hook
+        .events
+        .iter()
+        .position(|e| matches!(e, Event::Call(_)))
+        .unwrap();
+    let return_to_scan_idx = hook
+        .events
+        .iter()
+        .position(|e| matches!(e, Event::Return(Some(_))))
+        .unwrap();
+    let func2_instr_idxs: Vec<usize> = hook
+        .events
+        .iter()
+        .enumerate()
+        .filter_map(|(i, e)| match e {
+            Event::Instr(f, _) if *f == func2 => Some(i),
+            _ => None,
+        })
+        .collect();
+    assert!(!func2_instr_idxs.is_empty(), "callee ran no instructions");
+    assert!(func2_instr_idxs.iter().all(|&i| i > call_idx));
+    assert!(func2_instr_idxs.iter().all(|&i| i < return_to_scan_idx));
+}

--- a/compiler/vm/tests/it/debug_engine.rs
+++ b/compiler/vm/tests/it/debug_engine.rs
@@ -322,3 +322,107 @@ fn run_round_debug_when_trap_then_returns_fault_and_phase_faulted() {
     assert_eq!(err.trap, ironplc_vm::error::Trap::InvalidInstruction(0xFF));
     assert_eq!(vm.phase(), Phase::Faulted);
 }
+
+/// Container whose scan calls a doubling function, with fixed offsets used by
+/// the stepping tests: LOAD_CONST\@0, CALL\@3, STORE\@8, RET_VOID\@11; the
+/// callee runs LOAD_VAR\@0, LOAD_VAR\@3, ADD\@6, RET\@7.
+fn stepping_container() -> ironplc_container::Container {
+    #[rustfmt::skip]
+    let func_body: Vec<u8> = vec![
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::ADD_I32,
+        opcode::RET,
+    ];
+    #[rustfmt::skip]
+    let scan_bytecode: Vec<u8> = vec![
+        opcode::LOAD_CONST_I32, 0x00, 0x00,   // @0
+        opcode::CALL, 0x02, 0x00, 0x02, 0x00, // @3
+        opcode::STORE_VAR_I32, 0x00, 0x00,    // @8
+        opcode::RET_VOID,                     // @11
+    ];
+    call_container(&scan_bytecode, &[(&func_body, 4, 1, 1)], 3, &[21])
+}
+
+#[test]
+fn run_round_debug_when_step_over_call_then_lands_after_call_in_caller() {
+    let c = stepping_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let mut table = BreakpointTable::new();
+    table.add(FunctionId::SCAN, 3); // the CALL
+    let mut hook = DebuggerHook::new(&table);
+
+    // Pause on the CALL.
+    assert!(matches!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Breakpoint(_))
+    ));
+    assert_eq!(vm.debug_frames().last().unwrap().pc, 3);
+
+    // Step over the call: land on the next instruction in SCAN, not inside
+    // the callee.
+    hook.step_over();
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Paused(PauseReason::Step));
+    let frames = vm.debug_frames();
+    assert_eq!(frames.len(), 1, "must be back in the caller only");
+    assert_eq!(frames[0].function_id, FunctionId::SCAN);
+    assert_eq!(frames[0].pc, 8); // STORE, immediately after the CALL
+}
+
+#[test]
+fn run_round_debug_when_step_in_call_then_lands_on_first_callee_instruction() {
+    let c = stepping_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let mut table = BreakpointTable::new();
+    table.add(FunctionId::SCAN, 3); // the CALL
+    let mut hook = DebuggerHook::new(&table);
+
+    assert!(matches!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Breakpoint(_))
+    ));
+
+    // Step in: descend into the callee, landing on its first instruction.
+    hook.step_in();
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Paused(PauseReason::Step));
+    let frames = vm.debug_frames();
+    assert_eq!(frames.len(), 2, "must have descended one frame");
+    assert_eq!(frames[0].function_id, FunctionId::SCAN);
+    assert_eq!(frames[1].function_id, FunctionId::new(2));
+    assert_eq!(frames[1].pc, 0);
+}
+
+#[test]
+fn run_round_debug_when_step_out_of_callee_then_lands_in_caller_after_call() {
+    let c = stepping_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let func2 = FunctionId::new(2);
+    let mut table = BreakpointTable::new();
+    table.add(func2, 0); // first instruction inside the callee
+    let mut hook = DebuggerHook::new(&table);
+
+    // Pause inside the callee.
+    assert!(matches!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Breakpoint(_))
+    ));
+    assert_eq!(vm.debug_frames().len(), 2);
+
+    // Step out: run the callee to its return, landing back in SCAN just
+    // after the CALL.
+    hook.step_out();
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Paused(PauseReason::Step));
+    let frames = vm.debug_frames();
+    assert_eq!(frames.len(), 1, "must have returned to the caller");
+    assert_eq!(frames[0].function_id, FunctionId::SCAN);
+    assert_eq!(frames[0].pc, 8);
+}

--- a/compiler/vm/tests/it/debug_engine.rs
+++ b/compiler/vm/tests/it/debug_engine.rs
@@ -2,9 +2,11 @@
 //! [`DebugHook`], call/return depth callbacks, and the re-entrant
 //! `run_round_debug` driver.
 
-use crate::common::VmBuffers;
+use crate::common::{single_function_container, VmBuffers};
 use ironplc_container::{opcode, ContainerBuilder, FunctionId, VarIndex};
-use ironplc_vm::{DebugHook, HookAction, RoundOutcome};
+use ironplc_vm::{
+    BreakpointTable, DebugHook, DebuggerHook, HookAction, PauseReason, Phase, RoundOutcome,
+};
 
 /// Builds a container with init (RET_VOID), a scan entry function, and
 /// additional user functions starting at function id 2.
@@ -143,4 +145,180 @@ fn run_round_debug_when_call_then_call_and_return_callbacks_bracket_callee() {
     assert!(!func2_instr_idxs.is_empty(), "callee ran no instructions");
     assert!(func2_instr_idxs.iter().all(|&i| i > call_idx));
     assert!(func2_instr_idxs.iter().all(|&i| i < return_to_scan_idx));
+}
+
+/// Steel-thread scan: x := 10; y := x + 32. Used for breakpoint tests.
+/// Offsets: LOAD_CONST\@0 STORE_VAR x\@3 LOAD_VAR x\@6 LOAD_CONST\@9
+/// ADD\@12 STORE_VAR y\@13 RET_VOID\@16.
+fn steel_thread_scan() -> Vec<u8> {
+    #[rustfmt::skip]
+    let bytecode = vec![
+        opcode::LOAD_CONST_I32, 0x00, 0x00,
+        opcode::STORE_VAR_I32,  0x00, 0x00,
+        opcode::LOAD_VAR_I32,   0x00, 0x00,
+        opcode::LOAD_CONST_I32, 0x01, 0x00,
+        opcode::ADD_I32,
+        opcode::STORE_VAR_I32,  0x01, 0x00,
+        opcode::RET_VOID,
+    ];
+    bytecode
+}
+
+#[test]
+fn run_round_debug_when_breakpoint_in_entry_then_pauses_there_and_resumes_to_completion() {
+    let c = single_function_container(&steel_thread_scan(), 2, &[10, 32]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let mut table = BreakpointTable::new();
+    let id = table.add(FunctionId::SCAN, 6); // LOAD_VAR x, after x := 10
+    let mut hook = DebuggerHook::new(&table);
+
+    // First round pauses at the breakpoint.
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Paused(PauseReason::Breakpoint(id)));
+    assert_eq!(vm.phase(), Phase::PausedAt(PauseReason::Breakpoint(id)));
+
+    // The top frame sits exactly on the breakpoint instruction.
+    let frames = vm.debug_frames();
+    assert_eq!(frames.len(), 1);
+    assert_eq!(frames[0].function_id, FunctionId::SCAN);
+    assert_eq!(frames[0].pc, 6);
+
+    // x has been assigned (offset 3 executed), y not yet.
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 10);
+    assert_eq!(vm.read_variable(VarIndex::new(1)).unwrap(), 0);
+
+    // Resuming completes the scan; final state matches an unhooked run.
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Completed);
+    assert_eq!(vm.phase(), Phase::CompletedScan);
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 10);
+    assert_eq!(vm.read_variable(VarIndex::new(1)).unwrap(), 42);
+}
+
+#[test]
+fn run_round_debug_when_breakpoint_in_callee_then_frame_stack_shows_caller_beneath() {
+    // Same doubling function as the callback test.
+    #[rustfmt::skip]
+    let func_body: Vec<u8> = vec![
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::ADD_I32,
+        opcode::RET,
+    ];
+    #[rustfmt::skip]
+    let scan_bytecode: Vec<u8> = vec![
+        opcode::LOAD_CONST_I32, 0x00, 0x00,
+        opcode::CALL, 0x02, 0x00, 0x02, 0x00,
+        opcode::STORE_VAR_I32, 0x00, 0x00,
+        opcode::RET_VOID,
+    ];
+    let c = call_container(&scan_bytecode, &[(&func_body, 4, 1, 1)], 3, &[21]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let func2 = FunctionId::new(2);
+    let mut table = BreakpointTable::new();
+    let id = table.add(func2, 3); // second LOAD_VAR inside the callee
+    let mut hook = DebuggerHook::new(&table);
+
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Paused(PauseReason::Breakpoint(id)));
+
+    // Two frames: SCAN beneath, callee on top at the breakpoint offset.
+    let frames = vm.debug_frames();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0].function_id, FunctionId::SCAN);
+    assert_eq!(frames[1].function_id, func2);
+    assert_eq!(frames[1].pc, 3);
+
+    // Resume runs to completion with the correct result.
+    let outcome = vm.run_round_debug(0, &mut hook).unwrap();
+    assert_eq!(outcome, RoundOutcome::Completed);
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 42);
+}
+
+/// Pauses before every instruction, advancing exactly one instruction per
+/// resume, so a full scan is replayed one boundary at a time.
+#[derive(Default)]
+struct PauseEachInstruction {
+    skip: bool,
+    instructions: usize,
+}
+
+impl DebugHook for PauseEachInstruction {
+    fn before_instruction(&mut self, _f: FunctionId, _pc: usize, _op: u8) -> HookAction {
+        if self.skip {
+            self.skip = false;
+            self.instructions += 1;
+            HookAction::Continue
+        } else {
+            self.skip = true;
+            HookAction::Pause(PauseReason::Step)
+        }
+    }
+}
+
+#[test]
+fn run_round_debug_when_paused_at_every_instruction_then_final_state_matches_unhooked_run() {
+    #[rustfmt::skip]
+    let func_body: Vec<u8> = vec![
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::LOAD_VAR_I32, 0x02, 0x00,
+        opcode::ADD_I32,
+        opcode::RET,
+    ];
+    #[rustfmt::skip]
+    let scan_bytecode: Vec<u8> = vec![
+        opcode::LOAD_CONST_I32, 0x00, 0x00,
+        opcode::CALL, 0x02, 0x00, 0x02, 0x00,
+        opcode::STORE_VAR_I32, 0x00, 0x00,
+        opcode::RET_VOID,
+    ];
+
+    // Reference: an ordinary unhooked scan.
+    let c = call_container(&scan_bytecode, &[(&func_body, 4, 1, 1)], 3, &[21]);
+    let mut rb = VmBuffers::from_container(&c);
+    let mut reference = crate::common::load_and_start(&c, &mut rb).unwrap();
+    reference.run_round(0).unwrap();
+    let ref_vars: Vec<i32> = (0..3)
+        .map(|i| reference.read_variable(VarIndex::new(i)).unwrap())
+        .collect();
+    let ref_data = reference.data_region().to_vec();
+
+    // Hooked: resume one instruction at a time until the scan completes.
+    let mut db = VmBuffers::from_container(&c);
+    let mut debugged = crate::common::load_and_start(&c, &mut db).unwrap();
+    let mut hook = PauseEachInstruction::default();
+    let mut rounds = 0;
+    loop {
+        rounds += 1;
+        assert!(rounds < 1000, "pause/resume did not converge");
+        match debugged.run_round_debug(0, &mut hook).unwrap() {
+            RoundOutcome::Paused(_) => continue,
+            RoundOutcome::Completed | RoundOutcome::PausedAfterScan => break,
+        }
+    }
+
+    assert!(hook.instructions > 0);
+    let got_vars: Vec<i32> = (0..3)
+        .map(|i| debugged.read_variable(VarIndex::new(i)).unwrap())
+        .collect();
+    assert_eq!(got_vars, ref_vars);
+    assert_eq!(debugged.data_region(), ref_data.as_slice());
+}
+
+#[test]
+fn run_round_debug_when_trap_then_returns_fault_and_phase_faulted() {
+    // A single invalid opcode traps immediately.
+    let c = single_function_container(&[0xFF], 0, &[]);
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let table = BreakpointTable::new();
+    let mut hook = DebuggerHook::new(&table);
+    let err = vm.run_round_debug(0, &mut hook).unwrap_err();
+    assert_eq!(err.trap, ironplc_vm::error::Trap::InvalidInstruction(0xFF));
+    assert_eq!(vm.phase(), Phase::Faulted);
 }

--- a/compiler/vm/tests/it/main.rs
+++ b/compiler/vm/tests/it/main.rs
@@ -11,6 +11,7 @@
 
 mod common;
 
+mod debug_engine;
 mod execute_add_i32;
 mod execute_arith_f32;
 mod execute_arith_f64;


### PR DESCRIPTION
## Summary

Phase 3 of the debugger design (`specs/design/debugger-support.md` §"Phase 3: VM Debug Engine"), per plan `specs/plans/2026-06-25-vm-debug-engine.md`. Turns the VM's instruction-level hook into a debugger-grade engine that can **pause at breakpoints, single-step (over / in / out), and inspect a paused frame stack** — all driven by `(FunctionId, bytecode_offset)` coordinates. No DAP / source-line translation / VS Code yet (Phases 4–5); logpoints cut from this phase.

## What's included

- **Extended `DebugHook` trait** — `before_instruction` returns `HookAction::{Continue, Pause(PauseReason)}`; adds `before_call` / `after_return` (default no-op). `NoopDebugHook` stays a zero-cost ZST.
- **`execute_with_hook`** returns `ExecuteOutcome::{Completed, Paused}`, honoring `Pause` by writing `pc` back un-advanced so the paused instruction re-executes on resume; frame stack + temp-alloc position preserved.
- **`debug.rs`** — `BreakpointTable` (sorted `Vec`, binary-search lookup), `BreakpointId`, `StepMode`, `StepController` (over/in/out via frame-depth + offset origin), `DebuggerHook`.
- **`run_round_debug<H: DebugHook>`** — re-entrant driver returning `RoundOutcome::{Completed, Paused}`; `VmRunning` gains a `Phase` field and `debug_frames()` for stack inspection.
- **Shared instance-runner** — `run_round` (production) and `run_round_debug` (debug) route through one `run_instance<H>` core plus a shared `inject_system_uptime` helper, instead of duplicating scope construction and uptime injection. `run_round_debug` documents that it *intentionally* bypasses the scheduler (task readiness, cyclic re-arming, `record_execution`) and the watchdog, since a human controls the clock at a breakpoint.
- **Dispatch-loop readability** — the hot loop keeps the program counter in a local working copy and commits it back to the top frame; that was hard to follow when stepping. Now: a stated **invariant block** (frame `pc` authoritative at each boundary, local `pc` is the working copy), the write-back flag renamed `advance_pc → pc_dirty` (dirty-flag idiom) with each of the four reconcile points labeled, and the four `pc` write-back sites folded behind one `#[inline(always)]` `commit_pc` helper so they read identically. Comments/rename/extraction only — no codegen change.
- Re-exports from `vm/src/lib.rs`.

## Tests

170 vm tests pass, covering the plan's full list: breakpoint in entry fn, breakpoint in callee (caller frame beneath), step over/in/out, pause-at-every-instruction resume parity (bitwise-identical final state vs unhooked run), trap-during-debug → `Phase::Faulted`, and `BreakpointTable` mutators.

## Performance (plan risk #1: does the `HookAction` enum return regress the hot path?)

Measured the production `run_round` path on this branch vs the pre-implementation `main` baseline (`st_counter_loop/10000`, criterion): **~204µs (branch) vs ~258µs (main)**, reproducible — the dispatch refactor is **~26% faster**, so there is **no hot-path regression**. The later instance-runner extraction and the `commit_pc` fold both bench as no change (criterion noise threshold), confirming they inline away. Added `st_debug_scan_cost` to track the debug driver's cost going forward.

## CI note

Local `cd compiler && just` passes compile, coverage (≥85%), clippy, and `cargo fmt --check`. The `cargo dupes` step could not run locally (tool would not install in this environment); it runs for the first time in GitHub CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)