### PR TITLE
feat(twincat): register BOOL_TO_STRING/LREAL_TO_FMTSTR/ADR stdlib functions

### DIFF
--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -331,8 +331,8 @@ const STRING_TO_INT_TYPES: &[&str] = &["SINT", "INT", "DINT", "USINT", "UINT", "
 ///
 /// Covers all W32 numeric types: signed integers (SINT, INT, DINT),
 /// unsigned integers and bit-strings (USINT, UINT, UDINT, BYTE, WORD, DWORD),
-/// and REAL. Each type gets a *_TO_STRING function, and a subset gets
-/// STRING_TO_* functions.
+/// REAL, and BOOL. Each type gets a *_TO_STRING function, and a subset
+/// gets STRING_TO_* functions.
 fn get_string_conversion_functions() -> Vec<FunctionSignature> {
     let mut functions = Vec::new();
 
@@ -348,6 +348,12 @@ fn get_string_conversion_functions() -> Vec<FunctionSignature> {
 
     // REAL → STRING
     functions.push(build_conversion_function("REAL", "STRING"));
+
+    // BOOL → STRING ("TRUE"/"FALSE") -- standard IEC 61131-3 TO_STRING
+    // conversion, not a separate vendor library function, so it's
+    // unconditional like the rest of this group. Codegen does not yet
+    // implement it (see compile_call.rs's StringConversion::BoolToString).
+    functions.push(build_conversion_function("BOOL", "STRING"));
 
     // STRING → integer types
     for target in STRING_TO_INT_TYPES {
@@ -1045,6 +1051,55 @@ pub fn get_sizeof_function() -> FunctionSignature {
     )
 }
 
+// =============================================================================
+// ADR (Address Operator, Vendor Extension)
+// =============================================================================
+
+/// Returns the `ADR` function definition.
+///
+/// `ADR` is Beckhoff's own term for the "Address Operator": it returns the
+/// address of its argument. Beckhoff's docs document the return type as
+/// `PVOID`, or `DWORD`/`LWORD` depending on runtime architecture (`PVOID`
+/// is recommended for portability); IronPLC has no `PVOID` type today, so
+/// `DWORD` (the well-documented 32-bit fallback) is used instead -- a
+/// known simplification. It is registered conditionally based on the
+/// `allow_address_operator` compiler option. Codegen does not yet compute
+/// a real runtime address for it (see `compile_call.rs`).
+pub fn get_address_operator_function() -> FunctionSignature {
+    FunctionSignature::stdlib(
+        "ADR",
+        TypeName::from("DWORD"),
+        vec![input_param("IN", "ANY")],
+    )
+}
+
+// =============================================================================
+// Extended string functions (Beckhoff Tc2_Utilities library, Vendor Extension)
+// =============================================================================
+
+/// Returns the `LREAL_TO_FMTSTR` function definition.
+///
+/// `LREAL_TO_FMTSTR` is a Beckhoff `Tc2_Utilities` (`TcUtilities.Lib`)
+/// function that formats an `LREAL` as a `STRING` with a caller-controlled
+/// precision and optional rounding -- confirmed directly against Beckhoff's
+/// docs: `LREAL_TO_FMTSTR(in : LREAL, iPrecision : INT, bRound : BOOL) :
+/// STRING(510)`. It is registered conditionally based on the
+/// `allow_extended_string_functions` compiler option (room to add other
+/// `TcUtilities.Lib` string functions later without renaming). Codegen
+/// does not yet implement the real formatting/rounding semantics (see
+/// `compile_call.rs`).
+pub fn get_extended_string_functions() -> Vec<FunctionSignature> {
+    vec![FunctionSignature::stdlib(
+        "LREAL_TO_FMTSTR",
+        TypeName::from("STRING"),
+        vec![
+            input_param("IN", "LREAL"),
+            input_param("IPRECISION", "INT"),
+            input_param("BROUND", "BOOL"),
+        ],
+    )]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1453,5 +1508,61 @@ mod tests {
                 func.name.original()
             );
         }
+    }
+
+    #[test]
+    fn get_all_stdlib_functions_when_called_then_contains_bool_to_string() {
+        // BOOL_TO_STRING is a standard TO_STRING conversion, unconditional
+        // like REAL_TO_STRING -- not gated by any flag.
+        let functions = get_all_stdlib_functions();
+        let bool_to_string = functions
+            .iter()
+            .find(|f| f.name.original() == "BOOL_TO_STRING")
+            .expect("BOOL_TO_STRING should be an unconditional stdlib function");
+        assert_eq!(bool_to_string.parameters.len(), 1);
+        assert_eq!(
+            bool_to_string.parameters[0].param_type,
+            TypeName::from("BOOL")
+        );
+        assert_eq!(
+            bool_to_string.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("STRING")))
+        );
+    }
+
+    #[test]
+    fn get_address_operator_function_when_called_then_has_correct_signature() {
+        let adr = get_address_operator_function();
+        assert!(adr.is_stdlib());
+        assert_eq!(adr.parameters.len(), 1);
+        assert_eq!(adr.parameters[0].name.original(), "IN");
+        assert_eq!(adr.parameters[0].param_type, TypeName::from("ANY"));
+        assert_eq!(
+            adr.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("DWORD")))
+        );
+    }
+
+    #[test]
+    fn get_extended_string_functions_when_called_then_contains_lreal_to_fmtstr() {
+        let functions = get_extended_string_functions();
+        assert_eq!(functions.len(), 1);
+
+        let fmtstr = functions
+            .iter()
+            .find(|f| f.name.original() == "LREAL_TO_FMTSTR")
+            .unwrap();
+        assert!(fmtstr.is_stdlib());
+        assert_eq!(fmtstr.parameters.len(), 3);
+        assert_eq!(fmtstr.parameters[0].name.original(), "IN");
+        assert_eq!(fmtstr.parameters[0].param_type, TypeName::from("LREAL"));
+        assert_eq!(fmtstr.parameters[1].name.original(), "IPRECISION");
+        assert_eq!(fmtstr.parameters[1].param_type, TypeName::from("INT"));
+        assert_eq!(fmtstr.parameters[2].name.original(), "BROUND");
+        assert_eq!(fmtstr.parameters[2].param_type, TypeName::from("BOOL"));
+        assert_eq!(
+            fmtstr.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("STRING")))
+        );
     }
 }

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -109,6 +109,23 @@ pub fn resolve_types(
             .expect("SIZEOF should not conflict with stdlib");
     }
 
+    if options.allow_address_operator {
+        use crate::intermediates::stdlib_function::get_address_operator_function;
+        function_environment
+            .insert(get_address_operator_function())
+            .expect("ADR should not conflict with stdlib");
+    }
+
+    if options.allow_extended_string_functions {
+        use crate::intermediates::stdlib_function::get_extended_string_functions;
+        for sig in get_extended_string_functions() {
+            function_environment
+                .insert(sig)
+                .expect("LREAL_TO_FMTSTR should not conflict with stdlib");
+        }
+    }
+
+
     let mut symbol_environment = SymbolEnvironment::new();
 
     // Register implicit system globals when the uptime feature is enabled.

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -125,7 +125,6 @@ pub fn resolve_types(
         }
     }
 
-
     let mut symbol_environment = SymbolEnvironment::new();
 
     // Register implicit system globals when the uptime feature is enabled.

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use ironplc_container::opcode;
 use ironplc_dsl::core::{Id, Located};
-use ironplc_dsl::diagnostic::Diagnostic;
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::textual::{
     Expr, ExprKind, Function, ParamAssignmentKind, SymbolicVariableKind, Variable,
 };
@@ -175,6 +175,20 @@ pub(crate) fn compile_function_call(
         "trunc" => compile_trunc(emitter, ctx, func, op_type),
         // SIZEOF operator (vendor extension)
         "sizeof" => compile_sizeof(emitter, ctx, func),
+        // ADR (Address Operator, vendor extension) -- ironplcc check fully
+        // supports it; codegen does not yet compute a real runtime
+        // address. See specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md.
+        "adr" => Err(Diagnostic::not_implemented(Label::span(
+            func.name.span(),
+            "ADR",
+        ))),
+        // LREAL_TO_FMTSTR (Beckhoff Tc2_Utilities, vendor extension) --
+        // ironplcc check fully supports it; codegen does not yet
+        // implement the real formatting/rounding semantics.
+        "lreal_to_fmtstr" => Err(Diagnostic::not_implemented(Label::span(
+            func.name.span(),
+            "LREAL_TO_FMTSTR",
+        ))),
         // BCD conversion functions
         "bcd_to_int" => compile_bcd_to_int(emitter, ctx, func, op_type),
         "int_to_bcd" => compile_int_to_bcd(emitter, ctx, func, op_type),
@@ -1297,6 +1311,15 @@ pub(crate) enum StringConversion {
     NumToString { source: VarTypeInfo },
     /// STRING → Numeric (e.g., STRING_TO_INT, STRING_TO_REAL).
     StringToNum { target: VarTypeInfo },
+    /// BOOL → STRING ("TRUE"/"FALSE") -- deliberately *not* folded into
+    /// `NumToString`. `resolve_type_name` maps `BOOL` to the same
+    /// `VarTypeInfo` shape as any other signed-32-bit source (e.g.
+    /// `DINT`), so `NumToString` would silently compile it via the
+    /// generic integer-to-string opcode, producing `"1"`/`"0"` instead of
+    /// the documented `"TRUE"`/`"FALSE"` -- wrong output that compiles
+    /// cleanly. See
+    /// specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md.
+    BoolToString,
 }
 
 /// Checks if a function name is a string conversion (e.g., "int_to_string").
@@ -1310,6 +1333,9 @@ pub(crate) fn parse_string_conversion(name: &str) -> Option<StringConversion> {
         return None;
     }
     if parts[1] == "STRING" {
+        if parts[0] == "BOOL" {
+            return Some(StringConversion::BoolToString);
+        }
         let source = resolve_type_name(&Id::from(parts[0]))?;
         Some(StringConversion::NumToString { source })
     } else if parts[0] == "STRING" {
@@ -1376,6 +1402,21 @@ pub(crate) fn compile_string_conversion(
             emitter.emit_builtin(func_id);
             emit_truncation(emitter, target);
             Ok(())
+        }
+        StringConversion::BoolToString => {
+            // ironplcc check fully supports BOOL_TO_STRING; codegen does
+            // not yet implement the real "TRUE"/"FALSE" string-literal
+            // output (would need constant-pool string entries plus a
+            // runtime conditional branch, not a simple opcode dispatch).
+            // Deliberately not falling through to the generic
+            // NumToString/CONV_I32_TO_STR path, which would silently
+            // compile to "1"/"0" instead -- wrong output that compiles
+            // cleanly is worse than a clean rejection. See
+            // specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md.
+            Err(Diagnostic::not_implemented(Label::span(
+                func.name.span(),
+                "BOOL_TO_STRING",
+            )))
         }
     }
 }

--- a/compiler/codegen/tests/it/end_to_end_adr_and_extended_string.rs
+++ b/compiler/codegen/tests/it/end_to_end_adr_and_extended_string.rs
@@ -1,0 +1,59 @@
+//! End-to-end integration tests for the `ADR` address operator and
+//! `LREAL_TO_FMTSTR` (Beckhoff Tc2_Utilities). Both parse and analyze
+//! fine (registered as stdlib functions); codegen does not yet implement
+//! their real runtime semantics. See
+//! specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md.
+
+use crate::common::try_parse_and_compile;
+use ironplc_parser::options::CompilerOptions;
+
+fn adr_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_address_operator: true,
+        ..CompilerOptions::default()
+    }
+}
+
+fn extended_string_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_extended_string_functions: true,
+        ..CompilerOptions::default()
+    }
+}
+
+#[test]
+fn end_to_end_when_adr_called_then_returns_not_implemented() {
+    let source = "
+PROGRAM main
+  VAR
+    sContent : STRING;
+    addr : DWORD;
+  END_VAR
+  addr := ADR(sContent);
+END_PROGRAM
+";
+    let result = try_parse_and_compile(source, &adr_options());
+
+    assert!(result.is_err(), "expected compilation to fail for ADR");
+    assert_eq!(result.unwrap_err().code, "P9999");
+}
+
+#[test]
+fn end_to_end_when_lreal_to_fmtstr_called_then_returns_not_implemented() {
+    let source = "
+PROGRAM main
+  VAR
+    tempM1 : LREAL;
+    fmtStr : STRING;
+  END_VAR
+  fmtStr := LREAL_TO_FMTSTR(tempM1, 2, TRUE);
+END_PROGRAM
+";
+    let result = try_parse_and_compile(source, &extended_string_options());
+
+    assert!(
+        result.is_err(),
+        "expected compilation to fail for LREAL_TO_FMTSTR"
+    );
+    assert_eq!(result.unwrap_err().code, "P9999");
+}

--- a/compiler/codegen/tests/it/end_to_end_conv_string.rs
+++ b/compiler/codegen/tests/it/end_to_end_conv_string.rs
@@ -3,7 +3,7 @@
 use ironplc_container::STRING_HEADER_BYTES;
 use ironplc_parser::options::CompilerOptions;
 
-use crate::common::parse_and_run;
+use crate::common::{parse_and_run, try_parse_and_compile};
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -365,4 +365,34 @@ END_PROGRAM
 ";
     let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
     assert_eq!(bufs.vars[1].as_f32(), 0.0);
+}
+
+// =========================================================================
+// BOOL_TO_STRING (parses/analyzes fine, codegen not yet implemented)
+// =========================================================================
+
+#[test]
+fn bool_to_string_when_called_then_returns_not_implemented() {
+    // ironplcc check fully supports BOOL_TO_STRING (it's a standard,
+    // unconditional TO_STRING conversion); codegen deliberately refuses
+    // rather than silently emitting "1"/"0" via the generic integer path
+    // (see the StringConversion::BoolToString hazard note in
+    // compile_call.rs). See
+    // specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md.
+    let source = "
+PROGRAM main
+  VAR
+    ready : BOOL;
+    s : STRING;
+  END_VAR
+  s := BOOL_TO_STRING(ready);
+END_PROGRAM
+";
+    let result = try_parse_and_compile(source, &CompilerOptions::default());
+
+    assert!(
+        result.is_err(),
+        "expected compilation to fail for BOOL_TO_STRING"
+    );
+    assert_eq!(result.unwrap_err().code, "P9999");
 }

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -52,6 +52,7 @@ mod end_to_end_abs;
 mod end_to_end_abs_float;
 mod end_to_end_abs_lint;
 mod end_to_end_add;
+mod end_to_end_adr_and_extended_string;
 mod end_to_end_any_int_literals;
 mod end_to_end_array;
 mod end_to_end_array_ref_to;

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -198,6 +198,18 @@ struct FileArgs {
     /// extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_oop_extensions: bool,
+
+    /// Register the ADR (Address Operator) as a built-in stdlib function
+    /// (Beckhoff/CODESYS extension). This is a vendor extension not part of
+    /// the IEC 61131-3 standard.
+    #[arg(long)]
+    allow_address_operator: bool,
+
+    /// Register Beckhoff Tc2_Utilities library functions (LREAL_TO_FMTSTR)
+    /// as built-in stdlib functions. This is a vendor extension not part of
+    /// the IEC 61131-3 standard.
+    #[arg(long)]
+    allow_extended_string_functions: bool,
 }
 
 impl FileArgs {
@@ -229,6 +241,8 @@ impl FileArgs {
         options.allow_paren_string_length |= self.allow_paren_string_length;
         options.allow_struct_initializer_expressions |= self.allow_struct_initializer_expressions;
         options.allow_oop_extensions |= self.allow_oop_extensions;
+        options.allow_address_operator |= self.allow_address_operator;
+        options.allow_extended_string_functions |= self.allow_extended_string_functions;
         options
     }
 }

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -222,6 +222,20 @@ const FLAG_FIXTURES: &[FlagFixture] = &[
         prereqs: &[],
         source: "FUNCTION_BLOCK FB_Base\nVAR\nx : INT;\nEND_VAR\nEND_FUNCTION_BLOCK\nFUNCTION_BLOCK FB_Derived EXTENDS FB_Base\nEND_FUNCTION_BLOCK",
     },
+    // ADR is only registered as a stdlib function when the flag is on; with
+    // it off, the call is to an undeclared function.
+    FlagFixture {
+        key: "allow_address_operator",
+        prereqs: &[],
+        source: "PROGRAM main\nVAR\nx : INT;\na : DWORD;\nEND_VAR\na := ADR(x);\nEND_PROGRAM",
+    },
+    // LREAL_TO_FMTSTR is only registered as a stdlib function when the flag
+    // is on; with it off, the call is to an undeclared function.
+    FlagFixture {
+        key: "allow_extended_string_functions",
+        prereqs: &[],
+        source: "PROGRAM main\nVAR\nx : LREAL;\ns : STRING;\nEND_VAR\ns := LREAL_TO_FMTSTR(x, 2, TRUE);\nEND_PROGRAM",
+    },
 ];
 
 /// Wraps snippet text as the single-source input the tools expect.

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -345,6 +345,16 @@ define_compiler_options! {
     "--allow-oop-extensions",
     [Rusty, Codesys],
     allow_oop_extensions,
+
+    "Register the ADR (Address Operator) as a built-in stdlib function (Beckhoff/CODESYS extension)",
+    "--allow-address-operator",
+    [Rusty, Codesys],
+    allow_address_operator,
+
+    "Register Beckhoff Tc2_Utilities library functions (LREAL_TO_FMTSTR) as built-in stdlib functions",
+    "--allow-extended-string-functions",
+    [Rusty, Codesys],
+    allow_extended_string_functions,
 }
 
 /// Format a human-readable summary of all dialects and which features each
@@ -456,6 +466,8 @@ mod tests {
                 "allow_paren_string_length",
                 "allow_struct_initializer_expressions",
                 "allow_oop_extensions",
+                "allow_address_operator",
+                "allow_extended_string_functions",
             ],
         );
     }
@@ -493,6 +505,8 @@ mod tests {
                 "allow_paren_string_length",
                 "allow_struct_initializer_expressions",
                 "allow_oop_extensions",
+                "allow_address_operator",
+                "allow_extended_string_functions",
             ],
         );
     }
@@ -564,7 +578,6 @@ mod tests {
         );
     }
 
-    #[test]
     fn describe_dialects_when_called_then_contains_all_dialects() {
         let output = describe_dialects();
         assert!(output.contains("iec61131-3-ed2"));

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -578,6 +578,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn describe_dialects_when_called_then_contains_all_dialects() {
         let output = describe_dialects();
         assert!(output.contains("iec61131-3-ed2"));

--- a/specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md
+++ b/specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md
@@ -1,0 +1,176 @@
+# Plan: `BOOL_TO_STRING`, `LREAL_TO_FMTSTR`, `ADR` Stdlib Functions
+
+## Goal
+
+Three "undeclared function" gaps flagged by a separate corpus-check pass
+against the private test corpus: `BOOL_TO_STRING` (5 files, 72 call
+sites -- the single largest undeclared-function cluster seen in this
+series), `LREAL_TO_FMTSTR` (4 files), `ADR` (1 file). All three are real,
+documented Beckhoff/CODESYS built-ins, not typos or project-local
+helpers.
+
+## Verification against real documentation and the corpus
+
+Checked Beckhoff's own docs for each before designing anything (not
+assumed from memory):
+
+- **`BOOL_TO_STRING`**: part of the *standard* `TO_STRING` conversion
+  family (same category as `INT_TO_STRING`/`REAL_TO_STRING`, already
+  implemented) -- not a separate library function. `TRUE` converts to
+  `'TRUE'`, `FALSE` to `'FALSE'`.
+- **`LREAL_TO_FMTSTR`**: `TcUtilities.Lib` (Beckhoff `Tc2_Utilities`
+  library), a genuine vendor extension. Signature confirmed directly:
+  `LREAL_TO_FMTSTR(in : LREAL, iPrecision : INT, bRound : BOOL) : STRING(510)`.
+  `iPrecision` controls decimal places; `bRound` enables rounding;
+  documented special cases (`'#INF'`, `'#QNAN'`, `'#OVF'`) are a runtime
+  concern, not a parsing/registration one.
+- **`ADR`**: documented as the "Address Operator" (Beckhoff's own term),
+  a core TcPlcCtrl operator, not a library function. Returns the
+  argument's address as `PVOID`, or `DWORD`/`LWORD` depending on runtime
+  architecture; Beckhoff recommends `PVOID` for portability, but IronPLC
+  has no `PVOID` type today -- using `DWORD` (the well-documented 32-bit
+  fallback) instead, noting the `PVOID` gap as a known simplification.
+- Corpus usage confirmed directly: `ADR(sContent)`, `ADR(stIn_EL6001)`
+  (single positional argument, any type); `LREAL_TO_FMTSTR(tempM1, 2,
+  TRUE)` (matches the documented 3-argument signature exactly);
+  `BOOL_TO_STRING(ready)`, `BOOL_TO_STRING(error)` (single BOOL argument).
+- Confirmed `ADR`/`LREAL_TO_FMTSTR` are true syntactic function calls
+  (`NAME(args)`), so registering them in `FunctionEnvironment` is
+  sufficient for `ironplcc check` -- no new grammar needed, matching the
+  precedent already established for `SIZEOF` (also styled an "operator"
+  in Beckhoff's prose, but modeled as an ordinary stdlib function with an
+  `ANY`-typed parameter).
+
+## Design
+
+### `BOOL_TO_STRING`: unconditional core stdlib addition, but codegen needs a real fix, not a no-op
+
+Add `functions.push(build_conversion_function("BOOL", "STRING"));` to the
+*existing*, unconditional `get_string_conversion_functions()` -- same
+list `REAL_TO_STRING` already lives in, no new flag (matches how the
+standard `TO_STRING` family has never been flag-gated).
+
+**Codegen hazard found while designing (not just assumed a stub would
+be needed)**: `compile_call.rs`'s generic `*_TO_STRING` dispatcher
+(`parse_string_conversion`/`compile_string_conversion`) resolves `BOOL`
+to the *same* `VarTypeInfo` shape as any other signed-32-bit source
+(`resolve_type_name` maps `BOOL` to `(OpWidth::W32, Signedness::Signed)`,
+identical to `DINT`). Left as-is, `BOOL_TO_STRING` would silently compile
+via `CONV_I32_TO_STR`, producing `"1"`/`"0"` (or similar) instead of the
+documented `"TRUE"`/`"FALSE"` -- **wrong output that compiles cleanly**,
+strictly worse than a clean rejection. Fix: `parse_string_conversion`
+special-cases a `BOOL` source into a distinct `StringConversion::BoolToString`
+variant (checked by name, before generic numeric resolution), and
+`compile_string_conversion` returns `Diagnostic::not_implemented` for it
+-- real `"TRUE"`/`"FALSE"` codegen (constant-pool string literals +
+conditional branch) is a genuine implementation task, out of scope for
+"stop `ironplcc check` reporting undeclared function."
+
+### `LREAL_TO_FMTSTR` and `ADR`: new stdlib registrations behind a new flag each
+
+```rust
+// LREAL_TO_FMTSTR — Beckhoff Tc2_Utilities (TcUtilities.Lib)
+FunctionSignature::stdlib(
+    "LREAL_TO_FMTSTR",
+    TypeName::from("STRING"),
+    vec![
+        input_param("IN", "LREAL"),
+        input_param("IPRECISION", "INT"),
+        input_param("BROUND", "BOOL"),
+    ],
+)
+```
+
+```rust
+// ADR — Beckhoff Address Operator (TcPlcCtrl core)
+FunctionSignature::stdlib(
+    "ADR",
+    TypeName::from("DWORD"),
+    vec![input_param("IN", "ANY")],
+)
+```
+
+Two new flags (not reusing `allow_extended_math_functions`, which is
+specifically the Beckhoff `Tc2_Math` library -- these are a different
+library and a different core operator, and the project's own "dialect
+placement" convention keeps unrelated vendor extensions on separate
+flags):
+
+- `allow_extended_string_functions` -- gates `LREAL_TO_FMTSTR` (room to
+  add other `TcUtilities.Lib` string functions later without renaming).
+- `allow_address_operator` -- gates `ADR`, matching `allow_sizeof`'s
+  precedent (one flag per core vendor operator, not a library).
+
+Both registered in `stages.rs` conditionally, exactly like
+`allow_sizeof`/`allow_extended_math_functions` already are.
+
+### Codegen: `not_implemented` for both, not silently wrong or missing
+
+Neither has a sensible generic fallback the way `BOOL_TO_STRING` almost
+did:
+
+- `ADR` needs the argument's real runtime memory/data-region address --
+  a genuine VM feature (this VM's variable storage model isn't yet
+  investigated deeply enough to implement this correctly; a wrong
+  address is far worse than a clean rejection).
+- `LREAL_TO_FMTSTR` needs real floating-point formatting with rounding
+  and the documented special cases (`#INF`/`#QNAN`/`#OVF`) -- a
+  non-trivial runtime feature, not a simple opcode dispatch.
+
+Both `compile_call.rs` dispatch arms (matched by lowercased function
+name, same pattern as `"sizeof" => compile_sizeof(...)`) return
+`Diagnostic::not_implemented` -- `ironplcc check` fully supports all
+three functions (the actual motivating gap); `ironplcc compile` fails
+clearly instead of producing wrong or silently-missing bytecode.
+
+## Non-goals
+
+- `PVOID` type modeling for `ADR`'s Beckhoff-recommended portable return
+  type -- `DWORD` used instead, a known simplification.
+- Real codegen for any of the three (address computation, formatted
+  float-to-string with rounding, or `TRUE`/`FALSE` string codegen) --
+  explicitly deferred with `not_implemented`, matching the `AND_THEN`/
+  struct-init-expression precedent.
+- `STRING_TO_BOOL` (the reverse direction) -- not reported as missing in
+  the corpus survey; not added per "don't add capability beyond what's
+  verified needed."
+- Other `TcUtilities.Lib` functions beyond `LREAL_TO_FMTSTR` -- not
+  reported as missing; the new flag leaves room to add them later if
+  found.
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/parser/src/options.rs` | New `allow_extended_string_functions`, `allow_address_operator` flags |
+| `compiler/analyzer/src/intermediates/stdlib_function.rs` | `BOOL_TO_STRING` added to `get_string_conversion_functions()`; new `get_extended_string_functions()` (`LREAL_TO_FMTSTR`); new `get_address_operator_function()` (`ADR`) |
+| `compiler/analyzer/src/stages.rs` | Conditionally register the two new flag-gated functions |
+| `compiler/codegen/src/compile_call.rs` | `StringConversion::BoolToString` variant + `not_implemented`; `not_implemented` dispatch arms for `adr`/`lreal_to_fmtstr` |
+
+## Testing Strategy
+
+- Stdlib registration tests: `BOOL_TO_STRING` present unconditionally;
+  `LREAL_TO_FMTSTR`/`ADR` present only when their flag is set, absent
+  otherwise.
+- Parser/semantic test: the real motivating call shapes (`BOOL_TO_STRING(ready)`,
+  `LREAL_TO_FMTSTR(tempM1, 2, TRUE)`, `ADR(sContent)`) no longer report
+  `P4017` (undeclared function).
+- Codegen tests: compiling a call to each of the three produces
+  `Diagnostic::not_implemented` (`P9999`), not a panic or silently wrong
+  bytecode -- especially `BOOL_TO_STRING`, to lock in the
+  found-not-assumed codegen hazard above.
+- End-to-end: verify via the CLI that `ironplcc check` accepts all three
+  real motivating call shapes under `--dialect=codesys`.
+
+## Tasks
+
+- [x] Write plan (this document)
+- [x] Verify real signatures against Beckhoff docs and the private corpus
+- [ ] `BOOL_TO_STRING`: add to `get_string_conversion_functions()`
+- [ ] `BOOL_TO_STRING`: fix the codegen hazard (`StringConversion::BoolToString` -> `not_implemented`)
+- [ ] New flags: `allow_extended_string_functions`, `allow_address_operator`
+- [ ] `LREAL_TO_FMTSTR`, `ADR` stdlib registrations + `stages.rs` wiring
+- [ ] Codegen `not_implemented` arms for `adr`/`lreal_to_fmtstr`
+- [ ] Tests from Testing Strategy
+- [ ] Run full CI pipeline (`cd compiler && just`)
+- [ ] Push branch to fork

--- a/specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md
+++ b/specs/plans/2026-07-26-twincat-stdlib-bool-fmtstr-adr.md
@@ -166,11 +166,37 @@ clearly instead of producing wrong or silently-missing bytecode.
 
 - [x] Write plan (this document)
 - [x] Verify real signatures against Beckhoff docs and the private corpus
-- [ ] `BOOL_TO_STRING`: add to `get_string_conversion_functions()`
-- [ ] `BOOL_TO_STRING`: fix the codegen hazard (`StringConversion::BoolToString` -> `not_implemented`)
-- [ ] New flags: `allow_extended_string_functions`, `allow_address_operator`
-- [ ] `LREAL_TO_FMTSTR`, `ADR` stdlib registrations + `stages.rs` wiring
-- [ ] Codegen `not_implemented` arms for `adr`/`lreal_to_fmtstr`
-- [ ] Tests from Testing Strategy
-- [ ] Run full CI pipeline (`cd compiler && just`)
+- [x] `BOOL_TO_STRING`: add to `get_string_conversion_functions()`
+- [x] `BOOL_TO_STRING`: fix the codegen hazard (`StringConversion::BoolToString` -> `not_implemented`)
+- [x] New flags: `allow_extended_string_functions`, `allow_address_operator`
+- [x] `LREAL_TO_FMTSTR`, `ADR` stdlib registrations + `stages.rs` wiring
+- [x] Codegen `not_implemented` arms for `adr`/`lreal_to_fmtstr`
+- [x] Tests from Testing Strategy
+- [x] Run full CI pipeline (`cd compiler && just`)
 - [ ] Push branch to fork
+
+## Implementation Notes
+
+- **This branch (`twincat-dev`) predates upstream PR #1227's invariant-
+  style options tests** -- it still uses the older hardcoded-count style
+  (`from_dialect_when_rusty_then_all_vendor_flags_enabled_and_edition3_disabled`
+  etc. asserting each flag individually, plus
+  `feature_descriptors_when_called_then_contains_all_vendor_flags` and two
+  siblings asserting raw `FEATURE_DESCRIPTORS.len()`/per-dialect counts).
+  Adding two new flags required bumping four magic numbers across
+  `options.rs` (22->24 total/rusty, 21->23 codesys) plus
+  `compiler/mcp/src/tools/list_options.rs`'s own hardcoded count (22->24)
+  -- caught entirely by `cargo test --workspace` failures, not
+  anticipated in the original plan text.
+- **The `BoolToString` hazard fix works by intercepting the name inside
+  `parse_string_conversion` before generic `resolve_type_name`**: `BOOL`
+  and `DINT` resolve to the identical `VarTypeInfo` shape
+  `(OpWidth::W32, Signedness::Signed)`, so there's no way to distinguish
+  them *after* that resolution -- the check has to happen on the raw
+  `"BOOL_TO_STRING"` name string, before it's thrown away.
+- Confirmed via direct CLI runs (not just unit tests) that all three
+  functions: (a) resolve cleanly under `ironplcc check` when their flag
+  is set (`BOOL_TO_STRING` needs no flag at all), (b) `LREAL_TO_FMTSTR`/
+  `ADR` correctly still report `P4017` under the default dialect, and
+  (c) all three fail cleanly with `P9999` under `ironplcc compile`,
+  never a panic or silently wrong bytecode.


### PR DESCRIPTION
## Summary

Part of #1199 (TwinCAT vendor dialect support).

Standalone PR, no dependency on any other open PR. Adds two new flags (`--allow-address-operator`, `--allow-extended-string-functions`).

- `BOOL_TO_STRING` joins the existing, unconditional `TO_STRING` conversion family — this is a standard IEC 61131-3 conversion, not a separate vendor library function, so no new flag. Found and fixed a real codegen hazard along the way: `BOOL` and `DINT` resolve to the identical `VarTypeInfo` shape, so without a dedicated `StringConversion::BoolToString` variant, `BOOL_TO_STRING` would have silently compiled via the generic integer path, producing `"1"`/`"0"` instead of the documented `"TRUE"`/`"FALSE"` — wrong output that compiles cleanly, strictly worse than a clean rejection. Now returns `not_implemented` instead.
- `LREAL_TO_FMTSTR` (Beckhoff `Tc2_Utilities`) and `ADR` (the Address Operator) are new stdlib registrations behind two new flags, `allow_extended_string_functions` and `allow_address_operator`, with signatures verified against Beckhoff's own docs (`LREAL_TO_FMTSTR(in : LREAL, iPrecision : INT, bRound : BOOL) : STRING(510)`; `ADR(IN) : DWORD` — `PVOID` is Beckhoff's recommended portable return type, but IronPLC has no `PVOID` type, so `DWORD` is used as a known simplification).
- All three get `not_implemented` (`P9999`) codegen stubs: `ironplcc check` fully supports all three (the actual motivating "undeclared function" gap from a corpus-check pass); `ironplcc compile` fails clearly instead of computing a wrong address or silently-wrong formatted output.

## Test plan
- [x] `BOOL_TO_STRING` is unconditional and produces `not_implemented` at codegen (not silently wrong output)
- [x] `ADR`/`LREAL_TO_FMTSTR` are gated correctly by their new flags
- [x] End-to-end: both new functions resolve and produce `P9999` stubs, not silently-wrong codegen
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)