### PR TITLE
Support dual extension IDs for VS Code Marketplace and Open VSX

### DIFF
--- a/integrations/vscode/justfile
+++ b/integrations/vscode/justfile
@@ -58,6 +58,15 @@ update-grammar-snapshots:
 package filename:
   npx vsce package --out {{filename}}
 
+# Build the Marketplace VSIX package. The Visual Studio Marketplace uses the
+# extension ID ironplc.ironplc-vscode because the original ironplc.ironplc ID
+# cannot be reused; Open VSX keeps ironplc.ironplc. Only the `name` differs, so
+# `displayName` and publisher remain identical on both registries. Overriding
+# the name here mutates package.json in the (ephemeral) build tree only.
+package-marketplace filename:
+  npm pkg set name=ironplc-vscode
+  npx vsce package --out {{filename}}
+
 # Generate a CycloneDX JSON SBOM (bom.cdx.json) for the VS Code extension.
 sbom version:
   just _sbom-{{os()}} {{version}}

--- a/integrations/vscode/src/extension.ts
+++ b/integrations/vscode/src/extension.ts
@@ -64,16 +64,23 @@ const VERBOSITY = new Map<string, string[]>([
 let client: LanguageClient | undefined;
 let runSession: RunSession | undefined;
 
+// Captured at activation. Reading the version from the ExtensionContext keeps
+// this independent of the extension ID, which differs by registry: Open VSX
+// publishes ironplc.ironplc while the Marketplace publishes ironplc.ironplc-vscode.
+// A hardcoded getExtension('ironplc.ironplc') lookup would return undefined
+// under the Marketplace ID.
+let extensionVersion = '';
+
 function openProblemInBrowser(code: ProblemCode) {
-  const ext = vscode.extensions.getExtension('ironplc.ironplc');
-  const version = ext?.packageJSON?.version ?? '';
-  const url = 'https://www.ironplc.com/reference/editor/problems/' + code + '.html?version=' + encodeURIComponent(version);
+  const url = 'https://www.ironplc.com/reference/editor/problems/' + code + '.html?version=' + encodeURIComponent(extensionVersion);
   vscode.env.openExternal(vscode.Uri.parse(url));
 }
 
 // This method is called when this extension is activated.
 export function activate(context: vscode.ExtensionContext) {
   console.debug('Extension "ironplc" is activating!');
+
+  extensionVersion = context.extension.packageJSON?.version ?? '';
 
   context.subscriptions.push(vscode.commands.registerCommand('ironplc.createNewStructuredTextFile', async () => {
     await vscode.workspace.openTextDocument({ language: '61131-3-st' }).then((newFile) => {

--- a/specs/plans/vscode-marketplace-extension-id.md
+++ b/specs/plans/vscode-marketplace-extension-id.md
@@ -1,0 +1,68 @@
+# VS Code Marketplace Extension ID Plan
+
+This document describes how IronPLC publishes its VS Code extension to two
+independent registries — the Visual Studio Marketplace and Open VSX — using a
+different extension ID on each.
+
+## Problem
+
+Publishing access to the Visual Studio Marketplace has been restored, but the
+original extension ID `ironplc.ironplc` can no longer be reused there (the
+publisher was blocked and the extension removed; the ID is retired). Open VSX,
+however, still hosts a live `ironplc.ironplc` with an existing install base.
+
+A VS Code extension ID is `<publisher>.<name>`, and that value is baked into the
+VSIX manifest at package time, so a single VSIX carries a single ID. The two
+registries are independent namespaces, so the ID does **not** need to match
+across them.
+
+## Decision
+
+- **Open VSX** keeps `ironplc.ironplc` (unchanged) — protects existing users.
+- **Marketplace** publishes as `ironplc.ironplc-vscode` — same publisher and
+  same `displayName` ("IronPLC"), only the machine `name` differs. The differing
+  internal ID is invisible in the store UI.
+
+Only the `name` field changes for the Marketplace build. Command IDs, language
+IDs, and activation events are literal strings unaffected by `name`.
+
+## Rollout
+
+Automated Marketplace publishing is **deferred** until the new listing has been
+manually tested. This plan is delivered in two stages.
+
+### Stage 1 — enable local build/test (this change)
+
+1. **Decouple runtime code from the literal ID.**
+   `src/extension.ts` looked itself up via
+   `vscode.extensions.getExtension('ironplc.ironplc')` to read its version. That
+   returns `undefined` under the Marketplace ID. Capture the version from the
+   `ExtensionContext` at activation instead, so it is ID-agnostic. This is a
+   behavior-preserving change for the existing `ironplc.ironplc` build and is a
+   prerequisite for the new ID to report its version correctly.
+
+2. **Add a `package-marketplace` justfile recipe** that overrides `name` to
+   `ironplc-vscode` and packages a VSIX with extension ID `ironplc.ironplc-vscode`.
+   Run `just package-marketplace <file>.vsix` locally to build a VSIX for manual
+   install (`code --install-extension <file>.vsix`) or a manual `vsce publish`
+   test. The Open VSX / GitHub-release VSIX is unchanged (`name: ironplc`).
+
+### Stage 2 — automate Marketplace publishing (deferred)
+
+Once the new listing has been validated by hand:
+
+3. **Build the Marketplace VSIX in CI.** Add an optional
+   `marketplace-artifact-name` input to `partial_vscode_extension.yaml` that
+   builds and uploads the Marketplace VSIX as a separate build artifact, in the
+   credential-free build job (preserving ADR 0032's artifact producer/consumer
+   split).
+
+4. **Publish from `deployment.yaml`.** Request the Marketplace artifact from the
+   build job, download it in `publish-release`, and publish with `vsce` using
+   `VS_MARKETPLACE_TOKEN`. Open VSX publishing is unchanged.
+   - The smoke-test job's `ironplc-vscode-extension-name` input must be set to
+     the ID the release actually installs (`ironplc.ironplc-vscode`).
+
+5. **Docs.** Update `docs/quickstart/installation.rst` and
+   `integrations/vscode/README.md` to reflect Marketplace availability under the
+   new ID, leaving the Open VSX `ironplc.ironplc` link intact.


### PR DESCRIPTION
## Summary

This change enables IronPLC to publish its VS Code extension to both the Visual Studio Marketplace and Open VSX using different extension IDs, while maintaining backward compatibility with existing Open VSX users.

The original extension ID `ironplc.ironplc` cannot be reused on the Marketplace (the publisher was blocked and the ID is retired), but it remains active on Open VSX with an existing install base. This change decouples the runtime code from the hardcoded extension ID and adds tooling to build a Marketplace-specific VSIX with ID `ironplc.ironplc-vscode`.

## Key Changes

- **Decouple version lookup from extension ID** (`src/extension.ts`):
  - Replaced `vscode.extensions.getExtension('ironplc.ironplc')` lookup with version capture from `ExtensionContext` at activation time
  - This makes the extension ID-agnostic and allows it to work correctly under both `ironplc.ironplc` (Open VSX) and `ironplc.ironplc-vscode` (Marketplace)
  - Behavior is unchanged for the existing Open VSX build

- **Add Marketplace packaging recipe** (`integrations/vscode/justfile`):
  - New `package-marketplace` recipe overrides the `name` field to `ironplc-vscode` before packaging
  - Produces a VSIX with extension ID `ironplc.ironplc-vscode` for manual testing and validation
  - The Open VSX / GitHub-release VSIX remains unchanged

- **Document the plan** (`specs/plans/vscode-marketplace-extension-id.md`):
  - Explains the problem, decision, and two-stage rollout strategy
  - Stage 1 (this change): Enable local build/test with the new ID
  - Stage 2 (deferred): Automate Marketplace publishing in CI/CD once manual validation is complete

## Implementation Details

The `name` field in `package.json` is the only value that differs between the two builds. The `displayName` ("IronPLC"), publisher, command IDs, language IDs, and activation events remain identical and are unaffected by the `name` change. This ensures a consistent user experience across both registries while using different internal extension IDs.

https://claude.ai/code/session_01KVsAqGnLVZP6n3wyniFAPc