### PR TITLE
Attach Marketplace VSIX to GitHub Release

### DIFF
--- a/.github/workflows/partial_upload_release_artifacts.yaml
+++ b/.github/workflows/partial_upload_release_artifacts.yaml
@@ -61,8 +61,15 @@ jobs:
           fi
           find ./artifacts -path '*/ironplcc-*' -type f -exec cp {} release-assets/ \;
 
-          # VS Code extension VSIX.
+          # VS Code extension VSIX (Open VSX build, extension ID ironplc.ironplc).
           cp ./artifacts/ironplc-vscode-extension.vsix/ironplc-vscode-extension.vsix release-assets/
+
+          # Marketplace VSIX (Visual Studio Marketplace build, extension ID
+          # ironplc.ironplc-vscode). Attached to the GitHub Release so users can
+          # install the Marketplace build manually until automated Marketplace
+          # publishing is reinstated (Stage 2 of
+          # specs/plans/vscode-marketplace-extension-id.md).
+          cp ./artifacts/ironplc-vscode-extension-marketplace.vsix/ironplc-vscode-extension-marketplace.vsix release-assets/
 
           # SBOMs (renamed with the version number).
           cp ./artifacts/ironplc-compiler-sbom/bom.cdx.json \

--- a/.github/workflows/partial_vscode_extension.yaml
+++ b/.github/workflows/partial_vscode_extension.yaml
@@ -109,9 +109,9 @@ jobs:
           path: integrations/vscode/ironplc-vscode-extension.vsix
           if-no-files-found: error
       # Marketplace VSIX (ironplc.ironplc-vscode), uploaded as a separate build
-      # artifact for manual validation. The consolidated upload-release-artifacts
-      # job hand-picks known asset names, so this artifact is NOT attached to the
-      # GitHub Release. Publishing to the Marketplace remains deferred.
+      # artifact. The consolidated upload-release-artifacts job attaches it to
+      # the GitHub Release so users can install the Marketplace build manually.
+      # Automated publishing to the Marketplace remains deferred.
       - name: Upload Marketplace VSIX to build artifact
         if: ${{ inputs.marketplace-artifact-name }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/specs/plans/vscode-marketplace-extension-id.md
+++ b/specs/plans/vscode-marketplace-extension-id.md
@@ -55,11 +55,12 @@ Marketplace build (extension ID `ironplc.ironplc-vscode`) packages cleanly in
 CI. Packaging runs unconditionally; the resulting VSIX is uploaded as a separate
 build artifact when the optional `marketplace-artifact-name` input is set (the
 `deployment.yaml` and `integration.yaml` callers set it), so the VSIX can be
-downloaded and installed for **manual** validation. It is **not** published to
-the Marketplace, and — because the consolidated `upload-release-artifacts` job
-hand-picks known asset names — it is **not** attached to the GitHub Release. The
-packaging step runs after the Open VSX VSIX and the SBOM so its `package.json`
-`name` override does not affect those artifacts.
+downloaded and installed for **manual** validation. The consolidated
+`upload-release-artifacts` job attaches it to the GitHub Release so users can
+install the Marketplace build (extension ID `ironplc.ironplc-vscode`) manually.
+It is **not** automatically published to the Marketplace — that remains deferred
+to Stage 2. The packaging step runs after the Open VSX VSIX and the SBOM so its
+`package.json` `name` override does not affect those artifacts.
 
 ### Stage 2 — automate Marketplace publishing (deferred)
 


### PR DESCRIPTION
## Summary

The deployment build job (`partial_vscode_extension.yaml`) packages and uploads **two** VS Code extension VSIX build artifacts:

- `ironplc-vscode-extension.vsix` — the **Open VSX** build (extension ID `ironplc.ironplc`)
- `ironplc-vscode-extension-marketplace.vsix` — the **VS Code Marketplace** build (extension ID `ironplc.ironplc-vscode`)

However, the consolidated `upload-release-artifacts` job only attached the Open VSX VSIX to the GitHub Release, so the Marketplace build never appeared as a release asset.

This PR attaches the Marketplace VSIX to the GitHub Release as well, so users can install the Marketplace build manually until automated Marketplace publishing is reinstated.

## Changes

- **`.github/workflows/partial_upload_release_artifacts.yaml`** — copy `ironplc-vscode-extension-marketplace.vsix` into the release-asset set alongside the Open VSX VSIX. Uses a bare `cp` (no glob) so it fails loudly if the artifact is missing, matching the existing required-asset behavior. The job already downloads all build artifacts, and the only caller (`deployment.yaml`) always sets `marketplace-artifact-name`, so the artifact is always present.
- **`.github/workflows/partial_vscode_extension.yaml`** — update the now-stale comment that claimed the Marketplace VSIX was not attached to the release.
- **`specs/plans/vscode-marketplace-extension-id.md`** — update the Stage 1.5 note to reflect that the Marketplace VSIX is now a release asset.

## Notes

This only attaches the VSIX to the **GitHub Release** for manual install. It does **not** enable automated publishing to the VS Code Marketplace, which remains deferred (Stage 2) and is separately blocked on the Marketplace listing being restored.

`actionlint` passes on both workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014gZcsJoNP6bedqwqiRaWvR)_