### PR TITLE
feat(twincat): register MODABS as a Beckhoff Tc2_Math stdlib function

### DIFF
--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -1049,14 +1049,14 @@ pub fn get_sizeof_function() -> FunctionSignature {
 // Extended math functions (Beckhoff Tc2_Math library, Vendor Extension)
 // =============================================================================
 
-/// Returns the `LTRUNC`/`LMOD` function definitions.
+/// Returns the `LTRUNC`/`LMOD`/`MODABS` function definitions.
 ///
-/// Both are Beckhoff `Tc2_Math` library functions, not core IEC 61131-3
-/// (unlike `TRUNC`/`MOD` above) -- a real TwinCAT project must reference
-/// that library to use them. Registered conditionally based on the
-/// `allow_extended_math_functions` compiler option.
+/// All three are Beckhoff `Tc2_Math` library functions, not core IEC
+/// 61131-3 (unlike `TRUNC`/`MOD` above) -- a real TwinCAT project must
+/// reference that library to use them. Registered conditionally based on
+/// the `allow_extended_math_functions` compiler option.
 ///
-/// Unlike the generic `ANY_REAL`/`ANY_NUM`-typed `TRUNC`/`MOD`, both
+/// Unlike the generic `ANY_REAL`/`ANY_NUM`-typed `TRUNC`/`MOD`, all three
 /// operate on `LREAL` only, matching their real Beckhoff signatures:
 ///
 /// - `LTRUNC` truncates the fractional part like `TRUNC`, but returns
@@ -1064,6 +1064,10 @@ pub fn get_sizeof_function() -> FunctionSignature {
 ///   integer type's value range.
 /// - `LMOD` is a floating-point modulo (e.g. `LMOD(400.56, 360) = 40.56`),
 ///   unlike the integer-oriented `MOD`.
+/// - `MODABS` is like `LMOD` but always returns an unsigned/non-negative
+///   result (`MODABS(-400.56, 360) = 319.44`, where `LMOD` would return
+///   `-40.56`) -- used in NC-axis contexts where modulo values are
+///   conventionally unsigned.
 pub fn get_extended_math_functions() -> Vec<FunctionSignature> {
     vec![
         FunctionSignature::stdlib(
@@ -1073,6 +1077,11 @@ pub fn get_extended_math_functions() -> Vec<FunctionSignature> {
         ),
         FunctionSignature::stdlib(
             "LMOD",
+            TypeName::from("LREAL"),
+            vec![input_param("IN1", "LREAL"), input_param("IN2", "LREAL")],
+        ),
+        FunctionSignature::stdlib(
+            "MODABS",
             TypeName::from("LREAL"),
             vec![input_param("IN1", "LREAL"), input_param("IN2", "LREAL")],
         ),
@@ -1490,10 +1499,10 @@ mod tests {
     }
 
     #[test]
-    fn get_extended_math_functions_when_called_then_contains_ltrunc_and_lmod() {
+    fn get_extended_math_functions_when_called_then_contains_ltrunc_lmod_and_modabs() {
         let functions = get_extended_math_functions();
 
-        assert_eq!(functions.len(), 2);
+        assert_eq!(functions.len(), 3);
 
         let ltrunc = functions
             .iter()
@@ -1520,6 +1529,21 @@ mod tests {
         assert_eq!(lmod.parameters[1].param_type, TypeName::from("LREAL"));
         assert_eq!(
             lmod.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("LREAL")))
+        );
+
+        let modabs = functions
+            .iter()
+            .find(|f| f.name.original() == "MODABS")
+            .unwrap();
+        assert!(modabs.is_stdlib());
+        assert_eq!(modabs.parameters.len(), 2);
+        assert_eq!(modabs.parameters[0].name.original(), "IN1");
+        assert_eq!(modabs.parameters[1].name.original(), "IN2");
+        assert_eq!(modabs.parameters[0].param_type, TypeName::from("LREAL"));
+        assert_eq!(modabs.parameters[1].param_type, TypeName::from("LREAL"));
+        assert_eq!(
+            modabs.return_type,
             Some(FunctionReturnType::Named(TypeName::from("LREAL")))
         );
     }

--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -1045,6 +1045,40 @@ pub fn get_sizeof_function() -> FunctionSignature {
     )
 }
 
+// =============================================================================
+// Extended math functions (Beckhoff Tc2_Math library, Vendor Extension)
+// =============================================================================
+
+/// Returns the `LTRUNC`/`LMOD` function definitions.
+///
+/// Both are Beckhoff `Tc2_Math` library functions, not core IEC 61131-3
+/// (unlike `TRUNC`/`MOD` above) -- a real TwinCAT project must reference
+/// that library to use them. Registered conditionally based on the
+/// `allow_extended_math_functions` compiler option.
+///
+/// Unlike the generic `ANY_REAL`/`ANY_NUM`-typed `TRUNC`/`MOD`, both
+/// operate on `LREAL` only, matching their real Beckhoff signatures:
+///
+/// - `LTRUNC` truncates the fractional part like `TRUNC`, but returns
+///   `LREAL` rather than `ANY_INT` -- the result isn't clamped to an
+///   integer type's value range.
+/// - `LMOD` is a floating-point modulo (e.g. `LMOD(400.56, 360) = 40.56`),
+///   unlike the integer-oriented `MOD`.
+pub fn get_extended_math_functions() -> Vec<FunctionSignature> {
+    vec![
+        FunctionSignature::stdlib(
+            "LTRUNC",
+            TypeName::from("LREAL"),
+            vec![input_param("IN", "LREAL")],
+        ),
+        FunctionSignature::stdlib(
+            "LMOD",
+            TypeName::from("LREAL"),
+            vec![input_param("IN1", "LREAL"), input_param("IN2", "LREAL")],
+        ),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1453,5 +1487,40 @@ mod tests {
                 func.name.original()
             );
         }
+    }
+
+    #[test]
+    fn get_extended_math_functions_when_called_then_contains_ltrunc_and_lmod() {
+        let functions = get_extended_math_functions();
+
+        assert_eq!(functions.len(), 2);
+
+        let ltrunc = functions
+            .iter()
+            .find(|f| f.name.original() == "LTRUNC")
+            .unwrap();
+        assert!(ltrunc.is_stdlib());
+        assert_eq!(ltrunc.parameters.len(), 1);
+        assert_eq!(ltrunc.parameters[0].name.original(), "IN");
+        assert_eq!(ltrunc.parameters[0].param_type, TypeName::from("LREAL"));
+        assert_eq!(
+            ltrunc.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("LREAL")))
+        );
+
+        let lmod = functions
+            .iter()
+            .find(|f| f.name.original() == "LMOD")
+            .unwrap();
+        assert!(lmod.is_stdlib());
+        assert_eq!(lmod.parameters.len(), 2);
+        assert_eq!(lmod.parameters[0].name.original(), "IN1");
+        assert_eq!(lmod.parameters[1].name.original(), "IN2");
+        assert_eq!(lmod.parameters[0].param_type, TypeName::from("LREAL"));
+        assert_eq!(lmod.parameters[1].param_type, TypeName::from("LREAL"));
+        assert_eq!(
+            lmod.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("LREAL")))
+        );
     }
 }

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -577,6 +577,45 @@ END_FUNCTION_BLOCK";
         assert!(context.has_diagnostics());
     }
 
+    #[test]
+    fn analyze_when_modabs_used_then_resolves() {
+        let program = "
+FUNCTION_BLOCK FB_Example
+VAR
+    remainder : LREAL;
+END_VAR
+remainder := MODABS(-400.56, 360.0);
+END_FUNCTION_BLOCK";
+        let lib = parse_program(
+            program,
+            &FileId::default(),
+            &opts_with_extended_math_functions(),
+        )
+        .unwrap();
+        let (_library, context) = analyze(&[&lib], &opts_with_extended_math_functions()).unwrap();
+
+        assert!(
+            !context.has_diagnostics(),
+            "unexpected diagnostics: {:?}",
+            context.diagnostics()
+        );
+    }
+
+    #[test]
+    fn analyze_when_modabs_used_and_extended_math_functions_disabled_then_diagnostics() {
+        let program = "
+FUNCTION_BLOCK FB_Example
+VAR
+    remainder : LREAL;
+END_VAR
+remainder := MODABS(-400.56, 360.0);
+END_FUNCTION_BLOCK";
+        let lib = parse_program(program, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let (_library, context) = analyze(&[&lib], &CompilerOptions::default()).unwrap();
+
+        assert!(context.has_diagnostics());
+    }
+
     // ---------------------------------------------------------------------
     // FB-instance call-style initializer (distinct node).
     // See specs/plans/2026-08-01-fb-call-style-initializer-distinct-node.md.

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -109,6 +109,15 @@ pub fn resolve_types(
             .expect("SIZEOF should not conflict with stdlib");
     }
 
+    if options.allow_extended_math_functions {
+        use crate::intermediates::stdlib_function::get_extended_math_functions;
+        for sig in get_extended_math_functions() {
+            function_environment
+                .insert(sig)
+                .expect("LTRUNC/LMOD should not conflict with stdlib");
+        }
+    }
+
     let mut symbol_environment = SymbolEnvironment::new();
 
     // Register implicit system globals when the uptime feature is enabled.
@@ -471,6 +480,18 @@ END_FUNCTION_BLOCK
         }
     }
 
+    // ---------------------------------------------------------------------
+    // LTRUNC/LMOD extended math functions (Beckhoff Tc2_Math library).
+    // See specs/plans/2026-07-20-twincat-ltrunc-lmod.md.
+    // ---------------------------------------------------------------------
+
+    fn opts_with_extended_math_functions() -> CompilerOptions {
+        CompilerOptions {
+            allow_extended_math_functions: true,
+            ..CompilerOptions::default()
+        }
+    }
+
     #[test]
     fn analyze_when_constant_initializer_expression_and_flag_enabled_then_resolves() {
         let program = "
@@ -499,6 +520,32 @@ END_FUNCTION_BLOCK";
     }
 
     #[test]
+    fn analyze_when_ltrunc_and_lmod_used_then_resolve() {
+        let program = "
+FUNCTION_BLOCK FB_Example
+VAR
+    truncated : LREAL;
+    remainder : LREAL;
+END_VAR
+truncated := LTRUNC(123.456);
+remainder := LMOD(400.56, 360.0);
+END_FUNCTION_BLOCK";
+        let lib = parse_program(
+            program,
+            &FileId::default(),
+            &opts_with_extended_math_functions(),
+        )
+        .unwrap();
+        let (_library, context) = analyze(&[&lib], &opts_with_extended_math_functions()).unwrap();
+
+        assert!(
+            !context.has_diagnostics(),
+            "unexpected diagnostics: {:?}",
+            context.diagnostics()
+        );
+    }
+
+    #[test]
     fn analyze_when_constant_initializer_expression_and_flag_disabled_then_diagnostics() {
         let program = "
 VAR_GLOBAL CONSTANT
@@ -508,6 +555,21 @@ FUNCTION_BLOCK FB_Example
 VAR
     scaled : LREAL := SCALE*4.0;
 END_VAR
+END_FUNCTION_BLOCK";
+        let lib = parse_program(program, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let (_library, context) = analyze(&[&lib], &CompilerOptions::default()).unwrap();
+
+        assert!(context.has_diagnostics());
+    }
+
+    #[test]
+    fn analyze_when_ltrunc_used_and_extended_math_functions_disabled_then_diagnostics() {
+        let program = "
+FUNCTION_BLOCK FB_Example
+VAR
+    truncated : LREAL;
+END_VAR
+truncated := LTRUNC(123.456);
 END_FUNCTION_BLOCK";
         let lib = parse_program(program, &FileId::default(), &CompilerOptions::default()).unwrap();
         let (_library, context) = analyze(&[&lib], &CompilerOptions::default()).unwrap();

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -198,6 +198,12 @@ struct FileArgs {
     /// extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_oop_extensions: bool,
+
+    /// Register Beckhoff Tc2_Math library functions (LTRUNC, LMOD, MODABS)
+    /// as built-in stdlib functions. This is a vendor extension not part of
+    /// the IEC 61131-3 standard.
+    #[arg(long)]
+    allow_extended_math_functions: bool,
 }
 
 impl FileArgs {
@@ -229,6 +235,7 @@ impl FileArgs {
         options.allow_paren_string_length |= self.allow_paren_string_length;
         options.allow_struct_initializer_expressions |= self.allow_struct_initializer_expressions;
         options.allow_oop_extensions |= self.allow_oop_extensions;
+        options.allow_extended_math_functions |= self.allow_extended_math_functions;
         options
     }
 }

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -222,6 +222,13 @@ const FLAG_FIXTURES: &[FlagFixture] = &[
         prereqs: &[],
         source: "FUNCTION_BLOCK FB_Base\nVAR\nx : INT;\nEND_VAR\nEND_FUNCTION_BLOCK\nFUNCTION_BLOCK FB_Derived EXTENDS FB_Base\nEND_FUNCTION_BLOCK",
     },
+    // LTRUNC is only registered as a stdlib function when the flag is on;
+    // with it off, the call is to an undeclared function.
+    FlagFixture {
+        key: "allow_extended_math_functions",
+        prereqs: &[],
+        source: "FUNCTION_BLOCK FB_Example\nVAR\ntruncated : LREAL;\nEND_VAR\ntruncated := LTRUNC(123.456);\nEND_FUNCTION_BLOCK",
+    },
 ];
 
 /// Wraps snippet text as the single-source input the tools expect.

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -345,6 +345,11 @@ define_compiler_options! {
     "--allow-oop-extensions",
     [Rusty, Codesys],
     allow_oop_extensions,
+
+    "Register Beckhoff Tc2_Math library functions (LTRUNC, LMOD) as built-in stdlib functions",
+    "--allow-extended-math-functions",
+    [Rusty, Codesys],
+    allow_extended_math_functions,
 }
 
 /// Format a human-readable summary of all dialects and which features each
@@ -456,6 +461,7 @@ mod tests {
                 "allow_paren_string_length",
                 "allow_struct_initializer_expressions",
                 "allow_oop_extensions",
+                "allow_extended_math_functions",
             ],
         );
     }
@@ -493,6 +499,7 @@ mod tests {
                 "allow_paren_string_length",
                 "allow_struct_initializer_expressions",
                 "allow_oop_extensions",
+                "allow_extended_math_functions",
             ],
         );
     }

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -342,6 +342,18 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    :doc:`P9004 </reference/compiler/problems/P9004>` rather than a parse
    error. Enabled by ``--dialect=rusty`` and ``--dialect=codesys``.
 
+``--allow-extended-math-functions``
+   Register ``LTRUNC`` and ``LMOD`` as built-in stdlib functions. Both are
+   Beckhoff ``Tc2_Math`` library functions, not core IEC 61131-3, and unlike
+   the generic ``ANY_REAL``/``ANY_NUM``-typed ``TRUNC``/``MOD`` they operate
+   on ``LREAL`` only, matching their real Beckhoff signatures: ``LTRUNC``
+   truncates the fractional part like ``TRUNC`` but returns ``LREAL``
+   instead of ``ANY_INT`` (not clamped to an integer type's range), and
+   ``LMOD`` is a floating-point modulo that can return a non-integer
+   remainder (e.g. ``LMOD(400.56, 360) = 40.56``), unlike the
+   integer-oriented ``MOD``. Enabled by ``--dialect=rusty`` and
+   ``--dialect=codesys``.
+
 Pass the flag when running :program:`ironplcc`:
 
 .. code-block:: shell

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -343,16 +343,18 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    error. Enabled by ``--dialect=rusty`` and ``--dialect=codesys``.
 
 ``--allow-extended-math-functions``
-   Register ``LTRUNC`` and ``LMOD`` as built-in stdlib functions. Both are
-   Beckhoff ``Tc2_Math`` library functions, not core IEC 61131-3, and unlike
-   the generic ``ANY_REAL``/``ANY_NUM``-typed ``TRUNC``/``MOD`` they operate
-   on ``LREAL`` only, matching their real Beckhoff signatures: ``LTRUNC``
-   truncates the fractional part like ``TRUNC`` but returns ``LREAL``
-   instead of ``ANY_INT`` (not clamped to an integer type's range), and
-   ``LMOD`` is a floating-point modulo that can return a non-integer
-   remainder (e.g. ``LMOD(400.56, 360) = 40.56``), unlike the
-   integer-oriented ``MOD``. Enabled by ``--dialect=rusty`` and
-   ``--dialect=codesys``.
+   Register ``LTRUNC``, ``LMOD``, and ``MODABS`` as built-in stdlib
+   functions. All three are Beckhoff ``Tc2_Math`` library functions, not
+   core IEC 61131-3, and unlike the generic ``ANY_REAL``/``ANY_NUM``-typed
+   ``TRUNC``/``MOD`` they operate on ``LREAL`` only, matching their real
+   Beckhoff signatures: ``LTRUNC`` truncates the fractional part like
+   ``TRUNC`` but returns ``LREAL`` instead of ``ANY_INT`` (not clamped to
+   an integer type's range), ``LMOD`` is a floating-point modulo that can
+   return a non-integer remainder (e.g. ``LMOD(400.56, 360) = 40.56``),
+   unlike the integer-oriented ``MOD``, and ``MODABS`` is like ``LMOD``
+   but always returns an unsigned/non-negative result (e.g.
+   ``MODABS(-400.56, 360) = 319.44``, where ``LMOD`` would return
+   ``-40.56``). Enabled by ``--dialect=rusty`` and ``--dialect=codesys``.
 
 Pass the flag when running :program:`ironplcc`:
 

--- a/specs/plans/2026-07-20-twincat-ltrunc-lmod.md
+++ b/specs/plans/2026-07-20-twincat-ltrunc-lmod.md
@@ -1,0 +1,155 @@
+# Plan: `LTRUNC`/`LMOD` Stdlib Functions
+
+## Goal
+
+`LTRUNC(x)` and `LMOD(x, y)` are undeclared function calls today (`P4017`),
+blocking files that use them. They were assumed (per the originating
+survey) to be plain missing entries in the existing
+`FunctionSignature::stdlib(...)` table, "same shape as the already-registered
+`TRUNC`" — i.e. generic `ANY_REAL`/`ANY_NUM` functions like the rest of the
+core arithmetic table.
+
+## Verification against real documentation
+
+**That assumption doesn't hold.** Checked Beckhoff's own `Tc2_Math` library
+documentation directly before implementing (per the standing "verify before
+assuming" habit — the same kind of correction already made this session for
+the EXTENDS/IMPLEMENTS bucket and for `PI`):
+
+- `LTRUNC` — `FUNCTION LTRUNC : LREAL`, parameter `lr_in : LREAL`. Unlike
+  `TRUNC` (which returns `ANY_INT`, clamped to an integer type's range),
+  `LTRUNC` returns `LREAL` — it truncates the fractional part but keeps
+  the result as a float, specifically so values outside an integer type's
+  range don't overflow.
+- `LMOD` — `FUNCTION LMOD : LREAL`, parameters `lr_Value : LREAL`,
+  `lr_Arg : LREAL`. Unlike `MOD` (integer-oriented), `LMOD` performs a
+  floating-point modulo and can return a non-integer remainder (Beckhoff's
+  own example: `LMOD(400.56, 360) = 40.56`).
+
+Both are **`Tc2_Math` library functions** — a specific, named Beckhoff PLC
+library a TwinCAT project must reference — not core IEC 61131-3 functions,
+and not generic-CODESYS-core the way pragmas or `SIZEOF` are. They also
+aren't generic over `ANY_REAL`/`ANY_INT` the way `TRUNC`/`MOD` are: both
+operate on `LREAL` only, matching their real signatures.
+
+This changes the shape of the fix: not "two more rows in the always-on
+core arithmetic table," but two new vendor-extension function signatures,
+gated behind their own flag — the same treatment `SIZEOF` and `PI` already
+get (`allow_sizeof`, `allow_math_constants`), not folded into the
+unconditional `get_trunc_function()`/`get_arithmetic_functions()` tables.
+
+## Design
+
+### New flag: `--allow-extended-math-functions`
+
+A new `CompilerOptions` field via the existing `define_compiler_options!`
+macro, enabled by default under `[Rusty, Codesys]` (matching `allow_sizeof`).
+Kept separate from `allow_math_constants` (PI) since that flag's own
+description is specifically about constants, not functions — conflating
+the two would make either flag's name misleading.
+
+### New function signatures (`LREAL`-only, not generic)
+
+```rust
+pub fn get_extended_math_functions() -> Vec<FunctionSignature> {
+    vec![
+        FunctionSignature::stdlib(
+            "LTRUNC",
+            TypeName::from("LREAL"),
+            vec![input_param("IN", "LREAL")],
+        ),
+        FunctionSignature::stdlib(
+            "LMOD",
+            TypeName::from("LREAL"),
+            vec![input_param("IN1", "LREAL"), input_param("IN2", "LREAL")],
+        ),
+    ]
+}
+```
+
+(Parameter names normalized to IronPLC's existing `IN`/`IN1`/`IN2`
+convention, matching `TRUNC`/`MOD`, rather than Beckhoff's own
+`lr_in`/`lr_Value`/`lr_Arg` — IronPLC's stdlib table doesn't preserve
+vendor parameter names for any other function either, and call sites in
+real code use positional args, not named ones, for these two.)
+
+### Registration: conditional, in `stages.rs`, alongside `SIZEOF`
+
+```rust
+if options.allow_extended_math_functions {
+    use crate::intermediates::stdlib_function::get_extended_math_functions;
+    for sig in get_extended_math_functions() {
+        function_environment
+            .insert(sig)
+            .expect("LTRUNC/LMOD should not conflict with stdlib");
+    }
+}
+```
+
+## Non-goals
+
+- Any other `Tc2_Math` library function beyond `LTRUNC`/`LMOD` — no other
+  such function appears in the originating survey's failure set.
+- `NCError_TO_STRING` (same 5-file bucket in the survey) — a project-local
+  function, not a stdlib gap; explicitly out of scope here.
+- Generic widening/family-conversion support for `LTRUNC`/`LMOD` beyond
+  their real, `LREAL`-only signatures — Beckhoff's own docs don't define
+  them generically, so IronPLC shouldn't either.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/parser/src/options.rs` | New `allow_extended_math_functions` flag |
+| `compiler/analyzer/src/intermediates/stdlib_function.rs` | New `get_extended_math_functions()` |
+| `compiler/analyzer/src/stages.rs` | Conditional registration alongside `SIZEOF` |
+| `docs/explanation/enabling-dialects-and-features.rst` | Document the new flag |
+
+## Testing Strategy
+
+- Unit test on `get_extended_math_functions()`: correct names, param
+  counts/types, `LREAL` return type (mirrors existing `stdlib_function.rs`
+  tests for other functions).
+- Semantic test: `LTRUNC(x)`/`LMOD(x, y)` resolve without error when the
+  flag is on; still `P4017` (undeclared) when the flag is off.
+- Regression: flag off by default under `iec61131-3-ed2`/`iec61131-3-ed3`
+  (matches every other vendor-extension flag's default-off test pattern).
+
+## Tasks
+
+- [x] Write plan (this document)
+- [x] New `allow_extended_math_functions` flag
+- [x] `get_extended_math_functions()` in `stdlib_function.rs`
+- [x] Conditional registration in `stages.rs`
+- [x] Tests from Testing Strategy
+- [x] Docs
+- [x] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork
+- [ ] Merge into `twincat-dev`, update `twincat-status.md`, push
+
+## Implementation Notes
+
+- The originating survey's "same shape as `TRUNC`" assumption didn't
+  survive contact with Beckhoff's own `Tc2_Math` documentation — checked
+  before writing any code, per the standing "verify before assuming"
+  habit. `LTRUNC`/`LMOD` are `LREAL`-only, Beckhoff-library-specific
+  functions, not generic IEC 61131-3 stdlib entries, so they got their
+  own gated flag (`allow_extended_math_functions`) rather than joining
+  the always-on `get_arithmetic_functions()`/`get_trunc_function()`
+  tables.
+- `CompilerOptions` uses a macro (`define_compiler_options!`) that
+  auto-generates the CLI/LSP/MCP wiring from one table entry — no
+  exhaustive-match ripple from adding the flag itself. Three hardcoded
+  flag-count assertions still needed manual bumps, found by running the
+  full test suite, not by grep: `options.rs`'s own
+  `feature_descriptors_when_called_then_contains_all_vendor_flags`
+  (20→21), `feature_descriptors_when_rusty_then_all_features_listed`
+  (20→21), `feature_descriptors_when_codesys_then_omits_only_system_uptime_global`
+  (19→20), plus `mcp/src/tools/list_options.rs`'s
+  `build_response_when_called_then_contains_all_flags` (20→21) and its
+  `Vec::with_capacity(20)` — this is the same silent-drift hazard the
+  `twincat-status.md` "Rebase conflict resolution reference" section
+  already documents from earlier branches in this stack.
+- Verified end-to-end via the CLI: `LTRUNC`/`LMOD` resolve cleanly under
+  `--dialect=codesys`, and produce `P4017 Function is not declared` under
+  the default dialect (flag off) — confirming the gating works both ways.

--- a/specs/plans/2026-07-20-twincat-modabs.md
+++ b/specs/plans/2026-07-20-twincat-modabs.md
@@ -1,0 +1,75 @@
+# Plan: `MODABS` Stdlib Function
+
+## Goal
+
+`MODABS(x, y)` is an undeclared function call (`P4017`) — 6 files in the
+latest re-scan, the single biggest remaining one-fix win. Same shape as
+`LTRUNC`/`LMOD` (already landed): a Beckhoff `Tc2_Math` library
+function, not core IEC 61131-3.
+
+## Verification against real documentation
+
+Checked Beckhoff's own `Tc2_Math` docs before implementing (same habit
+as `LTRUNC`/`LMOD`):
+
+- `MODABS` — `FUNCTION MODABS : LREAL`, parameters `lr_val : LREAL`,
+  `lr_mod : LREAL`. Performs a modulo division and returns the
+  **unsigned** modulo value within the modulo range — unlike `LMOD`,
+  which can return a signed result. Beckhoff's own examples:
+  `MODABS(400.56, 360) = 40.56`, `MODABS(-400.56, 360) = 319.44` (an
+  `LMOD` call with the same arguments would return `-40.56` for the
+  second case). Used in NC-axis contexts where modulo values are
+  conventionally unsigned.
+
+Same `LREAL`-only, `Tc2_Math`-specific shape as `LTRUNC`/`LMOD` — belongs
+in the same `get_extended_math_functions()` table, gated by the same
+`allow_extended_math_functions` flag already added for those two. Not a
+new flag.
+
+## Design
+
+```rust
+FunctionSignature::stdlib(
+    "MODABS",
+    TypeName::from("LREAL"),
+    vec![input_param("IN1", "LREAL"), input_param("IN2", "LREAL")],
+),
+```
+
+Added to the existing `get_extended_math_functions()` in
+`stdlib_function.rs`, registered by the same existing conditional block
+in `stages.rs` (`if options.allow_extended_math_functions { ... }`) —
+no new registration code needed, just one more signature in the
+already-iterated `Vec`.
+
+## Non-goals
+
+- Any other `Tc2_Math` function beyond `MODABS` — no other function from
+  this family appears in the current re-scan.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/analyzer/src/intermediates/stdlib_function.rs` | Add `MODABS` to `get_extended_math_functions()` |
+| `docs/explanation/enabling-dialects-and-features.rst` | Update the `--allow-extended-math-functions` description |
+
+## Testing Strategy
+
+- Unit test: `get_extended_math_functions()` now returns 3 functions,
+  including `MODABS` with the correct signature.
+- Semantic test: `MODABS(x, y)` resolves when the flag is on, still
+  `P4017` when off (mirrors the `LTRUNC`/`LMOD` tests).
+- End-to-end: verify via the CLI that `MODABS` resolves under
+  `--dialect=codesys`.
+
+## Tasks
+
+- [x] Write plan (this document)
+- [ ] Add `MODABS` to `get_extended_math_functions()` + update its test
+- [ ] Semantic test
+- [ ] Docs update
+- [ ] Verify end-to-end via CLI
+- [ ] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork
+- [ ] Merge into `twincat-dev`, update `twincat-status.md`, push

--- a/specs/plans/2026-07-20-twincat-modabs.md
+++ b/specs/plans/2026-07-20-twincat-modabs.md
@@ -66,10 +66,10 @@ already-iterated `Vec`.
 ## Tasks
 
 - [x] Write plan (this document)
-- [ ] Add `MODABS` to `get_extended_math_functions()` + update its test
-- [ ] Semantic test
-- [ ] Docs update
-- [ ] Verify end-to-end via CLI
-- [ ] Run full CI pipeline (`cd compiler && just`)
+- [x] Add `MODABS` to `get_extended_math_functions()` + update its test
+- [x] Semantic test
+- [x] Docs update
+- [x] Verify end-to-end via CLI
+- [x] Run full CI pipeline (`cd compiler && just`)
 - [ ] Push branch to fork
 - [ ] Merge into `twincat-dev`, update `twincat-status.md`, push


### PR DESCRIPTION
## Summary

Part of #1199 (TwinCAT vendor dialect support).

**Stacked on #1217 (`ltrunc-lmod`)** -- this PR's branch is built directly on top of that one's, so the diff below currently includes both PRs' commits combined; it will automatically shrink to just this PR's own commit once #1217 merges into `main` (GitHub recomputes the diff against the new `main` at that point). This is a genuine dependency, not just a shared-file collision: `MODABS` is added to the same `get_extended_math_functions()` table and reuses the same `allow_extended_math_functions` flag that #1217 introduces.

- Same family as `LTRUNC`/`LMOD` (#1217): a Beckhoff `Tc2_Math` library function, `LREAL`-only, not core IEC 61131-3.
- Unlike `LMOD`, `MODABS` always returns an unsigned/non-negative modulo result (`MODABS(-400.56, 360) = 319.44`, where `LMOD` would return `-40.56`) -- used in NC-axis contexts where modulo values are conventionally unsigned.
- Added to the same `get_extended_math_functions()` table, gated by the existing `allow_extended_math_functions` flag (no new flag needed).

## Test plan
- [x] `get_extended_math_functions()` now returns `MODABS` alongside `LTRUNC`/`LMOD` with correct parameter/return types
- [x] `MODABS` resolves cleanly with the flag enabled
- [x] `MODABS` produces diagnostics (undeclared function) with the flag disabled (regression/default-off)
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmnbEUBJgbckxAU6aSg2Cu