### PR TITLE
fix(sources): recurse into subdirectories during project discovery

### DIFF
--- a/compiler/sources/src/discovery/mod.rs
+++ b/compiler/sources/src/discovery/mod.rs
@@ -99,23 +99,77 @@ fn detect_beremiz(dir: &Path) -> Option<DiscoveredProject> {
     }
 }
 
+/// Recursively collects all regular files under `dir`.
+///
+/// Skips hidden directories (name starts with `.` -- `.git`, `.idea`,
+/// `.vs`, etc., all commonly present alongside real TwinCAT checkouts)
+/// and does not follow symlinks (treated as neither a file nor a
+/// directory), which also rules out symlink cycles. Each directory's
+/// entries are sorted by name before recursing, so the result is
+/// deterministic regardless of filesystem iteration order.
+fn walk_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with('.'))
+        {
+            continue;
+        }
+
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+
+        if file_type.is_dir() {
+            walk_files(&entry.path(), out);
+        } else if file_type.is_file() {
+            out.push(entry.path());
+        }
+    }
+}
+
 /// Detect a TwinCAT project by searching for a `.plcproj` file.
+///
+/// Searches recursively, since real TwinCAT layouts commonly nest the
+/// `.plcproj` file several levels below the directory a user would
+/// naturally point the tool at (e.g. a Visual-Studio-style
+/// solution/project structure). If more than one `.plcproj` is found,
+/// picks deterministically (sorted by path) -- the pre-existing
+/// single-level behavior already picked an arbitrary match with no
+/// disambiguation when this happened within one directory.
 ///
 /// Returns `None` if no `.plcproj` exists. Returns `Some(Err(...))` if
 /// the `.plcproj` is found but malformed or references missing files.
 fn detect_twincat(dir: &Path) -> Option<Result<DiscoveredProject, Diagnostic>> {
-    let entries = fs::read_dir(dir).ok()?;
+    let mut files = Vec::new();
+    walk_files(dir, &mut files);
 
-    let plcproj = entries.filter_map(Result::ok).find(|entry| {
-        trace!("Check if file {entry:?} is plcproj");
-        entry
-            .path()
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("plcproj"))
-    })?;
+    let mut candidates: Vec<PathBuf> = files
+        .into_iter()
+        .filter(|path| {
+            trace!("Check if file {path:?} is plcproj");
+            path.extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("plcproj"))
+        })
+        .collect();
+    candidates.sort();
 
-    let plcproj_path = plcproj.path();
-    Some(parse_plcproj(&plcproj_path, dir))
+    let plcproj_path = candidates.into_iter().next()?;
+
+    // <Compile Include="..."> paths in the .plcproj are always relative
+    // to the .plcproj file's own directory, not the (possibly higher, now
+    // that the file can be nested arbitrarily deep) directory originally
+    // passed to discover().
+    let plcproj_dir = plcproj_path.parent().unwrap_or(dir);
+    Some(parse_plcproj(&plcproj_path, plcproj_dir))
 }
 
 /// Parse a `.plcproj` file and extract `<Compile Include="...">` paths.
@@ -177,15 +231,17 @@ fn parse_plcproj(plcproj_path: &Path, root_dir: &Path) -> Result<DiscoveredProje
     })
 }
 
-/// Fallback detection: enumerate all supported files in the directory.
+/// Fallback detection: recursively enumerate all supported files under
+/// the directory.
 ///
 /// Returns files sorted alphabetically for deterministic ordering.
 fn detect_fallback(dir: &Path) -> DiscoveredProject {
-    let mut files: Vec<PathBuf> = fs::read_dir(dir)
+    let mut files = Vec::new();
+    walk_files(dir, &mut files);
+
+    let mut files: Vec<PathBuf> = files
         .into_iter()
-        .flat_map(|entries| entries.filter_map(Result::ok))
-        .filter(|entry| entry.path().is_file() && FileType::from_path(&entry.path()).is_supported())
-        .map(|entry| entry.path())
+        .filter(|path| FileType::from_path(path).is_supported())
         .collect();
 
     files.sort();
@@ -469,5 +525,189 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let result = detect_fallback(dir.path());
         assert_eq!(result.root_dir, dir.path());
+    }
+
+    // -- Recursive discovery tests --
+
+    #[test]
+    fn discover_when_plcproj_nested_several_levels_then_finds_it() {
+        // Matches a real layout found in a private test corpus:
+        // TestProject/TestProject/TestProjectRuntime/TestProjectRuntime.plcproj
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("Solution").join("Runtime");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("MAIN.TcPOU"), "<TcPlcObject/>").unwrap();
+        fs::write(
+            nested.join("project.plcproj"),
+            r#"<Project>
+  <ItemGroup>
+    <Compile Include="MAIN.TcPOU" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        assert_eq!(result.project_type, ProjectType::TwinCat);
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("MAIN.TcPOU"));
+    }
+
+    #[test]
+    fn discover_when_nested_plcproj_then_root_dir_is_plcproj_directory() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("Solution").join("Runtime");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("MAIN.TcPOU"), "<TcPlcObject/>").unwrap();
+        fs::write(
+            nested.join("project.plcproj"),
+            r#"<Project>
+  <ItemGroup>
+    <Compile Include="MAIN.TcPOU" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        // root_dir must be where the .plcproj actually lives, not the
+        // top-level directory passed to discover() -- otherwise a
+        // .plcproj referencing a file in a further subdirectory of its
+        // own would resolve against the wrong base.
+        assert_eq!(result.root_dir, nested);
+    }
+
+    #[test]
+    fn discover_when_nested_plcproj_references_file_in_its_own_subdirectory_then_resolves() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("Solution").join("Runtime");
+        let pous_dir = nested.join("POUs");
+        fs::create_dir_all(&pous_dir).unwrap();
+        fs::write(pous_dir.join("MAIN.TcPOU"), "<TcPlcObject/>").unwrap();
+        fs::write(
+            nested.join("project.plcproj"),
+            r#"<Project>
+  <ItemGroup>
+    <Compile Include="POUs\MAIN.TcPOU" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        assert_eq!(result.project_type, ProjectType::TwinCat);
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("POUs/MAIN.TcPOU"));
+    }
+
+    #[test]
+    fn discover_when_hidden_directory_contains_plcproj_then_ignored() {
+        // .git/.idea-style directories must not be descended into, both
+        // for correctness (a decoy .plcproj shouldn't win) and to avoid
+        // wastefully/riskily walking into a real .git tree.
+        let dir = TempDir::new().unwrap();
+        let hidden = dir.path().join(".git");
+        fs::create_dir_all(&hidden).unwrap();
+        fs::write(hidden.join("decoy.plcproj"), "<Project/>").unwrap();
+
+        let real = dir.path().join("Runtime");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("MAIN.TcPOU"), "<TcPlcObject/>").unwrap();
+        fs::write(
+            real.join("project.plcproj"),
+            r#"<Project>
+  <ItemGroup>
+    <Compile Include="MAIN.TcPOU" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        assert_eq!(result.project_type, ProjectType::TwinCat);
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("MAIN.TcPOU"));
+    }
+
+    #[test]
+    fn discover_when_multiple_plcproj_candidates_then_picks_deterministically() {
+        // Matches a real duplicate found in a private test corpus (an
+        // apparent stale rename artifact): two .plcproj files in the
+        // same directory. Must not error or pick non-deterministically.
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("MAIN.TcPOU"), "<TcPlcObject/>").unwrap();
+        fs::write(
+            dir.path().join("AAA.plcproj"),
+            r#"<Project>
+  <ItemGroup>
+    <Compile Include="MAIN.TcPOU" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+        fs::write(dir.path().join("ZZZ.plcproj"), "<Project/>").unwrap();
+
+        let result1 = discover(dir.path()).unwrap();
+        let result2 = discover(dir.path()).unwrap();
+
+        // Sorted lexicographically: AAA.plcproj wins over ZZZ.plcproj.
+        assert_eq!(result1.files.len(), 1);
+        assert_eq!(result1.files, result2.files);
+    }
+
+    #[test]
+    fn detect_fallback_when_files_nested_in_subdirectories_then_finds_them() {
+        let dir = TempDir::new().unwrap();
+        let subdir = dir.path().join("src").join("nested");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(dir.path().join("a_top.st"), "PROGRAM END_PROGRAM").unwrap();
+        fs::write(subdir.join("b_nested.st"), "PROGRAM END_PROGRAM").unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        assert_eq!(result.project_type, ProjectType::Unstructured);
+        assert_eq!(result.files.len(), 2);
+        assert!(result.files[0].ends_with("a_top.st"));
+        assert!(result.files[1].ends_with("nested/b_nested.st"));
+    }
+
+    #[test]
+    fn detect_fallback_when_hidden_directory_present_then_ignored() {
+        let dir = TempDir::new().unwrap();
+        let hidden = dir.path().join(".git");
+        fs::create_dir_all(&hidden).unwrap();
+        fs::write(hidden.join("decoy.st"), "PROGRAM END_PROGRAM").unwrap();
+        fs::write(dir.path().join("main.st"), "PROGRAM END_PROGRAM").unwrap();
+
+        let result = detect_fallback(dir.path());
+
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("main.st"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_fallback_when_symlinked_directory_then_not_followed() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let real_subdir = dir.path().join("real");
+        fs::create_dir_all(&real_subdir).unwrap();
+        fs::write(real_subdir.join("main.st"), "PROGRAM END_PROGRAM").unwrap();
+
+        // Symlink pointing back at the parent directory -- if followed,
+        // this would recurse infinitely.
+        let link = dir.path().join("link_to_self");
+        symlink(dir.path(), &link).unwrap();
+
+        let result = detect_fallback(dir.path());
+
+        // Only the real file is found; the symlink is not traversed.
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("real/main.st"));
     }
 }

--- a/specs/plans/2026-07-19-twincat-recursive-project-discovery.md
+++ b/specs/plans/2026-07-19-twincat-recursive-project-discovery.md
@@ -1,0 +1,200 @@
+# Plan: Recursive Project Discovery (`.plcproj` and Fallback File Enumeration)
+
+## Goal
+
+`discover()` in `compiler/sources/src/discovery/mod.rs` only looks at the
+immediate children of the directory it's given — both `detect_twincat()`
+(searching for a `.plcproj`) and `detect_fallback()` (enumerating
+supported files when no project file is found) call `fs::read_dir(dir)`
+once and never recurse into subdirectories.
+
+Real TwinCAT project layouts are inherently nested (Visual-Studio-style
+solution/project structure). In a private test corpus of real TwinCAT
+projects, `.plcproj` lives 2-3 levels below the directory a user would
+naturally point the tool at:
+
+```
+TestProject/                             <- naturally the "project directory"
+  TestProject/
+    TestProjectRuntime/
+      TestProjectRuntime.plcproj         <- actual project file, 2 levels down
+      POUs/...
+```
+
+`ironplcc check TestProject` never finds the `.plcproj`, falls through to
+the fallback enumerator (which also only checks the top level), finds
+nothing there either, and reports `P9002 Set of valid source files has
+no content`. Pointing at the exact subdirectory works immediately —
+confirming discovery itself is the blocker, not anything downstream.
+
+## Verification this is real (not just theoretical)
+
+Confirmed directly against a private local checkout of a real TwinCAT
+project laid out exactly as above:
+
+```
+$ ironplcc check --dialect codesys TestProject
+error[P9002]: Set of valid source files has no content
+
+$ ironplcc check --dialect codesys TestProject/TestProject/TestProjectRuntime
+error[P6007]: File type is not supported ... VisualizationManager.TcVMO
+error[P0002]: Syntax error ... POUs/MAIN.TcPOU:66:33
+```
+
+The second command immediately finds and processes real content
+(different, unrelated errors — confirming the fix target is purely
+discovery, not something downstream).
+
+Also confirmed (relevant to the design below): the real corpus has a
+directory with **two** `.plcproj` files (`TestProjectRuntime.plcproj` and
+`TestRuntime.plcproj` — a stale duplicate from an apparent rename),
+and both `.git/` and `.idea/` directories are present under the
+project root — recursion must not wastefully (or riskily, in `.git`'s
+case) descend into these.
+
+Also confirmed multi-file cross-file type resolution already works
+correctly today once files ARE discovered together (verified separately,
+not part of this change) — this fix's payoff is real: it's what's
+actually standing between the tool and being usable against real TwinCAT
+checkouts at all, for both the single-project and (once resolvable)
+cross-file cases.
+
+## Design
+
+### One shared recursive-walk helper
+
+```rust
+/// Recursively collects all regular files under `dir`. Skips hidden
+/// directories (name starts with `.` -- `.git`, `.idea`, `.vs`, etc.,
+/// all observed in real checkouts) and does not follow symlinks (treats
+/// them as neither a file nor a directory), which also rules out
+/// symlink cycles. Each directory's entries are sorted by name before
+/// recursing, so the result is deterministic regardless of filesystem
+/// iteration order.
+fn walk_files(dir: &Path, out: &mut Vec<PathBuf>) { ... }
+```
+
+Both `detect_twincat()` and `detect_fallback()` call this once and then
+filter the shared file list according to their own criteria (`.plcproj`
+extension vs. `FileType::is_supported()`), instead of duplicating
+traversal logic.
+
+### `detect_twincat()`: multiple `.plcproj` candidates
+
+Since recursion can now surface more than one `.plcproj` in the tree
+(confirmed real, see above), candidates are sorted lexicographically by
+full path and the first is used — preserving the existing "just pick
+one, no ambiguity error" behavior (the pre-existing single-level code
+already picked an arbitrary match with no disambiguation), just made
+deterministic across the whole tree instead of non-deterministic within
+one directory's `read_dir` order. Verified this tie-break happens to pick
+the "obviously correct" one in the real duplicate case
+(`TestProjectRuntime.plcproj` sorts before `TestRuntime.plcproj`, and also
+happens to be the one whose name matches its containing folder).
+
+**Non-goal**: smarter disambiguation (e.g., preferring a `.plcproj` whose
+filename matches its parent directory's name) — no evidence this is
+needed beyond the one coincidental case already found, and it would add
+inference complexity beyond what this bug fix requires.
+
+### `detect_twincat()`: `root_dir` must resolve relative to the `.plcproj`'s own directory
+
+Currently `parse_plcproj(&plcproj_path, dir)` passes the *original*
+`dir` argument as the base for resolving each `<Compile Include="...">`
+path. That was correct when `.plcproj` was required to live directly in
+`dir`, but once it can be nested arbitrarily deep, `<Compile>` paths
+(which are always relative to the `.plcproj` file's own location) must
+resolve against `plcproj_path.parent()`, not the original `dir`. Also
+updates `DiscoveredProject.root_dir` to reflect the actual project
+directory (currently unused by any other code, but part of the public
+struct, so should be correct regardless).
+
+### `detect_fallback()`
+
+Same shared `walk_files()`, filtered by `FileType::is_supported()`,
+sorted for deterministic output — otherwise unchanged (still returns
+`dir` as `root_dir`, since fallback mode has no project-file location to
+derive it from).
+
+### `detect_beremiz()`: left unchanged, deliberately
+
+Beremiz's `plc.xml` convention is a flat, single-file-in-the-given-
+directory layout (unlike TwinCAT's nested Visual-Studio-style structure)
+— no evidence or report of this needing recursion, so left as-is to keep
+this change scoped to the actual reported problem.
+
+## Non-goals
+
+- A depth limit or file-count cap on the recursive walk. Hidden-directory
+  skipping (`.git` in particular) already rules out the realistic
+  pathological case; adding an arbitrary cap for defense-in-depth beyond
+  that isn't something the bug report calls for.
+- Making `detect_beremiz()` recursive.
+- Verifying/fixing cross-file type resolution itself — confirmed
+  separately (already works for ordinary FB/struct/enum references;
+  `INTERFACE`-typed variables still hit the pre-existing, unrelated
+  `P2008`/`INTERFACE`-as-variable-type gap regardless of file layout).
+- A new `walkdir` dependency — hand-rolled recursion is simple enough
+  here and avoids adding a dependency for this.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/sources/src/discovery/mod.rs` | `walk_files()` helper; `detect_twincat()`/`detect_fallback()` use it; `root_dir` fix in the `.plcproj` case |
+
+## Testing Strategy
+
+- `detect_twincat`: `.plcproj` nested 2-3 levels deep is found (matches
+  the real test-corpus layout); hidden directories (`.git`-named dir
+  containing a decoy `.plcproj`) are not descended into; multiple
+  `.plcproj` candidates at different depths resolve deterministically
+  (sorted); `<Compile Include="...">` paths in a nested `.plcproj`
+  resolve relative to the `.plcproj`'s own directory, not the original
+  root passed to `discover()`.
+- `detect_fallback`: supported files nested in subdirectories are found;
+  hidden directories are skipped; deterministic (sorted) output
+  preserved (regression, existing tests already check this at one
+  level).
+- Regression: all existing single-level tests continue to pass unchanged
+  (recursion is a superset of the single-level case).
+- Symlink handling: a symlinked directory is not followed (cheap to test
+  cross-platform via `std::os::unix::fs::symlink` under `#[cfg(unix)]`,
+  or skip if not practical in CI).
+
+## Tasks
+
+- [x] Write plan (this document)
+- [x] `walk_files()` shared recursive helper
+- [x] Wire into `detect_twincat()` (+ `root_dir`/`parse_plcproj` base-path fix)
+- [x] Wire into `detect_fallback()`
+- [x] Tests from Testing Strategy (including the symlink-cycle-safety test)
+- [x] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork (no PR against `ironplc/ironplc` without explicit
+      go-ahead, per standing instruction)
+- [ ] Merge into `twincat-dev`, update `twincat-status.md`, push
+
+## Implementation Notes
+
+- **Verified end-to-end against the real corpus, before and after**:
+  `ironplcc check TestProject` (top-level directory) went from
+  `P9002 Set of valid source files has no content` to actually parsing
+  real POUs (surfacing unrelated, pre-existing errors — unsupported
+  `.TcVMO`/`.TcTTO` visualization file types, an unsupported
+  `REFERENCE TO` variable, an unrelated parser edge case — confirming the
+  fix is isolated to discovery, nothing downstream needed to change).
+- **The real duplicate-`.plcproj` case resolved correctly by coincidence
+  of the lexicographic tie-break**: `TestProjectRuntime.plcproj` sorts
+  before `TestRuntime.plcproj`, and is also the one whose name matches
+  its containing folder (the "correct" one). Not a designed heuristic —
+  just confirms the simple tie-break didn't make things worse for the one
+  real case found with multiple candidates.
+- **The `root_dir`/base-path fix was easy to miss but load-bearing**:
+  `parse_plcproj`'s second argument is used to resolve every
+  `<Compile Include="...">` path, and those paths are always relative to
+  the `.plcproj` file's own directory — not the directory originally
+  passed to `discover()`. This was harmless before (when `.plcproj` was
+  required to live directly in that directory, the two were the same
+  path) but silently wrong once nesting is allowed. Caught by writing a
+  test with a `.plcproj` referencing a file in its own subdirectory
+  before assuming the straightforward wiring was correct.


### PR DESCRIPTION
Related to the TwinCAT dialect work tracked in #1199, but a standalone bug fix, not a dialect/grammar feature.

`detect_twincat()` and `detect_fallback()` in `compiler/sources/src/discovery/mod.rs` only listed a directory's immediate children, so a `.plcproj` nested 2-3 levels down (the normal Visual-Studio-style TwinCAT layout) was never found -- `ironplcc check <project-root>` reported "no content" even though the project was right there, just deeper.

Adds a shared `walk_files()` helper used by both detectors: recurses into subdirectories, skips hidden directories (`.git`, `.idea`, etc.), doesn't follow symlinks (avoids cycles), and sorts each directory's entries for deterministic output. Also fixes a latent bug this exposed: `<Compile Include="...">` paths in a `.plcproj` must resolve relative to the `.plcproj`'s own directory, not the directory originally passed to `discover()`, now that the two can differ.

Verified against a real TwinCAT checkout: `ironplcc check <root>` went from reporting no content to actually parsing real POUs.

See `specs/plans/2026-07-19-twincat-recursive-project-discovery.md` for full design notes.

## Test plan

- [x] `cd compiler && just` passes (compile, coverage, clippy, fmt, dupes)
- [x] New unit tests: nested `.plcproj` discovery, hidden-directory skipping, multiple-candidate tie-breaking, `root_dir` correctness, nested fallback file discovery, symlink-cycle safety
- [x] All existing single-level discovery tests pass unchanged (regression)
- [x] Verified end-to-end against a real TwinCAT checkout, before and after