### PR TITLE
Upgrade lsp-server to 0.9 and fix response deserialization

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-server"
-version = "0.7.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e"
+checksum = "62e55c013e58520c3471c904b6a4b95367acb73f20e718e1a0026d4297c9fc8e"
 dependencies = [
  "crossbeam-channel",
  "log",

--- a/compiler/ironplc-cli/Cargo.toml
+++ b/compiler/ironplc-cli/Cargo.toml
@@ -29,7 +29,7 @@ ironplc-vm = { path = "../vm", version = "0.228.0" }
 time = "0.3.47"
 clap = { version = "4.6", features = ["derive", "wrap_help"] }
 codespan-reporting = { version = "0.13" }
-lsp-server = "0.7"
+lsp-server = "0.9"
 lsp-types = "0.97"
 serde = "1.0"
 serde_json = "1.0"

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -661,7 +661,12 @@ mod test {
         fn receive_response<T: DeserializeOwned>(&mut self, request_id: RequestId) -> T {
             self.receive();
             let response = self.responses.get(&request_id).expect("No request");
-            let value = response.result.clone().unwrap();
+            let value = match &response.response_kind {
+                lsp_server::ResponseKind::Ok { result } => result.clone(),
+                lsp_server::ResponseKind::Err { error } => {
+                    panic!("Expected successful response but got error: {error:?}")
+                }
+            };
             serde_json::from_value::<T>(value).unwrap()
         }
 

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -661,12 +661,14 @@ mod test {
         fn receive_response<T: DeserializeOwned>(&mut self, request_id: RequestId) -> T {
             self.receive();
             let response = self.responses.get(&request_id).expect("No request");
-            let value = match &response.response_kind {
-                lsp_server::ResponseKind::Ok { result } => Some(result.clone()),
-                lsp_server::ResponseKind::Err { .. } => None,
-            }
-            .expect("Expected successful response");
-            serde_json::from_value::<T>(value).unwrap()
+            // A successful `ResponseKind` serializes to `{ "result": <value> }`;
+            // an error to `{ "error": ... }`, so `result` is absent on failure.
+            let value = serde_json::to_value(&response.response_kind).unwrap();
+            let result = value
+                .get("result")
+                .expect("Expected successful response")
+                .clone();
+            serde_json::from_value::<T>(result).unwrap()
         }
 
         fn receive_notification<T: DeserializeOwned>(&mut self) -> T {

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -662,11 +662,10 @@ mod test {
             self.receive();
             let response = self.responses.get(&request_id).expect("No request");
             let value = match &response.response_kind {
-                lsp_server::ResponseKind::Ok { result } => result.clone(),
-                lsp_server::ResponseKind::Err { error } => {
-                    panic!("Expected successful response but got error: {error:?}")
-                }
-            };
+                lsp_server::ResponseKind::Ok { result } => Some(result.clone()),
+                lsp_server::ResponseKind::Err { .. } => None,
+            }
+            .expect("Expected successful response");
             serde_json::from_value::<T>(value).unwrap()
         }
 


### PR DESCRIPTION
## Summary
Upgrades the `lsp-server` dependency from 0.7 to 0.9 and fixes the LSP test helper to correctly deserialize responses from the new version's `ResponseKind` structure.

## Changes
- **Dependency upgrade**: Updated `lsp-server` from 0.7 to 0.9 in `Cargo.toml`
- **Response deserialization fix**: Modified `receive_response()` test helper to properly extract the `result` field from the serialized `ResponseKind` structure
  - The new version serializes responses as `{ "result": <value> }` for success and `{ "error": ... }` for errors
  - Updated the helper to serialize `response_kind` to JSON and extract the `result` field before deserializing to the target type
  - Added clarifying comments explaining the response structure

## Implementation Details
The `lsp-server` 0.9 upgrade changed how responses are structured internally. The test helper now correctly handles this by:
1. Serializing the entire `response_kind` to a JSON value
2. Extracting the `result` field (which is absent on error responses)
3. Deserializing the extracted result to the expected type

This ensures test responses are properly validated and deserialized with the new library version.

https://claude.ai/code/session_012YhTUY3TEkP1AyjVqkNueR