### PR TITLE
Fix install-page reach tile to match the real .html path

### DIFF
--- a/infrastructure/posthog.tf
+++ b/infrastructure/posthog.tf
@@ -115,8 +115,8 @@ resource "posthog_insight" "install_page_reach" {
         properties = [{
           key      = "$pathname"
           type     = "event"
-          operator = "exact"
-          value    = ["/quickstart/installation/"]
+          operator = "icontains"
+          value    = ["/quickstart/installation"]
         }]
       }]
       interval     = "week"


### PR DESCRIPTION
## Summary

Follow-up to the merged #1171. The `install_page_reach` insight always read
zero even though the install page has real traffic (~84 views).

## Cause

The filter matched `$pathname` exactly against `/quickstart/installation/`
(trailing slash, no extension), but the Sphinx site serves the page at
`/quickstart/installation.html`. The exact match never hit, so the tile
reported zero while "Top pages" correctly showed the `.html` path.

## Fix

Switch the filter to an `icontains` match on `/quickstart/installation`, which
matches the `.html` page (and any future trailing-slash variant) without
over-matching any sibling page.

## Validation

- `terraform fmt -check` passes.
- Semantic validation (that the count now matches "Top pages") happens on
  `terraform apply` against the live PostHog project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RruW1ugpQqa8FphzjficdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RruW1ugpQqa8FphzjficdV)_