### PR TITLE
feat(twincat): STRING(n)/WSTRING(n) parentheses + FB call-style instance init

### DIFF
--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -359,4 +359,41 @@ END_FUNCTION_BLOCK";
         let src = read_shared_resource(name);
         parse_program(&src, &FileId::default(), &CompilerOptions::default()).unwrap()
     }
+
+    // ---------------------------------------------------------------------
+    // FB-instance call-style initializer.
+    // See specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn analyze_when_fb_call_style_init_references_earlier_declared_fb_then_no_diagnostics() {
+        // End-to-end regression for the toposort edge-direction bug found
+        // while adding this feature: `comm : FB_Comm(retries := 3);`
+        // constructs InitialValueAssignmentKind::FunctionBlock directly at
+        // parse time (unlike a bare declaration, which defers to
+        // LateResolvedType). Before the xform_toposort_declarations.rs fix,
+        // this produced a spurious P2011 "Parent type is not declared"
+        // because the referenced type was ordered after its referencing
+        // POU instead of before it.
+        let program = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm(retries := 3);
+END_VAR
+END_FUNCTION_BLOCK";
+        let lib = parse_program(program, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let (_library, context) = analyze(&[&lib], &CompilerOptions::default()).unwrap();
+
+        assert!(
+            !context.has_diagnostics(),
+            "unexpected diagnostics: {:?}",
+            context.diagnostics()
+        );
+    }
 }

--- a/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
@@ -158,6 +158,7 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                             FunctionBlockInitialValueAssignment {
                                 type_name: name,
                                 init: vec![],
+                                call_params: None,
                             },
                         ));
                     }
@@ -176,6 +177,7 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                         FunctionBlockInitialValueAssignment {
                             type_name: name,
                             init: vec![],
+                            call_params: None,
                         },
                     ));
                 }
@@ -197,6 +199,7 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                                 FunctionBlockInitialValueAssignment {
                                     type_name: name,
                                     init: vec![],
+                                    call_params: None,
                                 },
                             ))
                         }

--- a/compiler/analyzer/src/xform_toposort_declarations.rs
+++ b/compiler/analyzer/src/xform_toposort_declarations.rs
@@ -501,12 +501,16 @@ impl Visitor<Diagnostic> for RuleGraphReferenceableElements {
         &mut self,
         init: &FunctionBlockInitialValueAssignment,
     ) -> Result<Self::Value, Diagnostic> {
-        // Current context has a reference to this function block
+        // Current context has a reference to this function block. The
+        // referenced type must be ordered before the containing POU (same
+        // convention as the Structure/LateResolvedType arms below and
+        // visit_interface_declaration's EXTENDS edge), so the edge points
+        // from the referenced type to the containing POU, not the reverse.
         match &self.current_from {
             Some(from) => {
                 let from = self.declarations.add_node(from);
                 let to = self.declarations.add_node(&init.type_name.name);
-                self.declarations.graph.add_edge(from, to, ());
+                self.declarations.graph.add_edge(to, from, ());
             }
             None => return Err(Diagnostic::todo(file!(), line!())),
         }
@@ -527,10 +531,12 @@ impl Visitor<Diagnostic> for RuleGraphReferenceableElements {
                     InitialValueAssignmentKind::EnumeratedValues(_) => {}
                     InitialValueAssignmentKind::EnumeratedType(_) => {}
                     InitialValueAssignmentKind::FunctionBlock(fb) => {
-                        // We only care about these because these may be references to a function block
+                        // Same ordering convention as the Structure/LateResolvedType
+                        // arms below: the referenced type must come before the
+                        // containing POU.
                         let from = self.declarations.add_node(from);
                         let to = self.declarations.add_node(&fb.type_name.name);
-                        self.declarations.graph.add_edge(from, to, ());
+                        self.declarations.graph.add_edge(to, from, ());
                     }
                     InitialValueAssignmentKind::Subrange(_) => {}
                     InitialValueAssignmentKind::Structure(struct_init) => {
@@ -599,6 +605,46 @@ mod tests {
         FUNCTION_BLOCK Caller
             VAR
                 CalleeInstance : Callee;
+            END_VAR
+
+        END_FUNCTION_BLOCK";
+
+        let library = parse_only(program);
+        let (library, _reachable) = apply(library).unwrap();
+
+        let decl = library.elements.first().unwrap();
+        let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
+        assert_eq!(decl.name, TypeName::from("Callee"));
+
+        let decl = library.elements.get(1).unwrap();
+        let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
+        assert_eq!(decl.name, TypeName::from("Caller"));
+    }
+
+    #[test]
+    fn apply_when_function_block_call_style_init_then_return_ok() {
+        // Regression for a toposort edge-direction bug found while adding
+        // the CODESYS/TwinCAT call-style FB instance initializer
+        // (`name : FB_Type(args);`): unlike a bare declaration (which
+        // resolves via LateResolvedType, exercised by the test above),
+        // this syntax constructs InitialValueAssignmentKind::FunctionBlock
+        // directly at parse time. The FunctionBlock arms in this file
+        // previously added the dependency edge backwards relative to the
+        // Structure/LateResolvedType arms, so the referenced type
+        // (Callee) was ordered *after* the referencing POU (Caller)
+        // instead of before it, causing a spurious P2011 "Parent type is
+        // not declared" error downstream.
+        let program = "
+        FUNCTION_BLOCK Callee
+            VAR_INPUT
+               IN1: BOOL;
+            END_VAR
+
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Caller
+            VAR
+                CalleeInstance : Callee(IN1 := TRUE);
             END_VAR
 
         END_FUNCTION_BLOCK";

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -1912,6 +1912,7 @@ impl VarDecl {
                 FunctionBlockInitialValueAssignment {
                     type_name: TypeName::from(type_name),
                     init: vec![],
+                    call_params: None,
                 },
             ),
         }
@@ -2427,6 +2428,16 @@ pub struct FunctionBlockInitialValueAssignment {
     pub type_name: TypeName,
     // The initializer may be empty
     pub init: Vec<StructureElementInit>,
+    /// Present for the CODESYS/TwinCAT call-style instance initializer
+    /// (`name : FB_Type(args);`, no `:=`) -- `args` uses the same
+    /// positional-or-named shape as an ordinary FB call. `None` for the
+    /// standard `:= (member := value, ...)` form or no initializer at all.
+    /// Mutually exclusive with `init` being non-empty. Not yet wired into
+    /// codegen, matching `init`'s own pre-existing status (parsed and
+    /// stored, but instance field/input values are not yet applied from
+    /// either form).
+    #[recurse(ignore)]
+    pub call_params: Option<Vec<ParamAssignmentKind>>,
 }
 
 /// See section 2.4.3.2. #6

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -811,7 +811,7 @@ parser! {
     // We have to first handle the special case of enumeration or fb_name without an initializer
     // because these share the same syntax. We only know the type after trying to resolve the
     // type name.
-    rule var_init_decl() -> Vec<UntypedVarDecl> = structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() /  fb_name_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
+    rule var_init_decl() -> Vec<UntypedVarDecl> = structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() /  fb_name_decl() / fb_call_style_var_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
     rule var1_init_decl__with_ambiguous_struct() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ init:(a:simple_or_enumerated_or_subrange_ambiguous_struct_spec_init()) {
       // Each of the names variables has is initialized in the same way. Here we flatten initialization
       names.into_iter().map(|name| {
@@ -852,12 +852,36 @@ parser! {
       names.into_iter().map(|name| {
         UntypedVarDecl {
           name,
-          initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: init.clone().unwrap_or_else(Vec::new) }),
+          initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: init.clone().unwrap_or_else(Vec::new), call_params: None }),
         }
       }).collect()
     }
     rule fb_name_list() -> Vec<Id> = commasep_oneplus(<fb_name()>)
     rule fb_name() -> Id = i:identifier() { i }
+    // CODESYS/TwinCAT FB instance declaration with a call-style
+    // initialization parameter list (`FB_Type(args)`, no `:=`), using the
+    // same positional-or-named shape as an ordinary FB call -- e.g.
+    // `comm : FB_Comm(retries := 3, THIS);`. Deliberately uses var1_list()
+    // (not fb_name_list(), which has a pre-existing, unrelated bug --
+    // commasep_oneplus() requires a spurious trailing comma, making
+    // fb_name_decl() above unreachable in practice) and requires the
+    // parens unconditionally (not optional) so this rule can never match
+    // a bare "name : Type;" declaration -- that continues to flow through
+    // the existing late-bound-resolution fallback unchanged. No ordering
+    // hazard: every earlier alternative in var_init_decl() requires its
+    // own mandatory leading token (ARRAY, REF_TO, STRING/WSTRING, or a
+    // literal `:=`) and fails outright (not a partial match) on a bare
+    // type name followed by `(`.
+    rule fb_call_style_var_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ type_name:function_block_type_name() _ params:fb_call_style_init_params() {
+      names.into_iter().map(|name| {
+        UntypedVarDecl {
+          location: None,
+          name,
+          initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: Vec::new(), call_params: Some(params.clone()) }),
+        }
+      }).collect()
+    }
+    rule fb_call_style_init_params() -> Vec<ParamAssignmentKind> = tok(TokenType::LeftParen) _ params:param_assignment() ** (_ tok(TokenType::Comma) _) _ tok(TokenType::RightParen) { params }
     rule ref_to_var_init_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ tok(TokenType::RefTo) _ ref_target:ref_to_target() _ init:(tok(TokenType::Assignment) _ v:ref_initial_value() { v })? {
       names.into_iter().map(|name| {
         UntypedVarDecl {
@@ -975,7 +999,7 @@ parser! {
       }).collect()
     }
     // TODO this doesn't pass all information. I suspect the rule from the description is not right
-    rule global_var_decl() -> (Vec<VarDecl>) = vs:global_var_spec() _ tok:tok(TokenType::Colon) _ initializer:(l:located_var_spec_init() { l } / f:function_block_type_name() { InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment{type_name: f, init: vec![] })})? {
+    rule global_var_decl() -> (Vec<VarDecl>) = vs:global_var_spec() _ tok:tok(TokenType::Colon) _ initializer:(l:located_var_spec_init() { l } / f:function_block_type_name() { InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment{type_name: f, init: vec![], call_params: None })})? {
       vs.0.into_iter().map(|name| {
         let init = initializer.clone().unwrap_or(InitialValueAssignmentKind::None(SourceSpan::join(&tok.span, &tok.span)));
         VarDecl {
@@ -1007,7 +1031,7 @@ parser! {
         }
       }).collect()
     }
-    rule single_byte_string_spec() -> StringInitializer = start:tok(TokenType::String) _ length:(tok(TokenType::LeftBracket) _ i:integer_ref() _ tok(TokenType::RightBracket) {i})? _ initial_value:(tok(TokenType::Assignment) _ v:single_byte_character_string() {v})? {
+    rule single_byte_string_spec() -> StringInitializer = start:tok(TokenType::String) _ length:string_length_spec()? _ initial_value:(tok(TokenType::Assignment) _ v:single_byte_character_string() {v})? {
       StringInitializer {
         length,
         width: StringType::String,
@@ -1023,7 +1047,7 @@ parser! {
         }
       }).collect()
     }
-    rule double_byte_string_spec() -> StringInitializer = start:tok(TokenType::WString) _ length:(tok(TokenType::LeftBracket) _ i:integer_ref() _ tok(TokenType::RightBracket) {i})? _ initial_value:(tok(TokenType::Assignment) _ v:double_byte_character_string() {v})? {
+    rule double_byte_string_spec() -> StringInitializer = start:tok(TokenType::WString) _ length:string_length_spec()? _ initial_value:(tok(TokenType::Assignment) _ v:double_byte_character_string() {v})? {
       StringInitializer {
         length,
         width: StringType::WString,
@@ -1031,6 +1055,14 @@ parser! {
         keyword_span: start.span.clone(),
       }
     }
+    // CODESYS/TwinCAT accept STRING(n)/WSTRING(n) with parentheses as an
+    // alternate delimiter to the standard STRING[n]/WSTRING[n] brackets --
+    // same precedent as string_type_declaration__parenthesis() for TYPE
+    // alias declarations, which already accepts this unconditionally (no
+    // dialect flag: a delimiter choice, not a new keyword).
+    rule string_length_spec() -> IntegerRef =
+      tok(TokenType::LeftBracket) _ i:integer_ref() _ tok(TokenType::RightBracket) { i }
+      / tok(TokenType::LeftParen) _ i:integer_ref() _ tok(TokenType::RightParen) { i }
     rule incompl_located_var_declarations() -> VarDeclarations = tok(TokenType::Var) _ qualifier:(tok(TokenType::Retain) {DeclarationQualifier::Retain} / tok(TokenType::NonRetain) {DeclarationQualifier::NonRetain})? _ declarations:semisep_or_empty(<incompl_located_var_decl()>) _ tok(TokenType::EndVar) {
       let declarations = declarations.into_iter().map(|decl| {
         let qualifier = qualifier
@@ -1061,8 +1093,8 @@ parser! {
       sr:subrange_specification__with_range() { VariableSpecificationKind::Subrange(sr) }
       / e:enumerated_specification() { VariableSpecificationKind::Enumerated(e) }
       / a:array_specification() { VariableSpecificationKind::Array(a) }
-      / tok:tok(TokenType::String) length:(_ tok(TokenType::LeftBracket) _ l:integer_ref() tok(TokenType::RightBracket) { l })? { VariableSpecificationKind::String(StringSpecification{ width: StringType::String, length, keyword_span: tok.span.clone(), }) }
-      / tok:tok(TokenType::WString) length:(_ tok(TokenType::LeftBracket) _ l:integer_ref() tok(TokenType::RightBracket) { l })? { VariableSpecificationKind::String(StringSpecification{ width: StringType::WString, length, keyword_span: tok.span.clone(), }) }
+      / tok:tok(TokenType::String) length:(_ l:string_length_spec() { l })? { VariableSpecificationKind::String(StringSpecification{ width: StringType::String, length, keyword_span: tok.span.clone(), }) }
+      / tok:tok(TokenType::WString) length:(_ l:string_length_spec() { l })? { VariableSpecificationKind::String(StringSpecification{ width: StringType::WString, length, keyword_span: tok.span.clone(), }) }
       / et:elementary_type_name() { VariableSpecificationKind::Simple(et.into()) }
       / id:type_name() { VariableSpecificationKind::Ambiguous(id) }
 
@@ -1071,8 +1103,8 @@ parser! {
     rule standard_function_name() -> Id = identifier()
     rule derived_function_name() -> Id = identifier()
     rule function_return_type() -> FunctionReturnType =
-      tok:tok(TokenType::String) length:(_ tok(TokenType::LeftBracket) _ l:integer_ref() tok(TokenType::RightBracket) { l })? { FunctionReturnType::String(StringSpecification{ width: StringType::String, length, keyword_span: tok.span.clone(), }) }
-      / tok:tok(TokenType::WString) length:(_ tok(TokenType::LeftBracket) _ l:integer_ref() tok(TokenType::RightBracket) { l })? { FunctionReturnType::WString(StringSpecification{ width: StringType::WString, length, keyword_span: tok.span.clone(), }) }
+      tok:tok(TokenType::String) length:(_ l:string_length_spec() { l })? { FunctionReturnType::String(StringSpecification{ width: StringType::String, length, keyword_span: tok.span.clone(), }) }
+      / tok:tok(TokenType::WString) length:(_ l:string_length_spec() { l })? { FunctionReturnType::WString(StringSpecification{ width: StringType::WString, length, keyword_span: tok.span.clone(), }) }
       / et:elementary_type_name() { FunctionReturnType::Named(et.into()) }
       / dt:derived_type_name() { FunctionReturnType::Named(dt) }
     rule function_declaration() -> FunctionDeclaration = tok(TokenType::Function) _  name:derived_function_name() _ tok(TokenType::Colon) _ rt:function_return_type() _ var_decls:(io:io_var_declarations() / func:function_var_decls() { vec![ func ] } / temp:temp_var_decls() { vec![ temp ] }) ** _ _ body:function_body() _ tok(TokenType::EndFunction) {

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -875,7 +875,6 @@ parser! {
     rule fb_call_style_var_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ type_name:function_block_type_name() _ params:fb_call_style_init_params() {
       names.into_iter().map(|name| {
         UntypedVarDecl {
-          location: None,
           name,
           initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: Vec::new(), call_params: Some(params.clone()) }),
         }

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -828,6 +828,102 @@ END_FUNCTION";
     }
 
     #[test]
+    fn parse_when_function_with_string_paren_length_return_type_then_parses() {
+        // CODESYS/TwinCAT accept STRING(n) with parentheses as an
+        // alternate delimiter to the standard STRING[n] brackets --
+        // unconditional, no dialect flag (matches the existing
+        // string_type_declaration__parenthesis() precedent for TYPE alias
+        // declarations).
+        let lib = parse_text(
+            "FUNCTION my_func : STRING(255)
+            VAR_INPUT
+                x : INT;
+            END_VAR
+            my_func := 'hello';
+            END_FUNCTION",
+        );
+
+        assert_eq!(lib.elements.len(), 1);
+        let func = cast!(&lib.elements[0], LibraryElementKind::FunctionDeclaration);
+        let spec = cast!(&func.return_type, FunctionReturnType::String);
+        assert_eq!(spec.width, dsl::common::StringType::String);
+        assert!(spec.length.is_some());
+    }
+
+    #[test]
+    fn parse_when_function_with_wstring_paren_length_return_type_then_parses() {
+        let lib = parse_text(
+            "FUNCTION my_func : WSTRING(100)
+            VAR_INPUT
+                x : INT;
+            END_VAR
+            my_func := 'hello';
+            END_FUNCTION",
+        );
+
+        assert_eq!(lib.elements.len(), 1);
+        let func = cast!(&lib.elements[0], LibraryElementKind::FunctionDeclaration);
+        let spec = cast!(&func.return_type, FunctionReturnType::WString);
+        assert_eq!(spec.width, dsl::common::StringType::WString);
+        assert!(spec.length.is_some());
+    }
+
+    #[test]
+    fn parse_when_var_with_string_paren_length_then_parses() {
+        let lib = parse_text(
+            "PROGRAM main
+VAR
+    hostName : STRING(255);
+END_VAR
+END_PROGRAM",
+        );
+        let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+        let spec = cast!(
+            &prog.variables[0].initializer,
+            InitialValueAssignmentKind::String
+        );
+        assert_eq!(spec.width, dsl::common::StringType::String);
+        assert!(spec.length.is_some());
+    }
+
+    #[test]
+    fn parse_when_var_with_wstring_paren_length_then_parses() {
+        let lib = parse_text(
+            "PROGRAM main
+VAR
+    wideName : WSTRING(100);
+END_VAR
+END_PROGRAM",
+        );
+        let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+        let spec = cast!(
+            &prog.variables[0].initializer,
+            InitialValueAssignmentKind::String
+        );
+        assert_eq!(spec.width, dsl::common::StringType::WString);
+        assert!(spec.length.is_some());
+    }
+
+    #[test]
+    fn parse_when_var_with_string_bracket_length_then_parses() {
+        // Regression: the standard bracket form must still parse unchanged.
+        let lib = parse_text(
+            "PROGRAM main
+VAR
+    hostName : STRING[255];
+END_VAR
+END_PROGRAM",
+        );
+        let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+        let spec = cast!(
+            &prog.variables[0].initializer,
+            InitialValueAssignmentKind::String
+        );
+        assert_eq!(spec.width, dsl::common::StringType::String);
+        assert!(spec.length.is_some());
+    }
+
+    #[test]
     fn parse_when_function_with_bare_string_return_type_then_parses() {
         let lib = parse_text(
             "FUNCTION my_func : STRING
@@ -2628,5 +2724,125 @@ END_FUNCTION_BLOCK";
             "AND_THEN must remain a valid identifier in standard mode: {:?}",
             result.err()
         );
+    }
+
+    #[test]
+    fn parse_when_fb_call_style_init_named_and_positional_then_parses_call_params() {
+        // Matches real brotlib usage: both named (comm := comm) and
+        // positional (THIS) arguments in the same call-style initializer.
+        let source = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm(retries := 3, THIS);
+END_VAR
+END_FUNCTION_BLOCK";
+        let library = parse_text(source);
+
+        let fb = cast!(
+            &library.elements[1],
+            LibraryElementKind::FunctionBlockDeclaration
+        );
+        assert_eq!(fb.variables.len(), 1);
+        let fb_init = cast!(
+            &fb.variables[0].initializer,
+            InitialValueAssignmentKind::FunctionBlock
+        );
+        assert_eq!(fb_init.type_name.to_string(), "FB_Comm");
+        assert!(fb_init.init.is_empty());
+        let call_params = fb_init
+            .call_params
+            .as_ref()
+            .expect("call_params must be Some");
+        assert_eq!(call_params.len(), 2);
+        assert!(matches!(call_params[0], ParamAssignmentKind::NamedInput(_)));
+        assert!(matches!(
+            call_params[1],
+            ParamAssignmentKind::PositionalInput(_)
+        ));
+    }
+
+    #[test]
+    fn parse_when_fb_call_style_init_empty_parens_then_parses() {
+        let source = "
+FUNCTION_BLOCK FB_Comm
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm();
+END_VAR
+END_FUNCTION_BLOCK";
+        let library = parse_text(source);
+
+        let fb = cast!(
+            &library.elements[1],
+            LibraryElementKind::FunctionBlockDeclaration
+        );
+        let fb_init = cast!(
+            &fb.variables[0].initializer,
+            InitialValueAssignmentKind::FunctionBlock
+        );
+        assert_eq!(fb_init.call_params.as_ref().map(|p| p.len()), Some(0));
+    }
+
+    #[test]
+    fn parse_when_fb_bare_decl_then_no_call_params() {
+        // Regression: an ordinary bare FB instance declaration (no
+        // initializer at all) must be unaffected -- it continues to flow
+        // through the existing late-bound-resolution path, not the new
+        // call-style rule (which requires the parens unconditionally).
+        let source = "
+FUNCTION_BLOCK FB_Comm
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm;
+END_VAR
+END_FUNCTION_BLOCK";
+        let library = parse_text(source);
+
+        let fb = cast!(
+            &library.elements[1],
+            LibraryElementKind::FunctionBlockDeclaration
+        );
+        // Bare declarations resolve to LateResolvedType at parse time
+        // (kind is only known once the type environment is built), not
+        // eagerly to FunctionBlock.
+        assert!(matches!(
+            &fb.variables[0].initializer,
+            InitialValueAssignmentKind::LateResolvedType(_)
+        ));
+    }
+
+    #[test]
+    fn parse_when_fb_struct_init_then_still_parses() {
+        // Regression: the standard `:= (member := value)` named-struct-init
+        // form must still parse unchanged.
+        let source = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm := (retries := 3);
+END_VAR
+END_FUNCTION_BLOCK";
+        let library = parse_text(source);
+
+        let fb = cast!(
+            &library.elements[1],
+            LibraryElementKind::FunctionBlockDeclaration
+        );
+        assert_eq!(fb.variables.len(), 1);
     }
 }

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -2728,8 +2728,9 @@ END_FUNCTION_BLOCK";
 
     #[test]
     fn parse_when_fb_call_style_init_named_and_positional_then_parses_call_params() {
-        // Matches real brotlib usage: both named (comm := comm) and
-        // positional (THIS) arguments in the same call-style initializer.
+        // Matches real usage found in a private test corpus: both named
+        // (comm := comm) and positional (THIS) arguments in the same
+        // call-style initializer.
         let source = "
 FUNCTION_BLOCK FB_Comm
 VAR_INPUT

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -752,7 +752,17 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         &mut self,
         node: &FunctionBlockInitialValueAssignment,
     ) -> Result<Self::Value, Diagnostic> {
-        self.visit_type_name(&node.type_name)
+        self.visit_type_name(&node.type_name)?;
+
+        // CODESYS/TwinCAT call-style instance initializer
+        // (`name : FB_Type(args);`) -- see call_params' doc comment.
+        if let Some(params) = &node.call_params {
+            self.write_ws("(");
+            visit_comma_separated!(self, params.iter(), ParamAssignmentKind);
+            self.write_ws(")");
+        }
+
+        Ok(())
     }
 
     // 2.4.3.2

--- a/compiler/plc2plc/src/tests.rs
+++ b/compiler/plc2plc/src/tests.rs
@@ -508,4 +508,56 @@ END_FUNCTION_BLOCK
             .expect("rendered output must parse under the same dialect");
         assert_eq!(library_original, library_rendered);
     }
+
+    #[test]
+    fn write_to_string_when_string_parenthesis_length_then_normalizes_to_brackets() {
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    hostName : STRING(255);
+END_VAR
+END_FUNCTION_BLOCK
+";
+        let library_original =
+            parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let rendered = write_to_string(&library_original).unwrap();
+
+        // The renderer always normalizes to the bracket form -- there's no
+        // bracket/paren marker stored in the DSL, matching how
+        // StringSpecification/StringInitializer already only store
+        // length: Option<IntegerRef> with no delimiter distinction.
+        assert!(rendered.contains("STRING [ 255 ]"));
+
+        let library_rendered =
+            parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
+                .expect("rendered output must parse");
+        assert_eq!(library_original, library_rendered);
+    }
+
+    #[test]
+    fn write_to_string_when_fb_instance_call_style_init_then_round_trips() {
+        let source = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm(retries := 3, THIS);
+END_VAR
+END_FUNCTION_BLOCK
+";
+        let library_original =
+            parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let rendered = write_to_string(&library_original).unwrap();
+
+        assert!(rendered.contains("FB_Comm ( retries := 3 , THIS )"));
+
+        let library_rendered =
+            parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
+                .expect("rendered output must parse");
+        assert_eq!(library_original, library_rendered);
+    }
 }

--- a/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
+++ b/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
@@ -193,14 +193,98 @@ match) on `Type(args)` and correctly falls through to `fb_name_decl()`.
 
 ## Tasks
 
-- [ ] Write plan (this document)
-- [ ] Grammar: `STRING(n)`/`WSTRING(n)` parenthesis form (3 sites)
-- [ ] Grammar + DSL: FB-instance call-style initializer
-- [ ] Update the 3 `xform_resolve_late_bound_type_initializer.rs`
+- [x] Write plan (this document)
+- [x] Grammar: `STRING(n)`/`WSTRING(n)` parenthesis form (3 sites, via a
+      shared `string_length_spec()` rule)
+- [x] Grammar + DSL: FB-instance call-style initializer (design changed
+      during implementation — see Implementation Notes: `fb_name_decl()`
+      turned out to be dead code, so a new dedicated rule was added instead
+      of extending it)
+- [x] Update the 3 `xform_resolve_late_bound_type_initializer.rs`
       construction sites
-- [ ] Check plc2plc renderer for both changes; fix/extend if needed
-- [ ] Tests from Testing Strategy
-- [ ] Run full CI pipeline (`cd compiler && just`)
+- [x] Check plc2plc renderer for both changes; fix/extend if needed (added
+      `call_params` rendering; confirmed `STRING(n)`'s renderer already
+      normalizes to brackets unconditionally, no change needed)
+- [x] Tests from Testing Strategy, plus two regression tests not in the
+      original plan (see Implementation Notes: `commasep_oneplus` bug,
+      toposort edge-direction bug)
+- [x] Run full CI pipeline (`cd compiler && just`)
 - [ ] Push branch to fork (no PR against `ironplc/ironplc` without explicit
       go-ahead, per standing instruction)
 - [ ] Merge into `twincat-dev`, update `twincat-status.md`, push
+
+## Implementation Notes
+
+- **`fb_name_decl()` — the rule the plan intended to extend — turned out
+  to be pre-existing dead code**, found only by testing the simplest
+  possible case (`comm : FB_Comm;`, no init at all) with `peg`'s
+  `trace`/`debug` cargo feature (`cargo build -p ironplc-cli --features
+  trace`, which prints every rule attempt to stderr). Root cause:
+  `fb_name_list()` uses a shared combinator, `commasep_oneplus()`
+  (`compiler/parser/src/parser.rs` line 290),  defined as
+  `x() ++ (_ comma() _) comma()` — note the **extra trailing `comma()`**
+  after the already-complete comma-separated list. This requires a
+  spurious trailing comma after every name list, so `fb_name_decl()` (and
+  the only other caller, `prog_conf_elements()`) has never successfully
+  matched any real input. Every FB instance declaration in the existing
+  test suite and real files was actually being handled by the
+  `var1_init_decl__with_ambiguous_struct()` fallback instead (bare
+  declarations resolve to `LateResolvedType`, deferred to
+  `xform_resolve_late_bound_type_initializer.rs`; declarations with a
+  `:=` initializer are — somewhat incorrectly, but out of scope here —
+  parsed as `InitialValueAssignmentKind::Structure` via
+  `structured_var_init_decl__without_ambiguous()`, not `FunctionBlock`).
+  **Did not fix `commasep_oneplus()` itself** — `fb_name_decl()` being
+  unreachable is apparently load-bearing: since it eagerly commits a bare
+  type name to `FunctionBlock` with no way to check whether the type
+  actually *is* a function block (that's precisely why the
+  `LateResolvedType`-then-resolve deferral pattern exists), fixing the
+  shared combinator would have made `fb_name_decl()` newly reachable and
+  changed the parsed shape for every bare FB-shaped declaration in the
+  codebase from `LateResolvedType` to an eagerly-tagged `FunctionBlock` —
+  a much larger, riskier, and out-of-scope change. Instead, added a new,
+  narrowly-scoped rule, `fb_call_style_var_decl()`, using the *working*
+  `var1_list()` combinator and requiring the call-style parens
+  unconditionally (not optional) — the parens make this syntax
+  unambiguous (no other declaration shape can be followed directly by
+  `(`), so it never needs to defer to late-bound resolution the way a
+  bare type name does, and it cannot accidentally interfere with the bare
+  or `:=`-initializer cases either.
+- **A second, unrelated pre-existing bug surfaced downstream, once the
+  grammar fix made it possible to construct an eager `FunctionBlock`
+  initializer for a real, user-declared (not stdlib) FB type for the
+  first time**: `xform_toposort_declarations.rs`'s dependency-graph edges
+  for `InitialValueAssignmentKind::FunctionBlock` (both the dedicated
+  `visit_function_block_initial_value_assignment` and the inline arm in
+  `visit_initial_value_assignment_kind`) pointed the wrong direction
+  compared to the `Structure`/`LateResolvedType` arms and
+  `visit_interface_declaration`'s `EXTENDS` edge (confirmed by reading
+  all three side by side) — referenced-type-before-containing-POU is the
+  correct convention, but the `FunctionBlock` arms had it backwards. This
+  went unnoticed because eager `FunctionBlock` construction was
+  previously only reachable via `global_var_decl()` (`VAR_GLOBAL`) and
+  the `TYPE`-alias path, and no existing test exercised a `VAR_GLOBAL`
+  or type-alias forward-reference to a POU-local, later-processed FB
+  type. Confirmed via a real repro (`FB_Comm` declared first, `FB_Example`
+  referencing it via the new call-style syntax second — the natural
+  order) that this produced a spurious `P2011 Parent type is not
+  declared`. Fixed by flipping both edges to match the established
+  convention; verified with the full workspace test suite (no
+  regressions) plus two new targeted regression tests (a toposort-level
+  test in `xform_toposort_declarations.rs` and an end-to-end
+  `resolve_types`-level test in `stages.rs`).
+- **`STRING(n)`/`WSTRING(n)` needed no DSL or renderer changes beyond the
+  grammar itself** — `StringSpecification`/`StringInitializer` already
+  only store `length: Option<IntegerRef>` with no bracket/paren marker
+  (confirmed by reading the DSL before implementing), and the renderer
+  (`visit_string_initializer`) already unconditionally normalizes to the
+  bracket form. This means a `STRING(255)` input round-trips to
+  `STRING [ 255 ]` output (not byte-identical), which is expected
+  normalization, not a bug — the plc2plc test asserts on the normalized
+  bracket form rather than the original parenthesis spelling.
+- **Renderer spacing**: `write_ws` inserts a space before tokens like `(`
+  and `,` unless the buffer already ends in one, so the call-style
+  initializer renders as `FB_Comm ( retries := 3 , THIS )` (spaced),
+  matching this renderer's existing general convention (confirmed by
+  checking `visit_fb_call`'s own param rendering, which has the same
+  spacing) — not an inconsistency specific to this change.

--- a/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
+++ b/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
@@ -25,8 +25,9 @@ END_FUNCTION_BLOCK
 
 ## Verification against real files
 
-Checked `/home/husser/code/brotlib` directly before designing anything
-(per the standing "verify before assuming" habit):
+Checked a private local checkout of a real TwinCAT codebase directly
+before designing anything (per the standing "verify before assuming"
+habit):
 
 - `STRING(n)`/`WSTRING(n)`: 51 occurrences across 11 files (`STRING(255)`
   x45, `STRING(1)` x5, `STRING(511)` x1), all in `VAR` declarations
@@ -35,7 +36,7 @@ Checked `/home/husser/code/brotlib` directly before designing anything
   type (`FUNCTION NCError_TO_STRING : STRING(255)`).
 - Inline FB-constructor-call: 24 occurrences (`MAIN.TcPOU`,
   `FB_CoverControl.TcPOU`, `FB_PendantControl.TcPOU`,
-  `FB_DomeControl.TcPOU`, `MONETRoof/MAIN.TcPOU`), using **both** named
+  `FB_DomeControl.TcPOU`, `TestProject3/MAIN.TcPOU`), using **both** named
   args (`FB_CoverControl(comm := comm)`) **and** positional args
   (`FB_CoverIdleState(THIS)`) — confirming this needs the same
   positional-or-named parameter grammar as an ordinary FB call
@@ -178,7 +179,7 @@ match) on `Type(args)` and correctly falls through to `fb_name_decl()`.
   identically); `FUNCTION ... : STRING(255)` return type parses.
   Regression: bracket form still parses unchanged.
 - Parser tests: `name : FB_Type(a, b := c);` parses with `call_params`
-  populated (mixed positional/named, matching real brotlib usage);
+  populated (mixed positional/named, matching real test-corpus usage);
   `name : FB_Type := (member := value);` still parses unchanged
   (regression, `init` populated, `call_params: None`); `name : FB_Type;`
   (no initializer at all) still parses unchanged (regression, both empty/

--- a/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
+++ b/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
@@ -1,0 +1,206 @@
+# Plan: `STRING(n)`/`WSTRING(n)` Parenthesis Form + Inline FB-Instance Call-Style Initializer
+
+## Goal
+
+Survey item 1 from `twincat-status.md`'s "Next" list (13 files, ~7
+`STRING(n)`/`WSTRING(n)` + ~5-6 inline-constructor-call) bundles two
+unrelated syntax gaps. Split them apart and fix both:
+
+1. `STRING(n)`/`WSTRING(n)` — parenthesis-delimited length, instead of the
+   only currently-accepted `STRING[n]`/`WSTRING[n]` bracket form — in `VAR`
+   declarations and function return types.
+2. Inline FB-instance call-style initializer: `name : FB_Type(args);` —
+   passing an initialization parameter list directly after the type name,
+   instead of the only currently-accepted `name : FB_Type := (member :=
+   value, ...);` named-struct-init form.
+
+```
+FUNCTION_BLOCK FB_Example
+VAR
+    hostName : STRING(255);                      // currently a parse error -- only STRING[255] parses
+    comm     : FB_Comm(retries := 3, THIS);       // currently a parse error -- only FB_Comm := (...) parses
+END_VAR
+END_FUNCTION_BLOCK
+```
+
+## Verification against real files
+
+Checked `/home/husser/code/brotlib` directly before designing anything
+(per the standing "verify before assuming" habit):
+
+- `STRING(n)`/`WSTRING(n)`: 51 occurrences across 11 files (`STRING(255)`
+  x45, `STRING(1)` x5, `STRING(511)` x1), all in `VAR` declarations
+  (`hostName : STRING(255);`, some with `:=` string-literal initializers
+  too: `FormatString : STRING(255) := '%s';`) and one `FUNCTION` return
+  type (`FUNCTION NCError_TO_STRING : STRING(255)`).
+- Inline FB-constructor-call: 24 occurrences (`MAIN.TcPOU`,
+  `FB_CoverControl.TcPOU`, `FB_PendantControl.TcPOU`,
+  `FB_DomeControl.TcPOU`, `MONETRoof/MAIN.TcPOU`), using **both** named
+  args (`FB_CoverControl(comm := comm)`) **and** positional args
+  (`FB_CoverIdleState(THIS)`) — confirming this needs the same
+  positional-or-named parameter grammar as an ordinary FB call
+  (`param_assignment()`), not the named-only `member := value` shape that
+  `structure_initialization()` already provides for the `:=` form.
+
+## Key finding: the parenthesis form for `STRING`/`WSTRING` length already
+## has an unconditional (no dialect flag) precedent in this codebase
+
+`compiler/parser/src/parser.rs` already has
+`string_type_declaration__parenthesis()` (line 812) sitting right next to
+the bracket form `string_type_declaration()` (line 804) — for `TYPE ... :
+STRING(n) ...;` alias declarations — with **no dialect gate at all**, both
+unconditionally tried in `data_type_declaration()`. The gap is that the
+*same* parenthesis form was never added to the other three places
+`STRING`/`WSTRING` length appears with the bracket-only form:
+
+| Rule | Used for |
+|---|---|
+| `single_byte_string_spec()` / `double_byte_string_spec()` (~1139, 1156) | `VAR`-declared string variables |
+| `var_spec()` (~1194-1195) | `VAR` declarations going through the generic spec path |
+| `function_return_type()` (~1204-1205) | `FUNCTION ... : STRING(n)` return type |
+
+This confirms the design: extend these three sites the same way, as a
+**pure grammar addition with no new dialect flag**, matching the existing
+`string_type_declaration__parenthesis()` precedent exactly (parens are
+just an alternate delimiter; nothing about the resulting `StringSpecification`/
+`StringInitializer` DSL shape depends on which delimiter was used — both
+already store only `length: Option<IntegerRef>` with no bracket/paren
+marker).
+
+## Design: FB-instance call-style initializer
+
+### Why this also needs no new dialect flag
+
+Following the qualified-method-call precedent (previous branch): a
+construct needs a dialect gate only when it introduces a new keyword to
+demote/promote at the lexer level (`EXTENDS`, pragmas, `PI`). This
+construct introduces no new keyword — `(` is already a token used
+everywhere. Like the qualified-call fix, `P9004`/flag-gating isn't the
+right shape here either, for a different reason (see below): codegen
+**already silently ignores** FB instance initializer values for the
+existing, standard `:=  (member := value, ...)` form (confirmed by reading
+`compile_setup.rs:122-166` — `fb_init.init` is parsed and stored on the AST
+but never read by `compile_setup`, only `fb_init.type_name` is used to
+determine the instance's memory layout). Flagging *only* the new
+call-style form as "recognized but unsupported" would be inconsistent:
+the old form is equally not wired into codegen today, and isn't flagged.
+So: parse both forms the same permissive way, store the call-style
+argument list on the AST, and leave codegen's behavior exactly as it
+already is (ignores initializer values for FB instances either way) —
+this is a pure parser fix unblocking files that today fail to parse at
+all, not a new "vendor extension needs a stop-gap diagnostic" situation.
+
+### DSL: new optional field on `FunctionBlockInitialValueAssignment`
+
+```rust
+// compiler/dsl/src/common.rs
+pub struct FunctionBlockInitialValueAssignment {
+    pub type_name: TypeName,
+    pub init: Vec<StructureElementInit>,
+    /// Present for the CODESYS/TwinCAT call-style initializer
+    /// (`name : FB_Type(args)`, no `:=`) -- `args` uses the same
+    /// positional-or-named shape as an ordinary FB call. `None` for the
+    /// standard `:= (member := value, ...)` form (or no initializer at
+    /// all). Mutually exclusive with `init` being non-empty.
+    pub call_params: Option<Vec<ParamAssignmentKind>>,
+}
+```
+
+5 construction sites need the new field added (`init: vec![], call_params:
+None` for all but the new grammar path):
+`compiler/dsl/src/common.rs` (1), `compiler/parser/src/parser.rs` (2:
+`fb_name_decl()`, `global_var_decl()`),
+`compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs` (3).
+One more site (`compiler/mcp/src/tools/pou_lineage.rs:275`) pattern-matches
+with `..` and needs no change.
+
+### Grammar: new alternative in `fb_name_decl()`
+
+```
+rule fb_name_decl() -> Vec<UntypedVarDecl> =
+  names:fb_name_list() _ tok(Colon) _ type_name:function_block_type_name() _
+  init:fb_instance_init()? { ... }
+
+rule fb_instance_init() -> FbInstanceInit =
+  tok(Assignment) _ init:structure_initialization() { FbInstanceInit::Structure(init) }
+  / params:fb_call_style_init_params() { FbInstanceInit::CallParams(params) }
+
+rule fb_call_style_init_params() -> Vec<ParamAssignmentKind> =
+  tok(LeftParen) _ params:param_assignment() ** (_ tok(Comma) _) _ tok(RightParen) { params }
+```
+
+No PEG ordering hazard: both alternatives inside `fb_instance_init()`
+require a mandatory leading token (`:=` or `(`) with no partial-match
+shortcut, so when neither is present the optional `init:fb_instance_init()?`
+cleanly yields `None` (same safety check already applied to the qualified-
+method-call grammar change). `fb_name_decl()` is tried before the
+catch-all `var1_init_decl__with_ambiguous_struct()` in `var_init_decl()`'s
+ordered choice, so a fully-matched `Type(args)` is never reached by the
+fallback path.
+
+Also confirmed no interaction with `structured_var_init_decl__without_ambiguous()`
+(tried earlier in `var_init_decl()`'s ordered choice): its
+`initialized_structure__without_ambiguous()` requires a mandatory `:=`
+immediately after the type name, so it fails outright (not a partial
+match) on `Type(args)` and correctly falls through to `fb_name_decl()`.
+
+## Non-goals
+
+- Any codegen change — `call_params` is stored on the AST and otherwise
+  unused, matching the pre-existing behavior of `init` today. Actually
+  initializing FB instance fields/inputs from either form's values is a
+  separate, larger feature (would need real dataflow into `compile_setup`),
+  not attempted here.
+- Sized-string length validation/enforcement, or unifying the bracket and
+  parenthesis grammar productions into one shared rule (would touch more
+  call sites than necessary for this fix; kept as straightforward parallel
+  alternatives matching the existing `string_type_declaration()` /
+  `string_type_declaration__parenthesis()` precedent).
+- Array-element-type STRING/WSTRING length (`ARRAY[1..10] OF STRING(n)`,
+  parser.rs ~650-651) — not observed in the survey or cross-repo check;
+  left as bracket-only unless a real file needs it.
+- A dialect flag for either sub-feature — see rationale above for both.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/parser/src/parser.rs` | Add parenthesis alternative to `single_byte_string_spec()`, `double_byte_string_spec()`, `var_spec()`, `function_return_type()`; new `fb_instance_init()`/`fb_call_style_init_params()` rules used by `fb_name_decl()` |
+| `compiler/dsl/src/common.rs` | `FunctionBlockInitialValueAssignment.call_params: Option<Vec<ParamAssignmentKind>>` |
+| `compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs` | Update 3 construction sites |
+| Docs | No new `--allow-x` flag; no doc change needed (matches the qualified-call precedent of not documenting flag-less parser permissiveness beyond the plan itself) |
+
+## Testing Strategy
+
+- Parser tests: `STRING(255)`/`WSTRING(100)` in a `VAR` declaration parses
+  and matches the equivalent bracket form's AST shape (same
+  `StringSpecification`/`StringInitializer`, `length` populated
+  identically); `FUNCTION ... : STRING(255)` return type parses.
+  Regression: bracket form still parses unchanged.
+- Parser tests: `name : FB_Type(a, b := c);` parses with `call_params`
+  populated (mixed positional/named, matching real brotlib usage);
+  `name : FB_Type := (member := value);` still parses unchanged
+  (regression, `init` populated, `call_params: None`); `name : FB_Type;`
+  (no initializer at all) still parses unchanged (regression, both empty/
+  `None`).
+- No semantic-rule or plc2plc-renderer test needed for `call_params`
+  itself beyond round-tripping through the parser, since nothing downstream
+  reads it yet (matches the existing, pre-existing `init` field's own
+  status quo) — but add a plc2plc round-trip test to confirm the renderer
+  doesn't silently drop the call-style form (check `visit_var_decl`/
+  wherever `FunctionBlockInitialValueAssignment` is rendered today, and
+  update if needed).
+
+## Tasks
+
+- [ ] Write plan (this document)
+- [ ] Grammar: `STRING(n)`/`WSTRING(n)` parenthesis form (3 sites)
+- [ ] Grammar + DSL: FB-instance call-style initializer
+- [ ] Update the 3 `xform_resolve_late_bound_type_initializer.rs`
+      construction sites
+- [ ] Check plc2plc renderer for both changes; fix/extend if needed
+- [ ] Tests from Testing Strategy
+- [ ] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork (no PR against `ironplc/ironplc` without explicit
+      go-ahead, per standing instruction)
+- [ ] Merge into `twincat-dev`, update `twincat-status.md`, push

--- a/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
+++ b/specs/plans/2026-07-19-twincat-sized-string-and-inline-fb-ctor.md
@@ -35,10 +35,10 @@ habit):
   too: `FormatString : STRING(255) := '%s';`) and one `FUNCTION` return
   type (`FUNCTION NCError_TO_STRING : STRING(255)`).
 - Inline FB-constructor-call: 24 occurrences (`MAIN.TcPOU`,
-  `FB_CoverControl.TcPOU`, `FB_PendantControl.TcPOU`,
-  `FB_DomeControl.TcPOU`, `TestProject3/MAIN.TcPOU`), using **both** named
-  args (`FB_CoverControl(comm := comm)`) **and** positional args
-  (`FB_CoverIdleState(THIS)`) — confirming this needs the same
+  `FB_Comm.TcPOU`, `FB_Pendant.TcPOU`,
+  `FB_Sensor.TcPOU`, `TestProject3/MAIN.TcPOU`), using **both** named
+  args (`FB_Comm(comm := comm)`) **and** positional args
+  (`FB_IdleState(THIS)`) — confirming this needs the same
   positional-or-named parameter grammar as an ordinary FB call
   (`param_assignment()`), not the named-only `member := value` shape that
   `structure_initialization()` already provides for the `:=` form.


### PR DESCRIPTION
## Summary

Part of #1199 (TwinCAT vendor dialect support).

**Fourth in a stacked series of new-flag PRs** (`pi-constant` #1219 -> `var-initializer-expressions` #1220 -> `mixed-located-var-declarations` #1221 -> **this** -> `explicit-enum-values` -> `and-then-operator`), stacked purely to avoid colliding with each other in `options.rs`'s shared feature-count table if merged out of order (this one adds no new flag itself, but sits in the stack between others that do). This PR's diff currently includes all three prior PRs' commits too; it'll shrink to just this PR's own commits as they merge. No functional dependency on any of them -- bundles two unrelated sub-fixes that happened to be surveyed together:

**1. `STRING(n)`/`WSTRING(n)` parenthesis form** -- adds parenthesis-delimited `STRING`/`WSTRING` length as an alternate to the bracket form (`STRING(255)` alongside `STRING[255]`) in `VAR` declarations and function return types, matching the existing unconditional `string_type_declaration__parenthesis()` precedent already used for `TYPE` aliases. Unconditional, no dialect flag needed.

**2. CODESYS/TwinCAT call-style FB instance initialization** -- `comm : FB_Comm(retries := 3, THIS);`, reusing the same positional-or-named parameter shape as an ordinary FB call. Uncovered two pre-existing, unrelated bugs along the way:
- `fb_name_decl()` was dead code due to a spurious trailing-comma requirement in `commasep_oneplus()`.
- `xform_toposort_declarations.rs` ordered FunctionBlock-initializer dependency edges backwards relative to `Structure`/`LateResolvedType`, causing a spurious `P2011` once eager `FunctionBlock` construction became reachable for a real, user-declared FB type.

## Test plan
- [x] `STRING(n)`/`WSTRING(n)` parens parse in `VAR` declarations and function return types; standard bracket form still parses unchanged (regression)
- [x] FB call-style init parses with named args, positional args, and both combined; empty parens; bare declaration (no initializer) still resolves via the existing late-bound path (regression); standard `:= (member := value)` struct-init form still parses (regression)
- [x] plc2plc round-trip tests for both features (string parens normalize to brackets on render, matching the existing `STRING[n]`-only DSL shape)
- [x] Full workspace test suite passes
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmnbEUBJgbckxAU6aSg2Cu