### PR TITLE
Keep trap v-code structured through the playground WASM boundary

### DIFF
--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -23,7 +23,6 @@ use ironplc_dsl::core::FileId;
 use ironplc_dsl::diagnostic::{Diagnostic, LineColumn};
 use ironplc_parser::options::{CompilerOptions, Dialect, FeatureDescriptor};
 use ironplc_sources::{parse_source, FileType};
-use ironplc_vm::error::Trap;
 use ironplc_vm::{Slot, Vm, VmBuffers};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -190,19 +189,22 @@ fn diagnostic_info(diag: &Diagnostic, source: &str) -> DiagnosticInfo {
     }
 }
 
-/// A VM fault carried across a helper boundary without flattening the trap's
-/// structured v-code into the message string.
+/// A structured runtime error surfaced across the WASM boundary.
 ///
-/// Keeps the [`Trap`] itself (rather than pre-stringifying its code) so the
-/// boundary preserves the structured VM code: the caller reads a human-readable
-/// [`message`](Self::message) and derives the stable v-code (e.g. `"V4001"`)
-/// from [`Trap::v_code`] only when it builds the JSON result.
-struct VmFault {
-    /// The trap that halted execution, kept structured so `Trap::v_code` is
-    /// available at the boundary.
-    trap: Trap,
-    /// Human-readable message including task and instance context.
+/// Carries a human-readable `message` and, for VM traps, the trap's stable
+/// v-code (e.g. `"V4001"`). Kept as a single object — rather than sibling
+/// `error`/`error_code` fields — so the front end can treat it uniformly with a
+/// compiler diagnostic (which likewise has a message and a code) and render
+/// both through one path. This shape is also the natural fit as the playground
+/// moves toward JSON-RPC.
+#[derive(Debug, Serialize, Deserialize)]
+struct RunError {
+    /// Human-readable message including task and instance context for traps.
     message: String,
+    /// The trap's stable v-code (e.g. `"V4001"`). Absent for non-trap errors
+    /// such as a decode failure or a missing stepping session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    code: Option<String>,
 }
 
 /// Result of executing bytecode.
@@ -213,12 +215,7 @@ struct RunResult {
     variables: Vec<VariableInfo>,
     scans_completed: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-    /// The faulting trap's stable v-code (e.g. `"V4001"`) when execution
-    /// stopped on a VM trap. Kept separate from `error` so callers can act on
-    /// the code without re-parsing the message. Absent when there was no trap.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    error_code: Option<String>,
+    error: Option<RunError>,
 }
 
 /// A variable value read from the VM after execution.
@@ -474,7 +471,7 @@ struct RunSourceResult {
     variables: Vec<VariableInfo>,
     scans_completed: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
+    error: Option<RunError>,
 }
 
 /// Result of a step-through operation (load or step).
@@ -487,12 +484,7 @@ struct StepResult {
     variables: Vec<VariableInfo>,
     total_scans: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-    /// The faulting trap's stable v-code (e.g. `"V4001"`) when a step stopped
-    /// on a VM trap. Kept separate from `error` so callers can act on the code
-    /// without re-parsing the message. Absent when there was no trap.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    error_code: Option<String>,
+    error: Option<RunError>,
 }
 
 /// Parse IEC 61131-3 source code and produce bytecode.
@@ -622,7 +614,7 @@ fn compile_inner(source: &str, dialect: &str, allows: &str) -> CompileResult {
 pub fn run(bytecode_base64: &str, scans: u32) -> String {
     let result = run_inner(bytecode_base64, scans);
     serde_json::to_string(&result).unwrap_or_else(|e| {
-        format!(r#"{{"ok":false,"variables":[],"scans_completed":0,"error":"Serialization error: {e}"}}"#)
+        format!(r#"{{"ok":false,"variables":[],"scans_completed":0,"error":{{"message":"Serialization error: {e}"}}}}"#)
     })
 }
 
@@ -634,8 +626,10 @@ fn run_inner(bytecode_base64: &str, scans: u32) -> RunResult {
                 ok: false,
                 variables: vec![],
                 scans_completed: 0,
-                error: Some(format!("Invalid base64: {e}")),
-                error_code: None,
+                error: Some(RunError {
+                    message: format!("Invalid base64: {e}"),
+                    code: None,
+                }),
             };
         }
     };
@@ -651,8 +645,10 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
                 ok: false,
                 variables: vec![],
                 scans_completed: 0,
-                error: Some(format!("Invalid bytecode container: {e}")),
-                error_code: None,
+                error: Some(RunError {
+                    message: format!("Invalid bytecode container: {e}"),
+                    code: None,
+                }),
             };
         }
     };
@@ -666,11 +662,13 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
                 ok: false,
                 variables: vec![],
                 scans_completed: 0,
-                error: Some(format!(
-                    "VM trap during init: {} (task {}, instance {})",
-                    ctx.trap, ctx.task_id, ctx.instance_id
-                )),
-                error_code: Some(ctx.trap.v_code().to_string()),
+                error: Some(RunError {
+                    message: format!(
+                        "VM trap during init: {} (task {}, instance {})",
+                        ctx.trap, ctx.task_id, ctx.instance_id
+                    ),
+                    code: Some(ctx.trap.v_code().to_string()),
+                }),
             };
         }
     };
@@ -697,13 +695,15 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
                 ok: false,
                 variables,
                 scans_completed: round as u64,
-                error: Some(format!(
-                    "VM trap: {} (task {}, instance {})",
-                    faulted.trap(),
-                    faulted.task_id(),
-                    faulted.instance_id()
-                )),
-                error_code: Some(faulted.trap().v_code().to_string()),
+                error: Some(RunError {
+                    message: format!(
+                        "VM trap: {} (task {}, instance {})",
+                        faulted.trap(),
+                        faulted.task_id(),
+                        faulted.instance_id()
+                    ),
+                    code: Some(faulted.trap().v_code().to_string()),
+                }),
             };
         }
     }
@@ -719,7 +719,6 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
         variables,
         scans_completed,
         error: None,
-        error_code: None,
     }
 }
 
@@ -730,7 +729,7 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
 pub fn run_source(source: &str, scans: u32, dialect: &str, allows: &str) -> String {
     let result = run_source_inner(source, scans, dialect, allows);
     serde_json::to_string(&result).unwrap_or_else(|e| {
-        format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"scans_completed":0,"error":"Serialization error: {e}"}}"#)
+        format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"scans_completed":0,"error":{{"message":"Serialization error: {e}"}}}}"#)
     })
 }
 
@@ -841,7 +840,7 @@ fn format_value(
 pub fn load_program(source: &str, cycle_time_us: u32, dialect: &str, allows: &str) -> String {
     let result = load_program_inner(source, cycle_time_us, dialect, allows);
     serde_json::to_string(&result).unwrap_or_else(|e| {
-        format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"total_scans":0,"error":"Serialization error: {e}"}}"#)
+        format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"total_scans":0,"error":{{"message":"Serialization error: {e}"}}}}"#)
     })
 }
 
@@ -854,7 +853,6 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
             variables: vec![],
             total_scans: 0,
             error: None,
-            error_code: None,
         };
     }
 
@@ -869,8 +867,10 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
                 diagnostics: vec![],
                 variables: vec![],
                 total_scans: 0,
-                error: Some(format!("Failed to load bytecode: {e}")),
-                error_code: None,
+                error: Some(RunError {
+                    message: format!("Failed to load bytecode: {e}"),
+                    code: None,
+                }),
             };
         }
     };
@@ -889,8 +889,10 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
                 diagnostics: vec![],
                 variables: vec![],
                 total_scans: 0,
-                error: Some(format!("VM init trap: {}", ctx.trap)),
-                error_code: Some(ctx.trap.v_code().to_string()),
+                error: Some(RunError {
+                    message: format!("VM init trap: {}", ctx.trap),
+                    code: Some(ctx.trap.v_code().to_string()),
+                }),
             };
         }
     }
@@ -912,7 +914,6 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
         variables: vec![],
         total_scans: 0,
         error: None,
-        error_code: None,
     }
 }
 
@@ -924,7 +925,7 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
 pub fn step(scans: u32) -> String {
     let result = step_inner(scans);
     serde_json::to_string(&result).unwrap_or_else(|e| {
-        format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"total_scans":0,"error":"Serialization error: {e}"}}"#)
+        format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"total_scans":0,"error":{{"message":"Serialization error: {e}"}}}}"#)
     })
 }
 
@@ -939,8 +940,10 @@ fn step_inner(scans: u32) -> StepResult {
                     diagnostics: vec![],
                     variables: vec![],
                     total_scans: 0,
-                    error: Some("No program loaded. Call load_program first.".to_string()),
-                    error_code: None,
+                    error: Some(RunError {
+                        message: "No program loaded. Call load_program first.".to_string(),
+                        code: None,
+                    }),
                 };
             }
         };
@@ -951,8 +954,10 @@ fn step_inner(scans: u32) -> StepResult {
                 diagnostics: vec![],
                 variables: vec![],
                 total_scans: 0,
-                error: Some("Session is faulted. Call reset_session to start over.".to_string()),
-                error_code: None,
+                error: Some(RunError {
+                    message: "Session is faulted. Call reset_session to start over.".to_string(),
+                    code: None,
+                }),
             };
         }
 
@@ -964,13 +969,15 @@ fn step_inner(scans: u32) -> StepResult {
                     diagnostics: vec![],
                     variables: vec![],
                     total_scans: 0,
-                    error: Some(format!("Failed to load bytecode: {e}")),
-                    error_code: None,
+                    error: Some(RunError {
+                        message: format!("Failed to load bytecode: {e}"),
+                        code: None,
+                    }),
                 };
             }
         };
 
-        let (variables, total_scans, fault) = run_vm_step(
+        let (variables, total_scans, error) = run_vm_step(
             &container,
             &mut session.var_buf,
             &mut session.data_region,
@@ -980,14 +987,9 @@ fn step_inner(scans: u32) -> StepResult {
         );
 
         session.scan_count = total_scans;
-        if fault.is_some() {
+        if error.is_some() {
             session.faulted = true;
         }
-
-        let (error, error_code) = match fault {
-            Some(f) => (Some(f.message), Some(f.trap.v_code().to_string())),
-            None => (None, None),
-        };
 
         StepResult {
             ok: error.is_none(),
@@ -995,7 +997,6 @@ fn step_inner(scans: u32) -> StepResult {
             variables,
             total_scans,
             error,
-            error_code,
         }
     })
 }
@@ -1006,8 +1007,8 @@ fn step_inner(scans: u32) -> StepResult {
 /// (including initial values) persist across calls. The VM's internal scan
 /// counter is the source of truth for total cycles executed.
 ///
-/// Returns `(variables, total_scan_count, fault)`, where `fault` carries the
-/// structured [`Trap`] (and its message) when execution stopped on a trap.
+/// Returns `(variables, total_scan_count, error)`, where `error` carries the
+/// message and the trap's v-code when execution stopped on a trap.
 fn run_vm_step(
     container: &Container,
     var_buf: &mut Vec<Slot>,
@@ -1015,7 +1016,7 @@ fn run_vm_step(
     base_scan_count: u64,
     scans: u32,
     cycle_time_us: u64,
-) -> (Vec<VariableInfo>, u64, Option<VmFault>) {
+) -> (Vec<VariableInfo>, u64, Option<RunError>) {
     let mut bufs = VmBuffers::from_container(container);
     // Swap the session's persistent buffers into VmBuffers so the VM
     // operates on them directly, avoiding a copy.
@@ -1039,7 +1040,7 @@ fn run_vm_scans(
     base_scan_count: u64,
     scans: u32,
     cycle_time_us: u64,
-) -> (Vec<VariableInfo>, u64, Option<VmFault>) {
+) -> (Vec<VariableInfo>, u64, Option<RunError>) {
     let mut running = Vm::new().load(container, bufs).resume(base_scan_count);
 
     for _ in 0..scans {
@@ -1060,17 +1061,16 @@ fn run_vm_scans(
                 &string_layouts,
             );
             let faulted = running.fault(ctx);
-            let message = format!(
-                "VM trap: {} (task {}, instance {})",
-                faulted.trap(),
-                faulted.task_id(),
-                faulted.instance_id()
-            );
-            let fault = VmFault {
-                trap: faulted.trap().clone(),
-                message,
+            let error = RunError {
+                message: format!(
+                    "VM trap: {} (task {}, instance {})",
+                    faulted.trap(),
+                    faulted.task_id(),
+                    faulted.instance_id()
+                ),
+                code: Some(faulted.trap().v_code().to_string()),
             };
-            return (variables, total_scans, Some(fault));
+            return (variables, total_scans, Some(error));
         }
     }
 
@@ -1164,10 +1164,10 @@ END_PROGRAM
     }
 
     #[test]
-    fn run_when_program_traps_then_error_code_is_v_code() {
+    fn run_when_program_traps_then_error_has_v_code() {
         // Divide-by-zero traps with v-code V4001. The structured code must
-        // survive the WASM boundary as RunResult.error_code, not just be
-        // flattened into the error message.
+        // survive the WASM boundary in the error object's `code` member, not be
+        // flattened into the message.
         let source = "
 PROGRAM main
   VAR
@@ -1184,9 +1184,10 @@ END_PROGRAM
         let json = run(&bytecode, 1);
         let result: RunResult = serde_json::from_str(&json).unwrap();
         assert!(!result.ok);
-        assert_eq!(result.error_code.as_deref(), Some("V4001"));
-        // The JSON payload carries the structured code alongside the message.
-        assert!(json.contains("\"error_code\":\"V4001\""));
+        let error = result.error.expect("expected a runtime error");
+        assert_eq!(error.code.as_deref(), Some("V4001"));
+        // The JSON payload carries the code as a member of the error object.
+        assert!(json.contains("\"code\":\"V4001\""));
     }
 
     #[test]
@@ -1322,7 +1323,7 @@ END_PROGRAM
         reset_session();
         let result: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert!(!result.ok);
-        assert!(result.error.unwrap().contains("No program loaded"));
+        assert!(result.error.unwrap().message.contains("No program loaded"));
     }
 
     #[test]
@@ -1404,12 +1405,12 @@ END_PROGRAM
         // First step should fault (divide by zero)
         let r1: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert!(!r1.ok);
-        assert!(r1.error.as_ref().unwrap().contains("VM trap"));
+        assert!(r1.error.as_ref().unwrap().message.contains("VM trap"));
 
         // Subsequent step should report faulted session
         let r2: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert!(!r2.ok);
-        assert!(r2.error.unwrap().contains("faulted"));
+        assert!(r2.error.unwrap().message.contains("faulted"));
     }
 
     #[test]
@@ -1430,7 +1431,7 @@ END_PROGRAM
         // After reset, step should fail with no session
         let result: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert!(!result.ok);
-        assert!(result.error.unwrap().contains("No program loaded"));
+        assert!(result.error.unwrap().message.contains("No program loaded"));
     }
 
     #[test]

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -23,6 +23,7 @@ use ironplc_dsl::core::FileId;
 use ironplc_dsl::diagnostic::{Diagnostic, LineColumn};
 use ironplc_parser::options::{CompilerOptions, Dialect, FeatureDescriptor};
 use ironplc_sources::{parse_source, FileType};
+use ironplc_vm::error::Trap;
 use ironplc_vm::{Slot, Vm, VmBuffers};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -189,6 +190,21 @@ fn diagnostic_info(diag: &Diagnostic, source: &str) -> DiagnosticInfo {
     }
 }
 
+/// A VM fault carried across a helper boundary without flattening the trap's
+/// structured v-code into the message string.
+///
+/// Keeps the [`Trap`] itself (rather than pre-stringifying its code) so the
+/// boundary preserves the structured VM code: the caller reads a human-readable
+/// [`message`](Self::message) and derives the stable v-code (e.g. `"V4001"`)
+/// from [`Trap::v_code`] only when it builds the JSON result.
+struct VmFault {
+    /// The trap that halted execution, kept structured so `Trap::v_code` is
+    /// available at the boundary.
+    trap: Trap,
+    /// Human-readable message including task and instance context.
+    message: String,
+}
+
 /// Result of executing bytecode.
 #[derive(Serialize, Deserialize)]
 struct RunResult {
@@ -198,6 +214,11 @@ struct RunResult {
     scans_completed: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    /// The faulting trap's stable v-code (e.g. `"V4001"`) when execution
+    /// stopped on a VM trap. Kept separate from `error` so callers can act on
+    /// the code without re-parsing the message. Absent when there was no trap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    error_code: Option<String>,
 }
 
 /// A variable value read from the VM after execution.
@@ -467,6 +488,11 @@ struct StepResult {
     total_scans: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    /// The faulting trap's stable v-code (e.g. `"V4001"`) when a step stopped
+    /// on a VM trap. Kept separate from `error` so callers can act on the code
+    /// without re-parsing the message. Absent when there was no trap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    error_code: Option<String>,
 }
 
 /// Parse IEC 61131-3 source code and produce bytecode.
@@ -609,6 +635,7 @@ fn run_inner(bytecode_base64: &str, scans: u32) -> RunResult {
                 variables: vec![],
                 scans_completed: 0,
                 error: Some(format!("Invalid base64: {e}")),
+                error_code: None,
             };
         }
     };
@@ -625,6 +652,7 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
                 variables: vec![],
                 scans_completed: 0,
                 error: Some(format!("Invalid bytecode container: {e}")),
+                error_code: None,
             };
         }
     };
@@ -642,6 +670,7 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
                     "VM trap during init: {} (task {}, instance {})",
                     ctx.trap, ctx.task_id, ctx.instance_id
                 )),
+                error_code: Some(ctx.trap.v_code().to_string()),
             };
         }
     };
@@ -674,6 +703,7 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
                     faulted.task_id(),
                     faulted.instance_id()
                 )),
+                error_code: Some(faulted.trap().v_code().to_string()),
             };
         }
     }
@@ -689,6 +719,7 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
         variables,
         scans_completed,
         error: None,
+        error_code: None,
     }
 }
 
@@ -823,6 +854,7 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
             variables: vec![],
             total_scans: 0,
             error: None,
+            error_code: None,
         };
     }
 
@@ -838,6 +870,7 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
                 variables: vec![],
                 total_scans: 0,
                 error: Some(format!("Failed to load bytecode: {e}")),
+                error_code: None,
             };
         }
     };
@@ -857,6 +890,7 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
                 variables: vec![],
                 total_scans: 0,
                 error: Some(format!("VM init trap: {}", ctx.trap)),
+                error_code: Some(ctx.trap.v_code().to_string()),
             };
         }
     }
@@ -878,6 +912,7 @@ fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &
         variables: vec![],
         total_scans: 0,
         error: None,
+        error_code: None,
     }
 }
 
@@ -905,6 +940,7 @@ fn step_inner(scans: u32) -> StepResult {
                     variables: vec![],
                     total_scans: 0,
                     error: Some("No program loaded. Call load_program first.".to_string()),
+                    error_code: None,
                 };
             }
         };
@@ -916,6 +952,7 @@ fn step_inner(scans: u32) -> StepResult {
                 variables: vec![],
                 total_scans: 0,
                 error: Some("Session is faulted. Call reset_session to start over.".to_string()),
+                error_code: None,
             };
         }
 
@@ -928,11 +965,12 @@ fn step_inner(scans: u32) -> StepResult {
                     variables: vec![],
                     total_scans: 0,
                     error: Some(format!("Failed to load bytecode: {e}")),
+                    error_code: None,
                 };
             }
         };
 
-        let (variables, total_scans, error) = run_vm_step(
+        let (variables, total_scans, fault) = run_vm_step(
             &container,
             &mut session.var_buf,
             &mut session.data_region,
@@ -942,9 +980,14 @@ fn step_inner(scans: u32) -> StepResult {
         );
 
         session.scan_count = total_scans;
-        if error.is_some() {
+        if fault.is_some() {
             session.faulted = true;
         }
+
+        let (error, error_code) = match fault {
+            Some(f) => (Some(f.message), Some(f.trap.v_code().to_string())),
+            None => (None, None),
+        };
 
         StepResult {
             ok: error.is_none(),
@@ -952,6 +995,7 @@ fn step_inner(scans: u32) -> StepResult {
             variables,
             total_scans,
             error,
+            error_code,
         }
     })
 }
@@ -962,7 +1006,8 @@ fn step_inner(scans: u32) -> StepResult {
 /// (including initial values) persist across calls. The VM's internal scan
 /// counter is the source of truth for total cycles executed.
 ///
-/// Returns `(variables, total_scan_count, error)`.
+/// Returns `(variables, total_scan_count, fault)`, where `fault` carries the
+/// structured [`Trap`] (and its message) when execution stopped on a trap.
 fn run_vm_step(
     container: &Container,
     var_buf: &mut Vec<Slot>,
@@ -970,7 +1015,7 @@ fn run_vm_step(
     base_scan_count: u64,
     scans: u32,
     cycle_time_us: u64,
-) -> (Vec<VariableInfo>, u64, Option<String>) {
+) -> (Vec<VariableInfo>, u64, Option<VmFault>) {
     let mut bufs = VmBuffers::from_container(container);
     // Swap the session's persistent buffers into VmBuffers so the VM
     // operates on them directly, avoiding a copy.
@@ -994,7 +1039,7 @@ fn run_vm_scans(
     base_scan_count: u64,
     scans: u32,
     cycle_time_us: u64,
-) -> (Vec<VariableInfo>, u64, Option<String>) {
+) -> (Vec<VariableInfo>, u64, Option<VmFault>) {
     let mut running = Vm::new().load(container, bufs).resume(base_scan_count);
 
     for _ in 0..scans {
@@ -1015,13 +1060,17 @@ fn run_vm_scans(
                 &string_layouts,
             );
             let faulted = running.fault(ctx);
-            let error = format!(
+            let message = format!(
                 "VM trap: {} (task {}, instance {})",
                 faulted.trap(),
                 faulted.task_id(),
                 faulted.instance_id()
             );
-            return (variables, total_scans, Some(error));
+            let fault = VmFault {
+                trap: faulted.trap().clone(),
+                message,
+            };
+            return (variables, total_scans, Some(fault));
         }
     }
 
@@ -1112,6 +1161,32 @@ END_PROGRAM
         assert_eq!(result.scans_completed, 1);
         assert!(!result.variables.is_empty());
         assert_eq!(result.variables[2].value, "42"); // indices 0-1 are system globals
+    }
+
+    #[test]
+    fn run_when_program_traps_then_error_code_is_v_code() {
+        // Divide-by-zero traps with v-code V4001. The structured code must
+        // survive the WASM boundary as RunResult.error_code, not just be
+        // flattened into the error message.
+        let source = "
+PROGRAM main
+  VAR
+    x : DINT;
+    y : DINT;
+  END_VAR
+  y := 0;
+  x := 1 / y;
+END_PROGRAM
+";
+        let compile_result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let bytecode = compile_result.bytecode.unwrap();
+
+        let json = run(&bytecode, 1);
+        let result: RunResult = serde_json::from_str(&json).unwrap();
+        assert!(!result.ok);
+        assert_eq!(result.error_code.as_deref(), Some("V4001"));
+        // The JSON payload carries the structured code alongside the message.
+        assert!(json.contains("\"error_code\":\"V4001\""));
     }
 
     #[test]

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -2,6 +2,7 @@ import uPlot from "./uPlot.esm.js";
 import type {
   Diagnostic,
   DialectOption,
+  RunError,
   RunResult,
   Variable,
   WorkerRequest,
@@ -206,6 +207,19 @@ function markModified(): void {
   if (programModifiedRegistered) return;
   programModifiedRegistered = true;
   registerSuper({ program_modified: true });
+}
+
+// A runtime failure (a VM trap, or an infrastructure error like a decode
+// failure) carries the same message/code shape as a compiler diagnostic, so
+// present it as one. Runtime errors have no source location, so the line/column
+// fields are 0 — renderDiagnostics omits the location line when they are.
+function runErrorToDiagnostic(error: RunError): Diagnostic {
+  return {
+    code: error.code ?? "",
+    message: error.message,
+    start_line: 0,
+    start_column: 0,
+  };
 }
 
 function extractErrorCodes(diagnostics: Diagnostic[] | undefined): string[] {
@@ -563,27 +577,24 @@ function startStepLoop(): void {
 
     const result = JSON.parse(msg.json) as RunResult;
     if (!result.ok) {
-      const diagnostics = result.diagnostics || [];
-      // Prefer compiler diagnostic codes; otherwise a VM trap carries its
-      // structured v-code in error_code (e.g. "V4001").
-      const errorCodes =
-        diagnostics.length > 0
-          ? extractErrorCodes(diagnostics)
-          : result.error_code
-            ? [result.error_code]
-            : [];
-      captureRunStopped("error", errorCodes);
+      // Compiler diagnostics and a runtime fault share one representation, so
+      // fold a runtime error into the diagnostics list and render both alike.
+      const compileDiagnostics = result.diagnostics || [];
+      const isRuntimeError = compileDiagnostics.length === 0 && !!result.error;
+      const diagnostics = result.error
+        ? [...compileDiagnostics, runErrorToDiagnostic(result.error)]
+        : compileDiagnostics;
+      captureRunStopped("error", extractErrorCodes(diagnostics));
       stopExecution();
-      if (diagnostics.length > 0) {
-        renderDiagnostics(diagnostics);
-        activateTab("diagnostics");
-        statusEl.textContent = `${diagnostics.length} error(s)`;
-      } else if (result.error) {
+      if (isRuntimeError) {
+        // A trap can leave meaningful variable state; show it alongside.
         renderVariables(result.variables || []);
-        diagnosticsPanel.innerHTML = `<p class="error-message">${escapeHtml(result.error)}</p>`;
-        statusEl.textContent = "Runtime error";
-        activateTab("diagnostics");
       }
+      renderDiagnostics(diagnostics);
+      activateTab("diagnostics");
+      statusEl.textContent = isRuntimeError
+        ? "Runtime error"
+        : `${diagnostics.length} error(s)`;
       return;
     }
 
@@ -686,13 +697,15 @@ startBtn.addEventListener("click", async () => {
 
   const loadResult = JSON.parse(loadMsg.json) as RunResult;
   if (!loadResult.ok) {
-    const diagnostics = loadResult.diagnostics || [];
+    // Fold a load-time runtime error (e.g. an init-time VM trap) into the
+    // diagnostics list so it renders through the same path as compiler errors.
+    const diagnostics = loadResult.error
+      ? [...(loadResult.diagnostics || []), runErrorToDiagnostic(loadResult.error)]
+      : loadResult.diagnostics || [];
     if (diagnostics.length > 0) {
       renderDiagnostics(diagnostics);
       activateTab("diagnostics");
       statusEl.textContent = `${diagnostics.length} error(s)`;
-    } else if (loadResult.error) {
-      statusEl.textContent = loadResult.error;
     }
     capture("compile_finished", {
       success: false,
@@ -915,12 +928,16 @@ function renderDiagnostics(diagnostics: Diagnostic[]): void {
   let html = "";
   for (const d of diagnostics) {
     html += '<div class="diagnostic-item">';
-    const code = escapeHtml(d.code);
-    if (/^P\d{4}$/.test(d.code)) {
-      const url = `https://www.ironplc.com/reference/compiler/problems/${d.code}.html?version=${encodeURIComponent(compilerVersion)}`;
-      html += `<a class="diagnostic-code" href="${url}" target="_blank" rel="noopener">${code}</a>`;
-    } else {
-      html += `<span class="diagnostic-code">${code}</span>`;
+    // Infrastructure errors (e.g. a decode failure) carry no code; skip the
+    // code chip rather than render an empty one.
+    if (d.code) {
+      const code = escapeHtml(d.code);
+      if (/^P\d{4}$/.test(d.code)) {
+        const url = `https://www.ironplc.com/reference/compiler/problems/${d.code}.html?version=${encodeURIComponent(compilerVersion)}`;
+        html += `<a class="diagnostic-code" href="${url}" target="_blank" rel="noopener">${code}</a>`;
+      } else {
+        html += `<span class="diagnostic-code">${code}</span>`;
+      }
     }
     let message = escapeHtml(d.message);
     if (d.label) {

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -564,7 +564,15 @@ function startStepLoop(): void {
     const result = JSON.parse(msg.json) as RunResult;
     if (!result.ok) {
       const diagnostics = result.diagnostics || [];
-      captureRunStopped("error", extractErrorCodes(diagnostics));
+      // Prefer compiler diagnostic codes; otherwise a VM trap carries its
+      // structured v-code in error_code (e.g. "V4001").
+      const errorCodes =
+        diagnostics.length > 0
+          ? extractErrorCodes(diagnostics)
+          : result.error_code
+            ? [result.error_code]
+            : [];
+      captureRunStopped("error", errorCodes);
       stopExecution();
       if (diagnostics.length > 0) {
         renderDiagnostics(diagnostics);

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -932,8 +932,16 @@ function renderDiagnostics(diagnostics: Diagnostic[]): void {
     // code chip rather than render an empty one.
     if (d.code) {
       const code = escapeHtml(d.code);
-      if (/^P\d{4}$/.test(d.code)) {
-        const url = `https://www.ironplc.com/reference/compiler/problems/${d.code}.html?version=${encodeURIComponent(compilerVersion)}`;
+      // P#### are compiler problems and V#### are runtime (VM) problems; each
+      // has a documentation page under a different section of the reference
+      // site. Codes outside these families render as plain, unlinked chips.
+      const section = /^P\d{4}$/.test(d.code)
+        ? "compiler"
+        : /^V\d{4}$/.test(d.code)
+          ? "runtime"
+          : null;
+      if (section) {
+        const url = `https://www.ironplc.com/reference/${section}/problems/${d.code}.html?version=${encodeURIComponent(compilerVersion)}`;
         html += `<a class="diagnostic-code" href="${url}" target="_blank" rel="noopener">${code}</a>`;
       } else {
         html += `<span class="diagnostic-code">${code}</span>`;

--- a/playground/src/types/messages.d.ts
+++ b/playground/src/types/messages.d.ts
@@ -122,6 +122,8 @@ export interface RunResultErr {
   ok: false;
   diagnostics?: Diagnostic[];
   error?: string;
+  /** The faulting trap's stable v-code (e.g. "V4001") on a VM trap. */
+  error_code?: string;
   variables?: Variable[];
 }
 

--- a/playground/src/types/messages.d.ts
+++ b/playground/src/types/messages.d.ts
@@ -118,12 +118,21 @@ export interface RunResultOk {
   variables: Variable[];
 }
 
+/**
+ * A structured runtime error. Shares its `message`/`code` shape with
+ * {@link Diagnostic} so the front end can render runtime failures and compiler
+ * diagnostics through a single path.
+ */
+export interface RunError {
+  message: string;
+  /** The faulting trap's stable v-code (e.g. "V4001"). Absent for non-trap errors. */
+  code?: string;
+}
+
 export interface RunResultErr {
   ok: false;
   diagnostics?: Diagnostic[];
-  error?: string;
-  /** The faulting trap's stable v-code (e.g. "V4001") on a VM trap. */
-  error_code?: string;
+  error?: RunError;
   variables?: Variable[];
 }
 


### PR DESCRIPTION
The playground fault sites flattened a VM trap into a single
"VM trap: <Display> ..." message and discarded the structured v-code.
Preserve the code instead:

- Add a `VmFault` carrier that keeps the `Trap` itself (not a
  pre-stringified code), so the v-code is derived from `Trap::v_code`
  only when the JSON result is built.
- Change the `run_vm_scans`/`run_vm_step` helpers to return
  `Option<VmFault>` instead of `Option<String>`.
- Add `error_code: Option<String>` to `RunResult` and `StepResult`
  (serde default + skip when None); the run/step callers now set
  `error` from the message and `error_code` from the trap's v-code.
- messages.d.ts: add `error_code?` to `RunResultErr`.
- app.ts: in the VM-trap branch, report the trap code to analytics
  via `captureRunStopped` instead of an empty list.

Adds a Rust test asserting a divide-by-zero program surfaces
`RunResult.error_code == "V4001"` in the JSON.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014HYrYD9UzyK7KqYFruWfiF