### PR TITLE
fix(analyzer): diagnose constant division-by-zero and overflow

### DIFF
--- a/compiler/analyzer/src/constant_folding.rs
+++ b/compiler/analyzer/src/constant_folding.rs
@@ -11,7 +11,33 @@
 
 use ironplc_dsl::common::*;
 use ironplc_dsl::core::SourceSpan;
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::textual::*;
+use ironplc_problems::Problem;
+
+/// A constant expression whose operands are both known at compile time,
+/// but whose operation has no defined result (as opposed to an expression
+/// that simply isn't constant at all, which is `try_fold_binary`/
+/// `try_fold_unary` returning `Ok(None)` and is not an error here).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FoldError {
+    DivisionByZero,
+    Overflow,
+}
+
+/// Converts a `FoldError` into a user-facing diagnostic at the given span.
+pub(crate) fn fold_error_to_diagnostic(err: FoldError, span: SourceSpan) -> Diagnostic {
+    match err {
+        FoldError::DivisionByZero => Diagnostic::problem(
+            Problem::ConstantExpressionDivisionByZero,
+            Label::span(span, "Division or modulo by zero"),
+        ),
+        FoldError::Overflow => Diagnostic::problem(
+            Problem::ConstantExpressionOverflow,
+            Label::span(span, "Arithmetic overflow"),
+        ),
+    }
+}
 
 /// Extracts the value of an integer literal as an i128.
 pub(crate) fn integer_value(lit: &IntegerLiteral) -> i128 {
@@ -51,46 +77,65 @@ pub(crate) fn make_real_constant(value: f64) -> ConstantKind {
 }
 
 /// Attempts to fold a binary expression on two integer constants.
-pub(crate) fn fold_integer_binary(op: &Operator, left: i128, right: i128) -> Option<i128> {
+///
+/// The caller has already established that both operands are constant
+/// literals, so every arithmetic path here either succeeds or names a
+/// specific `FoldError` -- there is no silent "can't fold" case (the one
+/// exception, `Pow` with a negative exponent, is handled by the caller
+/// before this is invoked, since it isn't an error, just out of scope for
+/// integer exponentiation).
+pub(crate) fn fold_integer_binary(
+    op: &Operator,
+    left: i128,
+    right: i128,
+) -> Result<i128, FoldError> {
     match op {
-        Operator::Add => left.checked_add(right),
-        Operator::Sub => left.checked_sub(right),
-        Operator::Mul => left.checked_mul(right),
+        Operator::Add => left.checked_add(right).ok_or(FoldError::Overflow),
+        Operator::Sub => left.checked_sub(right).ok_or(FoldError::Overflow),
+        Operator::Mul => left.checked_mul(right).ok_or(FoldError::Overflow),
         Operator::Div => {
             if right == 0 {
-                None
+                Err(FoldError::DivisionByZero)
             } else {
-                left.checked_div(right)
+                left.checked_div(right).ok_or(FoldError::Overflow)
             }
         }
         Operator::Mod => {
             if right == 0 {
-                None
+                Err(FoldError::DivisionByZero)
             } else {
-                left.checked_rem(right)
+                left.checked_rem(right).ok_or(FoldError::Overflow)
             }
         }
         Operator::Pow => {
-            if right < 0 {
-                // Integer exponentiation with negative exponent is not meaningful.
-                None
-            } else {
-                let exp = right as u32;
-                left.checked_pow(exp)
-            }
+            // The caller guarantees `right >= 0` -- see `try_fold_binary`.
+            let exp = right as u32;
+            left.checked_pow(exp).ok_or(FoldError::Overflow)
         }
     }
 }
 
 /// Attempts to fold a binary expression on two real constants.
-pub(crate) fn fold_real_binary(op: &Operator, left: f64, right: f64) -> f64 {
+pub(crate) fn fold_real_binary(op: &Operator, left: f64, right: f64) -> Result<f64, FoldError> {
     match op {
-        Operator::Add => left + right,
-        Operator::Sub => left - right,
-        Operator::Mul => left * right,
-        Operator::Div => left / right,
-        Operator::Mod => left % right,
-        Operator::Pow => left.powf(right),
+        Operator::Add => Ok(left + right),
+        Operator::Sub => Ok(left - right),
+        Operator::Mul => Ok(left * right),
+        Operator::Div => {
+            if right == 0.0 {
+                Err(FoldError::DivisionByZero)
+            } else {
+                Ok(left / right)
+            }
+        }
+        Operator::Mod => {
+            if right == 0.0 {
+                Err(FoldError::DivisionByZero)
+            } else {
+                Ok(left % right)
+            }
+        }
+        Operator::Pow => Ok(left.powf(right)),
     }
 }
 
@@ -104,8 +149,13 @@ pub(crate) fn const_as_f64(kind: &ExprKind) -> Option<f64> {
 }
 
 /// Tries to fold a `BinaryExpr` whose operands are both constants.
-/// Returns `Some(folded_kind)` if folding succeeded, `None` otherwise.
-pub(crate) fn try_fold_binary(binary: &BinaryExpr) -> Option<ExprKind> {
+///
+/// Returns `Ok(Some(folded_kind))` if folding succeeded, `Ok(None)` if the
+/// operands aren't both constant literals (nothing to fold, not an
+/// error), and `Err(FoldError)` if both operands are constant but the
+/// operation itself has no defined result (e.g. division by zero,
+/// overflow).
+pub(crate) fn try_fold_binary(binary: &BinaryExpr) -> Result<Option<ExprKind>, FoldError> {
     match (&binary.left.kind, &binary.right.kind) {
         (
             ExprKind::Const(ConstantKind::IntegerLiteral(left)),
@@ -113,15 +163,21 @@ pub(crate) fn try_fold_binary(binary: &BinaryExpr) -> Option<ExprKind> {
         ) => {
             let lv = integer_value(left);
             let rv = integer_value(right);
+            if matches!(binary.op, Operator::Pow) && rv < 0 {
+                // Integer exponentiation with a negative exponent isn't
+                // meaningful; leave unfolded rather than misreporting it
+                // as an overflow.
+                return Ok(None);
+            }
             let result = fold_integer_binary(&binary.op, lv, rv)?;
-            Some(ExprKind::Const(make_integer_constant(result)))
+            Ok(Some(ExprKind::Const(make_integer_constant(result))))
         }
         (
             ExprKind::Const(ConstantKind::RealLiteral(left)),
             ExprKind::Const(ConstantKind::RealLiteral(right)),
         ) => {
-            let result = fold_real_binary(&binary.op, left.value, right.value);
-            Some(ExprKind::Const(make_real_constant(result)))
+            let result = fold_real_binary(&binary.op, left.value, right.value)?;
+            Ok(Some(ExprKind::Const(make_real_constant(result))))
         }
         // Mixed integer + real: promote the integer to f64 and fold as real.
         (
@@ -132,17 +188,24 @@ pub(crate) fn try_fold_binary(binary: &BinaryExpr) -> Option<ExprKind> {
             ExprKind::Const(ConstantKind::RealLiteral(_)),
             ExprKind::Const(ConstantKind::IntegerLiteral(_)),
         ) => {
-            let lv = const_as_f64(&binary.left.kind)?;
-            let rv = const_as_f64(&binary.right.kind)?;
-            let result = fold_real_binary(&binary.op, lv, rv);
-            Some(ExprKind::Const(make_real_constant(result)))
+            let (Some(lv), Some(rv)) = (
+                const_as_f64(&binary.left.kind),
+                const_as_f64(&binary.right.kind),
+            ) else {
+                return Ok(None);
+            };
+            let result = fold_real_binary(&binary.op, lv, rv)?;
+            Ok(Some(ExprKind::Const(make_real_constant(result))))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
 /// Tries to fold a `UnaryExpr` whose operand is a constant.
 /// Returns `Some(folded_kind)` if folding succeeded, `None` otherwise.
+/// Unary negation of a literal cannot fail (no division, no overflow --
+/// the operand is negated to a wider intermediate representation), so
+/// this stays infallible.
 pub(crate) fn try_fold_unary(unary: &UnaryExpr) -> Option<ExprKind> {
     match unary.op {
         UnaryOp::Neg => match &unary.term.kind {

--- a/compiler/analyzer/src/xform_fold_constant_expressions.rs
+++ b/compiler/analyzer/src/xform_fold_constant_expressions.rs
@@ -20,11 +20,12 @@
 //! x := 5;
 //! ```
 use ironplc_dsl::common::*;
+use ironplc_dsl::core::Located;
 use ironplc_dsl::diagnostic::Diagnostic;
 use ironplc_dsl::fold::Fold;
 use ironplc_dsl::textual::*;
 
-use crate::constant_folding::{try_fold_binary, try_fold_unary};
+use crate::constant_folding::{fold_error_to_diagnostic, try_fold_binary, try_fold_unary};
 
 pub fn apply(lib: Library) -> Result<Library, Vec<Diagnostic>> {
     let mut folder = ConstantFolder;
@@ -39,7 +40,9 @@ impl Fold<Diagnostic> for ConstantFolder {
         let node = Expr::recurse_fold(node, self)?;
 
         let folded_kind = match &node.kind {
-            ExprKind::BinaryOp(binary) => try_fold_binary(binary),
+            ExprKind::BinaryOp(binary) => {
+                try_fold_binary(binary).map_err(|e| fold_error_to_diagnostic(e, node.span()))?
+            }
             ExprKind::UnaryOp(unary) => try_fold_unary(unary),
             _ => None,
         };
@@ -60,6 +63,7 @@ mod tests {
     use crate::constant_folding::integer_value;
     use crate::test_helpers::parse_and_resolve_types;
     use ironplc_dsl::visitor::Visitor;
+    use ironplc_problems::Problem;
 
     fn apply_fold(program: &str) -> Library {
         let library = parse_and_resolve_types(program);
@@ -167,11 +171,65 @@ mod tests {
     }
 
     #[test]
-    fn fold_expr_when_div_by_zero_then_no_fold() {
-        let lib = apply_fold("PROGRAM main VAR x : INT; END_VAR x := 10 / 0; END_PROGRAM");
+    fn fold_expr_when_int_div_by_zero_then_error() {
+        let library =
+            parse_and_resolve_types("PROGRAM main VAR x : INT; END_VAR x := 10 / 0; END_PROGRAM");
+        let result = apply(library);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .iter()
+            .all(|d| d.code == Problem::ConstantExpressionDivisionByZero.code()));
+    }
+
+    #[test]
+    fn fold_expr_when_int_mod_by_zero_then_error() {
+        let library =
+            parse_and_resolve_types("PROGRAM main VAR x : INT; END_VAR x := 10 MOD 0; END_PROGRAM");
+        let result = apply(library);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .iter()
+            .all(|d| d.code == Problem::ConstantExpressionDivisionByZero.code()));
+    }
+
+    #[test]
+    fn fold_expr_when_real_div_by_zero_then_error() {
+        let library = parse_and_resolve_types(
+            "PROGRAM main VAR x : LREAL; END_VAR x := 1.0 / 0.0; END_PROGRAM",
+        );
+        let result = apply(library);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .iter()
+            .all(|d| d.code == Problem::ConstantExpressionDivisionByZero.code()));
+    }
+
+    #[test]
+    fn fold_expr_when_int_overflow_then_error() {
+        let library = parse_and_resolve_types(
+            "PROGRAM main VAR x : LINT; END_VAR x := 170141183460469231731687303715884105727 * 2; END_PROGRAM",
+        );
+        let result = apply(library);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .iter()
+            .all(|d| d.code == Problem::ConstantExpressionOverflow.code()));
+    }
+
+    #[test]
+    fn fold_expr_when_negative_integer_exponent_then_no_fold_no_error() {
+        // Negative integer exponentiation is not meaningful for integers;
+        // it stays unfolded and is not reported as an overflow.
+        let library =
+            parse_and_resolve_types("PROGRAM main VAR x : INT; END_VAR x := 2 ** -1; END_PROGRAM");
+        let lib = apply(library).unwrap();
         let exprs = collect_exprs(&lib);
         let has_binary = exprs.iter().any(|e| matches!(e, ExprKind::BinaryOp(_)));
-        assert!(has_binary, "Division by zero should not be folded");
+        assert!(has_binary, "Negative exponent should not be folded");
     }
 
     // --- Nested constant folding ---

--- a/compiler/analyzer/src/xform_fold_initializer_expressions.rs
+++ b/compiler/analyzer/src/xform_fold_initializer_expressions.rs
@@ -42,7 +42,7 @@ use ironplc_dsl::textual::*;
 use ironplc_parser::options::CompilerOptions;
 use ironplc_problems::Problem;
 
-use crate::constant_folding::{try_fold_binary, try_fold_unary};
+use crate::constant_folding::{fold_error_to_diagnostic, try_fold_binary, try_fold_unary};
 use crate::scoped_table::{ScopedTable, Value};
 
 impl Value for ConstantKind {}
@@ -136,27 +136,41 @@ fn register_constants(
 /// `ConstantKind` values (see `register_constants`), never an expression
 /// referencing another name, so a substituted value is always terminal --
 /// there is nothing left to look up again.
-fn substitute_and_fold(expr: Expr, constants: &mut ScopedTable<Id, ConstantKind>) -> Expr {
+///
+/// Returns `Err` if a sub-expression is a genuine constant expression
+/// (both operands known) whose operation has no defined result (division
+/// by zero, overflow) -- distinct from simply not folding, which leaves
+/// the node as an unfolded `BinaryOp`/`UnaryOp` for `normalize` to report
+/// as "not a constant expression".
+fn substitute_and_fold(
+    expr: Expr,
+    constants: &mut ScopedTable<Id, ConstantKind>,
+) -> Result<Expr, Diagnostic> {
+    let span = expr.span();
     let kind = match expr.kind {
         ExprKind::BinaryOp(binary) => {
-            let left = substitute_and_fold(binary.left, constants);
-            let right = substitute_and_fold(binary.right, constants);
+            let left = substitute_and_fold(binary.left, constants)?;
+            let right = substitute_and_fold(binary.right, constants)?;
             let binary = BinaryExpr {
                 op: binary.op,
                 left,
                 right,
             };
-            try_fold_binary(&binary).unwrap_or(ExprKind::BinaryOp(Box::new(binary)))
+            try_fold_binary(&binary)
+                .map_err(|e| fold_error_to_diagnostic(e, span))?
+                .unwrap_or(ExprKind::BinaryOp(Box::new(binary)))
         }
         ExprKind::UnaryOp(unary) => {
-            let term = substitute_and_fold(unary.term, constants);
+            let term = substitute_and_fold(unary.term, constants)?;
             let unary = UnaryExpr { op: unary.op, term };
             try_fold_unary(&unary).unwrap_or(ExprKind::UnaryOp(Box::new(unary)))
         }
         ExprKind::Expression(inner) => {
-            ExprKind::Expression(Box::new(substitute_and_fold(*inner, constants)))
+            ExprKind::Expression(Box::new(substitute_and_fold(*inner, constants)?))
         }
-        ExprKind::Deref(inner) => ExprKind::Deref(Box::new(substitute_and_fold(*inner, constants))),
+        ExprKind::Deref(inner) => {
+            ExprKind::Deref(Box::new(substitute_and_fold(*inner, constants)?))
+        }
         ExprKind::Variable(Variable::Symbolic(SymbolicVariableKind::Named(named))) => {
             match constants.find(&named.name) {
                 Some(value) => ExprKind::Const(value.clone()),
@@ -174,10 +188,10 @@ fn substitute_and_fold(expr: Expr, constants: &mut ScopedTable<Id, ConstantKind>
         other => other,
     };
 
-    Expr {
+    Ok(Expr {
         kind,
         resolved_type: expr.resolved_type,
-    }
+    })
 }
 
 struct InitializerFolder<'a> {
@@ -205,22 +219,31 @@ impl InitializerFolder<'_> {
             });
         }
 
-        let folded = substitute_and_fold(se.initial_value, &mut self.constants);
-        match folded.kind {
-            ExprKind::Const(c) => InitialValueAssignmentKind::Simple(SimpleInitializer {
-                type_name: se.type_name,
-                initial_value: Some(c),
-            }),
-            _ => {
-                self.diagnostics.push(
-                    Diagnostic::problem(
-                        Problem::InitializerNotConstantExpression,
-                        Label::span(folded.span(), "Initializer expression"),
-                    )
-                    .with_context("type", &se.type_name.to_string()),
-                );
+        let type_name = se.type_name;
+        match substitute_and_fold(se.initial_value, &mut self.constants) {
+            Ok(folded) => match folded.kind {
+                ExprKind::Const(c) => InitialValueAssignmentKind::Simple(SimpleInitializer {
+                    type_name,
+                    initial_value: Some(c),
+                }),
+                _ => {
+                    self.diagnostics.push(
+                        Diagnostic::problem(
+                            Problem::InitializerNotConstantExpression,
+                            Label::span(folded.span(), "Initializer expression"),
+                        )
+                        .with_context("type", &type_name.to_string()),
+                    );
+                    InitialValueAssignmentKind::Simple(SimpleInitializer {
+                        type_name,
+                        initial_value: None,
+                    })
+                }
+            },
+            Err(diag) => {
+                self.diagnostics.push(diag);
                 InitialValueAssignmentKind::Simple(SimpleInitializer {
-                    type_name: se.type_name,
+                    type_name,
                     initial_value: None,
                 })
             }
@@ -599,5 +622,36 @@ mod tests {
             ConstantKind::IntegerLiteral
         );
         assert_eq!(lit.value.value.value, 5);
+    }
+
+    #[test]
+    fn apply_when_initializer_divides_by_zero_then_division_by_zero_error_not_misleading_p4038() {
+        // 1.0/0.0 is a genuine constant expression (both operands known);
+        // it must be reported as "division by zero", not misdiagnosed as
+        // "not a constant expression" (P4038 / InitializerNotConstantExpression).
+        let lib = parse(
+            "PROGRAM main VAR x : LREAL := 1.0/0.0; END_VAR END_PROGRAM",
+            &opts(),
+        );
+        let result = apply(lib, &opts());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .iter()
+            .all(|d| d.code == Problem::ConstantExpressionDivisionByZero.code()));
+    }
+
+    #[test]
+    fn apply_when_initializer_int_overflows_then_overflow_error_not_misleading_p4038() {
+        let lib = parse(
+            "PROGRAM main VAR x : LINT := 170141183460469231731687303715884105727 * 2; END_VAR END_PROGRAM",
+            &opts(),
+        );
+        let result = apply(lib, &opts());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .iter()
+            .all(|d| d.code == Problem::ConstantExpressionOverflow.code()));
     }
 }

--- a/compiler/problems/resources/problem-codes.csv
+++ b/compiler/problems/resources/problem-codes.csv
@@ -83,6 +83,8 @@ P4035,AssignmentTypeMismatch,Assignment value type does not match assignment tar
 P4036,MixedLocatedVarDeclarationNotAllowed,AT-located variable in a plain VAR block requires --allow-mixed-located-var-declarations flag
 P4037,ConstantInitializerExpressionNotAllowed,Constant expression in VAR initializer requires --allow-constant-initializer-expressions flag
 P4038,InitializerNotConstantExpression,Variable initializer expression does not reduce to a constant value
+P4039,ConstantExpressionDivisionByZero,Constant expression divides or takes the modulo of a value by zero
+P4040,ConstantExpressionOverflow,Constant integer expression overflows its evaluation range
 P6001,CannotCanonicalizePath,Unable to canonicalize the path
 P6002,CannotReadMetadata,Unable to read metadata for the path
 P6003,CannotReadDirectory,Unable to read directory

--- a/docs/reference/compiler/problems/P4039.rst
+++ b/docs/reference/compiler/problems/P4039.rst
@@ -1,0 +1,51 @@
+=====
+P4039
+=====
+
+.. problem-summary:: P4039
+
+This error occurs when a constant expression divides or takes the modulo
+of a value by zero. This applies both to plain constant expressions in
+statement bodies and to constant expressions used as a ``VAR``
+initializer (enabled by ``--allow-constant-initializer-expressions``).
+
+The expression is a genuine constant expression -- both operands are
+known at compile time -- but the operation itself has no defined result,
+so it is reported distinctly from :doc:`P4038 <P4038>` ("does not reduce
+to a constant value"), which covers expressions that reference something
+that is not constant at all.
+
+Example
+-------
+
+The following code will generate error P4039:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       x : LREAL := 1.0 / 0.0;
+   END_VAR
+   END_PROGRAM
+
+To fix this error, ensure the divisor is not zero:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       x : LREAL := 1.0 / 2.0;
+   END_VAR
+   END_PROGRAM
+
+This also applies to integer division and modulo, and in statement
+bodies, not just ``VAR`` initializers:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       y : DINT;
+   END_VAR
+   y := 5 / 0;
+   END_PROGRAM

--- a/docs/reference/compiler/problems/P4039.rst
+++ b/docs/reference/compiler/problems/P4039.rst
@@ -49,3 +49,10 @@ bodies, not just ``VAR`` initializers:
    END_VAR
    y := 5 / 0;
    END_PROGRAM
+
+See Also
+--------
+
+- :doc:`P4038` -- initializer expression does not reduce to a constant value
+- :doc:`P4040` -- constant integer expression overflows its evaluation range
+- :doc:`/reference/language/data-types/index` -- integer and real type ranges

--- a/docs/reference/compiler/problems/P4040.rst
+++ b/docs/reference/compiler/problems/P4040.rst
@@ -1,0 +1,34 @@
+=====
+P4040
+=====
+
+.. problem-summary:: P4040
+
+This error occurs when evaluating a constant integer expression at
+compile time produces a result that overflows the arithmetic range used
+for constant folding. Both operands are genuine compile-time constants --
+the expression is not rejected because it "isn't constant"
+(see :doc:`P4038 <P4038>`), but because evaluating it is not possible.
+
+Example
+-------
+
+The following code will generate error P4040:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       x : LINT := 100000000000000000000 * 100000000000000000000;
+   END_VAR
+   END_PROGRAM
+
+To fix this error, use operand values that don't overflow:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       x : LINT := 1000 * 1000;
+   END_VAR
+   END_PROGRAM

--- a/docs/reference/compiler/problems/P4040.rst
+++ b/docs/reference/compiler/problems/P4040.rst
@@ -10,6 +10,16 @@ for constant folding. Both operands are genuine compile-time constants --
 the expression is not rejected because it "isn't constant"
 (see :doc:`P4038 <P4038>`), but because evaluating it is not possible.
 
+The compiler folds constant integer arithmetic (``+``, ``-``, ``*``,
+``/``, ``MOD``, ``**``) at compile time so that later analysis and code
+generation see a plain literal rather than an expression tree. This
+folding is checked: if the result of an operation cannot be represented,
+the compiler reports P4040 instead of silently producing a wrapped or
+truncated value that would not match what the target hardware computes
+at runtime. Reporting the failure at compile time is preferable to
+letting an overflow surface later as a wrong runtime value with no
+obvious cause.
+
 Example
 -------
 
@@ -32,3 +42,28 @@ To fix this error, use operand values that don't overflow:
        x : LINT := 1000 * 1000;
    END_VAR
    END_PROGRAM
+
+The same check applies to a constant expression anywhere in a program,
+not just a ``VAR`` initializer -- for example, in an assignment
+statement:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       y : LINT;
+   END_VAR
+   y := 100000000000000000000 * 100000000000000000000;  (* Error *)
+   END_PROGRAM
+
+If the values genuinely need to exceed what a single constant
+expression can represent, split the computation across multiple typed
+variables so each intermediate step stays within range, or compute the
+value at runtime instead of as a compile-time constant.
+
+See Also
+--------
+
+- :doc:`P4038` -- initializer expression does not reduce to a constant value
+- :doc:`P4039` -- constant expression divides or takes the modulo of a value by zero
+- :doc:`/reference/language/data-types/index` -- integer type ranges

--- a/specs/plans/2026-07-29-constant-fold-diagnostics.md
+++ b/specs/plans/2026-07-29-constant-fold-diagnostics.md
@@ -1,0 +1,105 @@
+# Plan: Diagnose unevaluable constant expressions (issue #1249)
+
+## Problem
+
+`compiler/analyzer/src/constant_folding.rs` (`fold_integer_binary`,
+`fold_real_binary`) collapses two distinct situations into one signal:
+
+- "operands aren't both constant literals" (genuinely not foldable, no
+  diagnostic needed -- the expression may still be valid at runtime)
+- "operands are both constant literals, but evaluating the operation is
+  impossible" (real division/modulo by zero silently folds to `inf`/`NaN`;
+  integer overflow and integer division/modulo by zero return `None`, which
+  either silently passes the unfolded node through with no diagnostic
+  (`xform_fold_constant_expressions`, statement bodies) or gets reported
+  under the wrong code -- P4037 "not a constant expression" -- in
+  `xform_fold_initializer_expressions`, even though the expression *is*
+  constant, it just doesn't evaluate)
+
+## Design
+
+Give the leaf arithmetic functions a three-way outcome instead of
+`Option`:
+
+```rust
+pub(crate) enum FoldError {
+    DivisionByZero,
+    Overflow,
+}
+```
+
+- `fold_integer_binary`/`fold_real_binary` return `Result<T, FoldError>`.
+  Both operands being constant is already established by the caller
+  (`try_fold_binary`) before these are invoked, so every path through them
+  now either succeeds or names a `FoldError` -- there is no more silent
+  `None`.
+- Integer `Div`/`Mod` by zero -> `FoldError::DivisionByZero`. Real
+  `Div`/`Mod` by zero -> `FoldError::DivisionByZero` (checked explicitly;
+  `f64` doesn't panic or return `None` on its own).
+  `checked_add`/`checked_sub`/`checked_mul`/`checked_div`/`checked_rem`/
+  `checked_pow` returning `None` for a non-zero-divisor reason ->
+  `FoldError::Overflow`.
+- Integer `Pow` with a negative exponent keeps today's behavior exactly:
+  `try_fold_binary` special-cases it and returns `Ok(None)` (leave
+  unfolded, no diagnostic) *before* calling `fold_integer_binary` --
+  out of scope for this issue, not a regression risk.
+- `try_fold_binary`/`try_fold_unary` return `Result<Option<ExprKind>,
+  FoldError>` (unary negation cannot fail today, so it stays infallible
+  internally and is wrapped as `Ok`).
+- Add `fold_error_to_diagnostic(FoldError, SourceSpan) -> Diagnostic` in
+  `constant_folding.rs` (it already encodes evaluation policy per the
+  PR #1220 review discussion, so this belongs there too), mapping to two
+  new problem codes.
+
+New problem codes (next available: P4042):
+
+- `P4042 ConstantExpressionDivisionByZero` -- constant division or modulo
+  by zero (covers both integer and real).
+- `P4043 ConstantExpressionOverflow` -- constant integer arithmetic
+  overflows its evaluation range.
+
+## Call sites
+
+- `xform_fold_constant_expressions.rs`: `ConstantFolder::fold_expr` already
+  returns `Result<Expr, Diagnostic>` (the `Fold` trait threads this through
+  the whole tree already) -- convert `FoldError` to a `Diagnostic` and
+  propagate with `?`. No new plumbing needed.
+- `xform_fold_initializer_expressions.rs`: `substitute_and_fold` changes
+  from `fn(...) -> Expr` to `fn(...) -> Result<Expr, Diagnostic>`,
+  propagating child-expression errors with `?` and converting a
+  `FoldError` at the point it's raised. `normalize()` matches on the
+  `Result` and, on `Err`, pushes the diagnostic and returns an
+  uninitialized `Simple` (same recovery shape as the existing "not a
+  constant expression" path) instead of treating the whole thing as
+  unreachable.
+
+## Tests
+
+- Update the existing `fold_expr_when_div_by_zero_then_no_fold` test in
+  `xform_fold_constant_expressions.rs` -- it currently asserts the
+  expression is silently left as an unfolded `BinaryOp`; division by zero
+  is now a diagnosed error, so rename it and assert `apply()` returns
+  `Err` with `Problem::ConstantExpressionDivisionByZero`.
+- Add new tests in `xform_fold_constant_expressions.rs`: real division by
+  zero, integer overflow (e.g. `DINT` multiplication past `i32`... note
+  folding here works in `i128` headroom before the value is later checked
+  against the declared type elsewhere, so "overflow" here means the
+  `i128` arithmetic itself overflows, e.g. via repeated `Pow`), modulo by
+  zero (integer and real).
+- Add new tests in `xform_fold_initializer_expressions.rs`: a `VAR`
+  initializer expression that divides/overflows, asserting the emitted
+  diagnostic is `ConstantExpressionDivisionByZero` /
+  `ConstantExpressionOverflow`, not the misleading
+  `InitializerNotConstantExpression`.
+- New docs: `docs/reference/compiler/problems/P4042.rst`,
+  `docs/reference/compiler/problems/P4043.rst`, plus an index.rst toctree
+  entry for both.
+
+## Out of scope
+
+- `CONFIGURATION`/`RESOURCE`-scoped constants (already deferred, unrelated
+  to this issue).
+- Any general "detect non-finite real result" check beyond division and
+  modulo by zero (e.g. real `Pow` overflowing to infinity) -- issue #1249
+  only reports division by zero for reals; broadening further is a
+  separate, unreported concern.

--- a/specs/plans/2026-07-29-constant-fold-diagnostics.md
+++ b/specs/plans/2026-07-29-constant-fold-diagnostics.md
@@ -51,11 +51,12 @@ pub(crate) enum FoldError {
   PR #1220 review discussion, so this belongs there too), mapping to two
   new problem codes.
 
-New problem codes (next available: P4042):
+New problem codes (next available on `origin/main`: P4039 -- the numbers
+from earlier local work were renumbered when #1253/#1254 merged):
 
-- `P4042 ConstantExpressionDivisionByZero` -- constant division or modulo
+- `P4039 ConstantExpressionDivisionByZero` -- constant division or modulo
   by zero (covers both integer and real).
-- `P4043 ConstantExpressionOverflow` -- constant integer arithmetic
+- `P4040 ConstantExpressionOverflow` -- constant integer arithmetic
   overflows its evaluation range.
 
 ## Call sites


### PR DESCRIPTION
## Summary

Fixes #1249. `fold_integer_binary`/`fold_real_binary` in `constant_folding.rs` collapsed two different situations into a single `None`:

- operands aren't both constant literals (nothing to fold, not an error)
- operands *are* both constant, but the operation has no defined result (division by zero, overflow)

That meant:
- Real division by zero (`1.0 / 0.0`) silently folded to `inf`/`NaN` with no diagnostic.
- Integer overflow / integer division-or-modulo by zero silently passed the unfolded node through with no diagnostic in statement bodies (`xform_fold_constant_expressions`).
- The same case reused from `xform_fold_initializer_expressions` (#1220) got reported as **P4038 "not a constant expression"** — misleading, since the expression *is* constant, it just can't be evaluated.

## Changes

- New `FoldError` enum (`DivisionByZero`, `Overflow`) in `constant_folding.rs`. `fold_integer_binary`/`fold_real_binary`/`try_fold_binary` now return `Result` instead of `Option`, since the caller has already established both operands are constant by the time these run.
- Integer `Pow` with a negative exponent is unchanged behavior (still silently left unfolded, not misreported as overflow) — handled explicitly by the caller before the fallible path runs.
- Two new problem codes: `P4039 ConstantExpressionDivisionByZero`, `P4040 ConstantExpressionOverflow`, each with docs.
- Both `xform_fold_constant_expressions` and `xform_fold_initializer_expressions` convert a `FoldError` into the appropriate diagnostic and propagate it through their existing `Result`-threaded `Fold` passes (no new plumbing needed for the statement-body pass; `substitute_and_fold` in the initializer pass now returns `Result<Expr, Diagnostic>`).
- New tests in both files covering integer div/mod by zero, real div by zero, integer overflow, and confirming the negative-exponent case still silently doesn't fold. Also a regression test proving the initializer-expression path reports the new codes instead of the misleading P4038.

## Test plan

- [x] `cargo test --workspace` — all passing
- [x] `cd compiler && just` (compile, coverage ≥85%, clippy, fmt, dupes) — all green