### PR TITLE
Align dependency update and Dependabot schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,37 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
+# All ecosystems run Saturday at 06:00 UTC, a few hours after the bulk
+# update workflow (update.yaml, Saturday 02:00 UTC) so Dependabot only
+# opens PRs for anything the bulk update could not handle.
+
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/integrations/vscode" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Etc/UTC"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/playground" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Etc/UTC"
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/compiler" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Etc/UTC"
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/docs" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -7,12 +7,13 @@
 #    2. Create the changes
 
 on:
-  # Automatically try to update every Friday at 19:00
-  # The idea is we do this before Dependabot's weekend run (so Dependabot finds
-  # nothing left to update individually) and before the weekly build on Monday
-  # so that the weekly build contains updated dependencies.
+  # Automatically try to update every Saturday at 02:00 UTC.
+  # The idea is we do this before Dependabot's Saturday 06:00 UTC run (so
+  # Dependabot finds nothing left to update individually) and before the
+  # weekly build on Monday so that the weekly build contains updated
+  # dependencies.
   schedule:
-      - cron: '0 19 * * 5'
+      - cron: '0 2 * * 6'
   # Allow triggering directly
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -7,11 +7,12 @@
 #    2. Create the changes
 
 on:
-  # Automatically try to update every Sunday at 19:00
-  # The idea is we do this a day before the weekly build so that the weekly build
-  # contains updated dependencies.
+  # Automatically try to update every Friday at 19:00
+  # The idea is we do this before Dependabot's weekend run (so Dependabot finds
+  # nothing left to update individually) and before the weekly build on Monday
+  # so that the weekly build contains updated dependencies.
   schedule:
-      - cron: '0 19 * * 0'
+      - cron: '0 19 * * 5'
   # Allow triggering directly
   workflow_dispatch:
     inputs:
@@ -85,10 +86,17 @@ jobs:
         with:
           ref: ${{ needs.update-dependencies.outputs.branch-name }}
           token: ${{secrets.IRONPLC_WORKFLOW_PUBLISH_ACCESS_TOKEN}}
+          # The rebase below needs the merge base between this branch and main.
+          # With the default shallow fetch there is no common ancestor, so the
+          # rebase sees unrelated histories and fails with add/add conflicts.
+          fetch-depth: 0
       - name: Fetch latest main
         run: git fetch origin main
       - name: Rebase branch on main
-        run: git rebase origin/main
+        run: |
+          git config user.name "Continuous Integration"
+          git config user.email "garretfick@users.noreply.github.com"
+          git rebase origin/main
       - name: Publish Changes
         if: ${{ !inputs.dryrun }}
         run: |


### PR DESCRIPTION
## Summary
Realign the automated dependency update workflow and Dependabot schedules to work together more effectively. The bulk update workflow now runs earlier in the week, allowing Dependabot to handle only remaining updates that the bulk workflow couldn't process.

## Key Changes
- **update.yaml**: Changed bulk update schedule from Sunday 19:00 UTC to Saturday 02:00 UTC, and added necessary git configuration for rebasing
  - Updated cron schedule: `0 19 * * 0` → `0 2 * * 6`
  - Added `fetch-depth: 0` to checkout action to ensure merge base is available for rebasing
  - Configured git user name and email before rebasing to prevent authentication failures
  - Updated comments to explain the new timing relative to Dependabot's run

- **.dependabot.yml**: Explicitly configured all four package ecosystems (npm, cargo, pip) to run on Saturday at 06:00 UTC
  - Added `day: "saturday"`, `time: "06:00"`, and `timezone: "Etc/UTC"` to all update entries
  - Added explanatory comment describing the coordination between bulk update and Dependabot workflows

## Implementation Details
The workflow now follows this sequence:
1. Saturday 02:00 UTC: Bulk update workflow runs and updates all dependencies it can handle
2. Saturday 06:00 UTC: Dependabot runs and only opens PRs for updates the bulk workflow couldn't process
3. Monday: Weekly build runs with all updated dependencies

This reduces duplicate PRs and consolidates dependency updates more efficiently.

https://claude.ai/code/session_01WRZ9v6pQSMmrarZJrYZvh9