### PR TITLE
feat(twincat): allow general expressions as struct/FB-instance init values

### DIFF
--- a/compiler/codegen/src/compile_struct.rs
+++ b/compiler/codegen/src/compile_struct.rs
@@ -405,6 +405,16 @@ fn compile_struct_field_init(
             // Nested structures and arrays in struct init are not yet supported.
             Ok(())
         }
+        StructInitialValueAssignmentKind::Expression(expr) => {
+            // A general (possibly non-constant) expression, e.g.
+            // `pDevice^.Delta` -- `ironplcc check` fully supports this;
+            // codegen does not yet implement evaluating it at instance
+            // construction time.
+            Err(Diagnostic::not_implemented(Label::span(
+                expr.span(),
+                "Expression-valued struct/FB-instance field initializer",
+            )))
+        }
     }
 }
 

--- a/compiler/codegen/tests/it/end_to_end_struct.rs
+++ b/compiler/codegen/tests/it/end_to_end_struct.rs
@@ -1,7 +1,7 @@
 //! End-to-end integration tests for structure field read support.
 //! Compiles ST programs with struct field access and runs them through the VM.
 
-use crate::common::parse_and_run;
+use crate::common::{parse_and_run, try_parse_and_compile};
 use ironplc_container::STRING_HEADER_BYTES;
 use ironplc_parser::options::{CompilerOptions, Dialect};
 
@@ -567,4 +567,45 @@ END_PROGRAM
     assert_eq!(bufs.vars[1].as_i32(), 0);
     assert_eq!(bufs.vars[2].as_i32(), 0);
     assert_eq!(bufs.vars[3].as_i32(), 0);
+}
+
+#[test]
+fn end_to_end_when_struct_init_value_is_expression_then_returns_not_implemented() {
+    // A struct/FB-instance field initializer whose value is a general
+    // (possibly non-constant) expression -- e.g. a pointer dereference
+    // plus member access -- fully parses and analyzes, but codegen does
+    // not yet implement evaluating it at instance construction time.
+    // `ironplcc check` already fully supports this; only codegen refuses.
+    // See specs/plans/2026-07-26-twincat-struct-init-expression-value.md.
+    let source = "
+FUNCTION_BLOCK FB_Device
+VAR_INPUT
+    Delta : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+TYPE MyStruct :
+STRUCT
+    x : INT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+VAR
+    pDevice : REF_TO FB_Device;
+    s : MyStruct := (x := pDevice^.Delta);
+END_VAR
+END_PROGRAM
+";
+    let options = CompilerOptions {
+        allow_ref_to: true,
+        ..CompilerOptions::default()
+    };
+    let result = try_parse_and_compile(source, &options);
+
+    assert!(
+        result.is_err(),
+        "expected compilation to fail for an expression-valued struct init"
+    );
+    assert_eq!(result.unwrap_err().code, "P9999");
 }

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -2324,6 +2324,10 @@ pub enum StructInitialValueAssignmentKind {
     EnumeratedValue(EnumeratedValue),
     Array(Vec<ArrayInitialElementKind>),
     Structure(Vec<StructureElementInit>),
+    /// A general expression value (e.g. `pDevice^.Delta`) -- used for
+    /// call-style FB-instance/struct initializers where the value is
+    /// computed at instantiation time, not a compile-time constant.
+    Expression(Expr),
 }
 
 #[derive(Clone, PartialEq, Debug, Recurse)]

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -638,7 +638,15 @@ parser! {
     }
     rule structure_element_name() ->Id = identifier()
     rule structure_initialization() -> Vec<StructureElementInit> = tok(TokenType::LeftParen) _ elems:structure_element_initialization() ++ (_ tok(TokenType::Comma) _) _ tok(TokenType::RightParen) { elems }
-    rule structure_element_initialization() -> StructureElementInit = name:structure_element_name() _ tok(TokenType::Assignment) _ init:(c:constant() { StructInitialValueAssignmentKind::Constant(c) } / ev:enumerated_value() { StructInitialValueAssignmentKind::EnumeratedValue(ev) } / ai:array_initialization() { StructInitialValueAssignmentKind::Array(ai) } / si:structure_initialization() {StructInitialValueAssignmentKind::Structure(si)}) {
+    // `constant()`/`enumerated_value()` are grammatically a strict subset of
+    // `expression()` (e.g. a bare identifier is a valid, but truncated,
+    // match for `pDevice^.Delta`) -- the trailing lookahead requires them to
+    // consume the *entire* value (immediately followed by the list
+    // terminator) before winning the choice, so a genuinely richer
+    // expression like a dereference-then-member-access chain falls through
+    // to the `expression()` alternative instead of matching only its first
+    // identifier and leaving `^.Delta` unconsumed.
+    rule structure_element_initialization() -> StructureElementInit = name:structure_element_name() _ tok(TokenType::Assignment) _ init:(c:constant() &(_ (tok(TokenType::Comma) / tok(TokenType::RightParen))) { StructInitialValueAssignmentKind::Constant(c) } / ev:enumerated_value() &(_ (tok(TokenType::Comma) / tok(TokenType::RightParen))) { StructInitialValueAssignmentKind::EnumeratedValue(ev) } / ai:array_initialization() { StructInitialValueAssignmentKind::Array(ai) } / si:structure_initialization() {StructInitialValueAssignmentKind::Structure(si)} / ex:expression() { StructInitialValueAssignmentKind::Expression(Expr::new(ex)) }) {
       StructureElementInit {
         name,
         init,

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -6,8 +6,8 @@ mod test {
         EnumeratedSpecificationInit, EnumerationDeclaration, FunctionBlockBodyKind,
         FunctionBlockDeclaration, FunctionDeclaration, FunctionReturnType,
         InitialValueAssignmentKind, Library, LibraryElementKind, ProgramDeclaration, RealLiteral,
-        ReferenceTarget, SimpleInitializer, SpecificationKind, TypeName, TypeReference, VarDecl,
-        VariableIdentifier, VariableType,
+        ReferenceTarget, SimpleInitializer, SpecificationKind, StructInitialValueAssignmentKind,
+        TypeName, TypeReference, VarDecl, VariableIdentifier, VariableType,
     };
     use dsl::configuration::{
         ConfigurationDeclaration, DataSourceKind, ProgramConfiguration, ResourceDeclaration,
@@ -2541,6 +2541,46 @@ END_FUNCTION_BLOCK";
         let case = extract_case(&library);
         assert_eq!(case.statement_groups.len(), 2);
         assert_eq!(case.statement_groups[1].statements.len(), 1);
+    }
+
+    #[test]
+    fn parse_when_struct_init_value_is_deref_member_expr_then_parses_as_expression() {
+        // Real motivating shape: a call-style FB-instance initializer whose
+        // value is a genuinely runtime expression (dereference + member
+        // access), not a compile-time constant. See
+        // specs/plans/2026-07-26-twincat-struct-init-expression-value.md.
+        let source = "
+FUNCTION_BLOCK FB_Device
+VAR_INPUT
+    Delta : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    pDevice : REF_TO FB_Device;
+    tonDelta : TON := (PT := pDevice^.Delta);
+END_VAR
+END_FUNCTION_BLOCK";
+        let options = CompilerOptions {
+            allow_ref_to: true,
+            ..CompilerOptions::default()
+        };
+        let library = parse_program(source, &FileId::default(), &options).unwrap();
+
+        let fb = cast!(
+            &library.elements[1],
+            LibraryElementKind::FunctionBlockDeclaration
+        );
+        let struct_init = cast!(
+            &fb.variables[1].initializer,
+            InitialValueAssignmentKind::Structure
+        );
+        assert_eq!(struct_init.elements_init.len(), 1);
+        assert!(matches!(
+            struct_init.elements_init[0].init,
+            StructInitialValueAssignmentKind::Expression(_)
+        ));
     }
 
     // -----------------------------------------------------------------

--- a/compiler/plc2plc/src/tests.rs
+++ b/compiler/plc2plc/src/tests.rs
@@ -539,3 +539,4 @@ END_FUNCTION_BLOCK
             .expect("rendered output must parse under the same dialect");
         assert_eq!(library_original, library_rendered);
     }
+}

--- a/compiler/plc2plc/src/tests.rs
+++ b/compiler/plc2plc/src/tests.rs
@@ -508,4 +508,34 @@ END_FUNCTION_BLOCK
             .expect("rendered output must parse under the same dialect");
         assert_eq!(library_original, library_rendered);
     }
-}
+
+    #[test]
+    fn write_to_string_when_struct_init_value_is_deref_member_expr_then_round_trips() {
+        let source = "
+FUNCTION_BLOCK FB_Device
+VAR_INPUT
+    Delta : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    pDevice : REF_TO FB_Device;
+    tonDelta : TON := (PT := pDevice^.Delta);
+END_VAR
+END_FUNCTION_BLOCK
+";
+        let options = CompilerOptions {
+            allow_ref_to: true,
+            ..CompilerOptions::default()
+        };
+        let library_original = parse_program(source, &FileId::default(), &options).unwrap();
+        let rendered = write_to_string(&library_original).unwrap();
+
+        assert!(rendered.contains("pDevice"));
+        assert!(rendered.contains("Delta"));
+
+        let library_rendered = parse_program(&rendered, &FileId::default(), &options)
+            .expect("rendered output must parse under the same dialect");
+        assert_eq!(library_original, library_rendered);
+    }

--- a/specs/plans/2026-07-26-twincat-struct-init-expression-value.md
+++ b/specs/plans/2026-07-26-twincat-struct-init-expression-value.md
@@ -160,10 +160,41 @@ uninitialized field.
 
 - [x] Write plan (this document)
 - [x] Verify the real failing shape and trace the exact grammar rule
-- [ ] DSL: `StructInitialValueAssignmentKind::Expression(Expr)`
-- [ ] Grammar: `expression()` fallback in `structure_element_initialization()`
-- [ ] Codegen: `not_implemented` for the new variant
-- [ ] Check plc2plc renderer; add explicit case only if the generic visitor doesn't already cover it
-- [ ] Tests from Testing Strategy
+- [x] DSL: `StructInitialValueAssignmentKind::Expression(Expr)`
+- [x] Grammar: `expression()` fallback in `structure_element_initialization()`
+- [x] Codegen: `not_implemented` for the new variant
+- [x] Check plc2plc renderer; add explicit case only if the generic visitor doesn't already cover it
+- [x] Tests from Testing Strategy
 - [ ] Run full CI pipeline (`cd compiler && just`)
 - [ ] Push branch to fork
+
+## Implementation Notes
+
+- **PEG ordered-choice hazard, found while implementing**: simply appending
+  `expression()` as a last alternative wasn't enough -- `constant()` and
+  `enumerated_value()` are both a strict grammatical *prefix* of
+  `expression()` (a bare identifier is a valid, but truncated, match for
+  `pDevice^.Delta`). PEG's `/` choice locks in the first alternative that
+  matches *at all*, not the one that lets the overall parse succeed, so
+  `enumerated_value()` matched just `pDevice` and left `^.Delta`
+  unconsumed, surfacing as a confusing "expected `,`/`)`, found `^`"
+  error from the *enclosing* rule rather than a grammar failure in the
+  choice itself. Fixed by adding a trailing lookahead
+  (`&(_ (tok(Comma) / tok(RightParen)))`) to the `constant()`/
+  `enumerated_value()` alternatives, requiring them to be immediately
+  followed by the list terminator to win the choice; a longer match falls
+  through to `expression()`. `array_initialization()`/
+  `structure_initialization()` didn't need this -- they're
+  bracket/paren-delimited, so they can't under-match the same way.
+- **`TON`'s call-style init doesn't reach `compile_struct_field_init` at
+  all**: the codegen test originally used the real motivating `TON := (PT
+  := pDevice^.Delta)` shape and unexpectedly *compiled successfully*
+  instead of returning `not_implemented`. Root-caused: `TON` is a
+  built-in/intrinsic FB type with its own special-cased instance codegen,
+  which doesn't route field initializers through the generic
+  struct-field-init path at all (a separate, pre-existing quirk, out of
+  scope here). Switched the codegen test to a plain user-defined `STRUCT`
+  field initializer, which does exercise the new code path and correctly
+  returns `P9999`. The parser/plc2plc tests keep the original `TON`
+  shape, since `ironplcc check`'s analysis path is unaffected by this
+  codegen-only quirk.

--- a/specs/plans/2026-07-26-twincat-struct-init-expression-value.md
+++ b/specs/plans/2026-07-26-twincat-struct-init-expression-value.md
@@ -1,0 +1,169 @@
+# Plan: General Expressions as Struct/FB-Instance Initializer Values
+
+## Goal
+
+Item 2 from `twincat-status.md`'s "Next" list. Support a general
+expression -- specifically a pointer dereference plus member access -- as
+the value in a structured/call-style initializer's `name := value` pairs:
+
+```
+FUNCTION_BLOCK FB_Example
+VAR
+    pDevice : REF_TO FB_Device;
+    tonDelta : TON := (PT := pDevice^.Delta);
+END_VAR
+END_FUNCTION_BLOCK
+```
+
+Currently **fails to parse** — confirmed directly: `P0002` exactly at the
+`^` in `pDevice^.Delta`.
+
+## Verification against the real file
+
+Reproduced directly against the current parser (not assumed from the
+status doc's prior framing): the failing construct is a `TON` (a
+function-block type) declared with a `:=`-prefixed parenthesized
+initializer, `(PT := pDevice^.Delta)`. Traced the exact grammar path: this
+goes through `initialized_structure__without_ambiguous()` ->
+`structure_initialization()` -> `structure_element_initialization()`
+(`compiler/parser/src/parser.rs`), which is used identically for plain
+`STRUCT` type initializers and function-block call-style initializers --
+both share `StructureInitializationDeclaration`/
+`StructInitialValueAssignmentKind`. `structure_element_initialization()`'s
+value position only accepts `constant()`, `enumerated_value()`,
+`array_initialization()`, or `structure_initialization()` -- no general
+`expression()` fallback, which is exactly what rejects `pDevice^.Delta`
+(a dereference-then-member-access chain, not a bare constant).
+
+Confirmed the fix is narrowly scoped to this one rule: ordinary `VAR`
+initializers already route through `expression()` (via the
+`--allow-constant-initializer-expressions` work) and already parse `^.`
+fine; this gap is specific to the parenthesized structured/call-style
+initializer position.
+
+## Design
+
+### Not the same shape as `--allow-constant-initializer-expressions`
+
+PR #1220's `SimpleExpr`/`xform_fold_initializer_expressions` requires the
+expression to fold to a compile-time constant (`P4037` if it doesn't).
+`pDevice^.Delta` is fundamentally **not** a compile-time constant -- it
+depends on a runtime pointer value. This is not a "constant expression"
+feature; it's the same shape as the *already-supported* FB call-style
+instantiation params (`comm : FB_Comm(retries := 3, THIS)` from PR #1222),
+where `param_assignment()` already accepts arbitrary runtime expressions
+for named/positional inputs. The `:=`-prefixed parenthesized form
+(`TON := (PT := ...)`) is a second, structurally distinct spelling of a
+call-style initializer that happens to share a grammar rule with plain
+`STRUCT` initializers -- and that shared rule is the one that's too
+narrow.
+
+### Grammar: `expression()` as a last-resort alternative
+
+```rust
+rule structure_element_initialization() -> StructureElementInit =
+  name:structure_element_name() _ tok(TokenType::Assignment) _
+  init:(c:constant() { StructInitialValueAssignmentKind::Constant(c) }
+      / ev:enumerated_value() { StructInitialValueAssignmentKind::EnumeratedValue(ev) }
+      / ai:array_initialization() { StructInitialValueAssignmentKind::Array(ai) }
+      / si:structure_initialization() { StructInitialValueAssignmentKind::Structure(si) }
+      / ex:expression() { StructInitialValueAssignmentKind::Expression(Expr::new(ex)) }) {
+    StructureElementInit { name, init }
+  }
+```
+
+Added last in the ordered choice, so existing constant/enum/array/struct
+cases are unaffected (PEG tries alternatives in order; `expression()` only
+fires when the earlier four all fail) -- same permissive-superset,
+zero-regression-risk pattern used for every prior grammar addition in this
+series.
+
+### DSL: `StructInitialValueAssignmentKind::Expression(Expr)`
+
+```rust
+// compiler/dsl/src/common.rs
+pub enum StructInitialValueAssignmentKind {
+    Constant(ConstantKind),
+    EnumeratedValue(EnumeratedValue),
+    Array(Vec<ArrayInitialElementKind>),
+    Structure(Vec<StructureElementInit>),
+    /// A general expression value (e.g. `pDevice^.Delta`) -- used for
+    /// call-style FB-instance/struct initializers where the value is
+    /// computed at instantiation time, not a compile-time constant. See
+    /// specs/plans/2026-07-26-twincat-struct-init-expression-value.md.
+    Expression(Expr),
+}
+```
+
+Already `#[derive(Recurse)]` -- the new `Expr` field is automatically
+walked by the existing generic visitor/fold dispatch
+(`dsl/src/visitor.rs`/`fold.rs`'s `dispatch!(StructInitialValueAssignmentKind)`),
+so it's automatically type-resolved by the existing
+`xform_resolve_expr_types.rs` pass with no new plumbing there -- the same
+"faithful representation, no persistent provenance marker" shape ADR-0040
+endorses (this *is* real source content, not an inference).
+
+### Semantic analysis: no new restriction
+
+Unlike `SimpleExpr`, this value is **not** required to reduce to a
+constant -- it's accepted as a genuine runtime expression, matching how
+`param_assignment()`'s named/positional inputs already work for FB
+call-style construction. No new problem code for "must be constant."
+
+### Codegen: explicit "not implemented" rather than silently wrong/no-op
+
+`compile_struct.rs`'s `compile_struct_field_init` currently no-ops
+`Array`/`Structure` (pre-existing gap, out of scope here). For the new
+`Expression` variant, return `Diagnostic::not_implemented(...)` (reusing
+the existing generic `P9998`/`NotImplemented` code, same as `AND_THEN`'s
+codegen stub) rather than silently emitting no bytecode for the field --
+`ironplcc check` fully supports the construct (the actual motivating use
+case); `ironplcc compile` fails clearly instead of producing an
+uninitialized field.
+
+## Non-goals
+
+- Compile-time constant folding for this position -- the whole point is
+  supporting genuinely runtime values; `--allow-constant-initializer-expressions`
+  already covers the compile-time-foldable case for plain `VAR`
+  initializers.
+- Codegen/VM execution of the runtime-evaluated initializer -- explicitly
+  refused with `not_implemented`, matching the `AND_THEN` precedent.
+- Any change to `Array`/`Structure` struct-field-init codegen (pre-existing
+  no-op, unrelated to this change).
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/dsl/src/common.rs` | New `StructInitialValueAssignmentKind::Expression(Expr)` variant |
+| `compiler/parser/src/parser.rs` | `expression()` fallback alternative in `structure_element_initialization()` |
+| `compiler/codegen/src/compile_struct.rs` | `Expression` arm -> `not_implemented` in `compile_struct_field_init`'s match |
+| `compiler/plc2plc/src/renderer.rs` | Render `Expression` (visitor recursion should cover this automatically; verify and add an explicit case only if needed) |
+
+## Testing Strategy
+
+- Parser test: the real motivating shape
+  (`tonDelta : TON := (PT := pDevice^.Delta);`) parses, with
+  `StructInitialValueAssignmentKind::Expression` holding the deref+member
+  expression.
+- Parser regression: existing constant/enum/array/struct-value struct
+  inits still parse unchanged (ordering doesn't shadow them).
+- plc2plc round-trip test for the new shape.
+- Codegen test: compiling a struct/FB-instance init using the `Expression`
+  variant produces `Diagnostic::not_implemented` rather than silently
+  emitting no bytecode.
+- End-to-end: verify via the CLI that `ironplcc check` accepts the real
+  motivating shape under `--dialect=codesys`.
+
+## Tasks
+
+- [x] Write plan (this document)
+- [x] Verify the real failing shape and trace the exact grammar rule
+- [ ] DSL: `StructInitialValueAssignmentKind::Expression(Expr)`
+- [ ] Grammar: `expression()` fallback in `structure_element_initialization()`
+- [ ] Codegen: `not_implemented` for the new variant
+- [ ] Check plc2plc renderer; add explicit case only if the generic visitor doesn't already cover it
+- [ ] Tests from Testing Strategy
+- [ ] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork


### PR DESCRIPTION
## Summary

Part of #1199 (TwinCAT vendor dialect support).

Standalone PR, no dependency on any other open PR and no new flag.

- Fixes `tonDelta : TON := (PT := pDevice^.Delta);` failing to parse — a pointer dereference plus member access as a call-style/struct-init value, which is a genuine runtime expression, not a compile-time constant. Adds `StructInitialValueAssignmentKind::Expression(Expr)`, tried as a last-resort alternative in `structure_element_initialization()` after `constant()`/`enumerated_value()`/`array_initialization()`/`structure_initialization()`.
- Not the same shape as `--allow-constant-initializer-expressions` — this value is **not** required to fold to a compile-time constant, matching how FB call-style construction params already accept arbitrary runtime expressions.
- Hit a PEG ordered-choice hazard along the way: `constant()`/`enumerated_value()` are a strict grammatical prefix of `expression()`, so simply appending `expression()` last wasn't enough — `enumerated_value()` matched just the leading identifier and left the rest unconsumed. Fixed with a trailing lookahead requiring those two alternatives to be immediately followed by the list terminator (`,`/`)`) to win the choice.
- Codegen returns `not_implemented` (`P9999`) for the new variant, same precedent already used elsewhere in this series: `ironplcc check` fully supports it, `ironplcc compile` fails clearly instead of silently skipping the field.

## Test plan
- [x] Parser: the motivating shape parses as `StructInitialValueAssignmentKind::Expression`
- [x] Regression: the standard `:= (member := value)` named-struct-init form still parses unchanged
- [x] plc2plc: round-trips through render/re-parse
- [x] End-to-end codegen: `P9999 not_implemented` for the new variant
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)