### PR TITLE
feat(lsp): merge multiple workspace folders into one compilation unit

### DIFF
--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -119,9 +119,7 @@ fn start_with_connection(
     match initialize_params.workspace_folders {
         Some(folders) => {
             debug!("Initialize server with workspace folders {folders:?}");
-            if let Some(folder) = folders.first() {
-                server.project.initialize(folder);
-            }
+            server.project.initialize_many(&folders);
         }
         None => {
             debug!("Initialize server without a workspace folder");

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -1,7 +1,7 @@
 //! Adapts data types between what is required by the compiler
 //! and the language server protocol.
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use ironplc_analyzer::extractors::TypeSymbolKind;
@@ -121,16 +121,24 @@ impl LspProject {
         }
     }
 
-    pub(crate) fn initialize(&mut self, folder: &WorkspaceFolder) {
-        let path = to_path_buf(&folder.uri);
-        if let Ok(path) = path {
-            self.wrapped.initialize(&path);
-        } else {
-            error!(
-                "URL must be convertible to a file path {}",
-                folder.uri.as_str()
-            );
-        }
+    /// Initializes the project from every given workspace folder, merged
+    /// into one compilation unit -- see `Project::initialize_many`.
+    pub(crate) fn initialize_many(&mut self, folders: &[WorkspaceFolder]) {
+        let paths: Vec<PathBuf> = folders
+            .iter()
+            .filter_map(|folder| match to_path_buf(&folder.uri) {
+                Ok(path) => Some(path),
+                Err(_) => {
+                    error!(
+                        "URL must be convertible to a file path {}",
+                        folder.uri.as_str()
+                    );
+                    None
+                }
+            })
+            .collect();
+        let refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
+        self.wrapped.initialize_many(&refs);
     }
 
     pub(crate) fn change_text_document(&mut self, uri: &Uri, content: String) {
@@ -744,6 +752,68 @@ mod test {
 
     fn new_empty_project() -> LspProject {
         LspProject::new(Box::new(FileBackedProject::new()))
+    }
+
+    // -----------------------------------------------------------------
+    // Multi-workspace-folder initialization.
+    // See specs/plans/2026-07-20-twincat-lsp-multi-workspace-folder.md.
+    // -----------------------------------------------------------------
+
+    fn workspace_folder(dir: &std::path::Path) -> lsp_types::WorkspaceFolder {
+        let uri_str = format!("file://{}", dir.display());
+        lsp_types::WorkspaceFolder {
+            uri: Uri::from_str(&uri_str).unwrap(),
+            name: dir.display().to_string(),
+        }
+    }
+
+    #[test]
+    fn initialize_many_when_two_folders_then_cross_folder_type_resolves() {
+        use std::fs;
+
+        let dir1 = tempfile::TempDir::new().unwrap();
+        fs::write(
+            dir1.path().join("base.st"),
+            "FUNCTION_BLOCK FB_Base\nEND_FUNCTION_BLOCK",
+        )
+        .unwrap();
+
+        let dir2 = tempfile::TempDir::new().unwrap();
+        fs::write(
+            dir2.path().join("caller.st"),
+            "FUNCTION_BLOCK FB_Caller\nVAR\n    inst : FB_Base;\nEND_VAR\nEND_FUNCTION_BLOCK",
+        )
+        .unwrap();
+
+        let mut proj = new_empty_project();
+        let folders = vec![workspace_folder(dir1.path()), workspace_folder(dir2.path())];
+        proj.initialize_many(&folders);
+
+        let diagnostics = proj.semantic_all();
+        let all_diagnostics: Vec<_> = diagnostics.values().flatten().collect();
+        assert!(
+            all_diagnostics.is_empty(),
+            "unexpected diagnostics: {all_diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn initialize_many_when_single_folder_then_still_works() {
+        use std::fs;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("main.st"), "PROGRAM Main\nEND_PROGRAM").unwrap();
+
+        let mut proj = new_empty_project();
+        let folders = vec![workspace_folder(dir.path())];
+        proj.initialize_many(&folders);
+
+        let diagnostics = proj.semantic_all();
+        let all_diagnostics: Vec<_> = diagnostics.values().flatten().collect();
+        assert!(
+            all_diagnostics.is_empty(),
+            "unexpected diagnostics: {all_diagnostics:?}"
+        );
     }
 
     #[test]

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -760,7 +760,16 @@ mod test {
     // -----------------------------------------------------------------
 
     fn workspace_folder(dir: &std::path::Path) -> lsp_types::WorkspaceFolder {
-        let uri_str = format!("file://{}", dir.display());
+        // Windows paths are backslash-separated and start with a drive
+        // letter (`C:\...`), neither of which is valid straight in a
+        // `file://` URI -- normalise separators and add the extra `/`
+        // before the drive letter, matching `UriKey::from_file_id`.
+        let normalised = dir.display().to_string().replace('\\', "/");
+        let uri_str = if normalised.starts_with('/') {
+            format!("file://{normalised}")
+        } else {
+            format!("file:///{normalised}")
+        };
         lsp_types::WorkspaceFolder {
             uri: Uri::from_str(&uri_str).unwrap(),
             name: dir.display().to_string(),

--- a/compiler/project/src/project.rs
+++ b/compiler/project/src/project.rs
@@ -73,6 +73,28 @@ pub trait Project {
     /// Initialize
     fn initialize(&mut self, dir: &Path) -> Vec<Diagnostic>;
 
+    /// Initialize from multiple directories, merging all discovered files
+    /// into one compilation unit (unlike calling `initialize` once per
+    /// directory, which would discard the previous directory's files).
+    ///
+    /// Default implementation delegates to `initialize` for a single
+    /// directory, or does nothing for zero directories -- sufficient for
+    /// implementors (e.g. `MemoryBackedProject`) that don't have a
+    /// meaningful multi-directory story.
+    fn initialize_many(&mut self, dirs: &[&Path]) -> Vec<Diagnostic> {
+        match dirs {
+            [] => vec![],
+            [dir] => self.initialize(dir),
+            _ => vec![Diagnostic::problem(
+                Problem::NoContent,
+                Label::span(
+                    SourceSpan::default(),
+                    "This project implementation does not support multiple directories",
+                ),
+            )],
+        }
+    }
+
     /// Updates the text for a document.
     fn change_text_document(&mut self, file_id: &FileId, content: String);
 
@@ -160,6 +182,12 @@ impl Project for FileBackedProject {
     /// Create a new project from the files in the specified directory.
     fn initialize(&mut self, dir: &Path) -> Vec<Diagnostic> {
         self.source_project.initialize_from_directory(dir)
+    }
+
+    /// Create a new project from the files in multiple directories,
+    /// merged into one compilation unit.
+    fn initialize_many(&mut self, dirs: &[&Path]) -> Vec<Diagnostic> {
+        self.source_project.initialize_from_directories(dirs)
     }
 
     fn change_text_document(&mut self, file_id: &FileId, content: String) {
@@ -491,6 +519,47 @@ END_CONFIGURATION
     fn memory_initialize_when_called_then_returns_error() {
         let mut project = MemoryBackedProject::new(CompilerOptions::default());
         let diagnostics = project.initialize(Path::new("/some/dir"));
+
+        assert!(!diagnostics.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Multi-directory initialization.
+    // See specs/plans/2026-07-20-twincat-lsp-multi-workspace-folder.md.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn file_backed_initialize_many_when_two_directories_then_merges_both() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir1 = TempDir::new().unwrap();
+        fs::write(dir1.path().join("a.st"), "PROGRAM A\nEND_PROGRAM").unwrap();
+
+        let dir2 = TempDir::new().unwrap();
+        fs::write(dir2.path().join("b.st"), "PROGRAM B\nEND_PROGRAM").unwrap();
+
+        let mut project = FileBackedProject::default();
+        let diagnostics = project.initialize_many(&[dir1.path(), dir2.path()]);
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(project.sources().len(), 2);
+    }
+
+    #[test]
+    fn file_backed_initialize_many_when_zero_directories_then_no_op() {
+        let mut project = FileBackedProject::default();
+        let diagnostics = project.initialize_many(&[]);
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(project.sources().len(), 0);
+    }
+
+    #[test]
+    fn memory_initialize_many_when_multiple_directories_then_returns_error() {
+        let mut project = MemoryBackedProject::new(CompilerOptions::default());
+        let diagnostics =
+            project.initialize_many(&[Path::new("/some/dir"), Path::new("/other/dir")]);
 
         assert!(!diagnostics.is_empty());
     }

--- a/compiler/sources/src/project.rs
+++ b/compiler/sources/src/project.rs
@@ -83,9 +83,33 @@ impl SourceProject {
     /// the appropriate set of files. Falls back to enumerating all
     /// supported files when no specific project is detected.
     pub fn initialize_from_directory(&mut self, dir: &Path) -> Vec<Diagnostic> {
-        info!("Initializing project from directory: {}", dir.display());
-
         self.sources.clear();
+        self.discover_and_add(dir)
+    }
+
+    /// Initialize project from multiple directories using project
+    /// discovery, merging all discovered files into one compilation unit.
+    ///
+    /// Unlike calling `initialize_from_directory` once per directory,
+    /// this does not clear sources between directories -- each directory
+    /// is discovered independently and its files are merged into the same
+    /// project. A directory that fails discovery contributes one
+    /// diagnostic but does not prevent the other directories from
+    /// loading.
+    pub fn initialize_from_directories(&mut self, dirs: &[&Path]) -> Vec<Diagnostic> {
+        self.sources.clear();
+        let mut errors = vec![];
+        for dir in dirs {
+            errors.extend(self.discover_and_add(dir));
+        }
+        errors
+    }
+
+    /// Discovers the project rooted at `dir` and adds every discovered
+    /// file to `self.sources`. Does not clear existing sources first --
+    /// callers control whether/when to clear.
+    fn discover_and_add(&mut self, dir: &Path) -> Vec<Diagnostic> {
+        info!("Initializing project from directory: {}", dir.display());
 
         let discovered = match crate::discovery::discover(dir) {
             Ok(project) => project,
@@ -301,6 +325,70 @@ mod tests {
 
         assert!(errors.is_empty());
         assert!(project.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Multi-directory initialization.
+    // See specs/plans/2026-07-20-twincat-lsp-multi-workspace-folder.md.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn initialize_from_directories_when_two_directories_then_merges_both() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir1 = TempDir::new().unwrap();
+        fs::write(dir1.path().join("a.st"), "PROGRAM A\nEND_PROGRAM").unwrap();
+
+        let dir2 = TempDir::new().unwrap();
+        fs::write(dir2.path().join("b.st"), "PROGRAM B\nEND_PROGRAM").unwrap();
+
+        let mut project = SourceProject::new();
+        let errors = project.initialize_from_directories(&[dir1.path(), dir2.path()]);
+
+        assert!(errors.is_empty(), "Expected no errors, got: {:?}", errors);
+        assert_eq!(project.len(), 2);
+    }
+
+    #[test]
+    fn initialize_from_directories_clears_existing_sources_once_not_per_directory() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir1 = TempDir::new().unwrap();
+        fs::write(dir1.path().join("a.st"), "PROGRAM A\nEND_PROGRAM").unwrap();
+
+        let dir2 = TempDir::new().unwrap();
+        fs::write(dir2.path().join("b.st"), "PROGRAM B\nEND_PROGRAM").unwrap();
+
+        let mut project = SourceProject::new();
+        project.add_source(FileId::from_string("old.st"), "old content".to_string());
+
+        let errors = project.initialize_from_directories(&[dir1.path(), dir2.path()]);
+
+        assert!(errors.is_empty());
+        // Old, pre-existing source is gone, but both new directories'
+        // files are present -- proving the second directory's discovery
+        // didn't wipe out the first directory's files.
+        assert!(project.get_source(&FileId::from_string("old.st")).is_none());
+        assert_eq!(project.len(), 2);
+    }
+
+    #[test]
+    fn initialize_from_directories_when_one_directory_fails_then_other_still_loads() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir1 = TempDir::new().unwrap();
+        fs::write(dir1.path().join("a.st"), "PROGRAM A\nEND_PROGRAM").unwrap();
+
+        let nonexistent = std::path::PathBuf::from("/nonexistent/does/not/exist");
+
+        let mut project = SourceProject::new();
+        let errors = project.initialize_from_directories(&[dir1.path(), &nonexistent]);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(project.len(), 1);
     }
 
     #[test]

--- a/specs/plans/2026-07-20-twincat-lsp-multi-workspace-folder.md
+++ b/specs/plans/2026-07-20-twincat-lsp-multi-workspace-folder.md
@@ -1,13 +1,12 @@
 # Plan: Merge Multiple LSP Workspace Folders Into One Compilation Unit
 
-**Status: drafted, not started.** This plan scopes a real, already-known
-gap (flagged under "What's Missing" in the pre-existing
+**Status: implemented.** This plan scopes a real, already-known gap
+(flagged under "What's Missing" in the pre-existing
 `specs/plans/multi-file-project-support.md`, but never given its own
-phase there) — written up here at a finer grain because it's now
-directly motivated by a concrete external use case (an editor plugin
-using `ironplcc lsp` as a diagnostics backend for a multi-sub-project
-TwinCAT solution). Not yet implemented; queued for prioritization
-alongside the other items in `twincat-status.md`'s "Next" list.
+phase there) — written up here at a finer grain because it's directly
+motivated by a concrete external use case (an editor plugin using
+`ironplcc lsp` as a diagnostics backend for a multi-sub-project TwinCAT
+solution).
 
 ## Goal
 
@@ -172,12 +171,43 @@ match initialize_params.workspace_folders {
 
 ## Tasks
 
-- [ ] Confirm priority against the rest of `twincat-status.md`'s "Next"
+- [x] Confirm priority against the rest of `twincat-status.md`'s "Next"
       list before starting implementation
-- [ ] `initialize_from_directories()` + tests
-- [ ] `Project` trait `initialize_many()` + `FileBackedProject` override
-- [ ] `lsp.rs`: pass all workspace folders
-- [ ] Tests from Testing Strategy
-- [ ] Run full CI pipeline (`cd compiler && just`)
+- [x] `initialize_from_directories()` + tests
+- [x] `Project` trait `initialize_many()` + `FileBackedProject` override
+- [x] `lsp.rs`: pass all workspace folders
+- [x] Tests from Testing Strategy
+- [x] Run full CI pipeline (`cd compiler && just`)
 - [ ] Push branch to fork
 - [ ] Merge into `twincat-dev`, update `twincat-status.md`, push
+
+## Implementation Notes
+
+- `SourceProject::initialize_from_directory` and the new
+  `initialize_from_directories` share a private `discover_and_add`
+  helper (discover one directory, add its files, don't clear) --
+  `initialize_from_directory` clears once then calls it once,
+  `initialize_from_directories` clears once then calls it per directory.
+  No duplicated discovery logic between the single- and multi-directory
+  paths.
+- `Project::initialize_many`'s default implementation (for any future
+  implementor that doesn't override it) delegates to `initialize` for
+  zero or one directories, and returns a `Problem::NoContent` diagnostic
+  for more than one -- deliberately not attempting a "call `initialize`
+  per directory" default, since that would silently reproduce the exact
+  clearing bug this plan fixes for any implementor whose `initialize`
+  clears state per call. Only `FileBackedProject` needed a real
+  multi-directory implementation; `MemoryBackedProject` never receives
+  directories at all (its `initialize` already errors unconditionally).
+- Renamed `LspProject::initialize` to `initialize_many` (no `initialize`
+  overload kept) -- one single-folder-shaped call site (`lsp.rs`), so a
+  parallel single-folder method would have been unused surface area.
+- The most direct verification of "does this actually fix the reported
+  problem" wasn't a unit test on the merge logic in isolation, but an
+  end-to-end test (`initialize_many_when_two_folders_then_cross_folder_type_resolves`):
+  two real temp directories, one declaring a function block, the other
+  referencing it by type name, wired through the real
+  `LspProject::initialize_many` -> `semantic_all()` path -- proving the
+  cross-folder type reference resolves with zero diagnostics once both
+  folders are loaded together, not just that files get merged into one
+  list.

--- a/specs/plans/2026-07-20-twincat-lsp-multi-workspace-folder.md
+++ b/specs/plans/2026-07-20-twincat-lsp-multi-workspace-folder.md
@@ -1,0 +1,183 @@
+# Plan: Merge Multiple LSP Workspace Folders Into One Compilation Unit
+
+**Status: drafted, not started.** This plan scopes a real, already-known
+gap (flagged under "What's Missing" in the pre-existing
+`specs/plans/multi-file-project-support.md`, but never given its own
+phase there) — written up here at a finer grain because it's now
+directly motivated by a concrete external use case (an editor plugin
+using `ironplcc lsp` as a diagnostics backend for a multi-sub-project
+TwinCAT solution). Not yet implemented; queued for prioritization
+alongside the other items in `twincat-status.md`'s "Next" list.
+
+## Goal
+
+`ironplcc lsp` currently only ever analyzes the **first** LSP workspace
+folder sent by the client on `initialize` — every other folder is
+silently dropped. A TwinCAT solution with multiple sub-projects (a
+common real layout: a top-level solution directory containing several
+independent `.plcproj`-rooted library projects as siblings, each
+referencing the others by relative path) needs all of them loaded
+together as one compilation unit for cross-project type resolution to
+work — the same way `ironplcc check dir1 dir2 ...` (multiple CLI
+arguments) already merges multiple directories today.
+
+```
+TestSolution/
+├── TestRuntime/            (main .plcproj, references the libraries below)
+├── TestLib1/                (sibling .plcproj, a shared library)
+└── TestLib2/                (sibling .plcproj, another shared library)
+```
+
+An editor client that's aware of this structure (e.g. via a
+`<PlaceholderReference>`-style cross-reference in a `.plcproj`, resolved
+against sibling directories) can already tell the LSP server about all
+three directories via `workspaceFolders` on `initialize` — every major
+LSP client library supports sending more than one folder. `ironplcc`
+just throws the extra ones away today.
+
+## Verification against real code
+
+Traced the exact behavior directly:
+
+- `ironplc-cli/src/lsp.rs:127`:
+  ```rust
+  match initialize_params.workspace_folders {
+      Some(folders) => {
+          if let Some(folder) = folders.first() {
+              server.project.initialize(folder);
+          }
+      }
+      None => {}
+  }
+  ```
+  Only `folders.first()` is ever used.
+- `LspProject::initialize` (`ironplc-cli/src/lsp_project.rs:124`) takes a
+  single `&WorkspaceFolder` and delegates to
+  `FileBackedProject::initialize(&mut self, dir: &Path)`
+  (`project/src/project.rs:161`), which delegates to
+  `SourceProject::initialize_from_directory` (`sources/src/project.rs:85`).
+- **`initialize_from_directory` calls `self.sources.clear()` before
+  discovering** (`sources/src/project.rs:88`). This means simply looping
+  over all `folders` and calling today's `initialize()` once per folder
+  would not merge them — each call would wipe out the previous folder's
+  sources, leaving only the last folder's files loaded (a different bug,
+  not a fix).
+- The correct merge pattern already exists, just not on this code path:
+  `ironplc-cli/src/cli.rs`'s `create_project` (backing the CLI's
+  multi-argument `ironplcc check dir1 dir2 ...`) loops over each input
+  path, calls `enumerate_files`/`discovery::discover()` independently per
+  path, accumulates every discovered file into one `Vec<PathBuf>`, and
+  only then builds a single `FileBackedProject` and pushes every file
+  into it. No clearing between iterations.
+
+So the fix is squarely "make the LSP path do what the CLI path already
+does," not new design space.
+
+## Design
+
+### New multi-directory initializer on `SourceProject`
+
+```rust
+/// Initialize project from multiple directories using project discovery,
+/// merging all discovered files into one compilation unit. Unlike calling
+/// initialize_from_directory per directory, this does not clear sources
+/// between directories.
+pub fn initialize_from_directories(&mut self, dirs: &[&Path]) -> Vec<Diagnostic> {
+    self.sources.clear();
+    let mut errors = vec![];
+    for dir in dirs {
+        match crate::discovery::discover(dir) {
+            Ok(project) => {
+                for file_path in &project.files {
+                    if let Err(err) = self.add_file(FileId::from_path(file_path)) {
+                        errors.push(err);
+                    }
+                }
+            }
+            Err(diag) => errors.push(diag),
+        }
+    }
+    errors
+}
+```
+
+A single unresolvable directory's discovery failure becomes one
+collected diagnostic, not an abort of the remaining directories --
+matching the same "one bad entry doesn't take down everything else"
+principle already applied to `.plcproj` resolution (see "Done" #11 in
+`twincat-status.md`).
+
+### `Project` trait and `FileBackedProject`
+
+Add a parallel `initialize_many(&mut self, dirs: &[&Path]) -> Vec<Diagnostic>`
+to the `Project` trait (default-implemented in terms of the existing
+single-directory `initialize` for any implementor that doesn't need the
+distinction, e.g. `MemoryBackedProject`), overridden in
+`FileBackedProject` to call the new `initialize_from_directories`.
+
+### `lsp.rs`: pass every folder, not just the first
+
+```rust
+match initialize_params.workspace_folders {
+    Some(folders) => {
+        let dirs: Vec<PathBuf> = folders.iter().filter_map(|f| to_path_buf(&f.uri).ok()).collect();
+        let paths: Vec<&Path> = dirs.iter().map(|p| p.as_path()).collect();
+        server.project.initialize_many(&paths);
+    }
+    None => {}
+}
+```
+
+## Non-goals
+
+- Any change to the CLI's own multi-argument `check` handling — already
+  correct, used as the template here.
+- Any IDE/editor-side logic for *deciding* which sibling directories to
+  advertise as workspace folders (e.g. parsing a `.plcproj`'s
+  cross-project references and resolving them against sibling
+  directories) — that's entirely client-side (editor plugin)
+  responsibility, out of scope for `ironplcc` itself. This plan only
+  covers `ironplcc` correctly using whatever folders a client already
+  sends.
+- Live re-initialization when workspace folders change after the initial
+  `initialize` (LSP's `workspace/didChangeWorkspaceFolders` notification)
+  — not confirmed as needed by the motivating use case; a separate
+  follow-up if it turns out to matter.
+- Deduplicating files that appear in more than one workspace folder's
+  discovered set (e.g. overlapping/nested folders) — no evidence this
+  occurs in practice; `add_file` already errors clearly on a duplicate
+  `FileId` if it ever does.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/sources/src/project.rs` | New `initialize_from_directories()` |
+| `compiler/project/src/project.rs` | `Project` trait: new `initialize_many()`; `FileBackedProject` override |
+| `compiler/ironplc-cli/src/lsp.rs` | Pass all `workspace_folders`, not just the first |
+
+## Testing Strategy
+
+- `initialize_from_directories()`: two directories' files both end up in
+  the same project; a directory that fails to discover doesn't prevent
+  the other directory's files from loading (mirrors the `.plcproj`
+  warnings test shape).
+- `FileBackedProject::initialize_many`: same coverage at the `Project`
+  trait level.
+- LSP integration-style test (if the existing LSP test harness supports
+  multi-folder `initialize` params): confirm a cross-folder type
+  reference resolves once both folders are loaded together.
+- Regression: single-workspace-folder `initialize` (today's only tested
+  case) still works unchanged.
+
+## Tasks
+
+- [ ] Confirm priority against the rest of `twincat-status.md`'s "Next"
+      list before starting implementation
+- [ ] `initialize_from_directories()` + tests
+- [ ] `Project` trait `initialize_many()` + `FileBackedProject` override
+- [ ] `lsp.rs`: pass all workspace folders
+- [ ] Tests from Testing Strategy
+- [ ] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork
+- [ ] Merge into `twincat-dev`, update `twincat-status.md`, push


### PR DESCRIPTION
## Summary

Part of #1199 (TwinCAT vendor dialect support).

- When an LSP client (e.g. VS Code) opens multiple workspace folders, the LSP previously only initialized from `workspace_folders.first()`, silently ignoring the rest -- so cross-folder type resolution (a common layout for multi-project TwinCAT solutions) never worked in the editor, even though the CLI's own multi-argument `ironplcc check dir1 dir2 ...` already merges multiple directories into one project correctly.
- Adds `initialize_many` (discovers and merges multiple directories without clearing between them, unlike naively looping over the existing single-directory `initialize`), a matching `Project::initialize_many` trait method, and wires `lsp.rs` to pass every `workspace_folders` entry instead of just the first.
- Mirrors the existing, working CLI pattern rather than inventing a new merge strategy.

## Test plan
- [x] Two workspace folders: a type declared in one folder resolves correctly when referenced from the other
- [x] A single folder still works (regression)
- [x] `Project::initialize_many` unit tests (two directories merge; single directory is unaffected)
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmnbEUBJgbckxAU6aSg2Cu