### PR TITLE
feat(vm-cli): DAP initialize/launch/disconnect handshake (Phase 4.3)

### DIFF
--- a/compiler/vm-cli/resources/problem-codes.csv
+++ b/compiler/vm-cli/resources/problem-codes.csv
@@ -6,3 +6,6 @@ V6004,DumpCreate,Unable to create variable dump file
 V6005,VarRead,Unable to read variable value
 V6006,DumpWrite,Unable to write to variable dump file
 V6007,LogConfig,Unable to configure the logger
+V6008,LaunchNoProgram,Launch request did not specify a program container path
+V6009,LaunchNoDebugInfo,Container was compiled without debug information
+V6010,LaunchMultiInstance,Container declares multiple program instances

--- a/compiler/vm-cli/src/dap/debug_info.rs
+++ b/compiler/vm-cli/src/dap/debug_info.rs
@@ -1,0 +1,100 @@
+//! The single Layer-1-coupled corner of the DAP server.
+//!
+//! Everything that maps between the debugger's `(FunctionId, bytecode_offset)`
+//! space and *source* coordinates — source line → offset for breakpoints, and
+//! variable slot → name/type for inspection — lives here and nowhere else. The
+//! rest of the server speaks only in offsets and raw slot values, so the debug
+//! section (line map, VAR_NAME, `debug_format`) is a dependency of exactly one
+//! module.
+//!
+//! This first cut ships **passthrough** resolvers (see the plan,
+//! `specs/plans/2026-06-25-dap-server-scaffold.md` §"Debug-info coupling,
+//! isolated"): the DAP `line` is treated as a raw bytecode offset and slots are
+//! rendered by index with no names. The two function signatures are the stable
+//! seam — commit 5 swaps real line-map / `debug_format` lookups in behind them
+//! without touching any other module.
+//!
+//! Both resolvers are consumed by the run/stop loop that lands in commit 4
+//! (`setBreakpoints` and `variables`); until then they are exercised only by
+//! the unit tests below, hence the module-level `dead_code` allowance.
+#![allow(dead_code)]
+
+use ironplc_container::debug_section::DebugSection;
+use ironplc_container::FunctionId;
+
+use super::types::Variable;
+
+/// Resolve a source breakpoint to the `(function, bytecode offset)` locations
+/// that should be armed for it.
+///
+/// **Passthrough:** the DAP `line` is interpreted directly as a bytecode offset
+/// in the scan function, ignoring `debug` and `source_path`. A negative line
+/// (never produced by a conformant client) resolves to nothing. Commit 5
+/// replaces the body with a real line-map + SOURCE_FILE lookup keyed off
+/// `source_path`; this signature stays fixed.
+pub fn resolve_breakpoint(
+    _debug: Option<&DebugSection>,
+    _source_path: &str,
+    line: i64,
+) -> Vec<(FunctionId, usize)> {
+    if line < 0 {
+        return Vec::new();
+    }
+    vec![(FunctionId::SCAN, line as usize)]
+}
+
+/// Render a run of variable slots for a `variables` response.
+///
+/// `values[i]` is the raw 64-bit slot for variable index `i`. **Passthrough:**
+/// each slot is named `var[i]` and rendered as a signed 32-bit decimal, with no
+/// type — `debug` is ignored. Commit 5 replaces the body with VAR_NAME lookups
+/// for names/types and `debug_format::format_variable_value` for the value;
+/// this signature stays fixed.
+pub fn render_variables(_debug: Option<&DebugSection>, values: &[u64]) -> Vec<Variable> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(i, &raw)| Variable {
+            name: format!("var[{i}]"),
+            value: (raw as i32).to_string(),
+            type_name: None,
+            variables_reference: 0,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_breakpoint_when_line_nonnegative_then_offset_passthrough_in_scan() {
+        // The passthrough treats the line as a raw offset in the scan function.
+        let locations = resolve_breakpoint(None, "any.st", 6);
+        assert_eq!(locations, vec![(FunctionId::SCAN, 6)]);
+    }
+
+    #[test]
+    fn resolve_breakpoint_when_line_negative_then_no_locations() {
+        assert!(resolve_breakpoint(None, "any.st", -1).is_empty());
+    }
+
+    #[test]
+    fn render_variables_when_slots_given_then_indexed_names_and_i32_values() {
+        let vars = render_variables(None, &[10, 0xFFFF_FFFF, 42]);
+        assert_eq!(vars.len(), 3);
+        assert_eq!(vars[0].name, "var[0]");
+        assert_eq!(vars[0].value, "10");
+        assert!(vars[0].type_name.is_none());
+        assert_eq!(vars[0].variables_reference, 0);
+        // Low 32 bits interpreted as signed.
+        assert_eq!(vars[1].name, "var[1]");
+        assert_eq!(vars[1].value, "-1");
+        assert_eq!(vars[2].value, "42");
+    }
+
+    #[test]
+    fn render_variables_when_no_slots_then_empty() {
+        assert!(render_variables(None, &[]).is_empty());
+    }
+}

--- a/compiler/vm-cli/src/dap/framing.rs
+++ b/compiler/vm-cli/src/dap/framing.rs
@@ -19,9 +19,6 @@ use std::io::{self, BufRead, Write};
 
 /// Writes a single DAP message: the `Content-Length` header, the blank-line
 /// separator, then `body`. Flushes so the peer sees the message immediately.
-// The server loop (next commit) is the production caller; for now this send
-// half of the framing API is exercised only by the roundtrip unit tests.
-#[allow(dead_code)]
 pub fn write_message<W: Write>(writer: &mut W, body: &[u8]) -> io::Result<()> {
     write!(writer, "Content-Length: {}\r\n\r\n", body.len())?;
     writer.write_all(body)?;

--- a/compiler/vm-cli/src/dap/launch.rs
+++ b/compiler/vm-cli/src/dap/launch.rs
@@ -13,15 +13,20 @@
 //!    [`LaunchError::MultiInstanceUnsupported`] (the v1 limitation described in
 //!    `specs/design/debugger-support.md` §"Multi-instance: not supported in v1").
 
+use std::fmt;
 use std::fs::File;
 use std::path::Path;
 
 use ironplc_container::Container;
 use ironplc_vm::{Vm, VmBuffers, VmRunning};
 
-/// A reason a `launch` request could not be satisfied. Each maps to the
-/// human-readable [`message`](LaunchError::message) carried in the failing DAP
-/// response.
+use super::problem_codes;
+
+/// A reason a `launch` request could not be satisfied.
+///
+/// Each variant carries a stable IronPLC [`v_code`](LaunchError::v_code); the
+/// [`Display`] rendering is `"V#### - message"`, matching the CLI's `VmError`
+/// surface, and is what fills the failing DAP response's `message` field.
 #[derive(Debug)]
 pub enum LaunchError {
     /// The `launch` arguments carried no usable `program` path.
@@ -37,12 +42,31 @@ pub enum LaunchError {
     /// single-instance programs only. Carries the declared instance count.
     MultiInstanceUnsupported(usize),
     /// The VM could not be started (an init function trapped). Carries the
-    /// trap description.
-    VmStartFailed(String),
+    /// trap's own V-code and its description.
+    VmStartFailed {
+        v_code: &'static str,
+        detail: String,
+    },
 }
 
 impl LaunchError {
-    /// The message placed in the failing DAP response's `message` field.
+    /// The stable V-code for this failure. File errors reuse the CLI's existing
+    /// `V6001`/`V6002`; a start-time trap surfaces the trap's own `V4xxx`/
+    /// `V9xxx`; the launch-specific preconditions use the `V6008`–`V6010` codes.
+    pub fn v_code(&self) -> &'static str {
+        match self {
+            LaunchError::ProgramArgMissing => problem_codes::LAUNCH_NO_PROGRAM,
+            LaunchError::ContainerOpen(_) => problem_codes::FILE_OPEN,
+            LaunchError::ContainerRead(_) => problem_codes::CONTAINER_READ,
+            LaunchError::NoDebugInfo => problem_codes::LAUNCH_NO_DEBUG_INFO,
+            LaunchError::MultiInstanceUnsupported(_) => problem_codes::LAUNCH_MULTI_INSTANCE,
+            LaunchError::VmStartFailed { v_code, .. } => v_code,
+        }
+    }
+
+    /// The human-readable text (without the V-code prefix). The
+    /// spec-mandated `MultiInstanceUnsupported:` wording is preserved verbatim
+    /// (see `specs/design/debugger-support.md` §"Multi-instance").
     pub fn message(&self) -> String {
         match self {
             LaunchError::ProgramArgMissing => {
@@ -50,16 +74,24 @@ impl LaunchError {
             }
             LaunchError::ContainerOpen(detail) => format!("unable to open container: {detail}"),
             LaunchError::ContainerRead(detail) => format!("unable to read container: {detail}"),
-            LaunchError::NoDebugInfo => "NoDebugInfo: compile with debug info enabled".to_string(),
+            LaunchError::NoDebugInfo => "compile with debug info enabled".to_string(),
             LaunchError::MultiInstanceUnsupported(count) => format!(
                 "MultiInstanceUnsupported: this program declares {count} program instances; \
                  the v1 debugger supports single-instance programs only. Multi-instance \
                  debugging is planned for a future phase."
             ),
-            LaunchError::VmStartFailed(detail) => {
+            LaunchError::VmStartFailed { detail, .. } => {
                 format!("launch failed to start the VM: {detail}")
             }
         }
+    }
+}
+
+impl fmt::Display for LaunchError {
+    /// Renders `"V#### - message"`, matching the CLI's `VmError` surface so a
+    /// DAP client sees the same coded error text.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} - {}", self.v_code(), self.message())
     }
 }
 
@@ -101,7 +133,10 @@ pub fn start_vm<'a>(
     Vm::new()
         .load(container, bufs)
         .start()
-        .map_err(|ctx| LaunchError::VmStartFailed(format!("{:?}", ctx.trap)))
+        .map_err(|ctx| LaunchError::VmStartFailed {
+            v_code: ctx.trap.v_code(),
+            detail: ctx.trap.to_string(),
+        })
 }
 
 #[cfg(test)]
@@ -171,8 +206,10 @@ mod tests {
             .build();
         let err = check_preconditions(&container).unwrap_err();
         assert!(matches!(err, LaunchError::NoDebugInfo));
-        assert!(err.message().contains("NoDebugInfo"));
+        assert_eq!(err.v_code(), "V6009");
         assert!(err.message().contains("debug info"));
+        // Display prefixes the V-code.
+        assert!(err.to_string().starts_with("V6009 - "));
     }
 
     #[test]
@@ -188,8 +225,10 @@ mod tests {
             .build();
         let err = check_preconditions(&container).unwrap_err();
         assert!(matches!(err, LaunchError::MultiInstanceUnsupported(2)));
+        assert_eq!(err.v_code(), "V6010");
         assert!(err.message().contains("MultiInstanceUnsupported"));
         assert!(err.message().contains("2 program instances"));
+        assert!(err.to_string().starts_with("V6010 - "));
     }
 
     #[test]
@@ -225,8 +264,11 @@ mod tests {
             Ok(_) => panic!("expected the dividing-by-zero init to trap"),
             Err(err) => err,
         };
-        assert!(matches!(err, LaunchError::VmStartFailed(_)));
+        assert!(matches!(err, LaunchError::VmStartFailed { .. }));
+        // The start-time trap surfaces its own V-code (divide by zero → V4001).
+        assert_eq!(err.v_code(), "V4001");
         assert!(err.message().contains("launch failed to start"));
+        assert!(err.to_string().starts_with("V4001 - "));
     }
 
     #[test]
@@ -234,6 +276,8 @@ mod tests {
         let err = load_container(Path::new("does/not/exist.iplc")).unwrap_err();
         assert!(matches!(err, LaunchError::ContainerOpen(_)));
         assert!(err.message().contains("unable to open"));
+        // Reuses the CLI's existing file-open code.
+        assert_eq!(err.v_code(), "V6001");
     }
 
     #[test]
@@ -245,6 +289,8 @@ mod tests {
         let err = load_container(file.path()).unwrap_err();
         assert!(matches!(err, LaunchError::ContainerRead(_)));
         assert!(err.message().contains("unable to read container"));
+        // Reuses the CLI's existing container-read code.
+        assert_eq!(err.v_code(), "V6002");
     }
 
     #[test]
@@ -252,5 +298,10 @@ mod tests {
         assert!(LaunchError::ProgramArgMissing
             .message()
             .contains("'program' path"));
+        assert_eq!(LaunchError::ProgramArgMissing.v_code(), "V6008");
+        assert_eq!(
+            LaunchError::ProgramArgMissing.to_string(),
+            "V6008 - launch requires a 'program' path to a compiled .iplc container"
+        );
     }
 }

--- a/compiler/vm-cli/src/dap/launch.rs
+++ b/compiler/vm-cli/src/dap/launch.rs
@@ -1,0 +1,256 @@
+//! `launch` preconditions and VM construction.
+//!
+//! On a DAP `launch`, the server loads the requested container, checks the two
+//! v1 preconditions, and — if they hold — sizes the VM buffers and starts the
+//! VM. The buffer sizing reuses `VmBuffers::from_container` (the same embedding
+//! path the production `ironplcvm` binary uses in `cli.rs`), so there is no
+//! duplicated sizing logic here.
+//!
+//! The preconditions (see the plan,
+//! `specs/plans/2026-06-25-dap-server-scaffold.md` §"Launch preconditions"):
+//! 1. A debug section must be present, else [`LaunchError::NoDebugInfo`].
+//! 2. There must be exactly one program instance, else
+//!    [`LaunchError::MultiInstanceUnsupported`] (the v1 limitation described in
+//!    `specs/design/debugger-support.md` §"Multi-instance: not supported in v1").
+
+use std::fs::File;
+use std::path::Path;
+
+use ironplc_container::Container;
+use ironplc_vm::{Vm, VmBuffers, VmRunning};
+
+/// A reason a `launch` request could not be satisfied. Each maps to the
+/// human-readable [`message`](LaunchError::message) carried in the failing DAP
+/// response.
+#[derive(Debug)]
+pub enum LaunchError {
+    /// The `launch` arguments carried no usable `program` path.
+    ProgramArgMissing,
+    /// The container file could not be opened.
+    ContainerOpen(String),
+    /// The container file could not be parsed.
+    ContainerRead(String),
+    /// The container has no debug section, so no source-level debugging is
+    /// possible.
+    NoDebugInfo,
+    /// The container declares more than one program instance; v1 debugs
+    /// single-instance programs only. Carries the declared instance count.
+    MultiInstanceUnsupported(usize),
+    /// The VM could not be started (an init function trapped). Carries the
+    /// trap description.
+    VmStartFailed(String),
+}
+
+impl LaunchError {
+    /// The message placed in the failing DAP response's `message` field.
+    pub fn message(&self) -> String {
+        match self {
+            LaunchError::ProgramArgMissing => {
+                "launch requires a 'program' path to a compiled .iplc container".to_string()
+            }
+            LaunchError::ContainerOpen(detail) => format!("unable to open container: {detail}"),
+            LaunchError::ContainerRead(detail) => format!("unable to read container: {detail}"),
+            LaunchError::NoDebugInfo => "NoDebugInfo: compile with debug info enabled".to_string(),
+            LaunchError::MultiInstanceUnsupported(count) => format!(
+                "MultiInstanceUnsupported: this program declares {count} program instances; \
+                 the v1 debugger supports single-instance programs only. Multi-instance \
+                 debugging is planned for a future phase."
+            ),
+            LaunchError::VmStartFailed(detail) => {
+                format!("launch failed to start the VM: {detail}")
+            }
+        }
+    }
+}
+
+/// Opens and parses the container at `path`.
+pub fn load_container(path: &Path) -> Result<Container, LaunchError> {
+    let mut file = File::open(path)
+        .map_err(|e| LaunchError::ContainerOpen(format!("{}: {e}", path.display())))?;
+    Container::read_from(&mut file)
+        .map_err(|e| LaunchError::ContainerRead(format!("{}: {e}", path.display())))
+}
+
+/// Checks the two v1 launch preconditions against a loaded container.
+///
+/// Debug info is checked first (per the plan), then the single-instance limit,
+/// so a container that is both missing debug info and multi-instance reports
+/// [`LaunchError::NoDebugInfo`].
+pub fn check_preconditions(container: &Container) -> Result<(), LaunchError> {
+    if container.debug_section.is_none() {
+        return Err(LaunchError::NoDebugInfo);
+    }
+    let instances = container.task_table.programs.len();
+    if instances != 1 {
+        return Err(LaunchError::MultiInstanceUnsupported(instances));
+    }
+    Ok(())
+}
+
+/// Loads the container, starts the VM into the caller-owned `bufs`, and returns
+/// the running VM.
+///
+/// The caller sizes `bufs` with [`VmBuffers::from_container`] and owns both
+/// `container` and `bufs` so the returned [`VmRunning`] can borrow them. This
+/// mirrors the `ironplcvm` `Run` embedding in `cli.rs`; the only added policy
+/// is mapping a start-time trap to [`LaunchError::VmStartFailed`].
+pub fn start_vm<'a>(
+    container: &'a Container,
+    bufs: &'a mut VmBuffers,
+) -> Result<VmRunning<'a>, LaunchError> {
+    Vm::new()
+        .load(container, bufs)
+        .start()
+        .map_err(|ctx| LaunchError::VmStartFailed(format!("{:?}", ctx.trap)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironplc_container::debug_section::{iec_type_tag, var_section, VarNameEntry};
+    use ironplc_container::{
+        ContainerBuilder, FunctionId, InstanceId, ProgramInstanceEntry, TaskEntry, TaskId,
+        TaskType, VarIndex,
+    };
+
+    fn a_var_name() -> VarNameEntry {
+        VarNameEntry {
+            var_index: VarIndex::new(0),
+            function_id: FunctionId::GLOBAL_SCOPE,
+            var_section: var_section::VAR,
+            iec_type_tag: iec_type_tag::DINT,
+            name: "x".into(),
+            type_name: "DINT".into(),
+        }
+    }
+
+    fn a_task(task_id: TaskId) -> TaskEntry {
+        TaskEntry {
+            task_id,
+            priority: 0,
+            task_type: TaskType::Freewheeling,
+            flags: 0x01,
+            interval_us: 0,
+            single_var_index: VarIndex::NO_SINGLE_VAR,
+            watchdog_us: 0,
+            input_image_offset: 0,
+            output_image_offset: 0,
+            reserved: [0; 4],
+        }
+    }
+
+    fn a_program(instance_id: InstanceId, task_id: TaskId) -> ProgramInstanceEntry {
+        ProgramInstanceEntry {
+            instance_id,
+            task_id,
+            entry_function_id: FunctionId::new(0),
+            var_table_offset: 0,
+            var_table_count: 1,
+            fb_instance_offset: 0,
+            fb_instance_count: 0,
+            init_function_id: FunctionId::new(0),
+        }
+    }
+
+    #[test]
+    fn check_preconditions_when_debug_and_single_instance_then_ok() {
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .add_var_name(a_var_name())
+            .build();
+        assert!(check_preconditions(&container).is_ok());
+    }
+
+    #[test]
+    fn check_preconditions_when_no_debug_section_then_no_debug_info() {
+        // No debug entries → builder emits no debug section.
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .build();
+        let err = check_preconditions(&container).unwrap_err();
+        assert!(matches!(err, LaunchError::NoDebugInfo));
+        assert!(err.message().contains("NoDebugInfo"));
+        assert!(err.message().contains("debug info"));
+    }
+
+    #[test]
+    fn check_preconditions_when_multiple_instances_then_multi_instance_unsupported() {
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .add_var_name(a_var_name())
+            .add_task(a_task(TaskId::new(0)))
+            .add_task(a_task(TaskId::new(1)))
+            .add_program_instance(a_program(InstanceId::new(0), TaskId::new(0)))
+            .add_program_instance(a_program(InstanceId::new(1), TaskId::new(1)))
+            .build();
+        let err = check_preconditions(&container).unwrap_err();
+        assert!(matches!(err, LaunchError::MultiInstanceUnsupported(2)));
+        assert!(err.message().contains("MultiInstanceUnsupported"));
+        assert!(err.message().contains("2 program instances"));
+    }
+
+    #[test]
+    fn start_vm_when_single_instance_debug_container_then_runs() {
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .add_var_name(a_var_name())
+            .build();
+        let mut bufs = VmBuffers::from_container(&container);
+        assert!(start_vm(&container, &mut bufs).is_ok());
+    }
+
+    #[test]
+    fn start_vm_when_init_traps_then_vm_start_failed() {
+        // The (default) init function divides by zero, so `start()` traps.
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool[0] (10)
+            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool[1] (0)
+            0x30,             // DIV_I32 -> DivideByZero
+            0x8C,             // RET_VOID
+        ];
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_i32_constant(10)
+            .add_i32_constant(0)
+            .add_function(FunctionId::new(0), &bytecode, 2, 1, 0)
+            .add_var_name(a_var_name())
+            .build();
+        let mut bufs = VmBuffers::from_container(&container);
+        let err = match start_vm(&container, &mut bufs) {
+            Ok(_) => panic!("expected the dividing-by-zero init to trap"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, LaunchError::VmStartFailed(_)));
+        assert!(err.message().contains("launch failed to start"));
+    }
+
+    #[test]
+    fn load_container_when_missing_file_then_container_open_error() {
+        let err = load_container(Path::new("does/not/exist.iplc")).unwrap_err();
+        assert!(matches!(err, LaunchError::ContainerOpen(_)));
+        assert!(err.message().contains("unable to open"));
+    }
+
+    #[test]
+    fn load_container_when_file_is_not_a_container_then_container_read_error() {
+        use std::io::Write as _;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"this is not a container").unwrap();
+        file.flush().unwrap();
+        let err = load_container(file.path()).unwrap_err();
+        assert!(matches!(err, LaunchError::ContainerRead(_)));
+        assert!(err.message().contains("unable to read container"));
+    }
+
+    #[test]
+    fn message_when_program_arg_missing_then_mentions_program_path() {
+        assert!(LaunchError::ProgramArgMissing
+            .message()
+            .contains("'program' path"));
+    }
+}

--- a/compiler/vm-cli/src/dap/launch.rs
+++ b/compiler/vm-cli/src/dap/launch.rs
@@ -192,6 +192,7 @@ mod tests {
         let container = ContainerBuilder::new()
             .num_variables(1)
             .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .max_call_depth(1)
             .add_var_name(a_var_name())
             .build();
         assert!(check_preconditions(&container).is_ok());
@@ -203,6 +204,7 @@ mod tests {
         let container = ContainerBuilder::new()
             .num_variables(1)
             .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .max_call_depth(1)
             .build();
         let err = check_preconditions(&container).unwrap_err();
         assert!(matches!(err, LaunchError::NoDebugInfo));
@@ -217,6 +219,7 @@ mod tests {
         let container = ContainerBuilder::new()
             .num_variables(1)
             .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .max_call_depth(1)
             .add_var_name(a_var_name())
             .add_task(a_task(TaskId::new(0)))
             .add_task(a_task(TaskId::new(1)))
@@ -236,6 +239,7 @@ mod tests {
         let container = ContainerBuilder::new()
             .num_variables(1)
             .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .max_call_depth(1)
             .add_var_name(a_var_name())
             .build();
         let mut bufs = VmBuffers::from_container(&container);
@@ -257,6 +261,7 @@ mod tests {
             .add_i32_constant(10)
             .add_i32_constant(0)
             .add_function(FunctionId::new(0), &bytecode, 2, 1, 0)
+            .max_call_depth(1)
             .add_var_name(a_var_name())
             .build();
         let mut bufs = VmBuffers::from_container(&container);

--- a/compiler/vm-cli/src/dap/mod.rs
+++ b/compiler/vm-cli/src/dap/mod.rs
@@ -14,6 +14,7 @@
 pub mod debug_info;
 pub mod framing;
 pub mod launch;
+pub mod problem_codes;
 pub mod server;
 pub mod state;
 pub mod types;

--- a/compiler/vm-cli/src/dap/mod.rs
+++ b/compiler/vm-cli/src/dap/mod.rs
@@ -5,10 +5,15 @@
 //!
 //! Phase 4 lands incrementally (see
 //! `specs/plans/2026-06-25-dap-server-scaffold.md`). So far: the wire
-//! [`framing`] layer, the hand-rolled message [`types`], and the request
-//! [`state`] legality table. The request-dispatch loop that consumes them
-//! arrives in a later commit.
+//! [`framing`] layer, the hand-rolled message [`types`], the request [`state`]
+//! legality table, the [`launch`] preconditions, the isolated [`debug_info`]
+//! resolver, and the [`server`] event loop implementing the
+//! `initialize`/`launch`/`disconnect` handshake. The run/stop loop that drives
+//! execution arrives in a later commit.
 
+pub mod debug_info;
 pub mod framing;
+pub mod launch;
+pub mod server;
 pub mod state;
 pub mod types;

--- a/compiler/vm-cli/src/dap/problem_codes.rs
+++ b/compiler/vm-cli/src/dap/problem_codes.rs
@@ -1,0 +1,10 @@
+//! V-code constants generated from `resources/problem-codes.csv`.
+//!
+//! The `ironplcvm` binary reaches these constants through `error.rs`; the
+//! `ironplcdap` binary does not compile that module, so this thin re-include
+//! gives the DAP server the same generated constants from the one CSV source of
+//! truth. Only a few are used on the launch path (`FILE_OPEN`, `CONTAINER_READ`,
+//! and the `LAUNCH_*` codes); the rest are unused here, hence the allowance.
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/io_codes.rs"));

--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -129,10 +129,10 @@ fn load_and_check(request: &Request) -> Result<Container, String> {
         .arguments
         .as_ref()
         .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .ok_or_else(|| launch::LaunchError::ProgramArgMissing.message())?;
+        .ok_or_else(|| launch::LaunchError::ProgramArgMissing.to_string())?;
 
-    let container = launch::load_container(Path::new(&args.program)).map_err(|e| e.message())?;
-    launch::check_preconditions(&container).map_err(|e| e.message())?;
+    let container = launch::load_container(Path::new(&args.program)).map_err(|e| e.to_string())?;
+    launch::check_preconditions(&container).map_err(|e| e.to_string())?;
     Ok(container)
 }
 
@@ -162,7 +162,7 @@ fn launched_session<R: BufRead, W: Write>(
         Err(err) => {
             send(
                 writer,
-                &Response::error(take_seq(seq), launch_request, err.message()),
+                &Response::error(take_seq(seq), launch_request, err.to_string()),
             )?;
             return Ok(());
         }
@@ -397,7 +397,8 @@ mod tests {
         let launch = out.last().unwrap();
         assert_eq!(launch["command"], "launch");
         assert_eq!(launch["success"], false);
-        assert!(launch["message"].as_str().unwrap().contains("NoDebugInfo"));
+        // The message is V-coded (V6009) rather than a bare string.
+        assert!(launch["message"].as_str().unwrap().starts_with("V6009 - "));
     }
 
     #[test]
@@ -410,10 +411,9 @@ mod tests {
         ]);
         let launch = out.last().unwrap();
         assert_eq!(launch["success"], false);
-        assert!(launch["message"]
-            .as_str()
-            .unwrap()
-            .contains("MultiInstanceUnsupported"));
+        let message = launch["message"].as_str().unwrap();
+        assert!(message.starts_with("V6010 - "));
+        assert!(message.contains("MultiInstanceUnsupported"));
     }
 
     #[test]
@@ -428,10 +428,10 @@ mod tests {
         let launch = out.last().unwrap();
         assert_eq!(launch["command"], "launch");
         assert_eq!(launch["success"], false);
-        assert!(launch["message"]
-            .as_str()
-            .unwrap()
-            .contains("launch failed to start"));
+        let message = launch["message"].as_str().unwrap();
+        // The start-time trap surfaces its own V-code (divide by zero → V4001).
+        assert!(message.starts_with("V4001 - "));
+        assert!(message.contains("launch failed to start"));
     }
 
     #[test]
@@ -458,7 +458,9 @@ mod tests {
         ]);
         let launch = out.last().unwrap();
         assert_eq!(launch["success"], false);
-        assert!(launch["message"].as_str().unwrap().contains("'program'"));
+        let message = launch["message"].as_str().unwrap();
+        assert!(message.starts_with("V6008 - "));
+        assert!(message.contains("'program'"));
     }
 
     #[test]

--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -1,0 +1,515 @@
+//! The single-threaded DAP event loop.
+//!
+//! This commit implements the `initialize` → `launch` → `disconnect`
+//! handshake against the Phase 3 VM engine. Every request is gated through the
+//! [`state::legal`] table; an illegal or not-yet-supported request is answered
+//! with a DAP error whose message is `requestNotApplicable`.
+//!
+//! The loop is split at the launch boundary so lifetimes stay simple: the
+//! *pre-launch* loop ([`serve`]) handles `initialize` / `disconnect` and the
+//! `launch` preconditions with nothing borrowed; once preconditions pass it
+//! hands the owned [`Container`] to [`launched_session`], which sizes the VM
+//! buffers, starts the VM, and runs the *post-launch* loop borrowing them.
+//!
+//! The full run/stop loop — `configurationDone` starting execution,
+//! `continue`/`next`/`stepIn`/`stepOut`, `stackTrace`/`scopes`/`variables`, and
+//! the `stopped`/`terminated` events — is commit 4. It slots into
+//! [`launched_session`]'s post-launch loop, where the live [`VmRunning`] is
+//! already in scope.
+
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+use ironplc_container::Container;
+use ironplc_vm::VmBuffers;
+use serde::Serialize;
+
+use super::framing;
+use super::launch;
+use super::state::{self, Command, Phase};
+use super::types::{Capabilities, Event, LaunchRequestArguments, Request, Response};
+
+/// The DAP `message` returned for any request that is illegal in the current
+/// phase or not supported by this server slice.
+const REQUEST_NOT_APPLICABLE: &str = "requestNotApplicable";
+
+/// Serializes a DAP message and writes it with Content-Length framing.
+fn send<W: Write, T: Serialize>(writer: &mut W, message: &T) -> io::Result<()> {
+    let body =
+        serde_json::to_vec(message).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    framing::write_message(writer, &body)
+}
+
+/// Returns the current outgoing sequence number and advances the counter.
+fn take_seq(seq: &mut i64) -> i64 {
+    let current = *seq;
+    *seq += 1;
+    current
+}
+
+/// Runs the DAP server over `reader`/`writer` until the client disconnects or
+/// the stream ends.
+///
+/// This is the pre-launch loop: it services `initialize` and `disconnect`,
+/// evaluates the `launch` preconditions, and — on a satisfied `launch` — hands
+/// off to [`launched_session`] and returns whatever that returns. A launch that
+/// fails a precondition is answered with an error and the loop continues, so
+/// the client may retry or disconnect.
+pub fn serve<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()> {
+    let mut seq: i64 = 1;
+    let mut phase = Phase::Initialized;
+
+    loop {
+        let Some(body) = framing::read_message(reader)? else {
+            // Clean end-of-stream between messages: the client went away.
+            return Ok(());
+        };
+        let Ok(request) = serde_json::from_slice::<Request>(&body) else {
+            // A frame we cannot parse as a request carries no seq to answer;
+            // skip it rather than crash the session.
+            continue;
+        };
+
+        let command = Command::from_request(&request.command);
+        let legal_here = command.is_some_and(|c| state::legal(phase, c));
+
+        match command {
+            Some(Command::Initialize) if legal_here => {
+                let caps = Capabilities {
+                    supports_configuration_done_request: true,
+                };
+                let body = serde_json::to_value(caps).ok();
+                send(
+                    writer,
+                    &Response::success(take_seq(&mut seq), &request, body),
+                )?;
+                // DAP: the `initialized` event follows the initialize response.
+                send(writer, &Event::new(take_seq(&mut seq), "initialized", None))?;
+                phase = Phase::Configuring;
+            }
+            Some(Command::Launch) if legal_here => {
+                match load_and_check(&request) {
+                    Ok(container) => {
+                        // Preconditions hold: own the container and run the
+                        // rest of the session against a live VM.
+                        return launched_session(reader, writer, &mut seq, container, &request);
+                    }
+                    Err(message) => {
+                        send(
+                            writer,
+                            &Response::error(take_seq(&mut seq), &request, message),
+                        )?;
+                    }
+                }
+            }
+            Some(Command::Disconnect) => {
+                send(
+                    writer,
+                    &Response::success(take_seq(&mut seq), &request, None),
+                )?;
+                return Ok(());
+            }
+            _ => {
+                // Illegal in this phase, an unknown command, or a request this
+                // slice does not yet implement.
+                send(
+                    writer,
+                    &Response::error(take_seq(&mut seq), &request, REQUEST_NOT_APPLICABLE),
+                )?;
+            }
+        }
+    }
+}
+
+/// Parses the `launch` arguments, loads the container, and checks the launch
+/// preconditions. Returns the loaded container on success, or the DAP error
+/// message to report on failure.
+fn load_and_check(request: &Request) -> Result<Container, String> {
+    let args: LaunchRequestArguments = request
+        .arguments
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .ok_or_else(|| launch::LaunchError::ProgramArgMissing.message())?;
+
+    let container = launch::load_container(Path::new(&args.program)).map_err(|e| e.message())?;
+    launch::check_preconditions(&container).map_err(|e| e.message())?;
+    Ok(container)
+}
+
+/// Owns the loaded `container`, starts the VM, answers the `launch` request,
+/// and runs the post-launch service loop.
+///
+/// The `container` and the buffers sized from it live here so the [`VmRunning`]
+/// can borrow them for the remainder of the session. Commit 4 replaces the
+/// handshake-only loop below with the run/stop loop; the live VM it needs is
+/// already constructed here.
+fn launched_session<R: BufRead, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    seq: &mut i64,
+    container: Container,
+    launch_request: &Request,
+) -> io::Result<()> {
+    let mut bufs = VmBuffers::from_container(&container);
+
+    // Construct + start the VM. Buffer sizing (operand stack, variable table,
+    // data region, and the frame stack from `header.max_call_depth`) is done by
+    // `VmBuffers::from_container`, reused from the `ironplcvm` embedding path.
+    // Commit 4 keeps `_running` live to drive the run/stop loop; the handshake
+    // only needs to prove the VM builds and starts.
+    let _running = match launch::start_vm(&container, &mut bufs) {
+        Ok(running) => running,
+        Err(err) => {
+            send(
+                writer,
+                &Response::error(take_seq(seq), launch_request, err.message()),
+            )?;
+            return Ok(());
+        }
+    };
+
+    // Preconditions, buffer sizing, and start all succeeded.
+    send(
+        writer,
+        &Response::success(take_seq(seq), launch_request, None),
+    )?;
+
+    // Post-launch loop. The DAP phase stays `Configuring` until
+    // `configurationDone` starts the run (commit 4). For the handshake slice we
+    // service `disconnect` and refuse everything else with
+    // `requestNotApplicable`.
+    loop {
+        let Some(body) = framing::read_message(reader)? else {
+            return Ok(());
+        };
+        let Ok(request) = serde_json::from_slice::<Request>(&body) else {
+            continue;
+        };
+
+        match Command::from_request(&request.command) {
+            Some(Command::Disconnect) => {
+                send(writer, &Response::success(take_seq(seq), &request, None))?;
+                return Ok(());
+            }
+            _ => {
+                send(
+                    writer,
+                    &Response::error(take_seq(seq), &request, REQUEST_NOT_APPLICABLE),
+                )?;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironplc_container::debug_section::{iec_type_tag, var_section, VarNameEntry};
+    use ironplc_container::{
+        ContainerBuilder, FunctionId, InstanceId, ProgramInstanceEntry, TaskEntry, TaskId,
+        TaskType, VarIndex,
+    };
+    use serde_json::{json, Value};
+    use std::io::Cursor;
+
+    fn a_var_name() -> VarNameEntry {
+        VarNameEntry {
+            var_index: VarIndex::new(0),
+            function_id: FunctionId::GLOBAL_SCOPE,
+            var_section: var_section::VAR,
+            iec_type_tag: iec_type_tag::DINT,
+            name: "x".into(),
+            type_name: "DINT".into(),
+        }
+    }
+
+    fn a_task(task_id: TaskId) -> TaskEntry {
+        TaskEntry {
+            task_id,
+            priority: 0,
+            task_type: TaskType::Freewheeling,
+            flags: 0x01,
+            interval_us: 0,
+            single_var_index: VarIndex::NO_SINGLE_VAR,
+            watchdog_us: 0,
+            input_image_offset: 0,
+            output_image_offset: 0,
+            reserved: [0; 4],
+        }
+    }
+
+    fn a_program(instance_id: InstanceId, task_id: TaskId) -> ProgramInstanceEntry {
+        ProgramInstanceEntry {
+            instance_id,
+            task_id,
+            entry_function_id: FunctionId::new(0),
+            var_table_offset: 0,
+            var_table_count: 1,
+            fb_instance_offset: 0,
+            fb_instance_count: 0,
+            init_function_id: FunctionId::new(0),
+        }
+    }
+
+    /// Writes a single-instance container with a debug section to a temp file
+    /// and returns the file (kept alive by the caller) plus its path string.
+    fn single_instance_debug_container_file() -> (tempfile::NamedTempFile, String) {
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .add_var_name(a_var_name())
+            .build();
+        write_container_to_temp(&container)
+    }
+
+    fn no_debug_container_file() -> (tempfile::NamedTempFile, String) {
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .build();
+        write_container_to_temp(&container)
+    }
+
+    fn multi_instance_container_file() -> (tempfile::NamedTempFile, String) {
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .add_var_name(a_var_name())
+            .add_task(a_task(TaskId::new(0)))
+            .add_task(a_task(TaskId::new(1)))
+            .add_program_instance(a_program(InstanceId::new(0), TaskId::new(0)))
+            .add_program_instance(a_program(InstanceId::new(1), TaskId::new(1)))
+            .build();
+        write_container_to_temp(&container)
+    }
+
+    /// Passes the launch preconditions (debug section, single instance) but the
+    /// init function divides by zero, so `start()` traps.
+    fn init_traps_container_file() -> (tempfile::NamedTempFile, String) {
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x00, 0x00, 0x00, // LOAD_CONST_I32 pool[0] (10)
+            0x00, 0x01, 0x00, // LOAD_CONST_I32 pool[1] (0)
+            0x30,             // DIV_I32 -> DivideByZero
+            0x8C,             // RET_VOID
+        ];
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_i32_constant(10)
+            .add_i32_constant(0)
+            .add_function(FunctionId::new(0), &bytecode, 2, 1, 0)
+            .add_var_name(a_var_name())
+            .build();
+        write_container_to_temp(&container)
+    }
+
+    fn write_container_to_temp(
+        container: &ironplc_container::Container,
+    ) -> (tempfile::NamedTempFile, String) {
+        use std::io::Write as _;
+        let mut buf = Vec::new();
+        container.write_to(&mut buf).unwrap();
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&buf).unwrap();
+        file.flush().unwrap();
+        let path = file.path().to_string_lossy().into_owned();
+        (file, path)
+    }
+
+    fn frame(request: &Value) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let body = serde_json::to_vec(request).unwrap();
+        framing::write_message(&mut buf, &body).unwrap();
+        buf
+    }
+
+    /// Feeds `requests` (each already a DAP request value) through `serve` and
+    /// returns the framed responses/events it wrote, decoded as JSON.
+    fn run_server(requests: &[Value]) -> Vec<Value> {
+        let mut input = Vec::new();
+        for req in requests {
+            input.extend_from_slice(&frame(req));
+        }
+        let mut reader = Cursor::new(input);
+        let mut writer: Vec<u8> = Vec::new();
+        serve(&mut reader, &mut writer).unwrap();
+
+        let mut out_reader = Cursor::new(writer);
+        let mut messages = Vec::new();
+        while let Some(body) = framing::read_message(&mut out_reader).unwrap() {
+            messages.push(serde_json::from_slice(&body).unwrap());
+        }
+        messages
+    }
+
+    #[test]
+    fn serve_when_initialize_then_returns_capabilities_and_initialized_event() {
+        let out = run_server(&[json!({"seq": 1, "type": "request", "command": "initialize"})]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["type"], "response");
+        assert_eq!(out[0]["command"], "initialize");
+        assert_eq!(out[0]["success"], true);
+        assert_eq!(out[0]["body"]["supportsConfigurationDoneRequest"], true);
+        // Only the one capability is advertised in this phase.
+        assert_eq!(out[0]["body"].as_object().unwrap().len(), 1);
+        assert_eq!(out[1]["type"], "event");
+        assert_eq!(out[1]["event"], "initialized");
+    }
+
+    #[test]
+    fn serve_when_initialize_launch_disconnect_then_full_handshake_succeeds() {
+        let (_file, path) = single_instance_debug_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+            json!({"seq": 3, "type": "request", "command": "disconnect"}),
+        ]);
+        // initialize response, initialized event, launch response, disconnect response.
+        assert_eq!(out.len(), 4);
+        let launch = &out[2];
+        assert_eq!(launch["command"], "launch");
+        assert_eq!(launch["success"], true);
+        assert_eq!(launch["request_seq"], 2);
+        let disconnect = &out[3];
+        assert_eq!(disconnect["command"], "disconnect");
+        assert_eq!(disconnect["success"], true);
+    }
+
+    #[test]
+    fn serve_when_launch_before_initialize_then_request_not_applicable() {
+        let (_file, path) = single_instance_debug_container_file();
+        let out = run_server(&[json!({"seq": 1, "type": "request", "command": "launch",
+                                      "arguments": {"program": path}})]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["success"], false);
+        assert_eq!(out[0]["message"], "requestNotApplicable");
+    }
+
+    #[test]
+    fn serve_when_launch_container_without_debug_then_no_debug_info_error() {
+        let (_file, path) = no_debug_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+        ]);
+        let launch = out.last().unwrap();
+        assert_eq!(launch["command"], "launch");
+        assert_eq!(launch["success"], false);
+        assert!(launch["message"].as_str().unwrap().contains("NoDebugInfo"));
+    }
+
+    #[test]
+    fn serve_when_launch_multi_instance_then_multi_instance_error() {
+        let (_file, path) = multi_instance_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+        ]);
+        let launch = out.last().unwrap();
+        assert_eq!(launch["success"], false);
+        assert!(launch["message"]
+            .as_str()
+            .unwrap()
+            .contains("MultiInstanceUnsupported"));
+    }
+
+    #[test]
+    fn serve_when_launch_vm_fails_to_start_then_launch_error() {
+        // Preconditions pass, but the init function traps → launch fails.
+        let (_file, path) = init_traps_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+        ]);
+        let launch = out.last().unwrap();
+        assert_eq!(launch["command"], "launch");
+        assert_eq!(launch["success"], false);
+        assert!(launch["message"]
+            .as_str()
+            .unwrap()
+            .contains("launch failed to start"));
+    }
+
+    #[test]
+    fn serve_when_launch_precondition_fails_then_session_continues_to_disconnect() {
+        // A failed precondition leaves the pre-launch loop live: a subsequent
+        // disconnect is still serviced.
+        let (_file, path) = no_debug_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+            json!({"seq": 3, "type": "request", "command": "disconnect"}),
+        ]);
+        let disconnect = out.last().unwrap();
+        assert_eq!(disconnect["command"], "disconnect");
+        assert_eq!(disconnect["success"], true);
+    }
+
+    #[test]
+    fn serve_when_launch_missing_program_arg_then_error() {
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch", "arguments": {}}),
+        ]);
+        let launch = out.last().unwrap();
+        assert_eq!(launch["success"], false);
+        assert!(launch["message"].as_str().unwrap().contains("'program'"));
+    }
+
+    #[test]
+    fn serve_when_pause_after_initialize_then_request_not_applicable() {
+        // `pause` is a modelled-but-cut request: always requestNotApplicable.
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "pause"}),
+        ]);
+        let pause = out.last().unwrap();
+        assert_eq!(pause["command"], "pause");
+        assert_eq!(pause["success"], false);
+        assert_eq!(pause["message"], "requestNotApplicable");
+    }
+
+    #[test]
+    fn serve_when_unknown_command_then_request_not_applicable() {
+        let out = run_server(&[json!({"seq": 1, "type": "request",
+                                      "command": "ironplc/stepScan"})]);
+        assert_eq!(out[0]["success"], false);
+        assert_eq!(out[0]["message"], "requestNotApplicable");
+    }
+
+    #[test]
+    fn serve_when_disconnect_after_launch_then_post_launch_loop_tears_down() {
+        // Exercise the post-launch loop's requestNotApplicable branch, then
+        // disconnect.
+        let (_file, path) = single_instance_debug_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+            json!({"seq": 3, "type": "request", "command": "threads"}),
+            json!({"seq": 4, "type": "request", "command": "disconnect"}),
+        ]);
+        // Post-launch `threads` is refused for now.
+        let threads = &out[3];
+        assert_eq!(threads["command"], "threads");
+        assert_eq!(threads["success"], false);
+        assert_eq!(threads["message"], "requestNotApplicable");
+        // Then disconnect is honored.
+        let disconnect = out.last().unwrap();
+        assert_eq!(disconnect["command"], "disconnect");
+        assert_eq!(disconnect["success"], true);
+    }
+
+    #[test]
+    fn serve_when_stream_ends_without_disconnect_then_returns_ok() {
+        // No trailing disconnect: a clean EOF just ends the session.
+        let out = run_server(&[json!({"seq": 1, "type": "request", "command": "initialize"})]);
+        // Handshake still produced its two messages; the loop returned on EOF.
+        assert_eq!(out.len(), 2);
+    }
+}

--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -257,6 +257,7 @@ mod tests {
         let container = ContainerBuilder::new()
             .num_variables(1)
             .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .max_call_depth(1)
             .add_var_name(a_var_name())
             .build();
         write_container_to_temp(&container)
@@ -266,6 +267,7 @@ mod tests {
         let container = ContainerBuilder::new()
             .num_variables(1)
             .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .max_call_depth(1)
             .build();
         write_container_to_temp(&container)
     }
@@ -274,6 +276,7 @@ mod tests {
         let container = ContainerBuilder::new()
             .num_variables(1)
             .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+            .max_call_depth(1)
             .add_var_name(a_var_name())
             .add_task(a_task(TaskId::new(0)))
             .add_task(a_task(TaskId::new(1)))
@@ -298,6 +301,7 @@ mod tests {
             .add_i32_constant(10)
             .add_i32_constant(0)
             .add_function(FunctionId::new(0), &bytecode, 2, 1, 0)
+            .max_call_depth(1)
             .add_var_name(a_var_name())
             .build();
         write_container_to_temp(&container)

--- a/compiler/vm-cli/src/dap_main.rs
+++ b/compiler/vm-cli/src/dap_main.rs
@@ -4,10 +4,9 @@
 //! debug session. Feature-gated behind `dap`; see
 //! `specs/plans/2026-06-25-dap-server-scaffold.md`.
 //!
-//! This first slice is a skeleton: the [`dap::framing`] layer is in place and
-//! unit-tested, and `main` drains framed messages to prove the binary builds
-//! and reads the wire correctly. Protocol handling (`initialize`, `launch`,
-//! breakpoints, stepping) arrives in later commits.
+//! This slice drives the `initialize` → `launch` → `disconnect` handshake
+//! ([`dap::server::serve`]) over stdin/stdout. Execution control (breakpoints,
+//! stepping, inspection) arrives in later commits.
 
 mod dap;
 
@@ -16,10 +15,8 @@ use std::io::{self, BufReader};
 fn main() -> io::Result<()> {
     let stdin = io::stdin();
     let mut reader = BufReader::new(stdin.lock());
+    let stdout = io::stdout();
+    let mut writer = stdout.lock();
 
-    // No-op handler: consume framed messages until the client disconnects.
-    // Later commits dispatch each message to the request handlers.
-    while dap::framing::read_message(&mut reader)?.is_some() {}
-
-    Ok(())
+    dap::server::serve(&mut reader, &mut writer)
 }

--- a/compiler/vm-cli/src/error.rs
+++ b/compiler/vm-cli/src/error.rs
@@ -5,8 +5,15 @@ use std::fmt;
 use ironplc_container::{InstanceId, TaskId};
 use ironplc_vm::error::Trap;
 
-// V6xxx code constants are generated from resources/problem-codes.csv
-include!(concat!(env!("OUT_DIR"), "/io_codes.rs"));
+// V6xxx code constants are generated from resources/problem-codes.csv. Some
+// codes (the DAP launch codes V6008–V6010) are consumed only by the
+// `ironplcdap` binary, so they are dead in this binary — the allow keeps that
+// from warning while the constants stay re-exported at `error::*`.
+#[allow(dead_code)]
+mod io_codes {
+    include!(concat!(env!("OUT_DIR"), "/io_codes.rs"));
+}
+pub use io_codes::*;
 
 /// Exit code for file system / IO errors.
 const IO_EXIT_CODE: u8 = 2;

--- a/compiler/vm-cli/tests/dap.rs
+++ b/compiler/vm-cli/tests/dap.rs
@@ -217,7 +217,8 @@ fn ironplcdap_when_launch_container_without_debug_then_no_debug_info() {
         .find(|m| m["command"] == "launch")
         .expect("launch response");
     assert_eq!(launch["success"], false);
-    assert!(launch["message"].as_str().unwrap().contains("NoDebugInfo"));
+    // The failure carries the V6009 launch-no-debug-info code.
+    assert!(launch["message"].as_str().unwrap().starts_with("V6009 - "));
 }
 
 #[test]
@@ -236,8 +237,8 @@ fn ironplcdap_when_launch_multi_instance_then_multi_instance_unsupported() {
         .find(|m| m["command"] == "launch")
         .expect("launch response");
     assert_eq!(launch["success"], false);
-    assert!(launch["message"]
-        .as_str()
-        .unwrap()
-        .contains("MultiInstanceUnsupported"));
+    // The failure carries the V6010 multi-instance code plus the descriptive text.
+    let message = launch["message"].as_str().unwrap();
+    assert!(message.starts_with("V6010 - "));
+    assert!(message.contains("MultiInstanceUnsupported"));
 }

--- a/compiler/vm-cli/tests/dap.rs
+++ b/compiler/vm-cli/tests/dap.rs
@@ -1,0 +1,243 @@
+//! End-to-end handshake tests for the `ironplcdap` Debug Adapter Protocol
+//! server (Phase 4.3). These spawn the real binary and drive the
+//! `initialize` → `launch` → `disconnect` path over stdin/stdout, asserting
+//! the framed responses and events, plus the two launch-precondition failures
+//! (`NoDebugInfo`, `MultiInstanceUnsupported`).
+//!
+//! Gated on the `dap` feature: the `ironplcdap` binary only exists when the
+//! feature is enabled (CI builds it via `--features ironplc-vm-cli/dap`).
+#![cfg(feature = "dap")]
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+
+use assert_cmd::cargo;
+use ironplc_container::debug_section::{iec_type_tag, var_section, VarNameEntry};
+use ironplc_container::{
+    Container, ContainerBuilder, FunctionId, InstanceId, ProgramInstanceEntry, TaskEntry, TaskId,
+    TaskType, VarIndex,
+};
+use serde_json::{json, Value};
+use tempfile::NamedTempFile;
+
+fn a_var_name() -> VarNameEntry {
+    VarNameEntry {
+        var_index: VarIndex::new(0),
+        function_id: FunctionId::GLOBAL_SCOPE,
+        var_section: var_section::VAR,
+        iec_type_tag: iec_type_tag::DINT,
+        name: "x".into(),
+        type_name: "DINT".into(),
+    }
+}
+
+fn a_task(task_id: TaskId) -> TaskEntry {
+    TaskEntry {
+        task_id,
+        priority: 0,
+        task_type: TaskType::Freewheeling,
+        flags: 0x01,
+        interval_us: 0,
+        single_var_index: VarIndex::NO_SINGLE_VAR,
+        watchdog_us: 0,
+        input_image_offset: 0,
+        output_image_offset: 0,
+        reserved: [0; 4],
+    }
+}
+
+fn a_program(instance_id: InstanceId, task_id: TaskId) -> ProgramInstanceEntry {
+    ProgramInstanceEntry {
+        instance_id,
+        task_id,
+        entry_function_id: FunctionId::new(0),
+        var_table_offset: 0,
+        var_table_count: 1,
+        fb_instance_offset: 0,
+        fb_instance_count: 0,
+        init_function_id: FunctionId::new(0),
+    }
+}
+
+fn write_container(container: &Container) -> NamedTempFile {
+    let mut buf = Vec::new();
+    container.write_to(&mut buf).unwrap();
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(&buf).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+/// Single program instance with a debug section — launches successfully.
+fn single_instance_debug_container() -> NamedTempFile {
+    let container = ContainerBuilder::new()
+        .num_variables(1)
+        .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+        .add_var_name(a_var_name())
+        .build();
+    write_container(&container)
+}
+
+/// Single instance but no debug section — fails `NoDebugInfo`.
+fn no_debug_container() -> NamedTempFile {
+    let container = ContainerBuilder::new()
+        .num_variables(1)
+        .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+        .build();
+    write_container(&container)
+}
+
+/// Two program instances with a debug section — fails `MultiInstanceUnsupported`.
+fn multi_instance_container() -> NamedTempFile {
+    let container = ContainerBuilder::new()
+        .num_variables(1)
+        .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+        .add_var_name(a_var_name())
+        .add_task(a_task(TaskId::new(0)))
+        .add_task(a_task(TaskId::new(1)))
+        .add_program_instance(a_program(InstanceId::new(0), TaskId::new(0)))
+        .add_program_instance(a_program(InstanceId::new(1), TaskId::new(1)))
+        .build();
+    write_container(&container)
+}
+
+/// Content-Length framing for a request value.
+fn frame(request: &Value) -> Vec<u8> {
+    let body = serde_json::to_vec(request).unwrap();
+    let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Decodes all Content-Length-framed messages in `bytes`.
+fn parse_messages(bytes: &[u8]) -> Vec<Value> {
+    let mut messages = Vec::new();
+    let mut rest = bytes;
+    while let Some(header_end) = find_subslice(rest, b"\r\n\r\n") {
+        let header = std::str::from_utf8(&rest[..header_end]).expect("ascii header");
+        let len: usize = header
+            .lines()
+            .find_map(|line| line.strip_prefix("Content-Length:"))
+            .expect("Content-Length header")
+            .trim()
+            .parse()
+            .expect("numeric Content-Length");
+        let body_start = header_end + 4;
+        let body_end = body_start + len;
+        let body = &rest[body_start..body_end];
+        messages.push(serde_json::from_slice(body).expect("json body"));
+        rest = &rest[body_end..];
+    }
+    messages
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// Spawns `ironplcdap`, sends each request framed, closes stdin, and returns
+/// the decoded response/event stream.
+fn run_dap(requests: &[Value]) -> Vec<Value> {
+    let mut child = Command::new(cargo::cargo_bin!("ironplcdap"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn ironplcdap");
+
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        for request in requests {
+            stdin.write_all(&frame(request)).expect("write request");
+        }
+        // stdin dropped here → the server sees EOF once it has drained input.
+    }
+
+    let mut stdout = child.stdout.take().expect("child stdout");
+    let mut out = Vec::new();
+    stdout.read_to_end(&mut out).expect("read stdout");
+    child.wait().expect("wait for ironplcdap");
+
+    parse_messages(&out)
+}
+
+#[test]
+fn ironplcdap_when_initialize_launch_disconnect_then_handshake_succeeds() {
+    let container = single_instance_debug_container();
+    let path = container.path().to_string_lossy().into_owned();
+
+    let messages = run_dap(&[
+        json!({"seq": 1, "type": "request", "command": "initialize",
+               "arguments": {"adapterID": "ironplc"}}),
+        json!({"seq": 2, "type": "request", "command": "launch",
+               "arguments": {"program": path}}),
+        json!({"seq": 3, "type": "request", "command": "disconnect"}),
+    ]);
+
+    assert_eq!(messages.len(), 4, "messages: {messages:?}");
+
+    // initialize response with the single advertised capability.
+    assert_eq!(messages[0]["type"], "response");
+    assert_eq!(messages[0]["command"], "initialize");
+    assert_eq!(messages[0]["success"], true);
+    assert_eq!(
+        messages[0]["body"]["supportsConfigurationDoneRequest"],
+        true
+    );
+
+    // initialized event follows.
+    assert_eq!(messages[1]["type"], "event");
+    assert_eq!(messages[1]["event"], "initialized");
+
+    // launch response.
+    assert_eq!(messages[2]["command"], "launch");
+    assert_eq!(messages[2]["success"], true);
+    assert_eq!(messages[2]["request_seq"], 2);
+
+    // disconnect response.
+    assert_eq!(messages[3]["command"], "disconnect");
+    assert_eq!(messages[3]["success"], true);
+}
+
+#[test]
+fn ironplcdap_when_launch_container_without_debug_then_no_debug_info() {
+    let container = no_debug_container();
+    let path = container.path().to_string_lossy().into_owned();
+
+    let messages = run_dap(&[
+        json!({"seq": 1, "type": "request", "command": "initialize"}),
+        json!({"seq": 2, "type": "request", "command": "launch",
+               "arguments": {"program": path}}),
+    ]);
+
+    let launch = messages
+        .iter()
+        .find(|m| m["command"] == "launch")
+        .expect("launch response");
+    assert_eq!(launch["success"], false);
+    assert!(launch["message"].as_str().unwrap().contains("NoDebugInfo"));
+}
+
+#[test]
+fn ironplcdap_when_launch_multi_instance_then_multi_instance_unsupported() {
+    let container = multi_instance_container();
+    let path = container.path().to_string_lossy().into_owned();
+
+    let messages = run_dap(&[
+        json!({"seq": 1, "type": "request", "command": "initialize"}),
+        json!({"seq": 2, "type": "request", "command": "launch",
+               "arguments": {"program": path}}),
+    ]);
+
+    let launch = messages
+        .iter()
+        .find(|m| m["command"] == "launch")
+        .expect("launch response");
+    assert_eq!(launch["success"], false);
+    assert!(launch["message"]
+        .as_str()
+        .unwrap()
+        .contains("MultiInstanceUnsupported"));
+}

--- a/compiler/vm-cli/tests/dap.rs
+++ b/compiler/vm-cli/tests/dap.rs
@@ -73,6 +73,7 @@ fn single_instance_debug_container() -> NamedTempFile {
     let container = ContainerBuilder::new()
         .num_variables(1)
         .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+        .max_call_depth(1)
         .add_var_name(a_var_name())
         .build();
     write_container(&container)
@@ -83,6 +84,7 @@ fn no_debug_container() -> NamedTempFile {
     let container = ContainerBuilder::new()
         .num_variables(1)
         .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+        .max_call_depth(1)
         .build();
     write_container(&container)
 }
@@ -92,6 +94,7 @@ fn multi_instance_container() -> NamedTempFile {
     let container = ContainerBuilder::new()
         .num_variables(1)
         .add_function(FunctionId::new(0), &[0x8C], 0, 1, 0)
+        .max_call_depth(1)
         .add_var_name(a_var_name())
         .add_task(a_task(TaskId::new(0)))
         .add_task(a_task(TaskId::new(1)))

--- a/docs/extensions/thin_problem_pages_allowlist.txt
+++ b/docs/extensions/thin_problem_pages_allowlist.txt
@@ -59,6 +59,9 @@ reference/runtime/problems/V6004
 reference/runtime/problems/V6005
 reference/runtime/problems/V6006
 reference/runtime/problems/V6007
+reference/runtime/problems/V6008
+reference/runtime/problems/V6009
+reference/runtime/problems/V6010
 reference/runtime/problems/V9001
 reference/runtime/problems/V9002
 reference/runtime/problems/V9003

--- a/docs/reference/runtime/problems/V6008.rst
+++ b/docs/reference/runtime/problems/V6008.rst
@@ -1,0 +1,16 @@
+=====
+V6008
+=====
+
+.. problem-summary:: V6008
+
+The Debug Adapter Protocol ``launch`` request did not include a ``program``
+path, so the debugger has no bytecode container to load and run.
+
+Solutions
+---------
+
+1. Ensure the launch configuration sets ``program`` to a compiled ``.iplc`` container
+2. In VS Code, check the ``program`` field of the IronPLC debug configuration in ``launch.json``
+3. Confirm the path is a string and is not empty after variable substitution
+4. Recompile the source program if the ``.iplc`` container has not been produced yet

--- a/docs/reference/runtime/problems/V6009.rst
+++ b/docs/reference/runtime/problems/V6009.rst
@@ -1,0 +1,17 @@
+=====
+V6009
+=====
+
+.. problem-summary:: V6009
+
+The debugger loaded the container, but it has no debug section, so there is no
+source-line or variable-name information to debug against. The container was
+compiled without debug information.
+
+Solutions
+---------
+
+1. Recompile the source program with debug information enabled
+2. Verify the build step that produced the ``.iplc`` container did not strip the debug section
+3. Confirm you are launching the debug build of the container, not a release build
+4. Run the program with ``ironplcvm`` instead if source-level debugging is not required

--- a/docs/reference/runtime/problems/V6010.rst
+++ b/docs/reference/runtime/problems/V6010.rst
@@ -1,0 +1,17 @@
+=====
+V6010
+=====
+
+.. problem-summary:: V6010
+
+The container declares more than one program instance. The first version of the
+debugger supports single-instance programs only; multi-instance debugging is
+planned for a future release.
+
+Solutions
+---------
+
+1. Debug a program that declares a single program instance
+2. Temporarily reduce the configuration to one program instance for the debug session
+3. Run the multi-instance program with ``ironplcvm`` when debugging is not required
+4. Track multi-instance debugger support in the IronPLC project roadmap

--- a/specs/plans/2026-07-19-dap-launch-error-vcodes.md
+++ b/specs/plans/2026-07-19-dap-launch-error-vcodes.md
@@ -1,0 +1,64 @@
+# DAP launch errors carry V-codes
+
+## Goal
+
+Make every `ironplcdap` `launch` failure carry a stable IronPLC **V-code**, so a
+DAP client sees the same `V#### - message` surface the `ironplcvm` CLI already
+emits (and can link to the runtime problem-code docs). Chosen approach:
+`LaunchError` owns its own `v_code()` and renders `"V#### - message"` via
+`Display` — it does **not** reuse `VmError` (whose `exit_code` field has no
+consumer on the DAP path, where a failed request returns a response rather than
+exiting the process).
+
+## Current state
+
+`compiler/vm-cli/src/dap/launch.rs` defines `LaunchError` with a `message()`
+that returns bare human text (`"NoDebugInfo: …"`, `"MultiInstanceUnsupported:
+…"`). The `ironplcdap` binary (`dap_main.rs`) does not compile `error.rs`, so it
+has no access to the generated V-code constants. V-codes come from
+`vm-cli/resources/problem-codes.csv` → `build.rs` → `io_codes.rs`
+(`pub const NAME: &str = "V6xxx"`). Runtime traps already expose `Trap::v_code()`.
+
+## Mapping
+
+| `LaunchError` variant | V-code |
+|---|---|
+| `ContainerOpen` | reuse `V6001` (`FILE_OPEN`) |
+| `ContainerRead` | reuse `V6002` (`CONTAINER_READ`) |
+| `VmStartFailed` | reuse the wrapped `Trap`'s own `v_code()` (a `V4xxx`/`V9xxx`) |
+| `ProgramArgMissing` | new `V6008` |
+| `NoDebugInfo` | new `V6009` |
+| `MultiInstanceUnsupported` | new `V6010` |
+
+## Changes
+
+1. **CSV** — add three rows to `vm-cli/resources/problem-codes.csv`:
+   `V6008 LaunchNoProgram`, `V6009 LaunchNoDebugInfo`, `V6010 LaunchMultiInstance`.
+   `build.rs` generates `LAUNCH_NO_PROGRAM` / `LAUNCH_NO_DEBUG_INFO` /
+   `LAUNCH_MULTI_INSTANCE` automatically.
+2. **Codes in the DAP bin** — add `dap/problem_codes.rs`
+   (`include!(".../io_codes.rs")`, `#![allow(dead_code)]` for the constants the
+   DAP path doesn't use) and `pub mod problem_codes;` in `dap/mod.rs`. The
+   `ironplcvm` binary keeps reaching the same generated constants through
+   `error.rs`; both are one CSV source of truth.
+3. **`LaunchError`** — `VmStartFailed` becomes
+   `{ v_code: &'static str, detail: String }`; add `v_code()`; implement
+   `Display` as `"{v_code} - {message}"` (keep `message()` as the plain text,
+   dropping the redundant `NoDebugInfo:` name prefix but keeping the
+   spec-mandated `MultiInstanceUnsupported:` wording). `start_vm` records
+   `ctx.trap.v_code()`.
+4. **Server** — `dap/server.rs` sends `err.to_string()` (V-coded) instead of
+   `err.message()` for the launch failure responses.
+5. **Docs** — add thin `docs/reference/runtime/problems/V6008.rst` …`V6010.rst`
+   mirroring the existing `V6xxx` pages, and list them in
+   `docs/extensions/thin_problem_pages_allowlist.txt` (the index regenerates
+   itself). Required because the problem-code extension `exit(1)`s on any CSV
+   code lacking a page.
+6. **Tests** — assert `v_code()` per variant + the `Display` format in
+   `launch.rs`; update the `server.rs` and `tests/dap.rs` assertions to check
+   the `V6009` / `V6010` codes.
+
+## Verification
+
+`cd compiler && just` green (compile, coverage ≥85%, clippy, fmt, dupes). Docs
+build is separate; the new pages + allowlist entries keep it green under `-W`.


### PR DESCRIPTION
Implements commit 3 of the DAP server scaffold: the handshake path driving
the Phase 3 VM engine, with the launch preconditions enforced and the
debug-info coupling quarantined behind a passthrough resolver.

- dap/launch.rs: load the container and check the two v1 preconditions
  (debug section present -> NoDebugInfo; exactly one program instance ->
  MultiInstanceUnsupported), then size the VM buffers via the reused
  VmBuffers::from_container embedding path and start the VM.
- dap/debug_info.rs: the only Layer-1-coupled module, shipped first with a
  passthrough resolver (DAP line treated as a raw bytecode offset; slots
  rendered by index) behind stable resolve_breakpoint/render_variables
  signatures so real line-map / debug_format lookups swap in later.
- dap/server.rs: the single-threaded event loop. initialize returns the
  supportsConfigurationDoneRequest capability and emits the initialized
  event; every request is gated through state::legal, with illegal or
  not-yet-supported requests answered requestNotApplicable. The loop is
  split at the launch boundary so the live VM the run/stop loop (commit 4)
  needs is already in scope.
- dap_main.rs wires stdin/stdout into server::serve.
- Unit tests for launch preconditions, the passthrough resolver, and the
  handshake dispatch, plus assert_cmd integration tests spawning ironplcdap
  for the happy path and the NoDebugInfo / MultiInstanceUnsupported cases.

Co-Authored-By: Claude <noreply@anthropic.com>