### PR TITLE
Manage PostHog "Adoption & Success" dashboard as Terraform

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "test -x docs/.venv/bin/sphinx-build || (echo 'Setting up docs venv...' && (cd docs && just setup) 2>/dev/null) || echo 'Warning: could not set up docs venv. Run manually with: cd docs && just setup'"
+          },
+          {
+            "type": "command",
+            "command": "which terraform >/dev/null 2>&1 || (echo 'Installing Terraform...' && sh scripts/install-terraform.sh 2>/dev/null) || echo 'Warning: could not install terraform. Run manually with: sh scripts/install-terraform.sh'"
           }
         ]
       }

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,8 +1,10 @@
 # infrastructure
 
-Terraform that provisions the GitHub-side workflow labels:
+Terraform that provisions:
 
-- 14 workflow labels (`status/*`, `review/*`, `flag/*`).
+- 14 GitHub workflow labels (`status/*`, `review/*`, `flag/*`) — `main.tf`.
+- The PostHog **"IronPLC — Adoption & Success"** product-analytics dashboard
+  and its insights — `posthog.tf`.
 
 This directory does **not** deploy app code.
 
@@ -25,6 +27,9 @@ used.
   ```
 
 - A fine-grained GitHub PAT with `issues: write` on the repo.
+- A PostHog **personal API key** with `insight:write` + `dashboard:write`
+  scopes (Settings → Personal API keys). This is *not* the public `phc_…`
+  ingestion key — that one cannot create dashboards.
 
 ## First apply
 
@@ -47,12 +52,15 @@ and add each one as a **Terraform variable**:
 | `github_token` | ✅ yes | `github_pat_…` |
 | `github_owner` | no | `ironplc` |
 | `github_repo` | no | `ironplc` |
+| `posthog_api_key` | ✅ yes | `phx_…` (personal key) |
+| `posthog_project_id` | no | `12345` |
+| `posthog_host` | no | `https://us.posthog.com` (default) |
 
 Then run the plan + apply from your laptop — it executes remotely in
 HCP, output streams back to your terminal:
 
 ```bash
-terraform plan      # 14 labels the first time
+terraform plan      # 14 labels + 1 dashboard + its insights the first time
 terraform apply
 ```
 
@@ -79,6 +87,24 @@ locally.
 | Stage status | `status/triage`, `status/requirements`, `status/design`, `status/plan`, `status/code`, `status/pr-open`, `status/closed`, `status/needs-info` |
 | Review | `review/requested`, `review/approved`, `review/changes-requested` |
 | Flags | `flag/agent-error`, `flag/revision-limit`, `flag/blocked` |
+
+## PostHog dashboard
+
+`posthog.tf` defines the **"IronPLC — Adoption & Success"** dashboard and one
+insight per tile, using only events already flowing into PostHog (website
+`$pageview` and the playground's `compile_finished` / `run_started` /
+`example_loaded` / … events). Tiles are grouped as acquisition, interest,
+activation, product-health, a visitor→success funnel, and compile retention.
+
+Install-adoption tiles (`install_completed`, `release_downloads`, Open VSX)
+are left as commented stubs at the bottom of `posthog.tf`; they light up once
+the collectors that emit those events exist.
+
+Each insight's `query_json` is the raw PostHog query node. Exact field values
+(boolean property filters, `breakdownFilter` shape, display enums) can vary by
+PostHog version, so if `terraform plan`/`apply` reports a rejected query,
+adjust the offending field and re-apply — the resources are additive and do
+not affect the GitHub labels.
 
 ## What is NOT managed here
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -16,12 +16,26 @@ terraform {
       source  = "integrations/github"
       version = "~> 6.0"
     }
+    posthog = {
+      source  = "PostHog/posthog"
+      version = "~> 1.0"
+    }
   }
 }
 
 provider "github" {
   token = var.github_token
   owner = var.github_owner
+}
+
+# PostHog product-analytics dashboard (see posthog.tf). api_key is a
+# personal API key with insight:write + dashboard:write scopes, supplied
+# as the sensitive HCP workspace variable `posthog_api_key`. host is the
+# app host (https://us.posthog.com), not the ingestion host.
+provider "posthog" {
+  api_key    = var.posthog_api_key
+  host       = var.posthog_host
+  project_id = var.posthog_project_id
 }
 
 # ---------------------------------------------------------------------------

--- a/infrastructure/posthog.tf
+++ b/infrastructure/posthog.tf
@@ -1,0 +1,414 @@
+# ---------------------------------------------------------------------------
+# PostHog "Adoption & Success" dashboard.
+#
+# One posthog_dashboard + one posthog_insight per tile. Each insight's
+# query_json is the raw PostHog query node (an InsightVizNode wrapping a
+# TrendsQuery / FunnelsQuery / RetentionQuery), serialized with jsonencode().
+#
+# The tiles below use only events that are ALREADY flowing into PostHog:
+#   - $pageview            (website + playground)
+#   - playground_loaded, compile_attempted, compile_finished,
+#     run_started, run_stopped, example_loaded  (playground)
+#   with super-properties: dialect, host_page, example_name, program_origin.
+#
+# Install-adoption tiles (install_completed / release_downloads / Open VSX)
+# depend on collectors not built yet and are left as commented stubs at the
+# bottom.
+#
+# NOTE: query_json field values (boolean property filters, breakdownFilter
+# shape, display enums) can vary by PostHog version. Validate with
+# `terraform plan` / `terraform apply` and adjust anything the API rejects.
+# ---------------------------------------------------------------------------
+
+locals {
+  # Shared 90-day trailing window for every insight.
+  ph_date_from = "-90d"
+  ph_tags      = ["managed-by-terraform", "adoption-success"]
+}
+
+resource "posthog_dashboard" "adoption" {
+  name        = "IronPLC — Adoption & Success"
+  description = "Acquisition → interest → activation → retention, plus product-health tiles. Managed by Terraform (infrastructure/posthog.tf)."
+  pinned      = true
+  tags        = local.ph_tags
+}
+
+# ---------------------------------------------------------------------------
+# Section A — Acquisition
+# ---------------------------------------------------------------------------
+
+resource "posthog_insight" "weekly_visitors" {
+  name          = "Weekly visitors"
+  description   = "Unique visitors per week across the website and playground."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind         = "TrendsQuery"
+      series       = [{ kind = "EventsNode", event = "$pageview", name = "$pageview", math = "dau" }]
+      interval     = "week"
+      dateRange    = { date_from = local.ph_date_from }
+      trendsFilter = { display = "ActionsLineGraph" }
+    }
+  })
+}
+
+resource "posthog_insight" "top_pages" {
+  name          = "Top pages"
+  description   = "Most-viewed paths."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind            = "TrendsQuery"
+      series          = [{ kind = "EventsNode", event = "$pageview", name = "$pageview", math = "total" }]
+      interval        = "week"
+      dateRange       = { date_from = local.ph_date_from }
+      breakdownFilter = { breakdowns = [{ property = "$pathname", type = "event" }] }
+      trendsFilter    = { display = "ActionsTable" }
+    }
+  })
+}
+
+resource "posthog_insight" "traffic_sources" {
+  name          = "Traffic sources"
+  description   = "Unique visitors by referring domain."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind            = "TrendsQuery"
+      series          = [{ kind = "EventsNode", event = "$pageview", name = "$pageview", math = "dau" }]
+      interval        = "week"
+      dateRange       = { date_from = local.ph_date_from }
+      breakdownFilter = { breakdowns = [{ property = "$referring_domain", type = "event" }] }
+      trendsFilter    = { display = "ActionsTable" }
+    }
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Section B — Interest
+# ---------------------------------------------------------------------------
+
+resource "posthog_insight" "install_page_reach" {
+  name          = "Install-page reach"
+  description   = "Unique visitors who view the installation instructions."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [{
+        kind  = "EventsNode"
+        event = "$pageview"
+        name  = "$pageview"
+        math  = "dau"
+        properties = [{
+          key      = "$pathname"
+          type     = "event"
+          operator = "exact"
+          value    = ["/quickstart/installation/"]
+        }]
+      }]
+      interval     = "week"
+      dateRange    = { date_from = local.ph_date_from }
+      trendsFilter = { display = "BoldNumber" }
+    }
+  })
+}
+
+resource "posthog_insight" "playground_reach" {
+  name          = "Playground reach"
+  description   = "Unique users who load the playground."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind         = "TrendsQuery"
+      series       = [{ kind = "EventsNode", event = "playground_loaded", name = "playground_loaded", math = "dau" }]
+      interval     = "week"
+      dateRange    = { date_from = local.ph_date_from }
+      trendsFilter = { display = "ActionsLineGraph" }
+    }
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Section C — Activation ("success")
+# ---------------------------------------------------------------------------
+
+resource "posthog_insight" "successful_compiles" {
+  name          = "Successful compiles"
+  description   = "Unique users with a successful playground compile per week. North-star proxy."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [{
+        kind       = "EventsNode"
+        event      = "compile_finished"
+        name       = "compile_finished"
+        math       = "dau"
+        properties = [{ key = "success", type = "event", operator = "exact", value = [true] }]
+      }]
+      interval     = "week"
+      dateRange    = { date_from = local.ph_date_from }
+      trendsFilter = { display = "ActionsLineGraph" }
+    }
+  })
+}
+
+resource "posthog_insight" "compile_success_rate" {
+  name          = "Compile success rate"
+  description   = "Successful compiles / all compiles (formula A/B)."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [
+        {
+          kind       = "EventsNode"
+          event      = "compile_finished"
+          name       = "compile_finished (success)"
+          math       = "total"
+          properties = [{ key = "success", type = "event", operator = "exact", value = [true] }]
+        },
+        {
+          kind  = "EventsNode"
+          event = "compile_finished"
+          name  = "compile_finished (all)"
+          math  = "total"
+        },
+      ]
+      interval     = "week"
+      dateRange    = { date_from = local.ph_date_from }
+      trendsFilter = { display = "ActionsLineGraph", formula = "A/B" }
+    }
+  })
+}
+
+resource "posthog_insight" "programs_run" {
+  name          = "Programs run"
+  description   = "Unique users who start a run per week."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind         = "TrendsQuery"
+      series       = [{ kind = "EventsNode", event = "run_started", name = "run_started", math = "dau" }]
+      interval     = "week"
+      dateRange    = { date_from = local.ph_date_from }
+      trendsFilter = { display = "ActionsLineGraph" }
+    }
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Section D — Health / friction
+# ---------------------------------------------------------------------------
+
+resource "posthog_insight" "broken_docs_examples" {
+  name          = "Broken docs examples"
+  description   = "Failed compiles broken down by the docs page hosting the embed."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [{
+        kind       = "EventsNode"
+        event      = "compile_finished"
+        name       = "compile_finished"
+        math       = "total"
+        properties = [{ key = "success", type = "event", operator = "exact", value = [false] }]
+      }]
+      interval        = "week"
+      dateRange       = { date_from = local.ph_date_from }
+      breakdownFilter = { breakdowns = [{ property = "host_page", type = "event" }] }
+      trendsFilter    = { display = "ActionsTable" }
+    }
+  })
+}
+
+resource "posthog_insight" "top_error_codes" {
+  name          = "Top error codes"
+  description   = "Error codes from runs that stopped on an error."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [{
+        kind       = "EventsNode"
+        event      = "run_stopped"
+        name       = "run_stopped"
+        math       = "total"
+        properties = [{ key = "reason", type = "event", operator = "exact", value = ["error"] }]
+      }]
+      interval        = "week"
+      dateRange       = { date_from = local.ph_date_from }
+      breakdownFilter = { breakdowns = [{ property = "error_codes", type = "event" }] }
+      trendsFilter    = { display = "ActionsBarValue" }
+    }
+  })
+}
+
+resource "posthog_insight" "dialect_adoption" {
+  name          = "Dialect adoption"
+  description   = "Playground loads by IEC 61131-3 dialect (2003 vs 2013)."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind            = "TrendsQuery"
+      series          = [{ kind = "EventsNode", event = "playground_loaded", name = "playground_loaded", math = "total" }]
+      interval        = "week"
+      dateRange       = { date_from = local.ph_date_from }
+      breakdownFilter = { breakdowns = [{ property = "dialect", type = "event" }] }
+      trendsFilter    = { display = "ActionsPie" }
+    }
+  })
+}
+
+resource "posthog_insight" "example_popularity" {
+  name          = "Example popularity"
+  description   = "Which built-in examples users load."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind            = "TrendsQuery"
+      series          = [{ kind = "EventsNode", event = "example_loaded", name = "example_loaded", math = "total" }]
+      interval        = "week"
+      dateRange       = { date_from = local.ph_date_from }
+      breakdownFilter = { breakdowns = [{ property = "example_name", type = "event" }] }
+      trendsFilter    = { display = "ActionsTable" }
+    }
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Section E — Visitor → success funnel
+# ---------------------------------------------------------------------------
+
+resource "posthog_insight" "visitor_success_funnel" {
+  name          = "Visitor → success funnel"
+  description   = "Pageview → playground load → successful compile → run, over a 7-day window. Steps 1→2 cross the www/playground subdomain boundary (directional for iframe embeds)."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "FunnelsQuery"
+      series = [
+        { kind = "EventsNode", event = "$pageview", name = "$pageview" },
+        { kind = "EventsNode", event = "playground_loaded", name = "playground_loaded" },
+        {
+          kind       = "EventsNode"
+          event      = "compile_finished"
+          name       = "compile_finished (success)"
+          properties = [{ key = "success", type = "event", operator = "exact", value = [true] }]
+        },
+        { kind = "EventsNode", event = "run_started", name = "run_started" },
+      ]
+      dateRange     = { date_from = local.ph_date_from }
+      funnelsFilter = { funnelWindowInterval = 7, funnelWindowIntervalUnit = "day" }
+    }
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Section F — Retention
+# ---------------------------------------------------------------------------
+
+resource "posthog_insight" "compile_retention" {
+  name          = "Compile retention"
+  description   = "Of users who compile in a week, how many return to compile in later weeks."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "RetentionQuery"
+      retentionFilter = {
+        period          = "Week"
+        totalIntervals  = 8
+        retentionType   = "retention_first_time"
+        targetEntity    = { id = "compile_finished", name = "compile_finished", type = "events" }
+        returningEntity = { id = "compile_finished", name = "compile_finished", type = "events" }
+      }
+      dateRange = { date_from = local.ph_date_from }
+    }
+  })
+}
+
+# ---------------------------------------------------------------------------
+# STUBS — install-adoption tiles. Uncomment once the collectors emit these
+# events (see the Tier 1 / Tier 2 follow-ups). They need no schema guesswork
+# beyond the event names below.
+# ---------------------------------------------------------------------------
+#
+# resource "posthog_insight" "cli_installs" {
+#   name          = "CLI installs by platform"
+#   description   = "install.sh completions, broken down by os/arch (Tier 2)."
+#   dashboard_ids = [posthog_dashboard.adoption.id]
+#   tags          = local.ph_tags
+#   query_json = jsonencode({
+#     kind = "InsightVizNode"
+#     source = {
+#       kind            = "TrendsQuery"
+#       series          = [{ kind = "EventsNode", event = "install_completed", name = "install_completed", math = "total" }]
+#       interval        = "week"
+#       dateRange       = { date_from = local.ph_date_from }
+#       breakdownFilter = { breakdowns = [{ property = "os", type = "event" }] }
+#       trendsFilter    = { display = "ActionsBarValue" }
+#     }
+#   })
+# }
+#
+# resource "posthog_insight" "release_downloads" {
+#   name          = "Release downloads by platform"
+#   description   = "GitHub release asset downloads per platform (Tier 1 collector)."
+#   dashboard_ids = [posthog_dashboard.adoption.id]
+#   tags          = local.ph_tags
+#   query_json = jsonencode({
+#     kind = "InsightVizNode"
+#     source = {
+#       kind            = "TrendsQuery"
+#       series          = [{ kind = "EventsNode", event = "release_downloads", name = "release_downloads", math = "sum", math_property = "count" }]
+#       interval        = "week"
+#       dateRange       = { date_from = local.ph_date_from }
+#       breakdownFilter = { breakdowns = [{ property = "platform", type = "event" }] }
+#       trendsFilter    = { display = "ActionsBarValue" }
+#     }
+#   })
+# }

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -12,3 +12,15 @@ github_owner = "ironplc"
 
 # Example: "ironplc" (repo name only, not "owner/repo").
 github_repo = "ironplc"
+
+# --- PostHog (Adoption & Success dashboard, see posthog.tf) ---
+
+# Personal API key with insight:write + dashboard:write scopes.
+# NOT the public phc_ ingestion key.
+posthog_api_key = ""
+
+# Project (environment) numeric ID, as a string. From Project Settings.
+posthog_project_id = ""
+
+# App host for the region (default is US). Not the ingestion host.
+# posthog_host = "https://us.posthog.com"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -13,3 +13,20 @@ variable "github_repo" {
   description = "Repository name without the owner prefix (e.g. ironplc)."
   type        = string
 }
+
+variable "posthog_api_key" {
+  description = "PostHog personal API key with insight:write + dashboard:write scopes. NOT the public phc_ ingestion key."
+  type        = string
+  sensitive   = true
+}
+
+variable "posthog_project_id" {
+  description = "PostHog project (environment) numeric ID, as a string. Found in Project Settings."
+  type        = string
+}
+
+variable "posthog_host" {
+  description = "PostHog app host for the API (region-specific). Not the ingestion host."
+  type        = string
+  default     = "https://us.posthog.com"
+}

--- a/scripts/install-terraform.sh
+++ b/scripts/install-terraform.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Install Terraform if it is not already on PATH.
+#
+# Shared by two environments that set up IronPLC dev tooling:
+#   - The Claude Code remote/web environment, via the SessionStart hook in
+#     .claude/settings.json (this env does not build the devcontainer image).
+#   - Available for local use / CI when a devcontainer is not in play.
+#
+# The devcontainer (.devcontainer/Dockerfile) installs Terraform from
+# HashiCorp's apt repo; this script is the apt-less equivalent for
+# environments without that image. It downloads the official release binary,
+# tracking latest (same "stay recent" philosophy as the Dockerfile). Pin a
+# specific version by exporting TERRAFORM_VERSION.
+#
+# Idempotent: exits 0 immediately if terraform is already installed. Safe to
+# run on every session start.
+set -eu
+
+if command -v terraform >/dev/null 2>&1; then
+  echo "terraform already installed: $(terraform version | head -n1)"
+  exit 0
+fi
+
+echo "Installing Terraform..."
+
+# --- resolve version ---------------------------------------------------------
+# Latest stable comes from the releases index (a public host reachable in both
+# the devcontainer and the Claude proxy environment). Override with
+# TERRAFORM_VERSION to pin. The checkpoint API is intentionally not used: it is
+# blocked by the Claude agent proxy.
+version="${TERRAFORM_VERSION:-}"
+if [ -z "$version" ]; then
+  version=$(curl -fsSL https://releases.hashicorp.com/terraform/index.json \
+    | python3 -c '
+import sys, json, re
+d = json.load(sys.stdin)
+vs = [v for v in d["versions"] if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", v)]
+vs.sort(key=lambda s: [int(x) for x in s.split(".")])
+print(vs[-1] if vs else "")')
+fi
+if [ -z "$version" ]; then
+  echo "Warning: could not determine Terraform version." >&2
+  exit 1
+fi
+
+# --- resolve os/arch for the release artifact --------------------------------
+case "$(uname -s)" in
+  Linux)  os=linux ;;
+  Darwin) os=darwin ;;
+  *) echo "Warning: unsupported OS $(uname -s) for Terraform install." >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64)  arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) echo "Warning: unsupported arch $(uname -m) for Terraform install." >&2; exit 1 ;;
+esac
+
+url="https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_${arch}.zip"
+
+# --- install dir: prefer a system bin on PATH, else ~/.local/bin -------------
+if [ -w /usr/local/bin ] || [ "$(id -u)" = "0" ]; then
+  bindir=/usr/local/bin
+else
+  bindir="$HOME/.local/bin"
+fi
+mkdir -p "$bindir"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading $url"
+curl -fsSL -o "$tmp/terraform.zip" "$url"
+
+# Unzip without assuming the unzip binary is present (Debian slim images omit
+# it); fall back to Python's zipfile, which is always available here.
+if command -v unzip >/dev/null 2>&1; then
+  unzip -o -q "$tmp/terraform.zip" -d "$tmp"
+else
+  python3 -m zipfile -e "$tmp/terraform.zip" "$tmp"
+fi
+
+install -m 0755 "$tmp/terraform" "$bindir/terraform"
+
+echo "Installed terraform ${version} to ${bindir}"
+case ":$PATH:" in
+  *":$bindir:"*) : ;;
+  *) echo "Note: $bindir is not on PATH; add it to use terraform." >&2 ;;
+esac

--- a/specs/plans/2026-07-12-posthog-dashboard-as-code.md
+++ b/specs/plans/2026-07-12-posthog-dashboard-as-code.md
@@ -1,0 +1,76 @@
+# Plan: PostHog "Adoption & Success" dashboard as code
+
+## Goal
+
+Manage the IronPLC product-analytics dashboard as version-controlled code instead
+of hand-built UI clicks, so the "Adoption & Success" dashboard (acquisition →
+interest → activation → retention, plus product-health tiles) is reproducible and
+reviewable. This turns the pageview and playground event streams already flowing
+into PostHog into a coherent set of insights.
+
+## Approach
+
+**Extend the existing `infrastructure/` Terraform module** rather than create a
+new one. That module already runs on HCP Terraform (workspace
+`ironplc-infrastructure`, remote state + remote execution) and manages the GitHub
+workflow labels via the `integrations/github` provider. Adding PostHog is one more
+provider in the same module:
+
+- Add the official `PostHog/posthog` provider to `required_providers` and a
+  `provider "posthog"` block.
+- Add a `posthog_dashboard` resource plus one `posthog_insight` per tile, linked
+  via `dashboard_ids`. Each insight's `query_json` is the raw PostHog query node
+  (`InsightVizNode` wrapping `TrendsQuery` / `FunnelsQuery` / `RetentionQuery`).
+
+Terraform (not OpenTofu) because HCP Terraform is already wired up; reusing it is
+simpler than a parallel toolchain and state.
+
+## Scope
+
+In scope (all inside `infrastructure/`):
+- `main.tf` — add the posthog provider + provider block.
+- `variables.tf` — `posthog_api_key` (sensitive), `posthog_project_id`,
+  `posthog_host`.
+- `posthog.tf` — the dashboard and one insight per **data-available-today** tile.
+- `terraform.tfvars.example` and `README.md` — document the new workspace
+  variables and the dashboard.
+
+Out of scope (documented as stubs / follow-ups):
+- The install-adoption tiles (`install_completed`, `release_downloads`, Open VSX)
+  — they depend on collectors not yet built (Tier 1 / Tier 2). Left as commented
+  stubs.
+- Any change to the PostHog SDK init files (`posthog-init.js`) — untouched.
+
+## Credentials & safety
+
+- Requires a **personal API key** with `insight:write` + `dashboard:write`
+  scopes, supplied as the **sensitive HCP workspace variable** `posthog_api_key`
+  — the same pattern the module already uses for `github_token`. Never committed.
+  The public `phc_…` ingestion key cannot create dashboards.
+- API host is the app host (`https://us.posthog.com`), not the ingestion host.
+- The dashboard/insight *definitions* are public (they live in the public repo),
+  which is fine: they reveal which metrics are tracked, not any data and no
+  secrets.
+
+## Tiles (data available today)
+
+Acquisition: weekly visitors; top pages; traffic sources.
+Interest: install-page reach; playground reach.
+Activation: successful compiles; compile success rate (formula); programs run.
+Health: broken docs examples (by `host_page`); top error codes; dialect
+adoption; example popularity.
+Funnel: `$pageview` → `playground_loaded` → `compile_finished{success}` →
+`run_started`.
+Retention: weekly retention on compiles.
+
+## Validation
+
+The `query_json` payloads follow PostHog's query-node schema, but exact field
+values (notably boolean property filters, `breakdownFilter` shape, and display
+enums) can vary by PostHog version. This module cannot be applied from CI (no
+personal API key here), so it is validated by running `terraform plan` /
+`terraform apply` against the live project and adjusting any field the API
+rejects. The change is purely additive (a new dashboard + insights); it does not
+touch the existing GitHub-label resources, and `terraform plan` shows exactly
+what will be created before apply. No IronPLC build/CI step is affected (the
+module lives outside `compiler/`, `docs/`, and `playground/`).


### PR DESCRIPTION
## Summary

Manage the IronPLC product-analytics dashboard as code by extending the existing
`infrastructure/` Terraform module (HCP Terraform) with the official PostHog
provider. This turns the pageview + playground event streams already flowing
into PostHog into a coherent, reviewable, reproducible dashboard.

> Note: this supersedes the now-closed #1169 (an earlier `cross_subdomain_cookie`
> tweak that was reverted — PostHog auto-detects that by default, so it added no
> value). No `posthog-init.js` files are touched here.

## Changes

- **`infrastructure/posthog.tf`** *(new)* — a `posthog_dashboard`
  ("IronPLC — Adoption & Success") plus one `posthog_insight` per tile:
  weekly visitors, top pages, traffic sources, install-page reach, playground
  reach, successful compiles, compile success rate (A/B formula), programs run,
  broken docs examples (by `host_page`), top error codes, dialect adoption,
  example popularity, a visitor→success funnel, and compile retention. All use
  events already flowing into PostHog. Install-adoption tiles
  (`install_completed` / `release_downloads` / Open VSX) are left as commented
  stubs pending their collectors.
- **`infrastructure/main.tf` / `variables.tf`** — add the `PostHog/posthog`
  provider and its variables. The personal API key is a **sensitive HCP
  workspace variable** (`posthog_api_key`), mirroring the existing
  `github_token` pattern — no secret is committed.
- **`infrastructure/terraform.tfvars.example` / `README.md`** — document the new
  workspace variables and the dashboard.
- **`scripts/install-terraform.sh`** *(new)* + **`.claude/settings.json`** — an
  idempotent, apt-less Terraform installer and a `SessionStart` hook that runs
  it, so the Claude remote environment (which does not build the devcontainer
  image) has Terraform available for this module.
- **`specs/plans/2026-07-12-posthog-dashboard-as-code.md`** *(new)* — the plan.

## How to run

From HCP Terraform (remote execution; secrets are workspace variables):

```bash
cd infrastructure
export TF_CLOUD_ORGANIZATION=<hcp-org>
terraform init     # pulls the new PostHog provider
·t·erraform p·lan     # expect +1 dashboard, +14 insights; GitHub labels unchanged
·t·erraform a·pply
```

Requires `posthog_api_key` (sensitive) and `posthog_project_id` set as workspace
variables.

## Validation

- `terraform fmt -check` passes on the module.
- `scripts/install-terraform.sh` was run successfully (installs Terraform, used
  to fmt-check the module).
- `.claude/settings.json` hook validated with `jq`.
- `terraform init`/`validate`/`plan` require the Terraform registry + PostHog
  API, which are not reachable from this environment — they run on HCP / locally.
  The `query_json` payloads follow PostHog's query-node schema, but a few field
  values (boolean property filters, `breakdownFilter` shape, display enums) can
  vary by PostHog version; any field the API rejects on `plan`/`apply` is a
  one-line fix. All changes are additive and do not affect the existing GitHub
  labels.
- The compiler/docs CI pipeline is not applicable — this PR changes no Rust or
  docs source (only `infrastructure/`, `scripts/`, `.claude/`, and `specs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RruW1ugpQqa8FphzjficdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RruW1ugpQqa8FphzjficdV)_