### PR TITLE
chore: ignore TypeScript major version bumps in VSCode integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
       day: "saturday"
       time: "06:00"
       timezone: "Etc/UTC"
+    ignore:
+      # typescript-eslint (via @typescript-eslint/typescript-estree) pins its
+      # peer dependency to `typescript >=4.8.4 <6.1.0`, so no released version
+      # supports the TypeScript 7 native rewrite. Bumping typescript to a new
+      # major here breaks `npm install`, `tsc`, and eslint until the
+      # typescript-eslint ecosystem adds support. Re-enable major bumps once it
+      # does. See PR #1159.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/playground" # Location of package manifests
     schedule:


### PR DESCRIPTION
## Summary
Configure Dependabot to ignore major version updates for TypeScript in the VSCode integration due to ecosystem compatibility constraints.

## Changes
- Added ignore rule to `.github/dependabot.yml` for the VSCode integration to prevent Dependabot from proposing TypeScript major version bumps
- Included detailed explanation of the constraint: `typescript-eslint` (via `@typescript-eslint/typescript-estree`) pins its peer dependency to `typescript >=4.8.4 <6.1.0`, which prevents support for TypeScript 7's native rewrite
- Bumping TypeScript to a new major version breaks `npm install`, `tsc`, and eslint until the typescript-eslint ecosystem adds support

## Notes
This is a configuration-only change that prevents dependency management issues until the typescript-eslint ecosystem catches up with TypeScript 7 support. See PR #1159 for related context.

https://claude.ai/code/session_013Df5hTaKjBMHbsRNFjhoMu