### PR TITLE
Add actionlint for GitHub Actions workflow validation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,10 @@
           {
             "type": "command",
             "command": "which terraform >/dev/null 2>&1 || (echo 'Installing Terraform...' && sh scripts/install-terraform.sh 2>/dev/null) || echo 'Warning: could not install terraform. Run manually with: sh scripts/install-terraform.sh'"
+          },
+          {
+            "type": "command",
+            "command": "which actionlint >/dev/null 2>&1 || (echo 'Installing actionlint...' && GOBIN=/usr/local/bin go install github.com/rhysd/actionlint/cmd/actionlint@latest 2>/dev/null) || echo 'Warning: could not install actionlint. Run manually with: GOBIN=/usr/local/bin go install github.com/rhysd/actionlint/cmd/actionlint@latest'"
           }
         ]
       }

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,6 +40,12 @@ RUN cargo install --root /usr/local just
 RUN cargo install --root /usr/local cargo-release
 RUN cargo install --root /usr/local cargo-llvm-cov
 
+# Install actionlint (GitHub Actions workflow linter) so that changes to the
+# workflows under .github/workflows can be validated locally before pushing.
+# Downloads the latest release binary; tracks latest, same philosophy as the
+# Rust and Terraform tooling above.
+RUN curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest /usr/local/bin
+
 # Install typecript for the VS code extension
 RUN npm install -g typescript@5.1.6 vscode
 

--- a/justfile
+++ b/justfile
@@ -59,6 +59,11 @@ _ci-publish-workflow-unix:
 ci-update-dependencies-workflow:
   act workflow_dispatch --workflows ./.github/workflows/update.yaml --verbose
 
+# Lint the GitHub Actions workflows with actionlint. Run this to verify any
+# changes to files under .github/workflows/.
+check-actions:
+  actionlint
+
 get-next-version type:
   #! /bin/bash
   RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'


### PR DESCRIPTION
## Summary
Add actionlint, a linter for GitHub Actions workflows, to the development environment and CI tooling. This enables developers to validate changes to `.github/workflows/` files locally before pushing.

## Changes
- **Dockerfile**: Install actionlint from the latest release binary using the official download script
- **justfile**: Add `check-actions` recipe to run actionlint validation
- **.claude/settings.json**: Add actionlint installation check to Claude environment setup, with fallback Go installation method

## Implementation Details
- Actionlint is installed in the devcontainer using the official bash download script from the rhysd/actionlint repository, following the same pattern as existing Rust and Terraform tooling
- The `check-actions` justfile recipe provides a simple interface for developers to lint workflows locally
- Claude environment setup includes both the devcontainer installation path and a fallback Go installation method for flexibility

https://claude.ai/code/session_01PfYqVEt1pKHwzwvpfdgvVh