### PR TITLE
Re-enable OpenCode E2E test in deployment pipeline

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -114,20 +114,17 @@ jobs:
     with:
       compiler-version: ${{ needs.release.outputs.version || inputs.dryrun-test-version-override }}
 
-  # TODO: Re-enable once OpenCode reliably passes in the release build.
-  # The reusable workflow (.github/workflows/partial_opencode_e2e.yaml) is
-  # retained but is no longer wired into the deployment pipeline.
-  # opencode-e2e-test:
-  #   name: OpenCode Integration E2E Test
-  #   # Install the just-published compiler and verify the ironplcmcp MCP server
-  #   # works with the OpenCode agent: a connectivity check plus a real-agent run
-  #   # against a local Ollama model.
-  #   needs: [release, publish-prerelease]
-  #   uses: ./.github/workflows/partial_opencode_e2e.yaml
-  #   if: ${{ !inputs.dryrun || inputs.dryrun-test-version-override }}
-  #   with:
-  #     compiler-version: ${{ needs.release.outputs.version || inputs.dryrun-test-version-override }}
-  #     model: "qwen2.5:1.5b"
+  opencode-e2e-test:
+    name: OpenCode Integration E2E Test
+    # Install the just-published compiler and verify the ironplcmcp MCP server
+    # works with the OpenCode agent: a connectivity check plus a real-agent run
+    # against a local Ollama model.
+    needs: [release, upload-release-artifacts]
+    uses: ./.github/workflows/partial_opencode_e2e.yaml
+    if: ${{ !inputs.dryrun || inputs.dryrun-test-version-override }}
+    with:
+      compiler-version: ${{ needs.release.outputs.version || inputs.dryrun-test-version-override }}
+      model: "qwen2.5:1.5b"
 
   playground-e2e-test:
     name: Playground E2E Test
@@ -142,7 +139,7 @@ jobs:
     # if those are failing so we depend on those. In particular,
     # install-script-smoke-test must pass before we publish the
     # docs site, because the site serves install.sh.
-    needs: [release, smoke-test, install-script-smoke-test, playground-e2e-test]
+    needs: [release, smoke-test, install-script-smoke-test, opencode-e2e-test, playground-e2e-test]
     # peaceiris/actions-gh-pages pushes the gh-pages branch via GITHUB_TOKEN.
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
Re-enables the OpenCode Integration E2E test that was previously disabled, and updates the deployment pipeline to include it as a required check before publishing documentation.

## Changes
- **Uncommented the `opencode-e2e-test` job** in the deployment workflow that was previously disabled with a TODO note
- **Updated job dependencies**: Changed from `publish-prerelease` to `upload-release-artifacts` as the prerequisite job
- **Added to publish-docs dependencies**: The `opencode-e2e-test` job is now included in the `needs` list for the `publish-docs` job, ensuring the test passes before documentation is published

## Details
The OpenCode E2E test verifies that the ironplcmcp MCP server works correctly with the OpenCode agent by running a connectivity check and a real-agent run against a local Ollama model (qwen2.5:1.5b). This test is now part of the critical path for releases, ensuring integration reliability before documentation is published.

https://claude.ai/code/session_01R8f8Xqk2ZMf5ZuqeEnn4w2