### PR TITLE
fix(lsp): adapt to lsp-server 0.10 Response API change

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-server"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e55c013e58520c3471c904b6a4b95367acb73f20e718e1a0026d4297c9fc8e"
+checksum = "3ee25a31f2e571e426eef2896179450cafc7e2f5be00d8a93b1c2d21c0ff7656"
 dependencies = [
  "crossbeam-channel",
  "log",

--- a/compiler/ironplc-cli/Cargo.toml
+++ b/compiler/ironplc-cli/Cargo.toml
@@ -29,7 +29,7 @@ ironplc-vm = { path = "../vm", version = "0.230.0" }
 time = "0.3.47"
 clap = { version = "4.6", features = ["derive", "wrap_help"] }
 codespan-reporting = { version = "0.13" }
-lsp-server = "0.9"
+lsp-server = "0.10"
 lsp-types = "0.97"
 serde = "1.0"
 serde_json = "1.0"

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -661,11 +661,11 @@ mod test {
         fn receive_response<T: DeserializeOwned>(&mut self, request_id: RequestId) -> T {
             self.receive();
             let response = self.responses.get(&request_id).expect("No request");
-            // A successful `ResponseKind` serializes to `{ "result": <value> }`;
-            // an error to `{ "error": ... }`, so `result` is absent on failure.
-            let value = serde_json::to_value(&response.response_kind).unwrap();
-            let result = value
-                .get("result")
+            // `response_result` is `Ok(value)` for a successful response and
+            // `Err(..)` for a failure, so `expect` asserts success here.
+            let result = response
+                .response_result
+                .as_ref()
                 .expect("Expected successful response")
                 .clone();
             serde_json::from_value::<T>(result).unwrap()


### PR DESCRIPTION
lsp-server 0.10.0 renamed `Response.response_kind` to `response_result`
and changed its type from the internal `ResponseKind` enum to a plain
`Result<serde_json::Value, ResponseError>`. Update the test helper to
read the `Result` directly instead of serializing the old field and
indexing into the JSON.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BsB4h1T8bgcmeVXfVMeqQL