### PR TITLE
Add one-click P9999 "Submit Code" reporting to playground

### DIFF
--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -112,6 +112,19 @@ struct DiagnosticInfo {
     start_column: u32,
     end_line: u32,
     end_column: u32,
+    /// The compiler source file that produced this diagnostic (e.g. the
+    /// `file!()` recorded by `Diagnostic::todo`). Present for the P9999/P9998
+    /// families; empty otherwise. This is the compiler's own location, never
+    /// the user's program, so it is safe to report automatically.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    compiler_file: String,
+    /// The compiler source line paired with `compiler_file`. Zero when absent.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    compiler_line: u32,
+}
+
+fn is_zero(n: &u32) -> bool {
+    *n == 0
 }
 
 /// Build a [`DiagnosticInfo`] from a compiler diagnostic, computing 1-based
@@ -127,6 +140,8 @@ fn diagnostic_info(diag: &Diagnostic, source: &str) -> DiagnosticInfo {
         start_column: start.column + 1,
         end_line: end.line + 1,
         end_column: end.column + 1,
+        compiler_file: diag.source_file.clone().unwrap_or_default(),
+        compiler_line: diag.source_line.unwrap_or(0),
     }
 }
 
@@ -513,6 +528,8 @@ fn compile_inner(source: &str, dialect: &str, allows: &str) -> CompileResult {
                 start_column: 1,
                 end_line: 1,
                 end_column: 1,
+                compiler_file: String::new(),
+                compiler_line: 0,
             }],
         };
     }
@@ -1456,6 +1473,34 @@ END_PROGRAM
         let result: RunSourceResult = serde_json::from_str(&run_source(source, 1, "", "")).unwrap();
         assert!(result.ok, "Expected ok but got error: {:?}", result.error);
         assert_eq!(result.variables[2].value, "16#42"); // indices 0-1 are system globals
+    }
+
+    #[test]
+    fn compile_when_p9999_then_diagnostic_has_compiler_file_and_line() {
+        // A direct hardware-address write is not supported by codegen and
+        // produces P9999. The diagnostic must carry the compiler file/line so
+        // the playground can report the location without the program source.
+        let source = "
+PROGRAM main
+  VAR
+    x : BOOL;
+  END_VAR
+  %QX0.0 := TRUE;
+END_PROGRAM
+";
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        assert!(!result.ok);
+        let diag = result
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "P9999")
+            .expect("expected a P9999 diagnostic");
+        assert!(
+            diag.compiler_file.ends_with(".rs"),
+            "expected a compiler .rs file, got {:?}",
+            diag.compiler_file
+        );
+        assert!(diag.compiler_line > 0, "expected a non-zero compiler line");
     }
 
     #[test]

--- a/docs/reference/compiler/problems/P9999.rst
+++ b/docs/reference/compiler/problems/P9999.rst
@@ -18,8 +18,8 @@ Reporting the program
 ---------------------
 
 We can only add support for an unsupported capability once we can see the
-program that needs it, so please send it to us. There are two ways, and no
-GitHub account is required:
+program that needs it. Sending us the program gives the best results, so please
+do — there are two ways, and no GitHub account is required:
 
 * **From the** `IronPLC Playground`_ **(easiest).** When a program produces
   P9999, a **Submit Code** button appears next to the diagnostic. Clicking it

--- a/docs/reference/compiler/problems/P9999.rst
+++ b/docs/reference/compiler/problems/P9999.rst
@@ -12,7 +12,26 @@ requires adding support for the elements to the IronPLC compiler.
 
 * avoid the particular elements (this is usually not feasible)
 * verify that you have the latest version of the IronPLC compiler
-* report the issue to `IronPLC GitHub issues`_.
+* report the program so support can be added (see below).
+
+Reporting the program
+---------------------
+
+We can only add support for an unsupported capability once we can see the
+program that needs it, so please send it to us. There are two ways, and no
+GitHub account is required:
+
+* **From the** `IronPLC Playground`_ **(easiest).** When a program produces
+  P9999, a **Submit Code** button appears next to the diagnostic. Clicking it
+  sends the program directly to the IronPLC team.
+* **As a** `GitHub issue`_. Attach the source file (or paste it) so we can
+  reproduce the problem.
+
+.. note::
+
+   Whichever route you choose, the program you submit is shared with the
+   IronPLC team and **may become public** — for example in a GitHub issue.
+   Do not submit anything confidential.
 
 Known Limitations
 -----------------
@@ -27,4 +46,5 @@ produce this error:
 * Direct variables (hardware-mapped I/O such as ``%IX0.0``)
 * Enumerated values in expressions and ``CASE`` selectors
 
-.. _IronPLC GitHub issues: https://github.com/ironplc/ironplc/issues/new?template=todo_report.md
+.. _IronPLC Playground: https://playground.ironplc.com/
+.. _GitHub issue: https://github.com/ironplc/ironplc/issues/new?template=todo_report.md

--- a/infrastructure/posthog.tf
+++ b/infrastructure/posthog.tf
@@ -309,6 +309,31 @@ resource "posthog_insight" "todo_report_submissions" {
   })
 }
 
+resource "posthog_insight" "top_compiler_error_locations" {
+  name          = "Top P9 compiler error locations"
+  description   = "Compiler source file#line of P9xxx errors (unimplemented capabilities / internal errors) from failed playground compiles, ranked by frequency. This is the compiler's own location — collected automatically because it never contains any program source — and it points maintainers straight at the code that needs work."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [{
+        kind       = "EventsNode"
+        event      = "compile_finished"
+        name       = "compile_finished"
+        math       = "total"
+        properties = [{ key = "success", type = "event", operator = "exact", value = [false] }]
+      }]
+      interval        = "week"
+      dateRange       = { date_from = local.ph_date_from }
+      breakdownFilter = { breakdowns = [{ property = "error_locations", type = "event" }] }
+      trendsFilter    = { display = "ActionsBarValue" }
+    }
+  })
+}
+
 resource "posthog_insight" "top_error_codes" {
   name          = "Top runtime error codes"
   description   = "Error codes from runs that stopped on an error while executing (as opposed to failing to compile)."

--- a/infrastructure/posthog.tf
+++ b/infrastructure/posthog.tf
@@ -15,6 +15,12 @@
 # compile) but never the program source, so error-code tiles reveal WHY
 # compiles fail without exposing anyone's code.
 #
+# The one exception is todo_report_submitted: fired only when a user clicks
+# "Submit Code" on a P9999 diagnostic, it DOES carry the program source (in the
+# `program` property) because fixing P9999 requires seeing the program. That
+# transmission is explicit and consented — the button and its consent line tell
+# the user their code is shared and may become public — never automatic.
+#
 # Install-adoption tiles (install_completed / release_downloads / Open VSX)
 # depend on collectors not built yet and are left as commented stubs at the
 # bottom.
@@ -276,6 +282,29 @@ resource "posthog_insight" "top_compile_error_codes" {
       dateRange       = { date_from = local.ph_date_from }
       breakdownFilter = { breakdowns = [{ property = "error_codes", type = "event" }] }
       trendsFilter    = { display = "ActionsBarValue" }
+    }
+  })
+}
+
+resource "posthog_insight" "todo_report_submissions" {
+  name          = "P9999 code submissions"
+  description   = "Programs users chose to submit (via the playground \"Submit Code\" button) after hitting P9999 — the capability-not-implemented error. Each event carries the program source so the reported feature can be added. Unlike the error-code tiles, this event intentionally includes source, transmitted only on explicit, consented user action."
+  dashboard_ids = [posthog_dashboard.adoption.id]
+  tags          = local.ph_tags
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [{
+        kind  = "EventsNode"
+        event = "todo_report_submitted"
+        name  = "todo_report_submitted"
+        math  = "total"
+      }]
+      interval     = "week"
+      dateRange    = { date_from = local.ph_date_from }
+      trendsFilter = { display = "ActionsLineGraph" }
     }
   })
 }

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -139,11 +139,12 @@ let currentIntervalMs = 500;
 // typing afterwards.
 let lastCompiledSource = "";
 
-// Diagnostic codes for which we surface the "Submit Code" affordance. P9999
-// ("capability not implemented yet") can only be fixed once we can see the
-// program that triggered it, so we ask the user to send it. Extend this set to
-// offer submission for other codes.
-const REPORTABLE_CODES = new Set<string>(["P9999"]);
+// The "P9xxx" codes are compiler errors (unimplemented capabilities and
+// internal errors) that we can only fix once we can see the program that
+// triggered them, so every P9 code gets the "Submit Code" affordance.
+function isReportable(code: string): boolean {
+  return /^P9\d{3}$/.test(code);
+}
 
 // Cap the source we transmit so a pathological paste can't bloat an event.
 const MAX_REPORT_SOURCE_CHARS = 50000;
@@ -217,6 +218,27 @@ function extractErrorCodes(diagnostics: Diagnostic[] | undefined): string[] {
     }
   }
   return codes;
+}
+
+// The compiler `file#Lline` locations of reportable (P9xxx) diagnostics. This
+// is the compiler's own source location — never the user's program — so it is
+// safe to attach to the automatic compile_finished event. It lets us rank the
+// most common unimplemented sites without collecting any program.
+function extractErrorLocations(diagnostics: Diagnostic[] | undefined): string[] {
+  if (!diagnostics) return [];
+  const seen = new Set<string>();
+  const locations: string[] = [];
+  for (const d of diagnostics) {
+    if (!isReportable(d.code) || !d.compiler_file) continue;
+    const loc = d.compiler_line
+      ? `${d.compiler_file}#L${d.compiler_line}`
+      : d.compiler_file;
+    if (!seen.has(loc)) {
+      seen.add(loc);
+      locations.push(loc);
+    }
+  }
+  return locations;
 }
 
 type StopReason = "user" | "error" | "reload";
@@ -644,6 +666,8 @@ startBtn.addEventListener("click", async () => {
       success: false,
       error_codes: extractErrorCodes(diagnostics),
       error_count: diagnostics.length,
+      // Compiler file/line of any P9xxx diagnostics — no program source.
+      error_locations: extractErrorLocations(diagnostics),
       program_lines: programLines,
       duration_ms: compileDurationMs,
     });
@@ -877,7 +901,7 @@ function renderDiagnostics(diagnostics: Diagnostic[]): void {
     html += "</div>";
   }
 
-  const reportable = diagnostics.filter((d) => REPORTABLE_CODES.has(d.code));
+  const reportable = diagnostics.filter((d) => isReportable(d.code));
   if (reportable.length > 0) {
     html += reportPanelHtml(reportable);
   }
@@ -889,27 +913,29 @@ function renderDiagnostics(diagnostics: Diagnostic[]): void {
   }
 }
 
-// --- P9999 "Submit Code" reporting ---
+// --- P9xxx "Submit Code" reporting ---
 //
-// P9999 means the program uses a capability the compiler cannot yet handle. We
-// can only prioritize and fix it if we can see the program, so we invite the
-// user to send it. Two things are non-negotiable in the UX:
+// The P9 codes are compiler errors (unimplemented capabilities and internal
+// errors). We can only prioritize and fix them once we can see the program that
+// triggered them, so we invite the user to send it. Two things are
+// non-negotiable in the UX:
 //   1. The button says exactly what happens: "Submit Code".
 //   2. A consent line makes clear the program is shared and MAY BECOME PUBLIC
 //      (this holds for the PostHog path and the GitHub path alike).
 // Source is only ever transmitted on the explicit click below — never
-// automatically.
+// automatically. (The compiler file/line IS reported automatically via
+// compile_finished, but that is the compiler's location, not the program.)
 
 const REPORT_CONSENT_HTML =
-  "Submitting sends the program in the editor to the IronPLC team so we can add " +
-  "support for it. <strong>Your code may be published publicly</strong> — for " +
-  "example in a GitHub issue. Don’t submit anything confidential.";
+  "Submitting sends the program in the editor to the IronPLC team so we can fix " +
+  "it. <strong>Your code may be published publicly</strong> — for example in a " +
+  "GitHub issue. Don’t submit anything confidential.";
 
 function reportPanelHtml(reportable: Diagnostic[]): string {
   const codes = extractErrorCodes(reportable).join(", ");
   return (
     '<div class="report-panel" data-testid="report-panel">' +
-    `<p class="report-title">${escapeHtml(codes)}: this isn’t supported yet. Help us add it.</p>` +
+    `<p class="report-title">${escapeHtml(codes)}: the compiler can’t handle this yet. Send us the program so we can fix it.</p>` +
     `<p class="report-consent">${REPORT_CONSENT_HTML}</p>` +
     '<div class="report-actions">' +
     '<button type="button" class="submit-code-btn" data-testid="submit-code-btn">Submit Code</button>' +
@@ -946,7 +972,8 @@ function submitCodeReport(reportable: Diagnostic[]): void {
     program_chars: source.length,
     program_lines: source.split("\n").length,
     program_truncated: truncated,
-    // Labels carry the compiler `file#Lline` of each unimplemented site.
+    // Structured compiler `file#Lline` of each reportable site.
+    error_locations: extractErrorLocations(reportable),
     diagnostic_labels: reportable.map((d) => d.label || ""),
     dialect: getDialect(),
     allows: getAllows(),
@@ -959,15 +986,14 @@ function submitCodeReport(reportable: Diagnostic[]): void {
 // consent line above the button already covers that this becomes public.
 function buildGithubIssueUrl(reportable: Diagnostic[]): string {
   const source = lastCompiledSource;
-  const labels = reportable
-    .map((d) => d.label)
-    .filter((l): l is string => !!l)
-    .map((l) => `- ${l}`)
-    .join("\n");
+  const codes = extractErrorCodes(reportable);
+  const primaryCode = codes[0] || "P9999";
+  const locations = extractErrorLocations(reportable);
+  const locationList = locations.map((l) => `- ${l}`).join("\n");
   const header =
-    "**What happened**\nThe playground reported P9999 (a capability the " +
-    "compiler doesn’t support yet) for this program.\n\n" +
-    (labels ? `**Compiler locations**\n${labels}\n\n` : "") +
+    `**What happened**\nThe playground reported ${codes.join(", ")} ` +
+    "(a compiler error) for this program.\n\n" +
+    (locationList ? `**Compiler locations**\n${locationList}\n\n` : "") +
     `**Compiler version:** ${compilerVersion || "unknown"}\n` +
     `**Dialect:** ${getDialect() || "default"}\n` +
     (getAllows() ? `**Allows:** ${getAllows()}\n` : "");
@@ -979,7 +1005,7 @@ function buildGithubIssueUrl(reportable: Diagnostic[]): string {
     "\n**Program**\nThe program is too large to prefill here — please " +
     "attach the source file to this issue.\n";
 
-  const base = `${GITHUB_NEW_ISSUE_URL}?labels=${encodeURIComponent("P9999")}&title=${encodeURIComponent("P9999 - Compiler To Do")}`;
+  const base = `${GITHUB_NEW_ISSUE_URL}?labels=${encodeURIComponent(primaryCode)}&title=${encodeURIComponent(`${primaryCode} - Compiler problem report`)}`;
   const candidate = `${base}&body=${encodeURIComponent(withProgram)}`;
   if (candidate.length <= MAX_GITHUB_URL_CHARS) {
     return candidate;

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -134,6 +134,22 @@ let stepInFlight = false;
 let previousValues: Map<number, string> = new Map();
 let compilerVersion = "";
 let currentIntervalMs = 500;
+// The exact source last handed to the compiler. Captured on Start so a report
+// reflects what actually produced the diagnostics, even if the user keeps
+// typing afterwards.
+let lastCompiledSource = "";
+
+// Diagnostic codes for which we surface the "Submit Code" affordance. P9999
+// ("capability not implemented yet") can only be fixed once we can see the
+// program that triggered it, so we ask the user to send it. Extend this set to
+// offer submission for other codes.
+const REPORTABLE_CODES = new Set<string>(["P9999"]);
+
+// Cap the source we transmit so a pathological paste can't bloat an event.
+const MAX_REPORT_SOURCE_CHARS = 50000;
+// Keep the prefilled GitHub issue URL under a length browsers reliably accept.
+const MAX_GITHUB_URL_CHARS = 7000;
+const GITHUB_NEW_ISSUE_URL = "https://github.com/ironplc/ironplc/issues/new";
 
 // --- URL parameter handling ---
 
@@ -577,6 +593,7 @@ function resetTransportButtons(): void {
 
 startBtn.addEventListener("click", async () => {
   const source = editor.value;
+  lastCompiledSource = source;
   const intervalMs = getIntervalMs();
   const cycleTimeUs = intervalMs * 1000;
   const programLines = source.split("\n").length;
@@ -859,7 +876,115 @@ function renderDiagnostics(diagnostics: Diagnostic[]): void {
     }
     html += "</div>";
   }
+
+  const reportable = diagnostics.filter((d) => REPORTABLE_CODES.has(d.code));
+  if (reportable.length > 0) {
+    html += reportPanelHtml(reportable);
+  }
+
   diagnosticsPanel.innerHTML = html;
+
+  if (reportable.length > 0) {
+    wireReportPanel(reportable);
+  }
+}
+
+// --- P9999 "Submit Code" reporting ---
+//
+// P9999 means the program uses a capability the compiler cannot yet handle. We
+// can only prioritize and fix it if we can see the program, so we invite the
+// user to send it. Two things are non-negotiable in the UX:
+//   1. The button says exactly what happens: "Submit Code".
+//   2. A consent line makes clear the program is shared and MAY BECOME PUBLIC
+//      (this holds for the PostHog path and the GitHub path alike).
+// Source is only ever transmitted on the explicit click below — never
+// automatically.
+
+const REPORT_CONSENT_HTML =
+  "Submitting sends the program in the editor to the IronPLC team so we can add " +
+  "support for it. <strong>Your code may be published publicly</strong> — for " +
+  "example in a GitHub issue. Don’t submit anything confidential.";
+
+function reportPanelHtml(reportable: Diagnostic[]): string {
+  const codes = extractErrorCodes(reportable).join(", ");
+  return (
+    '<div class="report-panel" data-testid="report-panel">' +
+    `<p class="report-title">${escapeHtml(codes)}: this isn’t supported yet. Help us add it.</p>` +
+    `<p class="report-consent">${REPORT_CONSENT_HTML}</p>` +
+    '<div class="report-actions">' +
+    '<button type="button" class="submit-code-btn" data-testid="submit-code-btn">Submit Code</button>' +
+    `<a class="report-github-link" data-testid="report-github-link" target="_blank" rel="noopener" href="${escapeHtml(buildGithubIssueUrl(reportable))}">or open a GitHub issue</a>` +
+    "</div>" +
+    "</div>"
+  );
+}
+
+function wireReportPanel(reportable: Diagnostic[]): void {
+  const btn = diagnosticsPanel.querySelector(
+    ".submit-code-btn",
+  ) as HTMLButtonElement | null;
+  if (!btn) return;
+  btn.addEventListener("click", () => {
+    submitCodeReport(reportable);
+    const panel = diagnosticsPanel.querySelector(".report-panel");
+    if (panel) {
+      panel.innerHTML =
+        '<p class="report-confirmation" data-testid="report-confirmation">' +
+        "✓ Thank you — your code was submitted. We’ll use it to add support." +
+        "</p>";
+    }
+  });
+}
+
+function submitCodeReport(reportable: Diagnostic[]): void {
+  const source = lastCompiledSource;
+  const truncated = source.length > MAX_REPORT_SOURCE_CHARS;
+  capture("todo_report_submitted", {
+    error_codes: extractErrorCodes(reportable),
+    error_count: reportable.length,
+    program: truncated ? source.slice(0, MAX_REPORT_SOURCE_CHARS) : source,
+    program_chars: source.length,
+    program_lines: source.split("\n").length,
+    program_truncated: truncated,
+    // Labels carry the compiler `file#Lline` of each unimplemented site.
+    diagnostic_labels: reportable.map((d) => d.label || ""),
+    dialect: getDialect(),
+    allows: getAllows(),
+    compiler_version: compilerVersion,
+  });
+}
+
+// Build a prefilled "new issue" URL. We include the source inline when it fits
+// under the URL length limit; otherwise we ask the user to attach it. The
+// consent line above the button already covers that this becomes public.
+function buildGithubIssueUrl(reportable: Diagnostic[]): string {
+  const source = lastCompiledSource;
+  const labels = reportable
+    .map((d) => d.label)
+    .filter((l): l is string => !!l)
+    .map((l) => `- ${l}`)
+    .join("\n");
+  const header =
+    "**What happened**\nThe playground reported P9999 (a capability the " +
+    "compiler doesn’t support yet) for this program.\n\n" +
+    (labels ? `**Compiler locations**\n${labels}\n\n` : "") +
+    `**Compiler version:** ${compilerVersion || "unknown"}\n` +
+    `**Dialect:** ${getDialect() || "default"}\n` +
+    (getAllows() ? `**Allows:** ${getAllows()}\n` : "");
+
+  const withProgram =
+    header + `\n**Program**\n\`\`\`iecst\n${source}\n\`\`\`\n`;
+  const withoutProgram =
+    header +
+    "\n**Program**\nThe program is too large to prefill here — please " +
+    "attach the source file to this issue.\n";
+
+  const base = `${GITHUB_NEW_ISSUE_URL}?labels=${encodeURIComponent("P9999")}&title=${encodeURIComponent("P9999 - Compiler To Do")}`;
+  const candidate = `${base}&body=${encodeURIComponent(withProgram)}`;
+  if (candidate.length <= MAX_GITHUB_URL_CHARS) {
+    return candidate;
+  }
+  return `${base}&body=${encodeURIComponent(withoutProgram)}`;
 }
 
 function activateTab(tabName: string): void {

--- a/playground/src/types/messages.d.ts
+++ b/playground/src/types/messages.d.ts
@@ -91,6 +91,10 @@ export interface Diagnostic {
   label?: string;
   start_line: number;
   start_column: number;
+  /** Compiler source file that produced the diagnostic (P9999/P9998 family). */
+  compiler_file?: string;
+  /** Compiler source line paired with `compiler_file`. */
+  compiler_line?: number;
 }
 
 export interface RunResultOk {

--- a/playground/style.css
+++ b/playground/style.css
@@ -322,6 +322,71 @@ a.diagnostic-code:hover {
   padding: 0.5rem 0;
 }
 
+/* --- P9999 "Submit Code" report panel --- */
+
+.report-panel {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(108, 140, 255, 0.08);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.report-title {
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.report-consent {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  margin-bottom: 0.6rem;
+}
+
+.report-consent strong {
+  color: var(--text);
+}
+
+.report-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.submit-code-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.9rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.submit-code-btn:hover {
+  background: var(--accent-hover);
+}
+
+.report-github-link {
+  color: var(--accent);
+  font-size: 0.8rem;
+  text-decoration: underline;
+}
+
+.report-github-link:hover {
+  color: var(--accent-hover);
+}
+
+.report-confirmation {
+  color: var(--success);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-weight: 500;
+}
+
 .success-message {
   color: var(--success);
 }

--- a/playground/tests/e2e.spec.ts
+++ b/playground/tests/e2e.spec.ts
@@ -315,6 +315,41 @@ END_PROGRAM
     expect(decodeURIComponent(href)).toContain("%QX0.0");
   });
 
+  test("compile_finished_when_p9999_then_auto_reports_compiler_location_without_program", async ({ page }) => {
+    await page.locator('[data-testid="editor"]').fill(P9999_PROGRAM);
+
+    // Intercept captures before compiling.
+    await page.evaluate(() => {
+      const w = window as unknown as { posthog?: unknown; __captured: unknown[] };
+      w.__captured = [];
+      const real = w.posthog as { register?: (p: unknown) => void } | undefined;
+      w.posthog = {
+        capture: (event: string, props: unknown) => w.__captured.push({ event, props }),
+        register: real?.register ? real.register.bind(real) : () => {},
+      };
+    });
+
+    await page.click('[data-testid="start-btn"]');
+    await expect(page.locator('[data-testid="report-panel"]')).toBeVisible({ timeout: 10000 });
+
+    const captured = await page.evaluate(
+      () =>
+        (window as unknown as {
+          __captured: Array<{
+            event: string;
+            props: { success?: boolean; error_locations?: string[]; program?: string };
+          }>;
+        }).__captured,
+    );
+    const finished = captured.find((c) => c.event === "compile_finished");
+    expect(finished).toBeTruthy();
+    expect(finished?.props.success).toBe(false);
+    // The compiler file#line is reported automatically...
+    expect(finished?.props.error_locations?.some((l) => /\.rs#L\d+/.test(l))).toBe(true);
+    // ...but the program itself is never on this automatic event.
+    expect(finished?.props.program).toBeUndefined();
+  });
+
   test("start_when_running_multiple_cycles_then_shows_sparklines", async ({ page }) => {
     const editor = page.locator('[data-testid="editor"]');
     await editor.fill(`PROGRAM main

--- a/playground/tests/e2e.spec.ts
+++ b/playground/tests/e2e.spec.ts
@@ -232,6 +232,89 @@ END_PROGRAM
     await expect(message).not.toHaveText("");
   });
 
+  // A direct hardware-address write. Hardware I/O is out of scope for the
+  // software playground VM, so this reliably produces P9999 in code generation.
+  const P9999_PROGRAM = `PROGRAM main
+  VAR
+    x : BOOL;
+  END_VAR
+  %QX0.0 := TRUE;
+END_PROGRAM
+`;
+
+  test("start_when_p9999_then_shows_submit_code_panel", async ({ page }) => {
+    await page.locator('[data-testid="editor"]').fill(P9999_PROGRAM);
+    await page.click('[data-testid="start-btn"]');
+
+    const diagnosticsPanel = page.locator('[data-testid="diagnostics-panel"]');
+    await expect(diagnosticsPanel).toContainText("P9999", { timeout: 10000 });
+
+    // The report panel appears with an explicit consent line and a button that
+    // says exactly what it does.
+    const panel = page.locator('[data-testid="report-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("may be published publicly");
+    await expect(page.locator('[data-testid="submit-code-btn"]')).toHaveText("Submit Code");
+  });
+
+  test("start_when_ordinary_syntax_error_then_no_submit_code_panel", async ({ page }) => {
+    await page.locator('[data-testid="editor"]').fill("PROGRAM main INVALID END_PROGRAM");
+    await page.click('[data-testid="start-btn"]');
+
+    const diagnosticsPanel = page.locator('[data-testid="diagnostics-panel"]');
+    await expect(diagnosticsPanel).not.toContainText("No diagnostics", { timeout: 10000 });
+
+    // Non-P9999 diagnostics must not offer the "Submit Code" affordance.
+    await expect(page.locator('[data-testid="report-panel"]')).toHaveCount(0);
+  });
+
+  test("submit_code_when_clicked_then_captures_event_and_confirms", async ({ page }) => {
+    await page.locator('[data-testid="editor"]').fill(P9999_PROGRAM);
+    await page.click('[data-testid="start-btn"]');
+
+    await expect(page.locator('[data-testid="report-panel"]')).toBeVisible({ timeout: 10000 });
+
+    // Record PostHog captures. `ph()` reads window.posthog on every call, so
+    // swapping it here is enough to intercept the submission event.
+    await page.evaluate(() => {
+      const w = window as unknown as { posthog?: unknown; __captured: unknown[] };
+      w.__captured = [];
+      const real = w.posthog as { register?: (p: unknown) => void } | undefined;
+      w.posthog = {
+        capture: (event: string, props: unknown) => w.__captured.push({ event, props }),
+        register: real?.register ? real.register.bind(real) : () => {},
+      };
+    });
+
+    await page.click('[data-testid="submit-code-btn"]');
+
+    // The user gets a clear confirmation and cannot re-submit.
+    await expect(page.locator('[data-testid="report-confirmation"]')).toBeVisible();
+    await expect(page.locator('[data-testid="submit-code-btn"]')).toHaveCount(0);
+
+    // The event carried the program source and the P9999 code.
+    const captured = await page.evaluate(
+      () => (window as unknown as { __captured: Array<{ event: string; props: { error_codes?: string[]; program?: string } }> }).__captured,
+    );
+    const report = captured.find((c) => c.event === "todo_report_submitted");
+    expect(report).toBeTruthy();
+    expect(report?.props.error_codes).toContain("P9999");
+    expect(report?.props.program).toContain("%QX0.0");
+  });
+
+  test("submit_code_when_p9999_then_github_link_is_prefilled", async ({ page }) => {
+    await page.locator('[data-testid="editor"]').fill(P9999_PROGRAM);
+    await page.click('[data-testid="start-btn"]');
+
+    const link = page.locator('[data-testid="report-github-link"]');
+    await expect(link).toBeVisible({ timeout: 10000 });
+    const href = (await link.getAttribute("href")) ?? "";
+    expect(href).toContain("https://github.com/ironplc/ironplc/issues/new");
+    expect(href).toContain("labels=P9999");
+    // The program body is prefilled (URL-encoded) for this small program.
+    expect(decodeURIComponent(href)).toContain("%QX0.0");
+  });
+
   test("start_when_running_multiple_cycles_then_shows_sparklines", async ({ page }) => {
     const editor = page.locator('[data-testid="editor"]');
     await editor.fill(`PROGRAM main

--- a/specs/plans/2026-07-12-p9999-playground-report.md
+++ b/specs/plans/2026-07-12-p9999-playground-report.md
@@ -1,0 +1,91 @@
+# Plan: One-click P9999 "Submit Code" reporting from the playground
+
+## Goal
+
+P9999 ("capability not implemented yet") is the second most common compile
+error, yet the project has never received a single report. The only documented
+path is a high-friction GitHub issue that asks users to build a minimal repro —
+and it is not surfaced at the point of failure. Meanwhile almost all P9999
+volume originates in the browser playground, which today has no report
+affordance at all.
+
+Add a low-friction, **consent-forward** "Submit Code" affordance to the
+playground diagnostics panel that appears whenever a P9999 diagnostic is shown.
+Submitting sends the program source (the thing we actually need) to the IronPLC
+team **without requiring a GitHub account**, via an explicit PostHog event, and
+also offers a prefilled GitHub issue for users who want to track it.
+
+## Consent / privacy
+
+This is the load-bearing requirement. Users must clearly understand, before they
+act, that:
+
+- they are submitting the **program in the editor**, and
+- **their code may become public** (e.g. in a GitHub issue) — this applies to
+  the PostHog path *and* the GitHub path.
+
+Design consequences:
+
+- The action verb is on the button itself: **"Submit Code"** (not "Report").
+- A plain-language consent line sits directly above the button.
+- Source is **only** ever transmitted on this explicit click. The existing
+  automatic `compile_finished` event stays source-free (its documented promise in
+  `infrastructure/posthog.tf` is preserved and clarified).
+
+## Architecture
+
+Client-only change in the playground (TypeScript + CSS + HTML), plus docs and
+an analytics dashboard tile. No Rust/WASM changes are needed: the playground
+`Diagnostic` already carries the compiler `file#Lline` inside `d.label` (from the
+`Diagnostic::todo` helper), and the WASM `compile` path already returns P9999 as
+a normal diagnostic (`compiler/playground/src/lib.rs`).
+
+- `renderDiagnostics()` appends a report panel when any reportable code
+  (P9999) is present.
+- The panel's **Submit Code** button fires a new explicit PostHog event
+  `todo_report_submitted` carrying the compiled source (truncated), the error
+  codes, the diagnostic labels (which include `file#Lline`), program size,
+  dialect/allows, and compiler version. Super-properties (`program_origin`,
+  `embed`, `host_page`, …) attach automatically.
+- The panel also offers a secondary **"open a GitHub issue"** link, prefilled
+  with a `P9999` label, a title, and a body containing the diagnostics and —
+  for small programs that fit under the browser URL limit — the source in a
+  fenced block. Larger programs get an "attach the file" note instead.
+- After a successful submit the panel is replaced with a thank-you confirmation
+  and the button cannot be fired again (idempotent per render).
+
+## Reliable P9999 trigger for tests
+
+`%QX0.0 := TRUE;` (a direct hardware-address write) yields P9999 from
+`codegen/src/compile_expr.rs` and is genuinely out of scope for a software
+playground VM, so it is a stable e2e trigger. Verified against the built CLI.
+
+## File map
+
+- `playground/src/app.ts` — capture compiled source; render + wire the report
+  panel; PostHog `todo_report_submitted`; GitHub link builder.
+- `playground/style.css` — styles for the report panel, consent text, button,
+  confirmation.
+- `playground/index.html` — (only if a static hook is needed; prefer
+  dynamic rendering, so likely unchanged).
+- `playground/tests/e2e.spec.ts` — new e2e tests.
+- `infrastructure/posthog.tf` — new "Todo (P9999) code submissions" tile;
+  clarify the privacy comment to note this event intentionally carries source
+  on explicit user action.
+- `docs/reference/compiler/problems/P9999.rst` — mention the one-click
+  playground path alongside the existing GitHub link.
+
+## Tasks
+
+- [ ] Commit this plan.
+- [ ] app.ts: capture `lastCompiledSource`; add `REPORTABLE_CODES`; render the
+      report panel in `renderDiagnostics`; wire the Submit Code button to a new
+      `todo_report_submitted` capture; build the prefilled GitHub link; show the
+      confirmation and prevent double-submit.
+- [ ] style.css: style the report panel, consent line, button, and confirmation
+      (standalone + embed + light of existing dark theme vars).
+- [ ] e2e tests: panel appears on P9999; not on ordinary syntax error; Submit
+      Code fires the event and shows the confirmation; GitHub link is prefilled.
+- [ ] posthog.tf: add the submissions tile; clarify the privacy comment.
+- [ ] docs: update P9999.rst.
+- [ ] Verify: `tsc` typecheck; run playground e2e if the toolchain is available.


### PR DESCRIPTION
## Summary

Adds a low-friction, consent-forward "Submit Code" affordance to the playground diagnostics panel that appears when P9999 ("capability not implemented yet") diagnostics are shown. Users can submit their program source directly to the IronPLC team via PostHog without requiring a GitHub account, or open a prefilled GitHub issue as an alternative.

## Key Changes

- **Capture compiled source** (`app.ts`): Store `lastCompiledSource` when compilation starts so reports reflect what actually produced the diagnostics, even if the user continues typing.

- **Report panel rendering** (`app.ts`): When P9999 diagnostics appear, render a report panel with:
  - Clear consent language stating the program may be published publicly
  - A "Submit Code" button with explicit action verb
  - A secondary "open a GitHub issue" link with prefilled details

- **PostHog event capture** (`app.ts`): New `todo_report_submitted` event carries:
  - Program source (truncated to 50KB to prevent pathological pastes)
  - Error codes and diagnostic labels (including compiler `file#Lline` locations)
  - Program metadata (size, line count, dialect, allows, compiler version)
  - Transmission only on explicit user click (never automatic)

- **GitHub issue builder** (`app.ts`): Generates prefilled GitHub issue URLs with:
  - P9999 label and title
  - Diagnostic locations and compiler metadata
  - Program source inline when it fits under browser URL limits (~7KB)
  - "Attach the file" note for larger programs

- **Styling** (`style.css`): Added styles for report panel, consent text, button, and confirmation message with theme variable support.

- **E2E tests** (`e2e.spec.ts`): Four new tests verify:
  - Panel appears on P9999 (using `%QX0.0 := TRUE;` as reliable P9999 trigger)
  - Panel does not appear on ordinary syntax errors
  - Submit Code button captures event with program source
  - GitHub link is properly prefilled

- **Documentation** (`P9999.rst`): Updated to surface the playground one-click path as the easiest reporting method, with privacy notice.

- **Analytics** (`posthog.tf`): Added "P9999 code submissions" dashboard tile and clarified privacy comment to document that `todo_report_submitted` intentionally carries source on explicit, consented user action.

## Implementation Details

- **Consent-first UX**: Button text says exactly what happens ("Submit Code"), and a plain-language consent line directly above makes clear the code is shared and may become public.
- **Idempotent submission**: After successful submit, the panel is replaced with a confirmation and the button is removed, preventing double-submission.
- **Reliable P9999 trigger**: Direct hardware-address writes (`%QX0.0 := TRUE;`) reliably produce P9999 from code generation and are genuinely out of scope for a software playground VM.
- **URL length management**: GitHub issue URLs are kept under 7000 characters by omitting source when necessary.
- **Privacy preservation**: The existing automatic `compile_finished` event remains source-free; only the explicit `todo_report_submitted` event carries program code.

https://claude.ai/code/session_01WwpkRmJB3CJVFLRkmbHX8e