### PR TITLE
feat(twincat): accept hex/binary/octal bit-string literals as CASE labels

### DIFF
--- a/compiler/codegen/src/compile_stmt.rs
+++ b/compiler/codegen/src/compile_stmt.rs
@@ -696,6 +696,7 @@ fn compile_case(
 /// - `SignedInteger`: `selector == value`
 /// - `Subrange`: `(selector >= start) AND (selector <= end)`
 /// - `EnumeratedValue`: not yet supported (returns todo diagnostic)
+/// - `BitStringLiteral`: `selector == value` (same shape as `SignedInteger`)
 fn compile_case_selector(
     emitter: &mut Emitter,
     ctx: &mut CompileContext,
@@ -770,6 +771,43 @@ fn compile_case_selector(
             let pool_index = ctx.add_i32_constant(ordinal);
             emitter.emit_load_const_i32(pool_index);
             emitter.emit_eq_i32();
+            Ok(())
+        }
+        CaseSelectionKind::BitStringLiteral(lit) => {
+            // A radix-prefixed literal (16#D012:, 2#1010:) used as a CASE
+            // label -- selector == value, same shape as SignedInteger,
+            // reusing the same u32/u64 narrowing already used for
+            // ConstantKind::BitStringLiteral in compile_expr.rs.
+            compile_expr(emitter, ctx, selector_expr, op_type)?;
+            let span = lit.value.span();
+            match op_type.0 {
+                OpWidth::W32 => {
+                    let value = u32::try_from(lit.value.value).map_err(|_| {
+                        Diagnostic::problem(
+                            Problem::ConstantOverflow,
+                            Label::span(span.clone(), "Bit string literal"),
+                        )
+                        .with_context("value", &lit.value.value.to_string())
+                    })? as i32;
+                    let pool_index = ctx.add_i32_constant(value);
+                    emitter.emit_load_const_i32(pool_index);
+                    emitter.emit_eq_i32();
+                }
+                OpWidth::W64 => {
+                    let value = u64::try_from(lit.value.value).map_err(|_| {
+                        Diagnostic::problem(
+                            Problem::ConstantOverflow,
+                            Label::span(span.clone(), "Bit string literal"),
+                        )
+                        .with_context("value", &lit.value.value.to_string())
+                    })? as i64;
+                    let pool_index = ctx.add_i64_constant(value);
+                    emitter.emit_load_const_i64(pool_index);
+                    emitter.emit_eq_i64();
+                }
+                // CASE with float types is not meaningful in IEC 61131-3.
+                _ => return Err(Diagnostic::todo(file!(), line!())),
+            }
             Ok(())
         }
     }

--- a/compiler/codegen/tests/it/end_to_end_case.rs
+++ b/compiler/codegen/tests/it/end_to_end_case.rs
@@ -131,3 +131,66 @@ END_PROGRAM
     assert_eq!(bufs.vars[0].as_i32(), 3);
     assert_eq!(bufs.vars[1].as_i32(), 50);
 }
+
+#[test]
+fn end_to_end_when_case_label_is_hex_literal_then_matches_correct_arm() {
+    // Real motivating shape: a private test corpus file uses radix-prefixed
+    // bit-string literals (16#D012:) as CASE labels. See
+    // specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md.
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DINT;
+  END_VAR
+  x := 16#D012;
+  CASE x OF
+    16#D012: y := 1;
+    2#1010: y := 2;
+  END_CASE;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
+
+    assert_eq!(bufs.vars[1].as_i32(), 1);
+}
+
+#[test]
+fn end_to_end_when_case_label_is_binary_literal_then_matches_correct_arm() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DINT;
+  END_VAR
+  x := 2#1010;
+  CASE x OF
+    16#D012: y := 1;
+    2#1010: y := 2;
+  END_CASE;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
+
+    assert_eq!(bufs.vars[1].as_i32(), 2);
+}
+
+#[test]
+fn end_to_end_when_case_label_is_hex_literal_and_no_match_then_no_arm_executes() {
+    let source = "
+PROGRAM main
+  VAR
+    x : DWORD;
+    y : DINT;
+  END_VAR
+  y := 99;
+  x := 1;
+  CASE x OF
+    16#D012: y := 1;
+  END_CASE;
+END_PROGRAM
+";
+    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
+
+    assert_eq!(bufs.vars[1].as_i32(), 99);
+}

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -2,8 +2,8 @@
 //!
 //! See section 3.
 use crate::common::{
-    AddressAssignment, ConstantKind, EnumeratedValue, Integer, IntegerLiteral, SignedInteger,
-    Subrange, TypeName,
+    AddressAssignment, BitStringLiteral, ConstantKind, EnumeratedValue, Integer, IntegerLiteral,
+    SignedInteger, Subrange, TypeName,
 };
 use crate::core::{Id, Located, SourceSpan};
 use std::fmt;
@@ -896,6 +896,10 @@ pub enum CaseSelectionKind {
     Subrange(Subrange),
     SignedInteger(SignedInteger),
     EnumeratedValue(EnumeratedValue),
+    /// A radix-prefixed bit-string literal used as a `CASE` label (e.g.
+    /// `16#D012:`, `2#1010:`). See
+    /// specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md.
+    BitStringLiteral(BitStringLiteral),
 }
 
 /// The for loop statement.

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1598,7 +1598,21 @@ parser! {
       }
     }
     rule case_list() -> Vec<CaseSelectionKind> = cases_list:case_list_element() ++ (_ tok(TokenType::Comma) _) { cases_list }
-    rule case_list_element() -> CaseSelectionKind = sr:subrange() {CaseSelectionKind::Subrange(sr)} / si:signed_integer() {CaseSelectionKind::SignedInteger(si)} / ev:enumerated_value() {CaseSelectionKind::EnumeratedValue(ev)}
+    rule case_list_element() -> CaseSelectionKind = sr:subrange() {CaseSelectionKind::Subrange(sr)} / si:signed_integer() {CaseSelectionKind::SignedInteger(si)} / ev:enumerated_value() {CaseSelectionKind::EnumeratedValue(ev)} / bsl:case_bit_string_literal() {CaseSelectionKind::BitStringLiteral(bsl)}
+    // A radix-prefixed bit-string literal used as a CASE label (e.g.
+    // `16#D012:`, `2#1010:`) -- a real grammar gap, not a stdlib gap.
+    // Deliberately narrower than the general bit_string_literal() rule,
+    // which also falls back to a bare decimal integer() -- including
+    // that fallback here would create a PEG ordering hazard with
+    // signed_integer() (a plain "5:" label could start matching as a
+    // BitStringLiteral instead of a SignedInteger). Radix-prefixed
+    // literals are already lexically distinct tokens from plain decimal
+    // digits, so this alternative can only ever fire for the genuinely
+    // new shape. See
+    // specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md.
+    rule case_bit_string_literal() -> BitStringLiteral = value:(bi:binary_integer() { bi } / oi:octal_integer() { oi } / hi:hex_integer() { hi }) {
+      BitStringLiteral { value, data_type: None }
+    }
 
     // B.3.2.4 Iteration statements
     rule iteration_statement() -> StmtKind = f:for_statement() {StmtKind::For(f)} / w:while_statement() {StmtKind::While(w)} / r:repeat_statement() {StmtKind::Repeat(r)} / exit_statement()

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -2629,4 +2629,78 @@ END_FUNCTION_BLOCK";
             result.err()
         );
     }
+
+    // -----------------------------------------------------------------
+    // Hex/binary/octal bit-string literals as CASE labels. See
+    // specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn parse_when_case_label_is_hex_and_binary_literal_then_parses_as_bit_string_literal() {
+        // The real motivating shape.
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : DWORD;
+    y : INT;
+END_VAR
+CASE x OF
+    16#D012: y := 1;
+    2#1010: y := 2;
+END_CASE;
+END_FUNCTION_BLOCK";
+        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+            .expect("hex/binary CASE labels must parse");
+        let case = extract_case(&library);
+        assert_eq!(case.statement_groups.len(), 2);
+
+        let hex_selector = &case.statement_groups[0].selectors[0];
+        let hex_lit = cast!(hex_selector, CaseSelectionKind::BitStringLiteral);
+        assert_eq!(hex_lit.value.value, 0xD012);
+
+        let bin_selector = &case.statement_groups[1].selectors[0];
+        let bin_lit = cast!(bin_selector, CaseSelectionKind::BitStringLiteral);
+        assert_eq!(bin_lit.value.value, 0b1010);
+    }
+
+    #[test]
+    fn parse_when_case_label_is_octal_literal_then_parses_as_bit_string_literal() {
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : DWORD;
+    y : INT;
+END_VAR
+CASE x OF
+    8#17: y := 1;
+END_CASE;
+END_FUNCTION_BLOCK";
+        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+            .expect("octal CASE label must parse");
+        let case = extract_case(&library);
+        let selector = &case.statement_groups[0].selectors[0];
+        let lit = cast!(selector, CaseSelectionKind::BitStringLiteral);
+        assert_eq!(lit.value.value, 0o17);
+    }
+
+    #[test]
+    fn parse_when_case_label_is_plain_decimal_then_regression_still_signed_integer() {
+        // Regression: a plain decimal label must not be shadowed by the
+        // new BitStringLiteral alternative.
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : INT;
+    y : INT;
+END_VAR
+CASE x OF
+    5: y := 1;
+END_CASE;
+END_FUNCTION_BLOCK";
+        let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
+            .expect("plain decimal CASE label must still parse");
+        let case = extract_case(&library);
+        let selector = &case.statement_groups[0].selectors[0];
+        assert!(matches!(selector, CaseSelectionKind::SignedInteger(_)));
+    }
 }

--- a/compiler/plc2plc/src/tests.rs
+++ b/compiler/plc2plc/src/tests.rs
@@ -508,4 +508,45 @@ END_FUNCTION_BLOCK
             .expect("rendered output must parse under the same dialect");
         assert_eq!(library_original, library_rendered);
     }
+
+    #[test]
+    fn write_to_string_when_case_label_is_hex_and_binary_literal_then_round_trips() {
+        // Bit-string literals already render decimalized everywhere in
+        // this codebase (confirmed: even an ordinary `x : DWORD := 16#D012;`
+        // VAR initializer renders as `53266`, not the original hex
+        // spelling) -- pre-existing behavior, not something new
+        // CASE-label support should fix (out of scope per the plan).
+        // A real, but likewise pre-existing, consequence: re-parsing the
+        // decimalized `53266:` label resolves to `SignedInteger`, not
+        // `BitStringLiteral` again -- same numeric value, different
+        // variant. So this asserts render *idempotency* (parse -> render
+        // -> reparse -> render again, same text) rather than AST
+        // equality, matching the pattern already established for
+        // REFERENCE TO/POINTER TO's analogous "normalizes to a different
+        // spelling" case.
+        let source = "
+FUNCTION_BLOCK FB_Example
+VAR
+    x : DWORD;
+    y : INT;
+END_VAR
+CASE x OF
+    16#D012: y := 1;
+    2#1010: y := 2;
+END_CASE;
+END_FUNCTION_BLOCK
+";
+        let library_original =
+            parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let rendered = write_to_string(&library_original).unwrap();
+
+        assert!(rendered.contains("53266"));
+        assert!(rendered.contains("10"));
+
+        let library_rendered =
+            parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
+                .expect("rendered output must parse");
+        let rendered_again = write_to_string(&library_rendered).unwrap();
+        assert_eq!(rendered, rendered_again);
+    }
 }

--- a/specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md
+++ b/specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md
@@ -1,0 +1,127 @@
+# Plan: Hex/Binary/Octal Bit-String Literals as `CASE` Labels
+
+## Goal
+
+`CASE` labels reject hex/binary/octal bit-string literals
+(`16#D012:`, `2#1010:`) -- a real grammar gap, not a stdlib gap. In the
+private test corpus, one file fails outright on its very first `CASE`
+label, which cascades into 5 separate "function not declared" hits
+elsewhere in the same project (once the parser gives up on that file,
+everything downstream that would have referenced its declarations is
+also unresolvable).
+
+## Verification against the current parser
+
+Reproduced directly (not assumed from the corpus report):
+
+```
+CASE x OF
+    16#D012:
+        y := 1;
+    2#1010:
+        y := 2;
+    ...
+```
+
+fails with `P0002` exactly at `16#D012`, with the parser's own error
+message confirming the token *is* correctly lexed (`"matched token
+16#[0-9A-F][0-9A-F_]* (hexadecimal bit string)"`) -- this is purely a
+grammar-acceptance gap in the `CASE` label position, not a lexer gap.
+
+Traced the exact rule: `case_list_element()` (`compiler/parser/src/parser.rs`)
+only accepts `subrange()`, `signed_integer()`, or `enumerated_value()` --
+no bit-string-literal alternative at all. Plain decimal integer labels
+(`5:`) already work fine (via `signed_integer()`); only the radix-prefixed
+forms are missing.
+
+## Design
+
+### Grammar: a new `CaseSelectionKind` alternative, without disturbing plain integers
+
+```rust
+// compiler/dsl/src/textual.rs
+pub enum CaseSelectionKind {
+    Subrange(Subrange),
+    SignedInteger(SignedInteger),
+    EnumeratedValue(EnumeratedValue),
+    BitStringLiteral(BitStringLiteral),  // NEW
+}
+```
+
+```rust
+rule case_list_element() -> CaseSelectionKind =
+  sr:subrange() { CaseSelectionKind::Subrange(sr) }
+  / si:signed_integer() { CaseSelectionKind::SignedInteger(si) }
+  / ev:enumerated_value() { CaseSelectionKind::EnumeratedValue(ev) }
+  / bsl:case_bit_string_literal() { CaseSelectionKind::BitStringLiteral(bsl) }
+
+// Deliberately narrower than the general bit_string_literal() rule,
+// which also falls back to a bare decimal integer() -- including that
+// fallback here would create a PEG ordering hazard with signed_integer()
+// (a plain "5:" label could start matching as a BitStringLiteral instead
+// of a SignedInteger, depending on alternative order). Radix-prefixed
+// literals (16#.../2#.../8#...) are already lexically distinct tokens
+// from plain decimal digits, so this alternative can only ever fire for
+// the genuinely new shape.
+rule case_bit_string_literal() -> BitStringLiteral =
+  value:(bi:binary_integer() { bi } / oi:octal_integer() { oi } / hi:hex_integer() { hi }) {
+    BitStringLiteral { value, data_type: None }
+  }
+```
+
+No lexer changes -- `binary_integer()`/`octal_integer()`/`hex_integer()`
+already exist and are already used by `bit_string_literal()` for the
+same underlying tokens (e.g. inside typed initializers).
+
+### Codegen: a real fix, not a stub
+
+Unlike the stdlib functions plan, this is a plain literal value with no
+runtime-computation ambiguity -- full codegen support is achievable
+directly, reusing the exact conversion already used for
+`ConstantKind::BitStringLiteral` in `compile_expr.rs` (`lit.value.value`
+-> `i32`/`i64` via `u32::try_from`/similar, with `Problem::ConstantOverflow`
+on failure). `compile_case_selector`'s existing `SignedInteger` arm is
+the direct template.
+
+## Non-goals
+
+- A base-type-prefixed radix literal in `CASE` position (e.g.
+  `WORD#16#D012:`) -- not the reported shape (which is bare `16#D012`);
+  not investigated.
+- Any change to `bit_string_literal()`'s existing behavior elsewhere
+  (typed initializers, expressions) -- untouched.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/dsl/src/textual.rs` | New `CaseSelectionKind::BitStringLiteral` variant |
+| `compiler/parser/src/parser.rs` | `case_bit_string_literal()` rule; `case_list_element()` gains the new alternative |
+| `compiler/codegen/src/compile_stmt.rs` | New `CaseSelectionKind::BitStringLiteral` arm in `compile_case_selector`, mirroring `SignedInteger` |
+| `compiler/plc2plc/src/renderer.rs` | Render the new variant (verify generic recursion covers it; add explicit case only if needed, per the recurring lesson in this series) |
+
+## Testing Strategy
+
+- Parser tests: the real motivating shape (`16#D012:`, `2#1010:` as
+  `CASE` labels) parses to `CaseSelectionKind::BitStringLiteral`;
+  regression -- plain decimal integer labels (`5:`) still resolve to
+  `SignedInteger`, not accidentally shadowed by the new alternative.
+- Codegen test: a `CASE` statement selecting on a hex-literal label
+  produces correct bytecode (matches the selector value), not
+  `not_implemented` -- this one should fully work, unlike the stdlib
+  functions plan.
+- plc2plc round-trip test.
+- End-to-end: verify via the CLI that `ironplcc check`/`ironplcc compile`
+  both accept the real motivating shape.
+
+## Tasks
+
+- [x] Write plan (this document)
+- [x] Verify the exact failure point and confirm it's grammar-only (lexer already tokenizes correctly)
+- [ ] DSL: `CaseSelectionKind::BitStringLiteral`
+- [ ] Grammar: `case_bit_string_literal()`, `case_list_element()` update
+- [ ] Codegen: `compile_case_selector` arm
+- [ ] Check plc2plc renderer; add explicit case only if the generic visitor doesn't already cover it
+- [ ] Tests from Testing Strategy
+- [ ] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork

--- a/specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md
+++ b/specs/plans/2026-07-26-twincat-case-label-bit-string-literals.md
@@ -118,10 +118,47 @@ the direct template.
 
 - [x] Write plan (this document)
 - [x] Verify the exact failure point and confirm it's grammar-only (lexer already tokenizes correctly)
-- [ ] DSL: `CaseSelectionKind::BitStringLiteral`
-- [ ] Grammar: `case_bit_string_literal()`, `case_list_element()` update
-- [ ] Codegen: `compile_case_selector` arm
-- [ ] Check plc2plc renderer; add explicit case only if the generic visitor doesn't already cover it
-- [ ] Tests from Testing Strategy
-- [ ] Run full CI pipeline (`cd compiler && just`)
+- [x] DSL: `CaseSelectionKind::BitStringLiteral`
+- [x] Grammar: `case_bit_string_literal()`, `case_list_element()` update
+- [x] Codegen: `compile_case_selector` arm
+- [x] Check plc2plc renderer (generic visitor already covers it -- no explicit override needed, see notes)
+- [x] Tests from Testing Strategy
+- [x] Run full CI pipeline (`cd compiler && just`)
 - [ ] Push branch to fork
+
+## Implementation Notes
+
+- **No new visitor/fold dispatch registration needed**: unlike
+  `SymbolicVariableKind::SelfRef`/`StmtKind::SelfInvocation`/
+  `MethodDeclaration` in earlier plans, `BitStringLiteral` is an
+  *already-dispatched* type (used elsewhere via
+  `ConstantKind::BitStringLiteral`) -- adding it as a new
+  `CaseSelectionKind` variant needed zero `dispatch!` changes in
+  `visitor.rs`/`fold.rs`. Confirmed by the build, not assumed.
+- **Renderer needed no explicit override either**, unlike every prior
+  plan in this series (`THIS`/`SUPER`, `METHOD`) -- `BitStringLiteral`
+  already has real content in every field (no `#[recurse(ignore)]`
+  leaf needing hand-written text), so the generic recursive visitor
+  correctly writes it via the same path already used for
+  `ConstantKind::BitStringLiteral`.
+- **Found and worked around a real, pre-existing round-trip gap while
+  writing the plc2plc test, not introduced by this change**:
+  `BitStringLiteral`'s `Display` already renders decimalized everywhere
+  in this codebase (confirmed: even an ordinary `x : DWORD := 16#D012;`
+  VAR initializer renders as `53266`, not the original hex spelling) --
+  and re-parsing that decimal text resolves to `SignedInteger`, not
+  `BitStringLiteral` again (same value, different variant), so a plain
+  `assert_eq!(original, reparsed)` fails. Not a regression from this
+  plan and explicitly out of scope to fix (would mean changing bit-string
+  literal rendering everywhere, not just `CASE` labels) -- worked around
+  with a render-*idempotency* assertion instead (parse -> render ->
+  reparse -> render again, same text), matching the pattern already
+  established for the analogous `REFERENCE TO`/`POINTER TO`
+  "normalizes to a different spelling" case in
+  specs/plans/2026-07-20-twincat-reference-to-no-explicit-deref.md.
+- **End-to-end codegen tests verify real execution correctness**, not
+  just successful compilation: matching on the correct hex/binary arm,
+  the correct binary arm, and confirming no arm executes on a
+  non-matching selector -- since this plan (unlike prior ones) claimed
+  *full*, not stubbed, codegen support, actual runtime behavior needed
+  checking, not just "doesn't error."


### PR DESCRIPTION
## Summary

Part of #1199 (TwinCAT vendor dialect support).

Standalone PR, no dependency on any other open PR and no new flag.

- Fixes `16#D012:`/`2#1010:`-style `CASE` labels failing to parse with `P0002` — the lexer already tokenizes hex/binary/octal bit-string literals correctly, but `case_list_element()` never accepted them as a label. Adds `CaseSelectionKind::BitStringLiteral` as a last-resort alternative, deliberately narrower than the general `bit_string_literal()` rule to avoid a PEG hazard with plain decimal labels.
- Gets full codegen support, not a stub — a plain literal value has no runtime-computation ambiguity, reusing the exact `u32`/`u64` narrowing already used for `ConstantKind::BitStringLiteral`. End-to-end tests confirm correct *execution* (matching the right `CASE` arm), not just successful compilation.
- Found and documented a pre-existing, unrelated round-trip quirk while testing: bit-string literals already render decimalized everywhere in this codebase, so re-parsing a rendered label resolves to `SignedInteger`, not `BitStringLiteral` again. Not fixed here (out of scope — would mean changing bit-string rendering everywhere, not just `CASE` labels); the plc2plc test asserts render *idempotency* instead of AST equality, matching the existing pattern for this exact situation.

## Test plan
- [x] Parser: hex/binary/octal `CASE` labels parse as `BitStringLiteral`; plain decimal labels are unaffected (regression)
- [x] End-to-end codegen: correct `CASE` arm executes for a bit-string-literal label
- [x] plc2plc: render idempotency for the pre-existing decimalization quirk
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)