### PR TITLE
reference-to-twincat.md with REQ-RTO markers (PR1)

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -910,11 +910,13 @@ dependencies = [
  "ironplc-dsl",
  "ironplc-parser",
  "ironplc-problems",
+ "ironplc-spec-requirements-gen",
  "ironplc-test",
  "log",
  "petgraph",
  "phf",
  "rstest",
+ "spec_test_macro",
 ]
 
 [[package]]
@@ -1034,11 +1036,13 @@ version = "0.232.0"
 dependencies = [
  "ironplc-dsl",
  "ironplc-problems",
+ "ironplc-spec-requirements-gen",
  "ironplc-test",
  "logos",
  "peg",
  "phf",
  "rstest",
+ "spec_test_macro",
  "time",
 ]
 
@@ -1068,8 +1072,10 @@ dependencies = [
  "dsl_macro_derive",
  "ironplc-dsl",
  "ironplc-parser",
+ "ironplc-spec-requirements-gen",
  "ironplc-test",
  "paste",
+ "spec_test_macro",
 ]
 
 [[package]]

--- a/compiler/analyzer/Cargo.toml
+++ b/compiler/analyzer/Cargo.toml
@@ -21,11 +21,15 @@ phf = { version = "0.14", features = ["macros"] }
 petgraph = { version = "0.8" }
 fixedbitset = { version = "0.5" }
 
+[build-dependencies]
+ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
+
 [dev-dependencies]
 ironplc-parser = { path = "../parser", version = "0.232.0" }
 ctor = "1.0"
 env_logger = "0.11"
 rstest = "0.26"
+spec_test_macro = { path = "../spec_test_macro" }
 
 [lints]
 workspace = true

--- a/compiler/analyzer/build.rs
+++ b/compiler/analyzer/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    ironplc_spec_requirements_gen::generate(&["reference-to-twincat.md"]);
+}

--- a/compiler/analyzer/src/intermediates/array.rs
+++ b/compiler/analyzer/src/intermediates/array.rs
@@ -76,8 +76,9 @@ pub fn try_from(
                 })
                 .collect::<Result<Vec<_>, Diagnostic>>()?;
 
-            // Wrap in Reference if the element type is REF_TO
-            let resolved_element_type = if array_subranges.ref_to {
+            // Wrap in Reference if the element type is a reference
+            // (REF_TO or REFERENCE TO — the surface syntax is immaterial here).
+            let resolved_element_type = if array_subranges.ref_to.is_some() {
                 IntermediateType::Reference {
                     target_type: Box::new(element_repr),
                 }
@@ -328,7 +329,7 @@ mod tests {
                 end: literal(10, false),
             }],
             type_name: ArrayElementType::Named(TypeName::from("int")),
-            ref_to: false,
+            ref_to: None,
         };
 
         let spec = SpecificationKind::Inline(array_subranges);
@@ -393,7 +394,7 @@ mod tests {
                 end: literal(10, false),
             }],
             type_name: ArrayElementType::Named(TypeName::from("MISSING_TYPE")),
-            ref_to: false,
+            ref_to: None,
         };
 
         let spec = SpecificationKind::Inline(array_subranges);
@@ -433,7 +434,7 @@ mod tests {
                 },
             ],
             type_name: ArrayElementType::Named(TypeName::from("bool")),
-            ref_to: false,
+            ref_to: None,
         };
 
         let spec = SpecificationKind::Inline(array_subranges);
@@ -472,7 +473,7 @@ mod tests {
                 end: literal(3, false),
             }],
             type_name: ArrayElementType::Named(TypeName::from("byte")),
-            ref_to: true,
+            ref_to: Some(RefSyntax::RefTo),
         };
 
         let spec = SpecificationKind::Inline(array_subranges);
@@ -519,7 +520,7 @@ mod tests {
                 })),
                 keyword_span: SourceSpan::default(),
             }),
-            ref_to: false,
+            ref_to: None,
         };
 
         let spec = SpecificationKind::Inline(array_subranges);
@@ -568,7 +569,7 @@ mod tests {
                 length: None,
                 keyword_span: SourceSpan::default(),
             }),
-            ref_to: false,
+            ref_to: None,
         };
 
         let spec = SpecificationKind::Inline(array_subranges);

--- a/compiler/analyzer/src/lib.rs
+++ b/compiler/analyzer/src/lib.rs
@@ -80,3 +80,11 @@ pub use type_environment::{TypeEnvironment, TypeEnvironmentBuilder, UsageContext
 
 #[cfg(test)]
 mod test_helpers;
+
+// Spec conformance testing infrastructure (test-only).
+#[cfg(test)]
+mod spec_requirements {
+    include!(concat!(env!("OUT_DIR"), "/spec_requirements.rs"));
+}
+#[cfg(test)]
+mod spec_conformance;

--- a/compiler/analyzer/src/spec_conformance.rs
+++ b/compiler/analyzer/src/spec_conformance.rs
@@ -1,0 +1,84 @@
+//! Spec conformance tests for TwinCAT `REFERENCE TO` support (analyzer-owned
+//! requirements).
+//!
+//! Each test is annotated with `#[spec_test(REQ_RTO_analyzer_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test fails
+//! to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test asserts every analyzer-owned
+//! requirement has a test here.
+//!
+//! See `specs/design/reference-to-twincat.md`.
+
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_parser::parse_program;
+use ironplc_problems::Problem;
+use spec_test_macro::spec_test;
+
+use crate::stages::analyze;
+
+#[test]
+fn all_spec_requirements_have_tests() {
+    assert!(
+        crate::spec_requirements::UNTESTED.is_empty(),
+        "Requirements in spec with no conformance test: {:?}",
+        crate::spec_requirements::UNTESTED
+    );
+}
+
+fn reference_to_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_reference_to: true,
+        ..CompilerOptions::default()
+    }
+}
+
+/// Analyze a program and return the set of problem codes it produced.
+fn analyze_codes(program: &str, options: &CompilerOptions) -> Vec<String> {
+    let library = parse_program(program, &FileId::default(), options).expect("program parses");
+    let (_library, context) = analyze(&[&library], options).expect("analysis returns a context");
+    context
+        .diagnostics()
+        .iter()
+        .map(|d| d.code.clone())
+        .collect()
+}
+
+/// REQ-RTO-analyzer-300: `REFERENCE TO T` resolves to a reference type — a
+/// `REFERENCE TO` variable can be bound and dereferenced without any
+/// "deref requires a reference type" (P2031) diagnostic, proving it resolved to
+/// `IntermediateType::Reference` (the same path `REF_TO` uses).
+#[spec_test(REQ_RTO_analyzer_300)]
+fn analyzer_spec_req_rto_300_reference_to_resolves_to_reference_type() {
+    let source = "PROGRAM Main
+VAR
+    x : INT;
+    r : REFERENCE TO INT;
+    y : INT;
+END_VAR
+    r REF= x;
+    y := r^;
+END_PROGRAM";
+    let codes = analyze_codes(source, &reference_to_options());
+    assert!(codes.is_empty(), "expected clean analysis, got {codes:?}");
+}
+
+/// REQ-RTO-analyzer-301: Binding a `REFERENCE TO` variable to a mismatched
+/// target type is rejected with P2032, reusing the `REF_TO` compatibility rule.
+#[spec_test(REQ_RTO_analyzer_301)]
+fn analyzer_spec_req_rto_301_reference_bind_type_mismatch_is_rejected() {
+    let source = "PROGRAM Main
+VAR
+    x : REAL;
+    r : REFERENCE TO INT;
+END_VAR
+    r REF= x;
+END_PROGRAM";
+    let codes = analyze_codes(source, &reference_to_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::ReferenceTypeMismatch.code()),
+        "expected P2032 (ReferenceTypeMismatch), got {codes:?}"
+    );
+}

--- a/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
@@ -224,6 +224,10 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                             InitialValueAssignmentKind::Reference(ReferenceInitializer {
                                 target: ref_target.clone(),
                                 initial_value: None,
+                                // Resolved from a named reference-type alias; the
+                                // original surface keyword is not preserved through
+                                // the alias and is not rendered for a named target.
+                                syntax: RefSyntax::RefTo,
                             }),
                         ),
                         TypeDefinitionKind::Subrange => Ok(InitialValueAssignmentKind::Subrange(

--- a/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
+++ b/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
@@ -93,6 +93,8 @@ impl TypeEnvironment {
                             target: ironplc_dsl::common::ReferenceTarget::Named(
                                 node.base_type_name,
                             ),
+                            // Resolved alias; original surface keyword not preserved.
+                            syntax: ironplc_dsl::common::RefSyntax::RefTo,
                         },
                     ))
                 }

--- a/compiler/codegen/build.rs
+++ b/compiler/codegen/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    ironplc_spec_requirements_gen::generate(&["enumeration-codegen.md"]);
+    ironplc_spec_requirements_gen::generate(&["enumeration-codegen.md", "reference-to-twincat.md"]);
 }

--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -364,7 +364,7 @@ pub(crate) fn array_spec_from_inline(
     Ok(ArraySpec {
         dimensions,
         element_type_name: Id::from(&subranges.type_name.to_type_name().to_string()),
-        ref_to: subranges.ref_to,
+        ref_to: subranges.ref_to.is_some(),
         string_max_len,
         string_char_width,
     })

--- a/compiler/codegen/src/spec_conformance.rs
+++ b/compiler/codegen/src/spec_conformance.rs
@@ -682,3 +682,120 @@ END_PROGRAM
 ";
     let _container = compile_only(source);
 }
+
+// ---------------------------------------------------------------------------
+// Section: TwinCAT REFERENCE TO execution (REQ-RTO-codegen-4xx)
+//
+// REFERENCE TO reuses the REF_TO backend wholesale, so these tests exercise the
+// TwinCAT surface syntax (REFERENCE TO declarations, REF= binding) and the
+// explicit `^` dereference through the same codegen and VM path.
+// See `specs/design/reference-to-twincat.md`.
+// ---------------------------------------------------------------------------
+
+fn reference_to_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_reference_to: true,
+        ..CompilerOptions::default()
+    }
+}
+
+/// Parse, analyze, compile, and run one scan cycle with the given options.
+fn compile_and_run_with(
+    source: &str,
+    options: &CompilerOptions,
+) -> (ironplc_container::Container, VmBuffers) {
+    compile_and_try_run_with(source, options).expect("VM execution trapped unexpectedly")
+}
+
+/// Like [`compile_and_run_with`] but returns `Err` on a VM trap.
+fn compile_and_try_run_with(
+    source: &str,
+    options: &CompilerOptions,
+) -> Result<(ironplc_container::Container, VmBuffers), ironplc_vm::FaultContext> {
+    let library = ironplc_parser::parse_program(source, &FileId::default(), options).unwrap();
+    let (analyzed, ctx) = ironplc_analyzer::stages::resolve_types(&[&library], options).unwrap();
+    let codegen_options = crate::CodegenOptions::default();
+    let container =
+        crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs)?;
+        vm.run_round(0)?;
+    }
+    Ok((container, bufs))
+}
+
+/// REQ-RTO-codegen-400: Reading a `REF=`-bound reference via `^` yields the
+/// referenced value.
+#[spec_test(REQ_RTO_codegen_400)]
+fn codegen_spec_req_rto_400_read_through_reference() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT := 42;
+    r : REFERENCE TO INT;
+    y : INT;
+  END_VAR
+  r REF= x;
+  y := r^;
+END_PROGRAM
+";
+    let (_c, bufs) = compile_and_run_with(source, &reference_to_options());
+    // vars: x=0, r=1, y=2
+    assert_eq!(bufs.vars[2].as_i32(), 42);
+}
+
+/// REQ-RTO-codegen-401: Writing through `^` stores to the referenced variable.
+#[spec_test(REQ_RTO_codegen_401)]
+fn codegen_spec_req_rto_401_write_through_reference() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT := 1;
+    r : REFERENCE TO INT;
+  END_VAR
+  r REF= x;
+  r^ := 99;
+END_PROGRAM
+";
+    let (_c, bufs) = compile_and_run_with(source, &reference_to_options());
+    // Writing through r must update x (var 0).
+    assert_eq!(bufs.vars[0].as_i32(), 99);
+}
+
+/// REQ-RTO-codegen-402: Dereferencing an unbound `REFERENCE TO` variable traps
+/// `NullDereference`.
+#[spec_test(REQ_RTO_codegen_402)]
+fn codegen_spec_req_rto_402_unbound_reference_deref_traps() {
+    let source = "
+PROGRAM main
+  VAR
+    r : REFERENCE TO INT;
+    y : INT;
+  END_VAR
+  y := r^;
+END_PROGRAM
+";
+    let err = compile_and_try_run_with(source, &reference_to_options()).unwrap_err();
+    assert_eq!(err.trap, ironplc_vm::error::Trap::NullDereference);
+}
+
+/// REQ-RTO-codegen-420: An `ARRAY [..] OF REFERENCE TO T` element can be bound
+/// (`REF=`) and accessed (`^`).
+#[spec_test(REQ_RTO_codegen_420)]
+fn codegen_spec_req_rto_420_array_of_reference_element_access() {
+    let source = "
+PROGRAM main
+  VAR
+    val : INT := 77;
+    refs : ARRAY[0..2] OF REFERENCE TO INT;
+    result : INT;
+  END_VAR
+  refs[0] REF= val;
+  result := refs[0]^;
+END_PROGRAM
+";
+    let (_c, bufs) = compile_and_run_with(source, &reference_to_options());
+    // vars: val=0, refs=1, result=2
+    assert_eq!(bufs.vars[2].as_i32(), 77);
+}

--- a/compiler/codegen/src/spec_conformance.rs
+++ b/compiler/codegen/src/spec_conformance.rs
@@ -715,8 +715,7 @@ fn compile_and_try_run_with(
     let library = ironplc_parser::parse_program(source, &FileId::default(), options).unwrap();
     let (analyzed, ctx) = ironplc_analyzer::stages::resolve_types(&[&library], options).unwrap();
     let codegen_options = crate::CodegenOptions::default();
-    let container =
-        crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
+    let container = crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
     let mut bufs = VmBuffers::from_container(&container);
     {
         let mut vm = load_and_start(&container, &mut bufs)?;

--- a/compiler/codegen/tests/it/end_to_end_reference_to.rs
+++ b/compiler/codegen/tests/it/end_to_end_reference_to.rs
@@ -1,0 +1,105 @@
+//! End-to-end integration tests for TwinCAT `REFERENCE TO` reference types.
+//!
+//! These exercise the full pipeline — parse -> semantic analysis -> codegen ->
+//! VM execution — for the TwinCAT surface syntax (`REFERENCE TO` declarations
+//! and the `REF=` binding operator) accessed via the explicit `^` operator.
+//! They prove the feature reuses the existing `REF_TO` backend unchanged.
+//! See `specs/design/reference-to-twincat.md`.
+
+use crate::common::{parse_and_run, parse_and_try_run};
+use ironplc_parser::options::CompilerOptions;
+use ironplc_vm::error::Trap;
+
+fn reference_to_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_reference_to: true,
+        ..CompilerOptions::default()
+    }
+}
+
+#[test]
+fn end_to_end_when_reference_to_bound_then_reads_through_caret() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT := 42;
+    r : REFERENCE TO INT;
+    y : INT;
+  END_VAR
+  r REF= x;
+  y := r^;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &reference_to_options());
+    // vars: x=0, r=1, y=2
+    assert_eq!(bufs.vars[2].as_i32(), 42);
+}
+
+#[test]
+fn end_to_end_when_reference_to_written_then_updates_referent() {
+    let source = "
+PROGRAM main
+  VAR
+    x : INT := 1;
+    r : REFERENCE TO INT;
+  END_VAR
+  r REF= x;
+  r^ := 99;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &reference_to_options());
+    assert_eq!(bufs.vars[0].as_i32(), 99);
+}
+
+#[test]
+fn end_to_end_when_reference_to_named_type_then_runs() {
+    let source = "
+TYPE IntRef : REFERENCE TO INT; END_TYPE
+
+PROGRAM main
+  VAR
+    x : INT := 7;
+    r : IntRef;
+    y : INT;
+  END_VAR
+  r REF= x;
+  y := r^;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &reference_to_options());
+    // vars: x=0, r=1, y=2
+    assert_eq!(bufs.vars[2].as_i32(), 7);
+}
+
+#[test]
+fn end_to_end_when_array_of_reference_to_element_bound_then_reads() {
+    let source = "
+PROGRAM main
+  VAR
+    val : INT := 77;
+    refs : ARRAY[0..2] OF REFERENCE TO INT;
+    result : INT;
+  END_VAR
+  refs[0] REF= val;
+  result := refs[0]^;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &reference_to_options());
+    // vars: val=0, refs=1, result=2
+    assert_eq!(bufs.vars[2].as_i32(), 77);
+}
+
+#[test]
+fn end_to_end_when_unbound_reference_to_dereferenced_then_traps() {
+    let source = "
+PROGRAM main
+  VAR
+    r : REFERENCE TO INT;
+    y : INT;
+  END_VAR
+  y := r^;
+END_PROGRAM
+";
+    let err = parse_and_try_run(source, &reference_to_options()).unwrap_err();
+    assert_eq!(err.trap, Trap::NullDereference);
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -136,6 +136,7 @@ mod end_to_end_partial_access;
 mod end_to_end_pow;
 mod end_to_end_ref;
 mod end_to_end_ref_to_array;
+mod end_to_end_reference_to;
 mod end_to_end_replace;
 mod end_to_end_right;
 mod end_to_end_sel;

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -1340,13 +1340,36 @@ impl ReferenceTarget {
     }
 }
 
-/// Reference type declaration (REF_TO).
+/// The surface syntax that produced a reference declaration or initializer.
 ///
-/// See IEC 61131-3 Edition 3, section 2.3.3.1.
+/// References share a single backend (a variable-table index), but two
+/// keywords produce them: the IEC 61131-3 `REF_TO` and the Beckhoff
+/// TwinCAT / CODESYS `REFERENCE TO`. This tag records which one appeared in
+/// the source so the renderer can reproduce it and so per-declaration
+/// dereference behavior can be keyed on it. See
+/// `specs/design/reference-to-twincat.md`.
+///
+/// This is a leaf tag, always carried behind a `#[recurse(ignore)]` field, so
+/// it deliberately does not derive `Recurse`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefSyntax {
+    /// IEC 61131-3 Edition 3 `REF_TO`.
+    RefTo,
+    /// Beckhoff TwinCAT / CODESYS `REFERENCE TO`.
+    ReferenceTo,
+}
+
+/// Reference type declaration (`REF_TO` or `REFERENCE TO`).
+///
+/// See IEC 61131-3 Edition 3, section 2.3.3.1, and
+/// `specs/design/reference-to-twincat.md`.
 #[derive(Clone, Debug, PartialEq, Recurse)]
 pub struct ReferenceDeclaration {
     pub type_name: TypeName,
     pub target: ReferenceTarget,
+    /// The surface keyword that produced this declaration.
+    #[recurse(ignore)]
+    pub syntax: RefSyntax,
 }
 
 /// See section 2.3.3.1.
@@ -1820,9 +1843,11 @@ impl ArrayElementType {
 pub struct ArraySubranges {
     pub ranges: Vec<Subrange>,
     pub type_name: ArrayElementType,
-    /// Whether the element type is wrapped in REF_TO (Edition 3).
+    /// The reference syntax of the element type, if any. `None` for a
+    /// non-reference element; `Some(_)` when the element is wrapped in a
+    /// reference keyword (`REF_TO` or `REFERENCE TO`), tagged with which one.
     #[recurse(ignore)]
-    pub ref_to: bool,
+    pub ref_to: Option<RefSyntax>,
 }
 
 /// Subrange of an array.
@@ -2462,13 +2487,18 @@ pub enum ReferenceInitialValue {
     Ref(Variable),
 }
 
-/// Initializer for a reference variable declaration (REF_TO).
+/// Initializer for a reference variable declaration (`REF_TO` or
+/// `REFERENCE TO`).
 ///
-/// See IEC 61131-3 Edition 3, section 2.4.3.2.
+/// See IEC 61131-3 Edition 3, section 2.4.3.2, and
+/// `specs/design/reference-to-twincat.md`.
 #[derive(Clone, Debug, PartialEq, Recurse)]
 pub struct ReferenceInitializer {
     pub target: ReferenceTarget,
     pub initial_value: Option<ReferenceInitialValue>,
+    /// The surface keyword that produced this initializer.
+    #[recurse(ignore)]
+    pub syntax: RefSyntax,
 }
 
 #[derive(Clone, PartialEq, Debug, Recurse)]

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -787,6 +787,7 @@ impl StmtKind {
         StmtKind::Assignment(Assignment {
             target,
             deref: false,
+            ref_bind: false,
             value: Expr::new(value),
             span: SourceSpan::default(),
         })
@@ -796,6 +797,7 @@ impl StmtKind {
         StmtKind::Assignment(Assignment {
             target: Variable::named(target),
             deref: false,
+            ref_bind: false,
             value: Expr::new(ExprKind::LateBound(LateBound {
                 value: Id::from(src),
             })),
@@ -813,6 +815,7 @@ impl StmtKind {
         StmtKind::Assignment(Assignment {
             target: Variable::named(target),
             deref: false,
+            ref_bind: false,
             value: Expr::new(ExprKind::Variable(variable)),
             span: SourceSpan::default(),
         })
@@ -827,6 +830,13 @@ pub struct Assignment {
     pub target: Variable,
     #[recurse(ignore)]
     pub deref: bool,
+    /// `true` when the assignment was written with the TwinCAT/CODESYS `REF=`
+    /// reference-binding operator rather than `:=`. The value is an
+    /// `ExprKind::Ref` either way (so the backend is identical to `r := REF(x)`);
+    /// this flag only lets the renderer reproduce the original `REF=` surface
+    /// syntax. See `specs/design/reference-to-twincat.md`.
+    #[recurse(ignore)]
+    pub ref_bind: bool,
     pub value: Expr,
     pub span: SourceSpan,
 }

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -104,6 +104,12 @@ struct FileArgs {
     #[arg(long)]
     allow_ref_to: bool,
 
+    /// Allow the Beckhoff TwinCAT/CODESYS `REFERENCE TO` reference type and the
+    /// `REF=` binding operator. This is a vendor extension, an alternative to
+    /// `--allow-ref-to`; the `twincat` and `codesys` dialects enable it.
+    #[arg(long)]
+    allow_reference_to: bool,
+
     /// Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types.
     /// This is a vendor extension not part of the IEC 61131-3 standard.
     #[arg(long)]
@@ -180,6 +186,7 @@ impl FileArgs {
         options.allow_time_as_function_name |= self.allow_time_as_function_name;
         options.allow_c_style_comments |= self.allow_c_style_comments;
         options.allow_ref_to |= self.allow_ref_to;
+        options.allow_reference_to |= self.allow_reference_to;
         options.allow_ref_arithmetic |= self.allow_ref_arithmetic;
         options.allow_ref_stack_variables |= self.allow_ref_stack_variables;
         options.allow_ref_type_punning |= self.allow_ref_type_punning;

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -1106,6 +1106,28 @@ mod test {
     }
 
     #[test]
+    fn extract_compiler_options_when_allow_reference_to_then_enables_flag() {
+        #[allow(deprecated)]
+        let params = InitializeParams {
+            process_id: None,
+            root_path: None,
+            root_uri: None,
+            initialization_options: Some(serde_json::json!({"allowReferenceTo": true})),
+            capabilities: ClientCapabilities::default(),
+            trace: None,
+            workspace_folders: None,
+            client_info: None,
+            locale: None,
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        };
+
+        let options = super::extract_compiler_options(&params);
+        assert!(options.allow_reference_to);
+    }
+
+    #[test]
     fn lsp_when_ed3_dialect_then_accepts_ltime() {
         use ironplc_parser::options::{CompilerOptions, Dialect};
 

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -609,6 +609,7 @@ impl From<LspTokenType> for Option<SemanticToken> {
             TokenType::RefTo => Some(KEYWORD_INDEX),
             TokenType::Ref => Some(KEYWORD_INDEX),
             TokenType::Null => Some(KEYWORD_INDEX),
+            TokenType::Reference => Some(KEYWORD_INDEX),
             TokenType::Date => Some(KEYWORD_INDEX),
             TokenType::TimeOfDay => Some(KEYWORD_INDEX),
             TokenType::DateAndTime => Some(KEYWORD_INDEX),

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -107,6 +107,13 @@ const FLAG_FIXTURES: &[FlagFixture] = &[
         prereqs: &[],
         source: "PROGRAM main\nVAR\nx : REF_TO INT;\nEND_VAR\nEND_PROGRAM",
     },
+    // TwinCAT REFERENCE TO: without the flag, REFERENCE is a demoted identifier
+    // and the declaration is a parse error; with it, the type parses.
+    FlagFixture {
+        key: "allow_reference_to",
+        prereqs: &[],
+        source: "PROGRAM main\nVAR\nx : REFERENCE TO INT;\nEND_VAR\nEND_PROGRAM",
+    },
     // Arithmetic on a REF_TO type (P2033). Needs REF_TO to parse at all.
     FlagFixture {
         key: "allow_ref_arithmetic",

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -23,8 +23,12 @@ ironplc-test = { path = "../test", version = "0.232.0" }
 logos = "0.16.1"
 peg = "0.8.5"
 
+[build-dependencies]
+ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
+
 [dev-dependencies]
 rstest = "0.26"
+spec_test_macro = { path = "../spec_test_macro" }
 
 [lints]
 workspace = true

--- a/compiler/parser/build.rs
+++ b/compiler/parser/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    ironplc_spec_requirements_gen::generate(&["reference-to-twincat.md"]);
+}

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -31,6 +31,14 @@ use xform_tokens::insert_keyword_statement_terminators;
 
 #[cfg(test)]
 mod tests;
+
+// Spec conformance testing infrastructure (test-only).
+#[cfg(test)]
+mod spec_requirements {
+    include!(concat!(env!("OUT_DIR"), "/spec_requirements.rs"));
+}
+#[cfg(test)]
+mod spec_conformance;
 pub mod token;
 
 /// Tokenize a IEC 61131 program.

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -14,6 +14,7 @@ mod vars;
 mod xform_assign_file_id;
 mod xform_collapse_pragmas;
 mod xform_demote_edition3_keywords;
+mod xform_demote_reference_keyword;
 mod xform_demote_short_circuit_operators;
 mod xform_demote_time_keyword;
 mod xform_tokens;
@@ -55,6 +56,7 @@ pub fn tokenize_program(
     let tokens = xform_collapse_pragmas::apply(tokens, options);
     let mut tokens = insert_keyword_statement_terminators(tokens, file_id, options);
     xform_demote_edition3_keywords::apply(&mut tokens, options);
+    xform_demote_reference_keyword::apply(&mut tokens, options);
     xform_demote_time_keyword::apply(&mut tokens, options);
     xform_demote_short_circuit_operators::apply(&mut tokens, options);
     let result = check_tokens(&tokens, options);

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -263,7 +263,7 @@ define_compiler_options! {
 
     "Allow Beckhoff TwinCAT/CODESYS REFERENCE TO reference types and the REF= binding operator",
     "--allow-reference-to",
-    [Codesys],
+    [Codesys, TwinCat],
     allow_reference_to,
 
     "Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types",
@@ -471,13 +471,13 @@ mod tests {
 
     /// The TwinCAT dialect is close to CODESYS (TwinCAT 3 runs on the CODESYS
     /// V3 runtime) but does *not* enable the `REF_TO` reference extensions.
-    /// TwinCAT spells references and pointers `REFERENCE TO` / `POINTER TO`
-    /// (not the CODESYS `REF_TO` / `REF()` / `NULL`), and IronPLC does not
-    /// parse those yet, so none of `allow_ref_to`, `allow_ref_arithmetic`,
-    /// `allow_ref_stack_variables`, or `allow_ref_type_punning` are enabled --
-    /// enabling them would accept `REF_TO` code that TwinCAT itself rejects.
-    /// Listed explicitly so an accidental divergence from the intended set is
-    /// caught.
+    /// TwinCAT spells references `REFERENCE TO` (not the CODESYS `REF_TO` /
+    /// `REF()` / `NULL`), so it enables `allow_reference_to` instead, and none
+    /// of `allow_ref_to`, `allow_ref_arithmetic`, `allow_ref_stack_variables`,
+    /// or `allow_ref_type_punning` are enabled -- enabling those would accept
+    /// `REF_TO` code that TwinCAT itself rejects. (Pointer types `POINTER TO`
+    /// with `ADR()` are not parsed yet.) Listed explicitly so an accidental
+    /// divergence from the intended set is caught.
     #[test]
     fn twincat_dialect_enables_exactly_these_vendor_flags() {
         assert!(!CompilerOptions::from_dialect(Dialect::TwinCat).allow_iec_61131_3_2013);
@@ -490,6 +490,7 @@ mod tests {
                 "allow_constant_type_params",
                 "allow_empty_var_blocks",
                 "allow_time_as_function_name",
+                "allow_reference_to",
                 "allow_int_to_bool_initializer",
                 "allow_sizeof",
                 "allow_cross_family_widening",

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -261,6 +261,11 @@ define_compiler_options! {
     [Rusty, Codesys],
     allow_ref_to,
 
+    "Allow Beckhoff TwinCAT/CODESYS REFERENCE TO reference types and the REF= binding operator",
+    "--allow-reference-to",
+    [Codesys],
+    allow_reference_to,
+
     "Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types",
     "--allow-ref-arithmetic",
     [Rusty, Codesys],
@@ -448,6 +453,7 @@ mod tests {
                 "allow_empty_var_blocks",
                 "allow_time_as_function_name",
                 "allow_ref_to",
+                "allow_reference_to",
                 "allow_ref_arithmetic",
                 "allow_ref_stack_variables",
                 "allow_ref_type_punning",

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1016,13 +1016,17 @@ parser! {
       tok(TokenType::RefTo) { RefSyntax::RefTo }
       / tok(TokenType::Reference) _ tok(TokenType::To) { RefSyntax::ReferenceTo }
     // Matches the TwinCAT/CODESYS `REF=` binding operator, returning the `=`
-    // token (used for the assignment span). `REF` may be the `Ref` keyword
-    // token (when `--allow-ref-to`/Edition 3 is also active) or a demoted
-    // identifier `REF` (when only `--allow-reference-to` is set); both are
-    // accepted, case-insensitively.
+    // token (used for the assignment span). The `=` must immediately follow
+    // `REF` with no intervening whitespace (no `_`), so `REF =` is not a binding
+    // operator. `REF` may be the `Ref` keyword token (when `--allow-ref-to`/
+    // Edition 3 is also active) or a demoted identifier `REF` (when only
+    // `--allow-reference-to` is set). Matching is case-insensitive to stay
+    // consistent with the rest of the lexer: the `Ref` keyword is itself lexed
+    // case-insensitively, so `ref=` behaves the same as `REF=`, exactly as IEC
+    // 61131-3 (a case-insensitive language) treats every other keyword.
     rule ref_bind_op() -> &'input Token =
-      tok(TokenType::Ref) _ eq:tok(TokenType::Equal) { eq }
-      / [t if t.token_type == TokenType::Identifier && t.text.eq_ignore_ascii_case("REF")] _ eq:tok(TokenType::Equal) { eq }
+      tok(TokenType::Ref) eq:tok(TokenType::Equal) { eq }
+      / [t if t.token_type == TokenType::Identifier && t.text.eq_ignore_ascii_case("REF")] eq:tok(TokenType::Equal) { eq }
     rule ref_initial_value() -> ReferenceInitialValue =
       t:tok(TokenType::Null) { ReferenceInitialValue::Null(t.span.clone()) }
       / tok(TokenType::Ref) _ tok(TokenType::LeftParen) _ v:variable() _ tok(TokenType::RightParen) { ReferenceInitialValue::Ref(v) }

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1004,7 +1004,7 @@ parser! {
           initializer: InitialValueAssignmentKind::Reference(ReferenceInitializer {
             target: ref_target.clone(),
             initial_value: init.clone(),
-            syntax: syntax.clone(),
+            syntax,
           }),
         }
       }).collect()

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -522,10 +522,11 @@ parser! {
       / structure_type_declaration__with_constant()
       / enumerated:enumerated_type_declaration__with_value() { DataTypeDeclarationKind::Enumeration(enumerated) }
       / simple:simple_type_declaration__with_constant() { DataTypeDeclarationKind::Simple(simple )}
-      / type_name:type_name() _ tok(TokenType::Colon) _ tok(TokenType::RefTo) _ ref_target:ref_to_target() {
+      / type_name:type_name() _ tok(TokenType::Colon) _ syntax:ref_to_keyword() _ ref_target:ref_to_target() {
         DataTypeDeclarationKind::Reference(ReferenceDeclaration {
           type_name,
           target: ref_target,
+          syntax,
         })
       }
       // The remaining are structure, enumerated and simple without an initializer
@@ -656,8 +657,8 @@ parser! {
         initial_values: init.unwrap_or_default()
       }
     }
-    rule array_specification() -> ArraySpecificationKind = tok(TokenType::Array) _ tok(TokenType::LeftBracket) _ ranges:subrange() ** (_ tok(TokenType::Comma) _ ) _ tok(TokenType::RightBracket) _ tok(TokenType::Of) _ ref_to:tok(TokenType::RefTo)? _ type_name:array_element_type() {
-      SpecificationKind::Inline(ArraySubranges { ranges, type_name, ref_to: ref_to.is_some() } )
+    rule array_specification() -> ArraySpecificationKind = tok(TokenType::Array) _ tok(TokenType::LeftBracket) _ ranges:subrange() ** (_ tok(TokenType::Comma) _ ) _ tok(TokenType::RightBracket) _ tok(TokenType::Of) _ ref_to:ref_to_keyword()? _ type_name:array_element_type() {
+      SpecificationKind::Inline(ArraySubranges { ranges, type_name, ref_to } )
     }
     rule array_element_type() -> ArrayElementType =
       tok:tok(TokenType::String) length:(_ tok(TokenType::LeftBracket) _ l:integer_ref() _ tok(TokenType::RightBracket) { l })? { ArrayElementType::String(StringSpecification { width: StringType::String, length, keyword_span: tok.span.clone() }) }
@@ -995,7 +996,7 @@ parser! {
     }
     rule fb_name_list() -> Vec<Id> = commasep_oneplus(<fb_name()>)
     rule fb_name() -> Id = i:identifier() { i }
-    rule ref_to_var_init_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ tok(TokenType::RefTo) _ ref_target:ref_to_target() _ init:(tok(TokenType::Assignment) _ v:ref_initial_value() { v })? {
+    rule ref_to_var_init_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ syntax:ref_to_keyword() _ ref_target:ref_to_target() _ init:(tok(TokenType::Assignment) _ v:ref_initial_value() { v })? {
       names.into_iter().map(|name| {
         UntypedVarDecl {
           location: None,
@@ -1003,10 +1004,25 @@ parser! {
           initializer: InitialValueAssignmentKind::Reference(ReferenceInitializer {
             target: ref_target.clone(),
             initial_value: init.clone(),
+            syntax: syntax.clone(),
           }),
         }
       }).collect()
     }
+    // Matches either the IEC `REF_TO` keyword or the TwinCAT/CODESYS
+    // `REFERENCE TO` keyword pair, returning which surface syntax matched.
+    // See `specs/design/reference-to-twincat.md`.
+    rule ref_to_keyword() -> RefSyntax =
+      tok(TokenType::RefTo) { RefSyntax::RefTo }
+      / tok(TokenType::Reference) _ tok(TokenType::To) { RefSyntax::ReferenceTo }
+    // Matches the TwinCAT/CODESYS `REF=` binding operator, returning the `=`
+    // token (used for the assignment span). `REF` may be the `Ref` keyword
+    // token (when `--allow-ref-to`/Edition 3 is also active) or a demoted
+    // identifier `REF` (when only `--allow-reference-to` is set); both are
+    // accepted, case-insensitively.
+    rule ref_bind_op() -> &'input Token =
+      tok(TokenType::Ref) _ eq:tok(TokenType::Equal) { eq }
+      / [t if t.token_type == TokenType::Identifier && t.text.eq_ignore_ascii_case("REF")] _ eq:tok(TokenType::Equal) { eq }
     rule ref_initial_value() -> ReferenceInitialValue =
       t:tok(TokenType::Null) { ReferenceInitialValue::Null(t.span.clone()) }
       / tok(TokenType::Ref) _ tok(TokenType::LeftParen) _ v:variable() _ tok(TokenType::RightParen) { ReferenceInitialValue::Ref(v) }
@@ -1672,10 +1688,24 @@ parser! {
 
     // B.3.2.1 Assignment statements
     pub rule assignment_statement() -> StmtKind =
-      var:variable() _ tok(TokenType::Caret) _ assign:tok(TokenType::Assignment) _ expr:expression() {
+      // TwinCAT / CODESYS reference binding: `r REF= x` binds the reference `r`
+      // to variable `x`, equivalent to the IEC `r := REF(x)`. It lowers to the
+      // same `ExprKind::Ref` value, so it reuses the entire reference backend.
+      // See `specs/design/reference-to-twincat.md`.
+      target:variable() _ eq:ref_bind_op() _ referent:variable() {
+        StmtKind::Assignment(Assignment {
+          target,
+          deref: false,
+          ref_bind: true,
+          value: Expr::new(ExprKind::Ref(Box::new(referent))),
+          span: eq.span.clone(),
+        })
+      }
+      / var:variable() _ tok(TokenType::Caret) _ assign:tok(TokenType::Assignment) _ expr:expression() {
         StmtKind::Assignment(Assignment {
           target: var,
           deref: true,
+          ref_bind: false,
           value: Expr::new(expr),
           span: assign.span.clone(),
         })
@@ -1684,6 +1714,7 @@ parser! {
         StmtKind::Assignment(Assignment {
           target: var,
           deref: false,
+          ref_bind: false,
           value: Expr::new(expr),
           span: assign.span.clone(),
         })

--- a/compiler/parser/src/spec_conformance.rs
+++ b/compiler/parser/src/spec_conformance.rs
@@ -1,0 +1,221 @@
+//! Spec conformance tests for TwinCAT `REFERENCE TO` support (parser-owned
+//! requirements).
+//!
+//! Each test is annotated with `#[spec_test(REQ_RTO_parser_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test fails
+//! to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test asserts every parser-owned
+//! requirement has a test here.
+//!
+//! See `specs/design/reference-to-twincat.md`.
+
+use dsl::common::{
+    DataTypeDeclarationKind, FunctionBlockBodyKind, InitialValueAssignmentKind, Library,
+    LibraryElementKind, RefSyntax, SpecificationKind,
+};
+use dsl::core::FileId;
+use dsl::textual::{ExprKind, StmtKind};
+use ironplc_test::cast;
+use spec_test_macro::spec_test;
+
+use crate::options::{CompilerOptions, Dialect};
+use crate::token::TokenType;
+
+// ---------------------------------------------------------------------------
+// Meta-test: completeness check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_spec_requirements_have_tests() {
+    assert!(
+        crate::spec_requirements::UNTESTED.is_empty(),
+        "Requirements in spec with no conformance test: {:?}",
+        crate::spec_requirements::UNTESTED
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn reference_to_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_reference_to: true,
+        ..CompilerOptions::default()
+    }
+}
+
+fn parse(source: &str, options: &CompilerOptions) -> Library {
+    crate::parse_program(source, &FileId::default(), options).expect("program should parse")
+}
+
+fn token_types(source: &str, options: &CompilerOptions) -> Vec<TokenType> {
+    let (tokens, _errors) = crate::tokenize_program(source, &FileId::default(), options, 0, 0);
+    tokens.iter().map(|t| t.token_type.clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Options & dialects
+// ---------------------------------------------------------------------------
+
+/// REQ-RTO-parser-001: The `codesys` dialect enables `allow_reference_to`.
+#[spec_test(REQ_RTO_parser_001)]
+fn options_spec_req_rto_001_codesys_enables_reference_to() {
+    assert!(CompilerOptions::from_dialect(Dialect::Codesys).allow_reference_to);
+}
+
+/// REQ-RTO-parser-002: The `rusty` dialect does not enable `allow_reference_to`.
+#[spec_test(REQ_RTO_parser_002)]
+fn options_spec_req_rto_002_rusty_does_not_enable_reference_to() {
+    assert!(!CompilerOptions::from_dialect(Dialect::Rusty).allow_reference_to);
+}
+
+/// REQ-RTO-parser-003: Setting both `allow_reference_to` and `allow_ref_to`
+/// together is accepted — no combination is rejected (ADR-0038).
+#[spec_test(REQ_RTO_parser_003)]
+fn options_spec_req_rto_003_reference_to_and_ref_to_coexist() {
+    let options = CompilerOptions {
+        allow_ref_to: true,
+        allow_reference_to: true,
+        ..CompilerOptions::default()
+    };
+    // A program using both syntaxes parses without any combination error.
+    let source = "TYPE A : REF_TO INT; END_TYPE
+TYPE B : REFERENCE TO INT; END_TYPE";
+    let lib = parse(source, &options);
+    assert_eq!(lib.elements.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Lexer & keyword demotion
+// ---------------------------------------------------------------------------
+
+/// REQ-RTO-parser-100: `REFERENCE` lexes as a single `Reference` keyword token
+/// (distinct from `REF`).
+#[spec_test(REQ_RTO_parser_100)]
+fn lexer_spec_req_rto_100_reference_lexes_as_reference_token() {
+    let types = token_types("REFERENCE", &reference_to_options());
+    assert!(types.contains(&TokenType::Reference));
+    assert!(!types.contains(&TokenType::Ref));
+}
+
+/// REQ-RTO-parser-101: With the flag off, `REFERENCE` is demoted to
+/// `Identifier`.
+#[spec_test(REQ_RTO_parser_101)]
+fn xform_spec_req_rto_101_reference_demoted_when_flag_off() {
+    let types = token_types("REFERENCE", &CompilerOptions::default());
+    assert!(types.contains(&TokenType::Identifier));
+    assert!(!types.contains(&TokenType::Reference));
+}
+
+/// REQ-RTO-parser-102: With the flag on, `REFERENCE` stays the `Reference`
+/// keyword.
+#[spec_test(REQ_RTO_parser_102)]
+fn xform_spec_req_rto_102_reference_kept_when_flag_on() {
+    let types = token_types("REFERENCE", &reference_to_options());
+    assert!(types.contains(&TokenType::Reference));
+}
+
+/// REQ-RTO-parser-103: `REFERENCE` is a valid identifier in standard mode.
+#[spec_test(REQ_RTO_parser_103)]
+fn parser_spec_req_rto_103_reference_is_identifier_in_standard_mode() {
+    let source = "PROGRAM main
+VAR
+    REFERENCE : INT;
+END_VAR
+END_PROGRAM";
+    let lib = parse(source, &CompilerOptions::default());
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let name = prog.variables[0]
+        .identifier
+        .symbolic_id()
+        .expect("variable has a symbolic name");
+    assert_eq!(name.to_string(), "REFERENCE");
+}
+
+// ---------------------------------------------------------------------------
+// Parser productions
+// ---------------------------------------------------------------------------
+
+/// REQ-RTO-parser-200: `r : REFERENCE TO INT;` yields an initializer tagged
+/// `RefSyntax::ReferenceTo`.
+#[spec_test(REQ_RTO_parser_200)]
+fn parser_spec_req_rto_200_reference_to_var_decl_is_tagged() {
+    let source = "PROGRAM main
+VAR
+    r : REFERENCE TO INT;
+END_VAR
+END_PROGRAM";
+    let lib = parse(source, &reference_to_options());
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let init = cast!(
+        &prog.variables[0].initializer,
+        InitialValueAssignmentKind::Reference
+    );
+    assert_eq!(init.syntax, RefSyntax::ReferenceTo);
+}
+
+/// REQ-RTO-parser-201: `TYPE T : REFERENCE TO INT; END_TYPE` yields a
+/// declaration tagged `RefSyntax::ReferenceTo`.
+#[spec_test(REQ_RTO_parser_201)]
+fn parser_spec_req_rto_201_reference_to_type_decl_is_tagged() {
+    let lib = parse(
+        "TYPE T : REFERENCE TO INT; END_TYPE",
+        &reference_to_options(),
+    );
+    let dt = cast!(&lib.elements[0], LibraryElementKind::DataTypeDeclaration);
+    let decl = cast!(dt, DataTypeDeclarationKind::Reference);
+    assert_eq!(decl.syntax, RefSyntax::ReferenceTo);
+}
+
+/// REQ-RTO-parser-202: A `REF_TO` declaration is tagged `RefSyntax::RefTo`.
+#[spec_test(REQ_RTO_parser_202)]
+fn parser_spec_req_rto_202_ref_to_is_tagged_ref_to() {
+    let options = CompilerOptions {
+        allow_ref_to: true,
+        ..CompilerOptions::default()
+    };
+    let lib = parse("TYPE T : REF_TO INT; END_TYPE", &options);
+    let dt = cast!(&lib.elements[0], LibraryElementKind::DataTypeDeclaration);
+    let decl = cast!(dt, DataTypeDeclarationKind::Reference);
+    assert_eq!(decl.syntax, RefSyntax::RefTo);
+}
+
+/// REQ-RTO-parser-210: `r REF= x;` parses as a reference binding equivalent to
+/// `r := REF(x)` (value is `ExprKind::Ref`).
+#[spec_test(REQ_RTO_parser_210)]
+fn parser_spec_req_rto_210_ref_assign_parses_as_reference_binding() {
+    let source = "PROGRAM main
+VAR
+    r : REFERENCE TO INT;
+    x : INT;
+END_VAR
+    r REF= x;
+END_PROGRAM";
+    let lib = parse(source, &reference_to_options());
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let stmts = cast!(&prog.body, FunctionBlockBodyKind::Statements);
+    let assignment = cast!(&stmts.body[0], StmtKind::Assignment);
+    assert!(assignment.ref_bind);
+    let referent = cast!(&assignment.value.kind, ExprKind::Ref);
+    assert_eq!(referent.to_string(), "x");
+}
+
+/// REQ-RTO-parser-220: `ARRAY [..] OF REFERENCE TO T` tags the element
+/// `Some(RefSyntax::ReferenceTo)`.
+#[spec_test(REQ_RTO_parser_220)]
+fn parser_spec_req_rto_220_array_of_reference_to_is_tagged() {
+    let source = "PROGRAM main
+VAR
+    a : ARRAY[0..3] OF REFERENCE TO INT;
+END_VAR
+END_PROGRAM";
+    let lib = parse(source, &reference_to_options());
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let arr = cast!(
+        &prog.variables[0].initializer,
+        InitialValueAssignmentKind::Array
+    );
+    let subranges = cast!(&arr.spec, SpecificationKind::Inline);
+    assert_eq!(subranges.ref_to, Some(RefSyntax::ReferenceTo));
+}

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -1465,6 +1465,25 @@ END_PROGRAM",
         assert!(assignment.ref_bind);
     }
 
+    /// A space between `REF` and `=` is not the binding operator: `REF` and `=`
+    /// must be adjacent, so `x REF = y` is rejected.
+    #[test]
+    fn ref_bind_when_space_between_ref_and_equals_then_error() {
+        let options = CompilerOptions {
+            allow_reference_to: true,
+            ..CompilerOptions::default()
+        };
+        let source = "PROGRAM main
+VAR
+    x : REFERENCE TO INT;
+    y : INT;
+END_VAR
+    x REF = y;
+END_PROGRAM";
+        let result = parse_program(source, &FileId::default(), &options);
+        assert!(result.is_err(), "REF = with a space must be rejected");
+    }
+
     /// The right-hand side of `REF=` must be a variable (address-of), matching
     /// `REF()` semantics — a literal is rejected rather than silently accepted.
     #[test]

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -1348,6 +1348,160 @@ END_PROGRAM";
         result.unwrap()
     }
 
+    fn parse_text_reference_to(source: &str) -> Library {
+        let options = CompilerOptions {
+            allow_reference_to: true,
+            ..CompilerOptions::default()
+        };
+        let result = parse_program(source, &FileId::default(), &options);
+        assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+        result.unwrap()
+    }
+
+    /// The single (non-FB-call) statement in a program body.
+    fn only_statement(lib: &Library) -> &StmtKind {
+        let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+        let stmts = cast!(&prog.body, FunctionBlockBodyKind::Statements);
+        assert_eq!(stmts.body.len(), 1, "expected exactly one statement");
+        &stmts.body[0]
+    }
+
+    // --- REF= disambiguation against other uses of `=` -----------------------
+
+    /// A variable *named* `REF` assigned with `:=` is a normal assignment, not a
+    /// `REF=` binding — even with `--allow-reference-to` active.
+    #[test]
+    fn ref_bind_when_variable_named_ref_assigned_then_normal_assignment() {
+        let lib = parse_text_reference_to(
+            "PROGRAM main
+VAR
+    REF : INT;
+END_VAR
+    REF := 5;
+END_PROGRAM",
+        );
+        let assignment = cast!(only_statement(&lib), StmtKind::Assignment);
+        assert!(
+            !assignment.ref_bind,
+            "must not be treated as a REF= binding"
+        );
+        assert_eq!(assignment.target.to_string(), "REF");
+    }
+
+    /// An `=` equality comparison in a condition still parses (the REF= rule
+    /// only fires on `REF` immediately followed by `=`).
+    #[test]
+    fn ref_bind_when_equality_in_condition_then_parses_as_comparison() {
+        let lib = parse_text_reference_to(
+            "PROGRAM main
+VAR
+    a : INT;
+    b : INT;
+    c : INT;
+END_VAR
+    IF a = b THEN
+        c := 1;
+    END_IF;
+END_PROGRAM",
+        );
+        // The single top-level statement is the IF, not an assignment.
+        cast!(only_statement(&lib), StmtKind::If);
+    }
+
+    /// An `=` comparison on the right-hand side of `:=` still parses as a normal
+    /// assignment whose value is the comparison.
+    #[test]
+    fn ref_bind_when_equality_in_rhs_then_normal_assignment() {
+        let lib = parse_text_reference_to(
+            "PROGRAM main
+VAR
+    a : INT;
+    c : INT;
+    result : BOOL;
+END_VAR
+    result := a = c;
+END_PROGRAM",
+        );
+        let assignment = cast!(only_statement(&lib), StmtKind::Assignment);
+        assert!(!assignment.ref_bind);
+    }
+
+    /// `REF=` binds when `REF` is the keyword token (both `--allow-ref-to` and
+    /// `--allow-reference-to` active, e.g. the `codesys` dialect).
+    #[test]
+    fn ref_bind_when_ref_is_keyword_token_then_binds() {
+        let options = CompilerOptions {
+            allow_ref_to: true,
+            allow_reference_to: true,
+            ..CompilerOptions::default()
+        };
+        let source = "PROGRAM main
+VAR
+    x : INT;
+    r : REFERENCE TO INT;
+END_VAR
+    r REF= x;
+END_PROGRAM";
+        let lib = parse_program(source, &FileId::default(), &options).unwrap();
+        let assignment = cast!(only_statement(&lib), StmtKind::Assignment);
+        assert!(assignment.ref_bind);
+        let referent = cast!(&assignment.value.kind, ExprKind::Ref);
+        assert_eq!(referent.to_string(), "x");
+    }
+
+    /// The `REF=` operator is case-insensitive (`ref=` binds too).
+    #[test]
+    fn ref_bind_when_lowercase_operator_then_binds() {
+        let lib = parse_text_reference_to(
+            "PROGRAM main
+VAR
+    x : INT;
+    r : REFERENCE TO INT;
+END_VAR
+    r ref= x;
+END_PROGRAM",
+        );
+        let assignment = cast!(only_statement(&lib), StmtKind::Assignment);
+        assert!(assignment.ref_bind);
+    }
+
+    /// The right-hand side of `REF=` must be a variable (address-of), matching
+    /// `REF()` semantics — a literal is rejected rather than silently accepted.
+    #[test]
+    fn ref_bind_when_rhs_is_literal_then_error() {
+        let options = CompilerOptions {
+            allow_reference_to: true,
+            ..CompilerOptions::default()
+        };
+        let source = "PROGRAM main
+VAR
+    r : REFERENCE TO INT;
+END_VAR
+    r REF= 5;
+END_PROGRAM";
+        let result = parse_program(source, &FileId::default(), &options);
+        assert!(result.is_err(), "REF= to a literal must be rejected");
+    }
+
+    /// A referent *named* `REF` can be bound: `x REF= REF` binds `x` to the
+    /// variable `REF`.
+    #[test]
+    fn ref_bind_when_referent_named_ref_then_binds() {
+        let lib = parse_text_reference_to(
+            "PROGRAM main
+VAR
+    REF : INT;
+    x : REFERENCE TO INT;
+END_VAR
+    x REF= REF;
+END_PROGRAM",
+        );
+        let assignment = cast!(only_statement(&lib), StmtKind::Assignment);
+        assert!(assignment.ref_bind);
+        let referent = cast!(&assignment.value.kind, ExprKind::Ref);
+        assert_eq!(referent.to_string(), "REF");
+    }
+
     #[test]
     fn parse_when_ref_to_int_type_decl_then_ok() {
         let lib = parse_text_edition3("TYPE IntRef : REF_TO INT; END_TYPE");

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -1712,7 +1712,7 @@ END_PROGRAM",
             InitialValueAssignmentKind::Array
         );
         let subranges = cast!(&arr.spec, SpecificationKind::Inline);
-        assert!(subranges.ref_to);
+        assert!(subranges.ref_to.is_some());
         assert_eq!(subranges.type_name.to_type_name().to_string(), "BYTE");
         assert_eq!(subranges.ranges.len(), 1);
     }
@@ -1723,7 +1723,7 @@ END_PROGRAM",
         let dt = cast!(&lib.elements[0], LibraryElementKind::DataTypeDeclaration);
         let arr = cast!(dt, DataTypeDeclarationKind::Array);
         let subranges = cast!(&arr.spec, SpecificationKind::Inline);
-        assert!(subranges.ref_to);
+        assert!(subranges.ref_to.is_some());
         assert_eq!(subranges.type_name.to_type_name().to_string(), "INT");
     }
 
@@ -1742,7 +1742,7 @@ END_PROGRAM",
             InitialValueAssignmentKind::Array
         );
         let subranges = cast!(&arr.spec, SpecificationKind::Inline);
-        assert!(!subranges.ref_to);
+        assert!(subranges.ref_to.is_none());
     }
 
     #[test]

--- a/compiler/parser/src/token.rs
+++ b/compiler/parser/src/token.rs
@@ -342,6 +342,10 @@ pub enum TokenType {
     Ref,
     #[token("NULL", ignore(case))]
     Null,
+    // Beckhoff TwinCAT / CODESYS `REFERENCE TO` reference types
+    // (`--allow-reference-to`). Longest-match keeps this distinct from `REF`.
+    #[token("REFERENCE", ignore(case))]
+    Reference,
 
     #[token("DATE", ignore(case))]
     Date,
@@ -586,6 +590,7 @@ impl TokenType {
             TokenType::RefTo => "'REF_TO'",
             TokenType::Ref => "'REF'",
             TokenType::Null => "'NULL'",
+            TokenType::Reference => "'REFERENCE'",
             TokenType::Date => "'DATE' | 'D'",
             TokenType::TimeOfDay => "'TIME_OF_DAY' | 'TOD'",
             TokenType::DateAndTime => "'DATE_AND_TIME' | 'DT'",

--- a/compiler/parser/src/xform_demote_reference_keyword.rs
+++ b/compiler/parser/src/xform_demote_reference_keyword.rs
@@ -1,0 +1,77 @@
+//! Demote the `REFERENCE` keyword to an identifier unless the Beckhoff /
+//! CODESYS `REFERENCE TO` extension is enabled.
+//!
+//! `REFERENCE` is a vendor-flag-gated keyword (`--allow-reference-to`), not an
+//! edition-gated one, so it lives in its own transform rather than in
+//! `xform_demote_edition3_keywords`. When the flag is off, `REFERENCE` behaves
+//! like any ordinary identifier so existing programs that use it as a name keep
+//! parsing. When the flag is on, the always-present `REFERENCE TO` grammar
+//! productions fire. See `specs/design/reference-to-twincat.md`.
+
+use crate::{
+    options::CompilerOptions,
+    token::{Token, TokenType},
+};
+
+/// Demote the `Reference` token to `Identifier` when `--allow-reference-to`
+/// is not set.
+pub fn apply(tokens: &mut [Token], options: &CompilerOptions) {
+    if options.allow_reference_to {
+        return;
+    }
+    for tok in tokens.iter_mut() {
+        if tok.token_type == TokenType::Reference {
+            tok.token_type = TokenType::Identifier;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dsl::core::SourceSpan;
+
+    use crate::{
+        options::CompilerOptions,
+        token::{Token, TokenType},
+        xform_demote_reference_keyword::apply,
+    };
+
+    fn make_token(token_type: TokenType, text: &str) -> Token {
+        Token {
+            token_type,
+            span: SourceSpan::default(),
+            line: 1,
+            col: 1,
+            text: String::from(text),
+        }
+    }
+
+    fn opts_enabled() -> CompilerOptions {
+        CompilerOptions {
+            allow_reference_to: true,
+            ..CompilerOptions::default()
+        }
+    }
+
+    #[test]
+    fn apply_when_reference_and_flag_off_then_demoted_to_identifier() {
+        let mut tokens = vec![make_token(TokenType::Reference, "REFERENCE")];
+        apply(&mut tokens, &CompilerOptions::default());
+        assert_eq!(tokens[0].token_type, TokenType::Identifier);
+        assert_eq!(tokens[0].text, "REFERENCE");
+    }
+
+    #[test]
+    fn apply_when_reference_and_flag_on_then_kept_as_keyword() {
+        let mut tokens = vec![make_token(TokenType::Reference, "REFERENCE")];
+        apply(&mut tokens, &opts_enabled());
+        assert_eq!(tokens[0].token_type, TokenType::Reference);
+    }
+
+    #[test]
+    fn apply_when_non_reference_token_then_unchanged() {
+        let mut tokens = vec![make_token(TokenType::Int, "INT")];
+        apply(&mut tokens, &CompilerOptions::default());
+        assert_eq!(tokens[0].token_type, TokenType::Int);
+    }
+}

--- a/compiler/plc2plc/Cargo.toml
+++ b/compiler/plc2plc/Cargo.toml
@@ -16,8 +16,12 @@ ironplc-test = { path = "../test", version = "0.232.0" }
 dsl_macro_derive = { path = "../dsl_macro_derive", version = "0.232.0" }
 paste = "1.0"
 
+[build-dependencies]
+ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
+
 [dev-dependencies]
 ironplc-parser = { path = "../parser", version = "0.232.0" }
+spec_test_macro = { path = "../spec_test_macro" }
 
 [lints]
 workspace = true

--- a/compiler/plc2plc/build.rs
+++ b/compiler/plc2plc/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    ironplc_spec_requirements_gen::generate(&["reference-to-twincat.md"]);
+}

--- a/compiler/plc2plc/resources/test/reference_to_rendered.st
+++ b/compiler/plc2plc/resources/test/reference_to_rendered.st
@@ -1,0 +1,26 @@
+TYPE
+   IntRef : REFERENCE TO INT ;
+END_TYPE
+PROGRAM main
+
+VAR
+   counter : INT := 42;
+END_VAR
+
+VAR
+   r : REFERENCE TO INT;
+END_VAR
+
+VAR
+   refs : ARRAY [ 0.. 2 ] OF REFERENCE TO INT;
+END_VAR
+
+VAR
+   value : INT;
+END_VAR
+r REF= counter ;
+value := r ^ ;
+r^ := 99 ;
+refs [ 0 ] REF= counter ;
+value := refs [ 0 ] ^ ;
+END_PROGRAM

--- a/compiler/plc2plc/src/lib.rs
+++ b/compiler/plc2plc/src/lib.rs
@@ -9,6 +9,14 @@ use renderer::apply;
 mod renderer;
 mod tests;
 
+// Spec conformance testing infrastructure (test-only).
+#[cfg(test)]
+mod spec_requirements {
+    include!(concat!(env!("OUT_DIR"), "/spec_requirements.rs"));
+}
+#[cfg(test)]
+mod spec_conformance;
+
 pub fn write_to_string(lib: &Library) -> Result<String, Vec<Diagnostic>> {
     apply(lib)
 }

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -87,6 +87,18 @@ impl LibraryRenderer {
         self.buffer.push('\n');
     }
 
+    /// Writes the reference-type keyword for the given surface syntax:
+    /// `REF_TO` for IEC, `REFERENCE TO` for the TwinCAT/CODESYS variant.
+    fn write_ref_keyword(&mut self, syntax: &RefSyntax) {
+        match syntax {
+            RefSyntax::RefTo => self.write_ws("REF_TO"),
+            RefSyntax::ReferenceTo => {
+                self.write_ws("REFERENCE");
+                self.write_ws("TO");
+            }
+        }
+    }
+
     fn indent(&mut self) {
         self.indents += 1;
     }
@@ -527,8 +539,8 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         self.write_ws("]");
         self.write_ws("OF");
 
-        if node.ref_to {
-            self.write_ws("REF_TO");
+        if let Some(syntax) = &node.ref_to {
+            self.write_ref_keyword(syntax);
         }
 
         match &node.type_name {
@@ -1252,6 +1264,19 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         node: &dsl::textual::Assignment,
     ) -> Result<Self::Value, Diagnostic> {
         self.visit_variable(&node.target)?;
+        if node.ref_bind {
+            // Reproduce the TwinCAT/CODESYS `REF=` binding. The value is always
+            // an `ExprKind::Ref(referent)`; render `target REF= referent`.
+            self.write_ws("REF=");
+            if let dsl::textual::ExprKind::Ref(referent) = &node.value.kind {
+                self.visit_variable(referent)?;
+            } else {
+                self.visit_expr(&node.value)?;
+            }
+            self.write_ws(";");
+            self.newline();
+            return Ok(());
+        }
         if node.deref {
             self.write("^");
         }
@@ -1551,7 +1576,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
     ) -> Result<Self::Value, Diagnostic> {
         self.visit_type_name(&node.type_name)?;
         self.write_ws(":");
-        self.write_ws("REF_TO");
+        self.write_ref_keyword(&node.syntax);
         self.visit_reference_target(&node.target)
     }
 
@@ -1559,7 +1584,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         &mut self,
         node: &ReferenceInitializer,
     ) -> Result<Self::Value, Diagnostic> {
-        self.write_ws("REF_TO");
+        self.write_ref_keyword(&node.syntax);
         self.visit_reference_target(&node.target)?;
 
         if let Some(init) = &node.initial_value {

--- a/compiler/plc2plc/src/spec_conformance.rs
+++ b/compiler/plc2plc/src/spec_conformance.rs
@@ -1,0 +1,89 @@
+//! Spec conformance tests for TwinCAT `REFERENCE TO` support (plc2plc-owned
+//! requirements): round-trip rendering of the surface syntax.
+//!
+//! Each test is annotated with `#[spec_test(REQ_RTO_plc2plc_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test fails
+//! to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test asserts every plc2plc-owned
+//! requirement has a test here.
+//!
+//! See `specs/design/reference-to-twincat.md`.
+
+use dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_parser::parse_program;
+use spec_test_macro::spec_test;
+
+use crate::write_to_string;
+
+#[test]
+fn all_spec_requirements_have_tests() {
+    assert!(
+        crate::spec_requirements::UNTESTED.is_empty(),
+        "Requirements in spec with no conformance test: {:?}",
+        crate::spec_requirements::UNTESTED
+    );
+}
+
+fn render(source: &str, options: &CompilerOptions) -> String {
+    let library = parse_program(source, &FileId::default(), options).expect("program parses");
+    write_to_string(&library).expect("library renders")
+}
+
+fn reference_to_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_reference_to: true,
+        ..CompilerOptions::default()
+    }
+}
+
+/// REQ-RTO-plc2plc-600: A `ReferenceTo`-tagged declaration renders as
+/// `REFERENCE TO <target>`.
+#[spec_test(REQ_RTO_plc2plc_600)]
+fn plc2plc_spec_req_rto_600_reference_to_declaration_renders() {
+    let rendered = render("TYPE T : REFERENCE TO INT; END_TYPE", &reference_to_options());
+    assert!(
+        rendered.contains("REFERENCE TO INT"),
+        "expected `REFERENCE TO INT` in:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("REF_TO"),
+        "REFERENCE TO must not render as REF_TO:\n{rendered}"
+    );
+}
+
+/// REQ-RTO-plc2plc-601: A `REF=` binding renders back as `REF=`.
+#[spec_test(REQ_RTO_plc2plc_601)]
+fn plc2plc_spec_req_rto_601_ref_assign_renders() {
+    let source = "PROGRAM main
+VAR
+    x : INT;
+    r : REFERENCE TO INT;
+END_VAR
+    r REF= x;
+END_PROGRAM";
+    let rendered = render(source, &reference_to_options());
+    assert!(
+        rendered.contains("REF="),
+        "expected `REF=` binding in:\n{rendered}"
+    );
+}
+
+/// REQ-RTO-plc2plc-602: A `RefTo`-tagged declaration still renders as `REF_TO`
+/// (regression).
+#[spec_test(REQ_RTO_plc2plc_602)]
+fn plc2plc_spec_req_rto_602_ref_to_still_renders() {
+    let options = CompilerOptions {
+        allow_ref_to: true,
+        ..CompilerOptions::default()
+    };
+    let rendered = render("TYPE T : REF_TO INT; END_TYPE", &options);
+    assert!(
+        rendered.contains("REF_TO INT"),
+        "expected `REF_TO INT` in:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("REFERENCE"),
+        "REF_TO must not render as REFERENCE TO:\n{rendered}"
+    );
+}

--- a/compiler/plc2plc/src/spec_conformance.rs
+++ b/compiler/plc2plc/src/spec_conformance.rs
@@ -41,7 +41,10 @@ fn reference_to_options() -> CompilerOptions {
 /// `REFERENCE TO <target>`.
 #[spec_test(REQ_RTO_plc2plc_600)]
 fn plc2plc_spec_req_rto_600_reference_to_declaration_renders() {
-    let rendered = render("TYPE T : REFERENCE TO INT; END_TYPE", &reference_to_options());
+    let rendered = render(
+        "TYPE T : REFERENCE TO INT; END_TYPE",
+        &reference_to_options(),
+    );
     assert!(
         rendered.contains("REFERENCE TO INT"),
         "expected `REFERENCE TO INT` in:\n{rendered}"

--- a/compiler/plc2plc/src/tests.rs
+++ b/compiler/plc2plc/src/tests.rs
@@ -38,6 +38,19 @@ mod test {
     }
 
     #[test]
+    fn write_to_string_when_reference_to_then_round_trips() {
+        let source = read_shared_resource("reference_to.st");
+        let options = CompilerOptions {
+            allow_reference_to: true,
+            ..CompilerOptions::default()
+        };
+        let library = parse_program(&source, &FileId::default(), &options).unwrap();
+        let rendered = write_to_string(&library).unwrap();
+        let expected = read_resource("reference_to_rendered.st");
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
     fn write_to_string_arrays() {
         let rendered = parse_and_render_resource("array.st");
         let expected = read_resource("array_rendered.st");

--- a/compiler/resources/test/reference_to.st
+++ b/compiler/resources/test/reference_to.st
@@ -1,0 +1,15 @@
+TYPE IntRef : REFERENCE TO INT; END_TYPE
+
+PROGRAM main
+VAR
+    counter : INT := 42;
+    r : REFERENCE TO INT;
+    refs : ARRAY[0..2] OF REFERENCE TO INT;
+    value : INT;
+END_VAR
+    r REF= counter;
+    value := r^;
+    r^ := 99;
+    refs[0] REF= counter;
+    value := refs[0]^;
+END_PROGRAM

--- a/compiler/sources/src/xml/transform.rs
+++ b/compiler/sources/src/xml/transform.rs
@@ -166,7 +166,7 @@ fn transform_array_decl(
         spec: SpecificationKind::Inline(ArraySubranges {
             ranges: subranges,
             type_name: ArrayElementType::Named(base_type_name),
-            ref_to: false,
+            ref_to: None,
         }),
         init: vec![],
     }))

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -151,6 +151,16 @@ features — they never disable features that a dialect already includes.
    Edition 2 keyword handling for the rest of your code. See
    :doc:`/reference/language/data-types/derived/reference-types`.
 
+``--allow-reference-to``
+   Allow the Beckhoff TwinCAT / CODESYS ``REFERENCE TO`` reference type and the
+   ``REF=`` binding operator. This is the TwinCAT/CODESYS-facing alternative to
+   ``--allow-ref-to``: the two describe the same underlying reference but with
+   different surface syntax. ``REFERENCE TO`` is bundled by the ``twincat`` and
+   ``codesys`` dialects. The compiler does not restrict flag combinations, so
+   ``--allow-ref-to`` and ``--allow-reference-to`` may be set at once, though no
+   single real dialect bundles both. See
+   :doc:`/reference/language/data-types/derived/reference-types`.
+
 ``--allow-ref-arithmetic``
    Allow arithmetic (``+``, ``-``) and ordering comparisons (``<``, ``>``,
    ``<=``, ``>=``) on ``REF_TO`` types. By default, only ``=`` and ``<>``

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -49,9 +49,10 @@ Supported Dialects
    such as curly-brace pragmas, C-style comments, and the ``AND_THEN``
    short-circuit operator. Unlike ``codesys``, it does **not** enable the
    ``REF_TO`` / ``REF()`` / ``NULL`` reference extensions: TwinCAT spells
-   references and pointers ``REFERENCE TO`` / ``POINTER TO`` (with ``ADR()``),
-   which IronPLC does not parse yet, so enabling ``REF_TO`` would accept code
-   that TwinCAT itself rejects. As with ``codesys``, the implicit
+   references ``REFERENCE TO`` (bound with ``REF=``), which this dialect
+   enables instead via ``--allow-reference-to``. (Pointer types —
+   ``POINTER TO`` with ``ADR()`` — are not parsed yet.) As with ``codesys``,
+   the implicit
    :doc:`__SYSTEM_UP_TIME </reference/extension-library/variables/system-uptime>`
    globals are not pre-bound, since they are an IronPLC runtime convention
    rather than a TwinCAT feature.

--- a/docs/reference/compiler/ironplcc.rst
+++ b/docs/reference/compiler/ironplcc.rst
@@ -133,6 +133,11 @@ Options
    Edition 3. This is a vendor extension useful when you need references
    but want to keep Edition 2 keyword handling for the rest of your code.
 
+``--allow-reference-to``
+   Allow the Beckhoff TwinCAT / CODESYS ``REFERENCE TO`` reference type and the
+   ``REF=`` binding operator — the TwinCAT/CODESYS-facing alternative to
+   ``--allow-ref-to``. Enabled by the ``twincat`` and ``codesys`` dialects.
+
 ``--allow-ref-arithmetic``
    Allow arithmetic (``+``, ``-``) and ordering comparisons (``<``, ``>``,
    ``<=``, ``>=``) on ``REF_TO`` types. By default, only ``=`` and ``<>``

--- a/docs/reference/language/data-types/derived/reference-types.rst
+++ b/docs/reference/language/data-types/derived/reference-types.rst
@@ -14,6 +14,21 @@ variable.
    ``--allow-ref-to`` or by selecting the ``rusty`` dialect.
    See :doc:`/explanation/enabling-dialects-and-features`.
 
+.. note::
+
+   Beckhoff TwinCAT and CODESYS spell references ``REFERENCE TO`` and bind them
+   with the ``REF=`` operator (``r REF= x;``) rather than ``REF_TO`` and
+   ``r := REF(x);``. Enable this variant with ``--allow-reference-to`` or the
+   ``codesys`` dialect. It describes the same underlying reference and, in this
+   release, is read and written through the same explicit ``^`` operator:
+
+   .. code-block::
+
+      r : REFERENCE TO INT;
+      r REF= counter;    (* bind the reference *)
+      value := r^;       (* read through the reference *)
+      r^ := 99;          (* write through the reference *)
+
 .. list-table::
    :widths: 30 70
 

--- a/docs/reference/language/data-types/derived/reference-types.rst
+++ b/docs/reference/language/data-types/derived/reference-types.rst
@@ -19,7 +19,7 @@ variable.
    Beckhoff TwinCAT and CODESYS spell references ``REFERENCE TO`` and bind them
    with the ``REF=`` operator (``r REF= x;``) rather than ``REF_TO`` and
    ``r := REF(x);``. Enable this variant with ``--allow-reference-to`` or the
-   ``codesys`` dialect. It describes the same underlying reference and, in this
+   ``twincat`` or ``codesys`` dialect. It describes the same underlying reference and, in this
    release, is read and written through the same explicit ``^`` operator:
 
    .. code-block::

--- a/specs/design/reference-to-twincat.md
+++ b/specs/design/reference-to-twincat.md
@@ -93,7 +93,7 @@ is required; the reference is bound exactly as the IEC form binds it.
 
 ## Requirements
 
-Each requirement below carries a `**REQ-RTO-<slug>-NNN**` marker, where the
+Each requirement below carries a bold `REQ-RTO-<slug>-NNN` marker, where the
 slug names the crate that owns (hosts) the conformance test. `RTO` is an unused
 area prefix. Every marker has a spec-linked test named
 `{area}_spec_req_rto_{nnn}_{description}` (the slug lives in the

--- a/specs/design/reference-to-twincat.md
+++ b/specs/design/reference-to-twincat.md
@@ -1,0 +1,214 @@
+# Design: TwinCAT `REFERENCE TO` Reference Types
+
+## Overview
+
+This document describes support for the Beckhoff TwinCAT / CODESYS
+`REFERENCE TO` reference type as a separately-flagged alternative to the
+IEC 61131-3 `REF_TO` syntax already implemented in IronPLC (see
+[ref-to.md](ref-to.md)). `REFERENCE TO` and `REF_TO` are surface variants of
+the *same* underlying concept — a strongly-typed reference implemented as a
+variable-table index — but with different usage models:
+
+| Concern | IEC `REF_TO` (`--allow-ref-to`) | TwinCAT `REFERENCE TO` (`--allow-reference-to`) |
+|---------|--------------------------------|------------------------------------------------|
+| Declare | `r : REF_TO INT;` | `r : REFERENCE TO INT;` |
+| Bind    | `r := REF(x);` | `r REF= x;` |
+| Read    | `y := r^;` (explicit `^`) | `y := r;` (implicit dereference) |
+| Write   | `r^ := 5;` (explicit `^`) | `r := 5;` (implicit dereference) |
+| Validity| `r = NULL` | `__ISVALIDREF(r)` / `r = 0` |
+
+The reference **backend is reused wholesale**: references are type-erased to
+`u64` variable-table indices, codegen emits `LOAD_INDIRECT`/`STORE_INDIRECT`,
+and the VM traps on null (V4004). None of that depends on the surface keyword,
+so `REFERENCE TO` maps onto the existing AST
+(`ReferenceDeclaration`, `ReferenceInitializer`, `IntermediateType::Reference`,
+`ExprKind::{Ref, Deref, Null}`) and needs **no new backend**.
+
+This document supersedes
+[beckhoff-twincat-dialect.md](beckhoff-twincat-dialect.md) §2.1 and §3.6, which
+treated `REFERENCE TO` as parse-only (a distinct `TypeSpec::ReferenceTo`
+reported as unsupported). Here `REFERENCE TO` reuses the `REF_TO` backend to
+produce executable code.
+
+## Delivery
+
+The feature is delivered in two phases, one PR each:
+
+- **PR 1 — Front end & binding (this phase).** Flag, lexer keyword, parser
+  productions for the `REFERENCE TO` type constructor and the `REF=` binding
+  operator, AST tagging so the two syntaxes round-trip distinctly, and reuse of
+  the whole existing `REF_TO` analyzer/codegen/VM backend. Access in this phase
+  is via the existing explicit `^` operator (enough to prove end-to-end
+  execution). Requirements `0xx`–`4xx` and `6xx`.
+- **PR 2 — Implicit dereference & TwinCAT-faithful semantics.** An analyzer
+  transform that makes bare uses of a `REFERENCE`-typed variable behave as an
+  automatic dereference, plus `__ISVALIDREF`. Requirements `5xx`.
+
+## Gating & coexistence
+
+`REFERENCE TO` is gated behind a new `--allow-reference-to` vendor flag,
+following the established token-demotion pattern. A new `REFERENCE` keyword
+token is demoted to `Identifier` unless `--allow-reference-to` is set — exactly
+how `REF_TO`/`REF`/`NULL` are demoted today. The always-present grammar
+productions never fire when the keyword is demoted.
+
+`REF_TO` and `REFERENCE TO` are **not** made mutually exclusive. Per
+[ADR-0038](../adrs/0038-no-restrictions-on-flag-combinations.md), the compiler
+does not restrict `--allow-*` flag combinations; preference is expressed through
+dialect presets. Only the CODESYS dialect bundles `REFERENCE TO`, and no dialect
+bundles both. Coexistence stays well-defined because each declaration carries a
+`RefSyntax` tag (`RefTo` vs `ReferenceTo`); the PR-2 implicit-dereference
+transform keys on `RefSyntax::ReferenceTo`, so `REF_TO` variables are never
+implicitly dereferenced even when both flags are set.
+
+## AST tagging
+
+`ReferenceDeclaration` and `ReferenceInitializer` are shared by both syntaxes.
+A `syntax: RefSyntax` discriminant records which keyword produced each node so
+the renderer can reproduce the original keyword and binding operator:
+
+```rust
+pub enum RefSyntax {
+    RefTo,        // IEC 61131-3 REF_TO
+    ReferenceTo,  // TwinCAT / CODESYS REFERENCE TO
+}
+```
+
+For `ARRAY [..] OF REFERENCE TO T`, the DSL `ArraySubranges.ref_to` field
+changes from `bool` to `Option<RefSyntax>` (`None` = non-reference element,
+`Some(_)` = reference element tagged with its surface syntax) so the two array
+element syntaxes round-trip distinctly. The tag is only needed up to the
+renderer; the analyzer and codegen collapse it to a bool
+(`ref_to.is_some()`) at their boundaries, leaving the type system and backend
+unchanged.
+
+## `REF=` binding
+
+The TwinCAT binding operator `r REF= x;` is recognized in assignment context
+and lowered to the existing reference-assignment form `r := REF(x)` — a normal
+assignment whose value expression is `ExprKind::Ref`. No new AST node or opcode
+is required; the reference is bound exactly as the IEC form binds it.
+
+---
+
+## Requirements
+
+Each requirement below carries a `**REQ-RTO-<slug>-NNN**` marker, where the
+slug names the crate that owns (hosts) the conformance test. `RTO` is an unused
+area prefix. Every marker has a spec-linked test named
+`{area}_spec_req_rto_{nnn}_{description}` (the slug lives in the
+`#[spec_test(REQ_RTO_<slug>_NNN)]` attribute, not the function name), enforced
+per-crate via the crate-slug mechanism from
+[ADR-0037](../adrs/0037-mandatory-crate-slug-in-requirement-ids.md).
+
+### Options & dialects (parser)
+
+**REQ-RTO-parser-001** The `codesys` dialect preset enables
+`allow_reference_to`.
+
+**REQ-RTO-parser-002** The `rusty` dialect preset does *not* enable
+`allow_reference_to` (Rusty already carries `REF_TO`).
+
+**REQ-RTO-parser-003** Setting both `allow_reference_to` and `allow_ref_to`
+together is accepted — the compiler rejects no `--allow-*` combination
+(ADR-0038).
+
+### Lexer & keyword demotion (parser)
+
+**REQ-RTO-parser-100** The text `REFERENCE` lexes as a single `Reference`
+keyword token (distinct from `REF`, which `REFERENCE` shares a prefix with;
+longest-match wins).
+
+**REQ-RTO-parser-101** With `allow_reference_to` off, the `Reference` token is
+demoted to `Identifier` so programs may use `REFERENCE` as an identifier.
+
+**REQ-RTO-parser-102** With `allow_reference_to` on, the `Reference` token is
+kept as the keyword.
+
+**REQ-RTO-parser-103** `REFERENCE` is a valid identifier in standard mode (flag
+off): a program declaring a variable named `REFERENCE` parses.
+
+### Parser productions (parser)
+
+**REQ-RTO-parser-200** `r : REFERENCE TO INT;` yields a
+`ReferenceInitializer` tagged `RefSyntax::ReferenceTo`.
+
+**REQ-RTO-parser-201** `TYPE T : REFERENCE TO INT; END_TYPE` yields a
+`ReferenceDeclaration` tagged `RefSyntax::ReferenceTo`.
+
+**REQ-RTO-parser-202** A `REF_TO` declaration is tagged `RefSyntax::RefTo`
+(regression: existing syntax keeps its tag).
+
+**REQ-RTO-parser-210** `r REF= x;` parses as a reference binding equivalent to
+`r := REF(x)` — an assignment whose value is `ExprKind::Ref`.
+
+**REQ-RTO-parser-220** `ARRAY [..] OF REFERENCE TO T` parses and tags the
+element `Some(RefSyntax::ReferenceTo)`.
+
+### Type resolution & checking (analyzer)
+
+**REQ-RTO-analyzer-300** `REFERENCE TO T` resolves to
+`IntermediateType::Reference`, reusing the `REF_TO` resolution path.
+
+**REQ-RTO-analyzer-301** Binding a `REFERENCE TO` variable to a mismatched
+target type is rejected (P2032), reusing the `REF_TO` type-compatibility rule.
+
+### Execution (codegen)
+
+**REQ-RTO-codegen-400** Reading a `REF=`-bound `REFERENCE TO` variable via `^`
+yields the referenced value.
+
+**REQ-RTO-codegen-401** Writing through `^` to a `REF=`-bound `REFERENCE TO`
+variable stores to the referenced variable.
+
+**REQ-RTO-codegen-402** Dereferencing an unbound `REFERENCE TO` variable traps
+`NullDereference` (V4004).
+
+**REQ-RTO-codegen-420** An `ARRAY [..] OF REFERENCE TO T` element can be bound
+(`REF=`) and accessed (`^`).
+
+### Round-trip rendering (plc2plc)
+
+**REQ-RTO-plc2plc-600** A `ReferenceTo`-tagged declaration renders as
+`REFERENCE TO <target>`.
+
+**REQ-RTO-plc2plc-601** A `REF=` binding renders back as `REF=`.
+
+**REQ-RTO-plc2plc-602** A `RefTo`-tagged declaration still renders as `REF_TO`
+(regression).
+
+---
+
+## Requirements traceability
+
+| Req | Claim | Test fn | Crate |
+|-----|-------|---------|-------|
+| **REQ-RTO-parser-001** | `codesys` enables `allow_reference_to` | `options_spec_req_rto_001_*` | parser |
+| **REQ-RTO-parser-002** | `rusty` does not enable `allow_reference_to` | `options_spec_req_rto_002_*` | parser |
+| **REQ-RTO-parser-003** | Both flags coexist (ADR-0038) | `options_spec_req_rto_003_*` | parser |
+| **REQ-RTO-parser-100** | `REFERENCE` lexes as `Reference` | `lexer_spec_req_rto_100_*` | parser |
+| **REQ-RTO-parser-101** | Flag off → `REFERENCE` demoted | `xform_spec_req_rto_101_*` | parser |
+| **REQ-RTO-parser-102** | Flag on → `REFERENCE` kept | `xform_spec_req_rto_102_*` | parser |
+| **REQ-RTO-parser-103** | `REFERENCE` identifier in standard mode | `parser_spec_req_rto_103_*` | parser |
+| **REQ-RTO-parser-200** | `REFERENCE TO` var decl tagged | `parser_spec_req_rto_200_*` | parser |
+| **REQ-RTO-parser-201** | `REFERENCE TO` type decl tagged | `parser_spec_req_rto_201_*` | parser |
+| **REQ-RTO-parser-202** | `REF_TO` tagged `RefTo` | `parser_spec_req_rto_202_*` | parser |
+| **REQ-RTO-parser-210** | `REF=` parses as reference binding | `parser_spec_req_rto_210_*` | parser |
+| **REQ-RTO-parser-220** | `ARRAY OF REFERENCE TO` tagged | `parser_spec_req_rto_220_*` | parser |
+| **REQ-RTO-analyzer-300** | `REFERENCE TO T` resolves to Reference | `analyzer_spec_req_rto_300_*` | analyzer |
+| **REQ-RTO-analyzer-301** | Reference bind type mismatch rejected | `analyzer_spec_req_rto_301_*` | analyzer |
+| **REQ-RTO-codegen-400** | Read through `^` yields value | `codegen_spec_req_rto_400_*` | codegen |
+| **REQ-RTO-codegen-401** | Write through `^` stores value | `codegen_spec_req_rto_401_*` | codegen |
+| **REQ-RTO-codegen-402** | Unbound deref traps NullDereference | `codegen_spec_req_rto_402_*` | codegen |
+| **REQ-RTO-codegen-420** | `ARRAY OF REFERENCE TO` element access | `codegen_spec_req_rto_420_*` | codegen |
+| **REQ-RTO-plc2plc-600** | `REFERENCE TO` declaration renders | `plc2plc_spec_req_rto_600_*` | plc2plc |
+| **REQ-RTO-plc2plc-601** | `REF=` binding renders | `plc2plc_spec_req_rto_601_*` | plc2plc |
+| **REQ-RTO-plc2plc-602** | `REF_TO` still renders (regression) | `plc2plc_spec_req_rto_602_*` | plc2plc |
+
+## Out of scope (this document)
+
+- Implicit dereference and `__ISVALIDREF` — PR 2, requirements `5xx` (added to
+  this document in that phase).
+- `POINTER TO` and the `ADR()`/`^` pointer model.
+- `S=` / `R=` extended assignment operators.
+- TwinCAT OOP features (methods, properties, interfaces).

--- a/specs/steering/syntax-support-guide.md
+++ b/specs/steering/syntax-support-guide.md
@@ -164,6 +164,7 @@ table is a convenience mirror, so consult the macro if the two ever disagree.
 | `allow_empty_var_blocks` | `--allow-empty-var-blocks` | Empty variable blocks (VAR END_VAR etc.) |
 | `allow_time_as_function_name` | `--allow-time-as-function-name` | TIME as function name (OSCAT compat) |
 | `allow_ref_to` | `--allow-ref-to` | REF_TO/REF/NULL syntax without full Edition 3 |
+| `allow_reference_to` | `--allow-reference-to` | TwinCAT/CODESYS `REFERENCE TO` reference types and the `REF=` binding operator (alternative to `--allow-ref-to`; enabled by the `twincat` and `codesys` dialects) |
 | `allow_ref_arithmetic` | `--allow-ref-arithmetic` | Arithmetic (`+`, `-`) and ordering comparisons on REF_TO types |
 | `allow_ref_stack_variables` | `--allow-ref-stack-variables` | REF() on stack-allocated vars (VAR_TEMP, function VAR_INPUT/VAR_OUTPUT) |
 | `allow_ref_type_punning` | `--allow-ref-type-punning` | Assigning between REF_TO types of different base types |
@@ -187,7 +188,7 @@ Dialects (`--dialect`) set the base configuration. Individual `--allow-*` flags 
 | IEC 61131-3 Ed 3 | `iec61131-3-ed3` | ON | ON | all OFF |
 | RuSTy | `rusty` | OFF | ON | all ON |
 | CODESYS | `codesys` | OFF | ON | all ON except `allow_system_uptime_global` |
-| TwinCAT | `twincat` | OFF | OFF | CODESYS set minus the whole `REF_TO` family (`allow_ref_to`, `allow_ref_arithmetic`, `allow_ref_stack_variables`, `allow_ref_type_punning`) — TwinCAT uses `REFERENCE TO`/`POINTER TO`, not yet parsed |
+| TwinCAT | `twincat` | OFF | OFF | CODESYS set minus the whole `REF_TO` family (`allow_ref_to`, `allow_ref_arithmetic`, `allow_ref_stack_variables`, `allow_ref_type_punning`), plus `allow_reference_to` — TwinCAT uses `REFERENCE TO` (parsed) / `POINTER TO` (not yet parsed) |
 
 ### Grouping Guidance
 


### PR DESCRIPTION
Author the single design document for TwinCAT REFERENCE TO support with
all PR-1 REQ-RTO-<slug>-NNN markers (parser/analyzer/codegen/plc2plc) and
the requirements->test traceability table. Supersedes
beckhoff-twincat-dialect.md 2.1/3.6.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xm88yRD7YfLG9RtAvEVxfv