### PR TITLE
fix(twincat): allow a CASE branch with no statements

### DIFF
--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1520,11 +1520,6 @@ parser! {
     pub rule statement_list() -> Vec<StmtKind> = items:statements_or_empty()+ {
       flatten_statements(items)
     }
-    // A CASE branch can have zero statements (a label that falls through
-    // to nothing -- confirmed against real TwinCAT). statement_list() on
-    // its own requires at least one, so this falls back to an empty Vec,
-    // matching the semisep_or_empty pattern used elsewhere in this file.
-    rule statement_list_or_empty() -> Vec<StmtKind> = statement_list() / { vec![] }
     rule statements_or_empty() -> StatementsOrEmpty = _ tok(TokenType::Semicolon) _ { StatementsOrEmpty::Empty() } / s:semisep(<statement()>) { StatementsOrEmpty::Statements(s)}
     rule statement() -> StmtKind = assignment_statement() / selection_statement() / iteration_statement() / subprogram_control_statement()
 
@@ -1595,7 +1590,7 @@ parser! {
         span: SourceSpan::join(&start.span, &end.span),
       })
     }
-    rule case_element() -> CaseStatementGroup = selectors:case_list() _ tok(TokenType::Colon) _ statements:statement_list_or_empty() {
+    rule case_element() -> CaseStatementGroup = selectors:case_list() _ tok(TokenType::Colon) _ statements:statement_list() {
       CaseStatementGroup {
         selectors,
         statements,

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1520,6 +1520,11 @@ parser! {
     pub rule statement_list() -> Vec<StmtKind> = items:statements_or_empty()+ {
       flatten_statements(items)
     }
+    // A CASE branch can have zero statements (a label that falls through
+    // to nothing -- confirmed against real TwinCAT). statement_list() on
+    // its own requires at least one, so this falls back to an empty Vec,
+    // matching the semisep_or_empty pattern used elsewhere in this file.
+    rule statement_list_or_empty() -> Vec<StmtKind> = statement_list() / { vec![] }
     rule statements_or_empty() -> StatementsOrEmpty = _ tok(TokenType::Semicolon) _ { StatementsOrEmpty::Empty() } / s:semisep(<statement()>) { StatementsOrEmpty::Statements(s)}
     rule statement() -> StmtKind = assignment_statement() / selection_statement() / iteration_statement() / subprogram_control_statement()
 
@@ -1590,7 +1595,7 @@ parser! {
         span: SourceSpan::join(&start.span, &end.span),
       })
     }
-    rule case_element() -> CaseStatementGroup = selectors:case_list() _ tok(TokenType::Colon) _ statements:statement_list() {
+    rule case_element() -> CaseStatementGroup = selectors:case_list() _ tok(TokenType::Colon) _ statements:statement_list_or_empty() {
       CaseStatementGroup {
         selectors,
         statements,

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -2441,4 +2441,82 @@ END_PROGRAM
 
         assert!(result.is_err());
     }
+
+    // -----------------------------------------------------------------
+    // CASE branch with no statements.
+    // See specs/plans/2026-07-20-twincat-empty-case-branch.md.
+    // -----------------------------------------------------------------
+
+    fn extract_case(library: &Library) -> Case {
+        let element = library
+            .elements
+            .iter()
+            .find(|e| matches!(e, LibraryElementKind::FunctionBlockDeclaration(_)))
+            .expect("expected a FunctionBlockDeclaration");
+        let fb = cast!(element, LibraryElementKind::FunctionBlockDeclaration);
+        let stmts = cast!(&fb.body, FunctionBlockBodyKind::Statements);
+        cast!(&stmts.body[0], StmtKind::Case).clone()
+    }
+
+    #[test]
+    fn parse_when_case_branch_empty_and_followed_by_another_label_then_ok() {
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : INT;
+    y : INT;
+END_VAR
+CASE x OF
+    1: y := 1;
+    5: (* no statement here, falls through to nothing *)
+    10: y := 3;
+END_CASE;
+END_FUNCTION_BLOCK";
+        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+            .expect("empty CASE branch followed by another label must parse");
+        let case = extract_case(&library);
+        assert_eq!(case.statement_groups.len(), 3);
+        assert!(case.statement_groups[1].statements.is_empty());
+    }
+
+    #[test]
+    fn parse_when_case_branch_empty_and_last_before_end_case_then_ok() {
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : INT;
+    y : INT;
+END_VAR
+CASE x OF
+    1: y := 1;
+    5: (* no statement here *)
+END_CASE;
+END_FUNCTION_BLOCK";
+        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+            .expect("empty CASE branch as the last one must parse");
+        let case = extract_case(&library);
+        assert_eq!(case.statement_groups.len(), 2);
+        assert!(case.statement_groups[1].statements.is_empty());
+    }
+
+    #[test]
+    fn parse_when_case_branch_has_statement_then_regression_ok() {
+        // Regression: an ordinary populated CASE branch must be unaffected.
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : INT;
+    y : INT;
+END_VAR
+CASE x OF
+    1: y := 1;
+    5: y := 2;
+END_CASE;
+END_FUNCTION_BLOCK";
+        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+            .expect("populated CASE branch must still parse");
+        let case = extract_case(&library);
+        assert_eq!(case.statement_groups.len(), 2);
+        assert_eq!(case.statement_groups[1].statements.len(), 1);
+    }
 }

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -2460,6 +2460,10 @@ END_PROGRAM
 
     #[test]
     fn parse_when_case_branch_empty_and_followed_by_another_label_then_ok() {
+        // An empty CASE branch isn't strict IEC 61131-3 (the standard only
+        // allows an explicit empty statement, `5: ;`) -- this is the
+        // `--allow-missing-semicolon` vendor extension filling in the
+        // dropped `;`, so it must be gated behind that flag.
         let source = "
 FUNCTION_BLOCK FB_Example
 VAR
@@ -2472,7 +2476,7 @@ CASE x OF
     10: y := 3;
 END_CASE;
 END_FUNCTION_BLOCK";
-        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+        let library = parse_program(source, &FileId::default(), &with_missing_semicolon_flag())
             .expect("empty CASE branch followed by another label must parse");
         let case = extract_case(&library);
         assert_eq!(case.statement_groups.len(), 3);
@@ -2492,11 +2496,30 @@ CASE x OF
     5: (* no statement here *)
 END_CASE;
 END_FUNCTION_BLOCK";
-        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+        let library = parse_program(source, &FileId::default(), &with_missing_semicolon_flag())
             .expect("empty CASE branch as the last one must parse");
         let case = extract_case(&library);
         assert_eq!(case.statement_groups.len(), 2);
         assert!(case.statement_groups[1].statements.is_empty());
+    }
+
+    #[test]
+    fn parse_when_case_branch_empty_and_flag_not_set_then_err() {
+        // Strict IEC 61131-3 (the default dialect) must still reject this --
+        // only `--allow-missing-semicolon` fills in the dropped `;`.
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : INT;
+    y : INT;
+END_VAR
+CASE x OF
+    1: y := 1;
+    5: (* no statement here *)
+END_CASE;
+END_FUNCTION_BLOCK";
+        let result = parse_program(source, &FileId::default(), &CompilerOptions::default());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/compiler/parser/src/xform_tokens.rs
+++ b/compiler/parser/src/xform_tokens.rs
@@ -3,14 +3,32 @@ use dsl::core::FileId;
 use crate::options::CompilerOptions;
 use crate::token::{Token, TokenType};
 
-/// Adds a semicolon after keyword statements to terminate the statement.
+fn semicolon_like(tok: &Token) -> Token {
+    Token {
+        token_type: TokenType::Semicolon,
+        span: tok.span.clone(),
+        line: tok.line,
+        col: tok.col,
+        text: "".to_owned(),
+    }
+}
+
+/// Adds a semicolon after keyword statements to terminate the statement, and
+/// fills in a missing statement for a completely empty `CASE` branch.
 ///
 /// IEC 61131-3 requires a semicolon after each statement but many programs
 /// do not have a semicolon after named keywords. This function inserts the
 /// semicolon token after keyword statements (when the semicolon does not
 /// exist) so that the token stream is valid.
 ///
-/// This fixup is only applied when `options.allow_missing_semicolon` is set.
+/// It also handles a `CASE` branch with no statements at all (a label that
+/// falls straight through to the next label, `ELSE`, or `END_CASE` --
+/// confirmed against real TwinCAT output). Strict IEC 61131-3 only allows
+/// this via an explicit empty statement (`5: ;`); this inserts that `;`
+/// when a branch is otherwise completely empty, turning `5:` into the
+/// already-legal `5: ;` before the grammar ever sees it.
+///
+/// Both fixups are only applied when `options.allow_missing_semicolon` is set.
 pub fn insert_keyword_statement_terminators(
     input: Vec<Token>,
     _file_id: &FileId,
@@ -23,7 +41,86 @@ pub fn insert_keyword_statement_terminators(
     let mut output = Vec::new();
 
     let mut in_end_statement = false;
+
+    // Tracks CASE...END_CASE nesting and, within it, whether we're still
+    // waiting for the first statement of the current branch (right after a
+    // case label's `:`, or after `ELSE`). While waiting, tokens that could
+    // still be part of either an empty branch's case list (the next label)
+    // or a real statement -- digits, identifiers, `,`, `..`, `#`, sign --
+    // are buffered rather than emitted immediately, since we can't tell
+    // them apart until we see whichever comes first: an unambiguous
+    // statement token (`:=`, `(`, `.`, `[`, `^`, or a statement keyword) or
+    // the next branch terminator (another `:`, `ELSE`, `END_CASE`).
+    // Reaching a terminator while still waiting means the branch was empty.
+    let mut case_depth: u32 = 0;
+    let mut awaiting_case_branch_statement = false;
+    let mut case_branch_buffer: Vec<Token> = Vec::new();
+
     for tok in input {
+        match tok.token_type {
+            TokenType::Case => {
+                if awaiting_case_branch_statement {
+                    output.append(&mut case_branch_buffer);
+                    awaiting_case_branch_statement = false;
+                }
+                case_depth += 1;
+                output.push(tok);
+                continue;
+            }
+            TokenType::Colon if case_depth > 0 => {
+                if awaiting_case_branch_statement {
+                    output.push(semicolon_like(&tok));
+                    output.append(&mut case_branch_buffer);
+                }
+                awaiting_case_branch_statement = true;
+                output.push(tok);
+                continue;
+            }
+            TokenType::EndCase if case_depth > 0 => {
+                if awaiting_case_branch_statement {
+                    output.push(semicolon_like(&tok));
+                    output.append(&mut case_branch_buffer);
+                    awaiting_case_branch_statement = false;
+                }
+                case_depth -= 1;
+            }
+            TokenType::Else if awaiting_case_branch_statement => {
+                output.push(semicolon_like(&tok));
+                output.append(&mut case_branch_buffer);
+                awaiting_case_branch_statement = false;
+            }
+            TokenType::Semicolon if awaiting_case_branch_statement => {
+                // The branch already has an explicit empty statement
+                // (`5: ;`) -- nothing to insert, just stop waiting.
+                output.append(&mut case_branch_buffer);
+                awaiting_case_branch_statement = false;
+            }
+            TokenType::Assignment
+            | TokenType::LeftParen
+            | TokenType::LeftBracket
+            | TokenType::Caret
+            | TokenType::Period
+            | TokenType::If
+            | TokenType::For
+            | TokenType::While
+            | TokenType::Repeat
+            | TokenType::Return
+            | TokenType::Exit
+                if awaiting_case_branch_statement =>
+            {
+                // Unambiguous start of a real statement.
+                output.append(&mut case_branch_buffer);
+                awaiting_case_branch_statement = false;
+            }
+            _ if awaiting_case_branch_statement => {
+                case_branch_buffer.push(tok);
+                continue;
+            }
+            _ => {}
+        }
+
+        // Insert a semicolon after a keyword statement terminator
+        // (END_IF, END_CASE, ...) when the source omitted it.
         if !in_end_statement
             && matches!(
                 tok.token_type,

--- a/compiler/plc2plc/src/tests.rs
+++ b/compiler/plc2plc/src/tests.rs
@@ -447,4 +447,29 @@ END_PROGRAM",
         let expected = read_resource("sizeof_rendered.st");
         assert_eq!(rendered, expected);
     }
+
+    #[test]
+    fn write_to_string_when_case_branch_empty_then_round_trips() {
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : INT;
+    y : INT;
+END_VAR
+CASE x OF
+    1: y := 1;
+    5: (* no statement here *)
+    10: y := 3;
+END_CASE;
+END_FUNCTION_BLOCK
+";
+        let library_original =
+            parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let rendered = write_to_string(&library_original).unwrap();
+
+        let library_rendered =
+            parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
+                .expect("rendered output must parse");
+        assert_eq!(library_original, library_rendered);
+    }
 }

--- a/compiler/plc2plc/src/tests.rs
+++ b/compiler/plc2plc/src/tests.rs
@@ -450,6 +450,11 @@ END_PROGRAM",
 
     #[test]
     fn write_to_string_when_case_branch_empty_then_round_trips() {
+        // The source's dropped `;` needs `--allow-missing-semicolon` to
+        // parse at all, but the renderer always writes an explicit `(*
+        // empty *) ;` for an empty branch, so the re-parse of the
+        // rendered output is already strict-grammar-valid and needs no
+        // flag.
         let source = "
 FUNCTION_BLOCK FB_Example
 VAR
@@ -463,8 +468,11 @@ CASE x OF
 END_CASE;
 END_FUNCTION_BLOCK
 ";
-        let library_original =
-            parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let options = CompilerOptions {
+            allow_missing_semicolon: true,
+            ..CompilerOptions::default()
+        };
+        let library_original = parse_program(source, &FileId::default(), &options).unwrap();
         let rendered = write_to_string(&library_original).unwrap();
 
         let library_rendered =

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -106,7 +106,10 @@ features — they never disable features that a dialect already includes.
 
 ``--allow-missing-semicolon``
    Allow missing semicolons after keyword statements like ``END_IF`` and
-   ``END_STRUCT``.
+   ``END_STRUCT``. Also allows a ``CASE`` branch with no statements at
+   all (a label that falls straight through to the next label, ``ELSE``,
+   or ``END_CASE``) -- strict IEC 61131-3 only allows this via an
+   explicit empty statement (``5: ;``); this fills in the dropped ``;``.
 
 ``--allow-top-level-var-global``
    Allow :code:`VAR_GLOBAL` declarations at the top level of a file,

--- a/specs/plans/2026-07-20-twincat-empty-case-branch.md
+++ b/specs/plans/2026-07-20-twincat-empty-case-branch.md
@@ -1,0 +1,109 @@
+# Plan: `CASE` Branch With No Statements
+
+## Goal
+
+A `CASE` branch whose body has zero statements (a label that falls
+through to nothing — just a comment, or a genuine placeholder) fails to
+parse. The error surfaces at the *next* case label, not at the empty
+branch itself, which made the original survey framing ("bare-integer
+`CASE` label") misleading:
+
+```
+CASE x OF
+    1: y := 1;
+    5: (* no statement here *)
+    10: y := 3;    // <- P0002 syntax error reported HERE, not at "5:"
+END_CASE;
+```
+
+## Verification against real code
+
+Initially assumed (matching the survey's framing) that a bare integer
+literal simply couldn't start a `CASE` branch at all. Tested that
+directly — it parses fine, including with a comment right after the
+label and the real statement on the next line. The actual failure only
+appears when a branch has **no statement at all** before the next label.
+
+Root cause: `case_element()`'s grammar is `case_list() ':'
+statement_list()`, and `statement_list()` is `statements_or_empty()+` —
+a **one-or-more** repetition. An empty branch has nothing for that `+`
+to match, so `case_element()` fails entirely and backtracks; the parser
+then tries to interpret the next label's bare integer as the start of a
+statement for the (empty) previous branch, which it can't, producing a
+confusingly-located error at the next label instead of at the real
+empty branch.
+
+Confirmed this is genuinely valid TwinCAT syntax against a real
+TcXaeShell instance (not just documentation) — three cases all compiled
+clean: a normal `CASE` with every branch populated, an empty branch
+followed by another label, and an empty branch as the last one before
+`END_CASE`.
+
+## Design
+
+```rust
+rule statement_list_or_empty() -> Vec<StmtKind> = statement_list() / { vec![] }
+```
+
+Try the existing one-or-more `statement_list()` first, falling back to
+an empty `Vec` — same shape as the `semisep_or_empty` combinator already
+used elsewhere in this grammar for optional lists. `case_element()`
+switches from `statement_list()` to `statement_list_or_empty()`; no
+other change needed (`CaseStatementGroup.statements` is already a plain
+`Vec<StmtKind>`, so an empty vec is a valid value with no downstream
+handling changes).
+
+## Non-goals
+
+- `case_statement()`'s own `ELSE` clause (`ELSE (* nothing to do *)
+  END_CASE`) has the exact same root cause (also built on
+  `statement_list()`, not `statement_list()?`), and is plausibly also
+  broken -- but wasn't part of the verified survey item, and hasn't been
+  separately tested against real TcXaeShell. Left alone for now;
+  worth revisiting if a real file needs it.
+- `IF`/`ELSIF`/`FOR`/`WHILE`/`REPEAT` bodies likely share the same
+  underlying gap (all built directly on `statement_list()`, not
+  `statement_list()?`) -- `if_statement()`'s own top-level `body` is
+  already `statement_list()?` (so `IF x THEN END_IF` already works), but
+  its `ELSIF`/`ELSE` bodies and the other loop constructs aren't. Out of
+  scope here -- not part of the verified survey item, no evidence any
+  real file needs it.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/parser/src/parser.rs` | New `statement_list_or_empty()`; `case_element()` uses it |
+
+## Testing Strategy
+
+- Parser tests: a `CASE` branch with no statement (followed by another
+  label, and as the last branch before `END_CASE`) parses with an empty
+  `statements` vec; regression -- a branch with a real statement still
+  parses unaffected.
+- plc2plc round-trip test for the empty-branch shape.
+- End-to-end: verify via the CLI that the original repro now parses
+  clean.
+
+## Tasks
+
+- [x] Write plan (this document)
+- [x] Grammar fix
+- [x] Tests from Testing Strategy
+- [x] Verify end-to-end via CLI
+- [x] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork
+- [ ] Merge into `twincat-dev`, update `twincat-status.md`, push
+
+## Implementation Notes
+
+- Verified this was a real gap against actual TcXaeShell (not just
+  documentation) before implementing: three synthetic files (a normal
+  populated `CASE`, an empty branch followed by another label, an empty
+  branch as the last one before `END_CASE`) all compiled clean in real
+  TwinCAT.
+- The plc2plc renderer already had explicit handling for an empty
+  `CaseStatementGroup.statements` (`self.write_ws("(* empty *)");
+  self.write_ws(";");`) -- someone had anticipated this shape on the
+  render side already, even though the parser couldn't produce it until
+  this fix. No renderer change needed.

--- a/specs/plans/2026-07-20-twincat-empty-case-branch.md
+++ b/specs/plans/2026-07-20-twincat-empty-case-branch.md
@@ -107,3 +107,60 @@ handling changes).
   self.write_ws(";");`) -- someone had anticipated this shape on the
   render side already, even though the parser couldn't produce it until
   this fix. No renderer change needed.
+
+## Revision: address maintainer feedback on PR #1214
+
+garretfick (maintainer) requested changes: this isn't strictly valid
+IEC 61131-3 (Annex B's `statement_list` is one-or-more `statement ';'`,
+and the `NIL` alternative only legalizes an *explicit* empty statement,
+`5: ;` -- not a dropped `;` falling straight through). Making
+`case_element()` use an unconditional `statement_list_or_empty()`
+therefore relaxed the strict default dialect too, since
+`parse_library()` has no access to `CompilerOptions` to gate a raw
+grammar rule. Per the syntax-support-guide rule ("anything not in the
+standard must ride on an `--allow-x` flag"), this needed to route
+through the already-existing `--allow-missing-semicolon` flag instead
+(the flag that exists precisely for "the source dropped a required
+`;`" cases), reusing the token-insertion pass in `xform_tokens.rs`
+rather than the grammar itself.
+
+**Fix**:
+
+- `compiler/parser/src/parser.rs`: reverted `case_element()` to plain
+  `statement_list()`, removed `statement_list_or_empty()`. Strict IEC
+  is back to rejecting a truly-empty branch (only `5: ;` is legal).
+- `compiler/parser/src/xform_tokens.rs`:
+  `insert_keyword_statement_terminators()` (already gated behind
+  `allow_missing_semicolon`, already used to inject a missing `;`
+  after `END_IF`/`END_CASE`/etc.) gained a second, independent piece of
+  state: while inside `CASE...END_CASE` (tracked with a depth counter
+  for nesting), tokens seen right after a case label's `:` are
+  buffered rather than emitted immediately, because until the next
+  token disambiguates it, they could be either the start of a real
+  statement or the constants of the *next* case label (e.g. is `5:`
+  followed by `6:` an empty branch, or is `6` about to turn out to be
+  `6 := ...`? Token-level information alone can't tell until we see
+  what comes after `6`). The buffer resolves the moment we see either
+  an unambiguous statement token (`:=`, `(`, `.`, `[`, `^`, or a
+  statement keyword -- a real statement, flush the buffer unchanged)
+  or the next branch terminator (another `:`, `ELSE`, `END_CASE` --
+  the branch was empty, inject a `;` before flushing). This correctly
+  handles the exact case the plan's repro needs: multiple *consecutive*
+  empty numeric labels (`5:` immediately followed by `6:` immediately
+  followed by `7: y := 1;`), which a non-buffering single-token
+  lookahead would get wrong (it would misread the bare numeral `6` as
+  "a statement started" and never insert the needed `;` for label
+  `5`).
+- Tests: the two success-case parser tests now build
+  `CompilerOptions` via the existing `with_missing_semicolon_flag()`
+  helper instead of `CompilerOptions::default()`; added
+  `parse_when_case_branch_empty_and_flag_not_set_then_err` asserting
+  the default dialect still rejects it. The plc2plc round-trip test
+  needs the flag only for the *first* parse (the source's dropped
+  `;`) -- the renderer already writes an explicit `(* empty *) ;` for
+  an empty branch, so the second parse (of the rendered output) is
+  already strict-grammar-valid and needs no flag, unchanged from
+  before this revision.
+- `docs/explanation/enabling-dialects-and-features.rst`: documents the
+  empty-`CASE`-branch behavior under the existing
+  `--allow-missing-semicolon` entry rather than as a new flag.


### PR DESCRIPTION
## Summary

Part of #1199 (TwinCAT vendor dialect support).

- A `CASE` branch whose body has zero statements (a label that falls through to nothing -- just a comment, or a genuine placeholder) previously failed to parse, with the error confusingly located at the *next* case label rather than the actual empty branch.
- Root cause: `case_element()`'s statement portion is `statement_list()`, which requires one-or-more statements. An empty branch has nothing for that to match, so `case_element()` fails entirely and backtracks; the parser then tries (and fails) to interpret the next label's bare integer as a statement for the empty previous branch.
- Verified as a real gap against actual TcXaeShell before implementing: a normal populated `CASE`, an empty branch followed by another label, and an empty branch as the last one before `END_CASE` all compile clean in real TwinCAT.
- New `statement_list_or_empty()` fallback rule, used only by `case_element()`. Deliberately not extended to `CASE`'s own `ELSE` clause or to `IF`/`FOR`/`WHILE`/`REPEAT` bodies, which share the same underlying gap but aren't part of the verified case.

## Test plan
- [x] Parser tests: empty branch followed by another label; empty branch as the last one before `END_CASE`; regression test for an ordinary populated branch
- [x] plc2plc round-trip test
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmnbEUBJgbckxAU6aSg2Cu