### PR TITLE
Use npm ci instead of npm install in justfiles

### DIFF
--- a/integrations/vscode/justfile
+++ b/integrations/vscode/justfile
@@ -13,7 +13,7 @@ ci:
 
 # Setup required dependencies. Use this to bootstrap a new host.
 setup:
-  npm install
+  npm ci
 
 # Compile the application code. Because this is type script, this effectively validates the code.
 compile:

--- a/playground/justfile
+++ b/playground/justfile
@@ -7,7 +7,7 @@ setup:
 # Build the wasm package and assemble the deployable site into _build/
 compile:
   mkdir -p _build/pkg
-  npm install
+  npm ci
   wasm-pack build ../compiler/playground --target web --out-dir ../../playground/_build/pkg --no-typescript
   cp node_modules/uplot/dist/uPlot.esm.js _build/
   cp node_modules/uplot/dist/uPlot.min.css _build/


### PR DESCRIPTION
Switch the VS Code extension setup recipe and the playground compile
recipe to use `npm ci` so automated GitHub Actions installs are
reproducible from package-lock.json.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011q5zPepc6EWbfeb9RiBanp