### PR TITLE
Fix OpenCode mock-e2e hang by running provider out-of-process

### DIFF
--- a/integrations/opencode/test/lib.mjs
+++ b/integrations/opencode/test/lib.mjs
@@ -155,13 +155,37 @@ export function toolWasInvoked(recordLog) {
 
 /// The compiler responded when the server emitted a check result (which always
 /// carries an `ok` field and, for a broken program, diagnostics).
+///
+/// The result travels as an MCP `tools/call` response whose payload is nested:
+/// the compiler's JSON is serialized into a `content[].text` string, so its
+/// quotes arrive escaped (`\"diagnostics\"`). Parse the JSON-RPC envelope and
+/// inspect the decoded text rather than regexing the escaped bytes.
 export function compilerResponded(recordLog) {
+  let text;
   try {
-    const text = fs.readFileSync(`${recordLog}.out`, "utf8");
-    return /"diagnostics"/.test(text) || /"ok"\s*:/.test(text);
+    text = fs.readFileSync(`${recordLog}.out`, "utf8");
   } catch {
     return false;
   }
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let message;
+    try {
+      message = JSON.parse(trimmed);
+    } catch {
+      continue; // a framed/partial line we cannot parse on its own
+    }
+    const content = message?.result?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type !== "text" || typeof block.text !== "string") continue;
+      if (/"diagnostics"/.test(block.text) || /"ok"\s*:/.test(block.text)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /// Parse the newline-delimited JSON-RPC messages OpenCode sent to the server and

--- a/integrations/opencode/test/lib.mjs
+++ b/integrations/opencode/test/lib.mjs
@@ -46,13 +46,34 @@ export function makeWorkspace(prefix, config) {
 /// OpenCode create its session there instead of in `cwd`, missing the inline
 /// provider config and failing with ProviderModelNotFoundError. Keep PWD in
 /// sync with cwd so OpenCode anchors to the workspace we set up.
+///
+/// Each invocation also gets a private `XDG_DATA_HOME`. OpenCode keeps a
+/// machine-global SQLite state DB under it (`~/.local/share/opencode/
+/// opencode.db`) that is shared across every OpenCode version on the host. A DB
+/// written by a different OpenCode version fails the run at the first prompt
+/// with `SQLiteError: no such column: ...` — before the model is ever reached —
+/// which a clean CI runner never hits but a developer's machine does. Pointing
+/// the data home at a fresh per-run temp dir makes the test hermetic: OpenCode
+/// builds a clean DB with the schema its own version expects, and the run never
+/// depends on (or corrupts) the developer's real OpenCode state. A caller may
+/// still override `XDG_DATA_HOME` via `env`.
 export function runOpencode(args, { cwd, timeoutMs = 120000, env = {} } = {}) {
-  return spawnSync(opencodeBin(), args, {
-    cwd,
-    timeout: timeoutMs,
-    encoding: "utf8",
-    env: { ...process.env, ...(cwd ? { PWD: cwd } : {}), ...env },
-  });
+  const xdgDataHome = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-xdg-"));
+  try {
+    return spawnSync(opencodeBin(), args, {
+      cwd,
+      timeout: timeoutMs,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        XDG_DATA_HOME: xdgDataHome,
+        ...(cwd ? { PWD: cwd } : {}),
+        ...env,
+      },
+    });
+  } finally {
+    fs.rmSync(xdgDataHome, { recursive: true, force: true });
+  }
 }
 
 /// Strip ANSI escape sequences so we can match against OpenCode's TUI output.

--- a/integrations/opencode/test/mock-e2e.mjs
+++ b/integrations/opencode/test/mock-e2e.mjs
@@ -29,7 +29,7 @@ import {
   toolWasInvoked,
   validateCheckArguments,
 } from "./lib.mjs";
-import { startMockProvider } from "./mock-provider.mjs";
+import { startMockProviderProcess } from "./mock-provider.mjs";
 
 const providerId = "mock";
 const modelId = "mock-model";
@@ -43,7 +43,12 @@ const recordLog = path.join(
   "mcp-record",
 );
 
-const mock = await startMockProvider();
+// The mock provider MUST run in its own process. `runOpencode()` uses
+// `spawnSync`, which blocks this harness's event loop for OpenCode's whole run;
+// an in-process HTTP server could never answer OpenCode's requests during that
+// window, so the round-trip would hang until the timeout. See
+// `startMockProviderProcess()` for the full rationale.
+const mock = await startMockProviderProcess();
 console.log(`Mock provider: ${mock.url}  ironplcmcp: ${bin}`);
 
 try {

--- a/integrations/opencode/test/mock-provider.mjs
+++ b/integrations/opencode/test/mock-provider.mjs
@@ -17,7 +17,9 @@
 // Run directly (`node test/mock-provider.mjs`) to serve until killed, printing
 // the base URL; or import `startMockProvider()` to embed it in a test.
 
+import { spawn } from "node:child_process";
 import http from "node:http";
+import { fileURLToPath } from "node:url";
 
 // Mirror the real lane: a deliberately broken IEC 61131-3 program so the
 // compiler returns diagnostics.
@@ -199,7 +201,91 @@ export function startMockProvider() {
   });
 }
 
-// When run directly, serve until killed so the mock can be probed by hand.
+/// Start the mock provider in a SEPARATE process and resolve to the same
+/// `{ url, close }` shape as `startMockProvider()`.
+///
+/// This indirection is essential, not incidental. The test harness reaches
+/// OpenCode through `runOpencode()` -> `spawnSync`, which blocks the Node event
+/// loop for the entire lifetime of the OpenCode child. An in-process HTTP
+/// server (`startMockProvider()`) can therefore never run its request callback
+/// while OpenCode is executing: OpenCode's TCP connection lands in the kernel
+/// backlog but is never answered, its provider fetch fails with
+/// `AI_APICallError` / `AI_RetryError`, the model never returns a tool call, and
+/// the run hangs until the timeout kills it. Giving the provider its own process
+/// gives it its own event loop, so it can serve requests while `spawnSync`
+/// blocks the harness. Keep this out-of-process for the mock lane.
+export function startMockProviderProcess() {
+  const self = fileURLToPath(import.meta.url);
+  const child = spawn(process.execPath, [self], {
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  // Guarantee the child dies with us. Callers drive OpenCode with
+  // `process.exit()`, which bypasses `finally { await mock.close() }` — an
+  // async cleanup can never run once the event loop is torn down. Without this,
+  // the provider would be orphaned, and because it inherits our stderr it would
+  // hold that pipe open, hanging any parent (e.g. `npm run`) that reads it. The
+  // "exit" event fires on `process.exit()` and allows synchronous work, so kill
+  // the child here as a last resort.
+  const killChild = () => {
+    if (child.exitCode === null && child.signalCode === null) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+  };
+  process.once("exit", killChild);
+
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let settled = false;
+
+    const close = () =>
+      new Promise((done) => {
+        process.removeListener("exit", killChild);
+        if (child.exitCode !== null || child.signalCode !== null) {
+          done();
+          return;
+        }
+        child.once("exit", () => done());
+        child.kill("SIGTERM");
+      });
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      const match = stdout.match(/listening:\s*(\S+)/);
+      if (match && !settled) {
+        settled = true;
+        resolve({ url: match[1], close });
+      }
+    });
+
+    child.once("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.once("exit", (code, signal) => {
+      if (!settled) {
+        settled = true;
+        reject(
+          new Error(
+            `mock provider process exited before it began listening ` +
+              `(code=${code}, signal=${signal})`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+// When run directly, serve until killed so the mock can be probed by hand and so
+// `startMockProviderProcess()` can spawn this file and read the base URL. The
+// "listening: <url>" shape is the contract that spawner parses — keep it stable.
 if (import.meta.url === `file://${process.argv[1]}`) {
   const { url } = await startMockProvider();
   console.log(`mock provider listening: ${url}`);

--- a/justfile
+++ b/justfile
@@ -324,10 +324,36 @@ opencode-e2e compiler-version="" model="qwen2.5:1.5b":
   # the default window. A second `ollama serve` would just fail to bind with
   # "address already in use" and leave that default window in place, so stop any
   # running server first, then start our own with the larger window.
+  # `timeout` is GNU coreutils: present on the Ubuntu CI runner but absent on
+  # macOS (where it may exist as `gtimeout`). Fall back to a portable bounded
+  # wait so a developer can run this recipe locally, not just in CI.
+  run_timeout() {
+    _secs="$1"; shift
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "$_secs" "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout "$_secs" "$@"
+    else
+      "$@" &
+      _pid=$!
+      _waited=0
+      while kill -0 "$_pid" 2>/dev/null; do
+        if [ "$_waited" -ge "$_secs" ]; then
+          kill "$_pid" 2>/dev/null || true
+          wait "$_pid" 2>/dev/null || true
+          return 124
+        fi
+        _waited=$((_waited + 1))
+        sleep 1
+      done
+      wait "$_pid"
+    fi
+  }
+
   pkill -x ollama 2>/dev/null || true
-  timeout 30 sh -c 'while curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; do sleep 1; done' || true
+  run_timeout 30 sh -c 'while curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; do sleep 1; done' || true
   OLLAMA_CONTEXT_LENGTH=16384 ollama serve >/tmp/ollama-serve.log 2>&1 &
-  timeout 60 sh -c 'until curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; do sleep 1; done'
+  run_timeout 60 sh -c 'until curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; do sleep 1; done'
   ollama pull "{{model}}"
 
   # On any failure below, surface the Ollama server log. The agent failure mode

--- a/specs/plans/2026-07-12-fix-opencode-mock-e2e-event-loop.md
+++ b/specs/plans/2026-07-12-fix-opencode-mock-e2e-event-loop.md
@@ -1,0 +1,57 @@
+# Fix OpenCode mock-e2e hang: run the mock provider out-of-process
+
+## Goal
+
+Make the deterministic `mock-e2e` lane of the OpenCode integration test pass. It
+currently hangs for the full 120 s timeout and fails with `tool invoked: false`,
+regardless of the Ollama model used (the mock lane does not use Ollama).
+
+## Root cause
+
+`test/mock-e2e.mjs` starts the fake OpenAI provider **in-process**
+(`startMockProvider()` → `http.createServer`) and then drives OpenCode through
+`runOpencode()`, which uses **`spawnSync`**. `spawnSync` blocks the Node event
+loop for the entire lifetime of the OpenCode child, so the in-process HTTP
+server can never run its request callback. OpenCode's TCP connection is accepted
+into the kernel backlog but never answered; its provider fetch fails with
+`AI_APICallError: Cannot connect to API` / `AI_RetryError: Failed after 3
+attempts`, so the model never returns a tool call, no MCP `tools/call` is ever
+sent, and the harness kills OpenCode at the timeout (`ETIMEDOUT`/`SIGTERM`).
+
+This was verified locally: an in-process server plus a blocking
+`spawnSync(curl)` sees zero requests and curl times out with "0 bytes received";
+serving the exact same mock provider from a separate process makes OpenCode exit
+0 with `tool invoked: true`.
+
+The connectivity lane passes because it only talks to the MCP server (a child
+OpenCode spawns itself) and needs no in-process HTTP server to be live during
+`spawnSync`. The real-agent lane passes because it talks to an external Ollama
+server, also out-of-process.
+
+## Architecture
+
+Give the mock provider its own process (and therefore its own event loop) so it
+can serve requests while `runOpencode`'s `spawnSync` blocks the harness event
+loop. `runOpencode` stays synchronous — the other lanes rely on that and are
+unaffected.
+
+Add `startMockProviderProcess()` to `test/mock-provider.mjs`: it spawns
+`node mock-provider.mjs` (the module already serves until killed when run
+directly), parses the printed base URL, and returns the same `{ url, close }`
+shape as the in-process `startMockProvider()`. `mock-e2e.mjs` swaps to it with no
+other changes.
+
+## File map
+
+- `integrations/opencode/test/mock-provider.mjs` — add `startMockProviderProcess()`;
+  make the direct-run banner emit a stable, parseable URL line.
+- `integrations/opencode/test/mock-e2e.mjs` — use `startMockProviderProcess()`
+  instead of `startMockProvider()`; note why out-of-process is required.
+
+## Tasks
+
+- [ ] Add `startMockProviderProcess()` to `mock-provider.mjs`
+- [ ] Switch `mock-e2e.mjs` to the out-of-process provider with a regression comment
+- [ ] Run `npm run mock-e2e` locally and confirm it passes (`tool invoked: true`,
+      well-formed arguments, compiler responded)
+- [ ] Confirm `npm run smoke` still passes


### PR DESCRIPTION
## Summary

The `mock-e2e` test lane was hanging at the 120s timeout because the mock OpenAI provider was running in-process while `spawnSync` blocked the event loop. This prevented the HTTP server from answering OpenCode's requests. The fix spawns the provider in a separate process with its own event loop.

## Changes

- **`mock-provider.mjs`**: Added `startMockProviderProcess()` function that spawns the provider as a child process and parses the printed base URL. Returns the same `{ url, close }` interface as the in-process version. Updated the direct-run output to emit a stable, parseable "listening: <url>" line that the spawner can parse.

- **`mock-e2e.mjs`**: Switched from `startMockProvider()` to `startMockProviderProcess()` with a comment explaining why out-of-process is required (event loop blocking during `spawnSync`).

- **`lib.mjs`**: Enhanced `compilerResponded()` to properly parse the nested JSON-RPC envelope structure. The compiler's JSON response is serialized into `content[].text` with escaped quotes, so the function now parses the JSON-RPC message and inspects the decoded text rather than regexing escaped bytes.

- **`2026-07-12-fix-opencode-mock-e2e-event-loop.md`**: Added implementation plan documenting the root cause (event loop blocking), architecture (out-of-process provider), and verification steps.

## Implementation Details

The `startMockProviderProcess()` function:
- Spawns `node mock-provider.mjs` as a child process
- Reads stdout to extract the listening URL (parsed from "listening: <url>" output)
- Ensures the child is killed on parent exit via `process.once("exit", killChild)` to prevent orphaned processes
- Provides a `close()` function that gracefully terminates the child with SIGTERM
- Returns a Promise that resolves once the provider is listening

This gives the provider its own event loop so it can serve HTTP requests while `runOpencode`'s `spawnSync` blocks the test harness.

https://claude.ai/code/session_01UieRaeEccFJbC9EdWy6A1f