### PR TITLE
Design: library support

### DIFF
--- a/specs/design/library-support.md
+++ b/specs/design/library-support.md
@@ -2,103 +2,119 @@
 
 ## Overview
 
-IronPLC has no library mechanism. Its "standard library" (TON, CTU, string
-functions, …) is hand-written Rust baked into the compiler and registered
-programmatically (`analyzer/src/stages.rs`, `analyzer/src/stdlib.rs`). Every
-function IronPLC lacks — e.g. Beckhoff's `LTRUNC`/`LMOD`
-([#1217](https://github.com/ironplc/ironplc/pull/1217), part of #1199) — today
-requires new Rust and, often, a per-function `--allow-*` flag. That does not
-scale and pushes ordinary library functions into the compiler.
+IronPLC's standard library (TON, CTU, string functions, …) is hand-written Rust
+baked into the compiler (`analyzer/src/stages.rs`, `analyzer/src/stdlib.rs`).
+**That Rust-baked standard library stays.** This design adds a complementary
+mechanism: **compatibility libraries** — IronPLC-authored IEC 61131-3 **source**
+that the compiler reads and compiles through the same pipeline as user code,
+shipped and installed alongside the compiler.
 
-This design introduces a **library**: IronPLC's own IEC 61131-3 **source** that
-the compiler reads and compiles through the same pipeline as user code, shipped
-with the compiler and installed alongside it. It follows the conventional model
-— a library that ships with the toolchain and is available to every program,
-like a language's standard library.
+The purpose is to provide implementations **equivalent to the base libraries of
+other runtimes** (e.g. Beckhoff TwinCAT and CODESYS), so a program written for
+one of those runtimes compiles against IronPLC-authored source instead of
+requiring new Rust and a per-function `--allow-*` flag for every missing function
+(e.g. `LTRUNC`/`LMOD`, [#1217](https://github.com/ironplc/ironplc/pull/1217),
+part of #1199).
 
-IronPLC provides its **own** libraries. It does **not** redistribute third-party
-vendor libraries (Beckhoff `Tc2_*`, etc.) — that is a licensing non-starter.
-Instead, to be compatible with vendor and edition dialects, IronPLC provides
-**compatibility libraries** it authors itself.
+**This is deliberately not a complete, general library system, and not a
+replacement for the Rust-baked standard library.** It is a targeted way to ship
+runtime-equivalent library content as source, opted into per library. IronPLC
+provides only its **own** source; it does **not** redistribute third-party vendor
+libraries (Beckhoff `Tc2_*`, etc.) — a licensing non-starter.
 
 ### Scope
 
-**In scope:** shipping a single IronPLC-authored library as `.st` source,
-selected by the active dialect/edition, loaded from disk, compiled by the normal
-pipeline, verified by CI, and installed with the compiler.
+**In scope:** shipping IronPLC-authored `.st` libraries, each selected
+**explicitly** (by a compiler flag and/or a library reference in project
+configuration), loaded from disk, compiled by the normal pipeline, verified by
+CI, and installed with the compiler. The first library defines the constant `PI`.
 
 **Out of scope (future designs):**
 
-- *How to offer multiple or vendor-specific compatibility libraries* and
-  reference them individually. For now IronPLC offers a single dialect-matched
-  library.
+- A complete/general library system (versioning, dependency resolution, a full
+  reference model). Libraries here are a flat set of named files, opted into
+  individually.
 - Functions that require an operation the language cannot express (a float→float
-  truncation, etc.) and the compiler/VM support they need. `LTRUNC`/`LMOD` fall
-  here and are deferred to a follow-on design; this design builds the library
-  foundation they will use.
+  truncation, etc.) and the compiler/VM primitives they need — `LTRUNC`/`LMOD`
+  are deferred to a follow-on design that builds on this foundation.
 
 ### Goals
 
-- Ship IronPLC's library as IEC 61131-3 `.st` source the compiler reads, not
-  Rust baked into the binary.
-- Make the dialect-appropriate library available to every compilation.
+- Ship IronPLC-authored compatibility libraries as `.st` source the compiler
+  reads.
+- Let a user **opt into** a library by name (compiler flag and/or project-config
+  reference); dialects do not select libraries.
 - Install the library files alongside the compiler so users can see and read
   them.
 - Verify in CI that every shipped library file compiles.
+- Ship a first library that defines `PI` (the right resolution for #1219).
 
-### Approach: what other compilers do
+### Approach
 
-- A library ships with the toolchain and is available by default (Rust's
-  `std`/prelude, Go's `std`, the C runtime).
-- Library code is **ordinary source** compiled by the same front end. The
-  compiler already supports this: `analyze()` merges all units into one library
-  and `xform_toposort_declarations` prunes everything unreachable from a PROGRAM
-  root, so the library can be supplied and only used POUs are emitted.
+- Libraries ship with the toolchain but are **opted into explicitly**, the way a
+  TwinCAT/CODESYS project adds a library reference or a C build links a library —
+  not implicitly global. Those runtimes offer many libraries and you opt into the
+  specific ones you use.
+- Library code is **ordinary source** compiled by the same front end. `analyze()`
+  merges selected libraries with user code into one unit, and the reachability
+  pass prunes everything unused — **including global constants** — so a library
+  can define `PI` and it is emitted only when a program uses it.
 
 ## Architecture
 
 ### Library source
 
 **REQ-LIB-sources-100** IronPLC ships library source under `compiler/library/`.
-Each immediate subdirectory of `compiler/library/` is one library, named by the
-directory.
-
-**REQ-LIB-sources-101** A library is named to match a dialect/edition (the same
-names the compiler uses for its dialects), so the standard library can differ by
-IEC 61131-3 edition. The library matching the active dialect is available to
-every compilation by default. IronPLC ships a single such library initially.
+Each immediate subdirectory of `compiler/library/` is one library, identified by
+its directory name.
 
 **REQ-LIB-sources-102** Library source files are `.st` files, parsed by the same
-parser as user source with no library-only grammar.
+parser as user source, with no library-only grammar.
+
+**REQ-LIB-sources-180** The first shipped library defines the constant `PI` (an
+`LREAL` global constant), providing the resolution for #1219 in library source
+rather than a compiler flag.
 
 Keeping the files as real `.st` source (rather than Rust string literals) makes
 them reviewable, diffable, editable, **visible to users after install**, and —
 critically — compilable by the same CI that builds user programs (see
 [Build-time compile check](#build-time-compile-check)).
 
-### Delivery: installed alongside the binary
+### Selecting a library
 
-Library files are shipped as files and installed next to the compiler, then
-loaded from disk at runtime. This keeps the library **visible and readable to
-users** and makes the set **extensible** — adding or adjusting a library is a
-file change, not a compiler rebuild.
+**REQ-LIB-sources-130** A library is included in a compilation only when
+explicitly selected — by a compiler flag naming the library, and/or by a library
+reference embedded in project configuration (e.g. a TwinCAT `.plcproj`
+`<LibraryReference>`). Dialects do not select libraries, and no library is
+included by default.
 
-**REQ-LIB-sources-110** The compiler locates its library directory relative to
-the installed executable, independent of the current working directory and of
-the user's project directory.
+Selection is resolved in the CLI/`sources` layer. The **parser crate does not
+learn about libraries**; if library selection ever needs option plumbing,
+`CompilerOptions` should be restructured so the parser holds only its
+syntax-affecting subset and the CLI owns the rest.
 
-**REQ-LIB-sources-140** If the library for the active dialect cannot be located
-or read, the compiler emits a clear diagnostic (proposed `P4039`) identifying
-the missing library, rather than silently omitting standard functions.
+### Compiling a library — per-file compiler flags via pragma
 
-Because the library is read from disk as ordinary files, its elements carry
-normal file-based `FileId`s — no special builtin tagging is needed, and
-diagnostics and debug info point at the real library file on disk.
+A library may need to be compiled with compiler flags that differ from the
+user's. The immediate case: defining `PI` needs a **global constant declaration
+block** (a top-level `VAR_GLOBAL CONSTANT`, gated by `--allow-top-level-var-global`
+today). Rather than compile all libraries under a fixed flag set, a library
+source file declares the flags it needs via a **pragma**.
+
+**REQ-LIB-parser-200** A source file may enable specific compiler flags for its
+own compilation via a pragma. Initially this covers allowing a global constant
+declaration block (needed to define `PI`). The mechanism is a general,
+file-scoped flag directive — it is not library-specific.
+
+This separates two kinds of rule, and the pragma feeds both: **parse-time rules**
+a pragma switches on while parsing, and **analysis rules** that operate on what
+was written. Start with only the flag `PI` needs; grow the recognized set as
+further libraries require it, toward a general mechanism.
 
 ### Semantic integration
 
-**REQ-LIB-analyzer-300** POUs, types, and global variables exported by the
-active library resolve in user code as if declared in the compilation, using the
+**REQ-LIB-analyzer-300** POUs, types, and global variables exported by a selected
+library resolve in user code as if declared in the compilation, using the
 existing merge performed by `analyze()`.
 
 **REQ-LIB-analyzer-330** A user declaration whose name collides with a library
@@ -108,10 +124,11 @@ declaration.
 
 ### Code generation and linking
 
-**REQ-LIB-codegen-400** Library POUs reachable from a PROGRAM root are compiled
-and linked into the output container; library POUs not reachable from any PROGRAM
-root are omitted (the existing `xform_toposort_declarations` reachability pass,
-applied to merged library + user code).
+**REQ-LIB-codegen-400** After merging selected libraries with user code,
+declarations not reachable from a PROGRAM root — POUs **and global constants** —
+are pruned and omitted from the output container. This extends the existing
+`xform_toposort_declarations` reachability pass to global constants, so an unused
+library `PI` is not emitted.
 
 **REQ-LIB-codegen-410** A call to a library function is compiled as a `CALL` to
 the compiled library POU, using the same path as a call to a user-defined
@@ -120,8 +137,8 @@ function.
 ### Build-time compile check
 
 **REQ-LIB-sources-190** Every source file under `compiler/library/` parses,
-analyzes, and compiles to a container without error. CI fails if any shipped
-library file does not compile.
+analyzes, and compiles to a container without error — each compiled with the
+flags its pragma declares. CI fails if any shipped library file does not compile.
 
 Implemented as an integration test that runs the real `check()` + `compile()`
 entry points over the `compiler/library/` tree (directory input is already
@@ -130,18 +147,20 @@ supported; see the existing `check(&[resource_path("set")], …)` test in
 (`compile`/`coverage`) so a change that breaks a library file fails CI the same
 as any other test. It is the guardrail the current Rust-baked stdlib lacks.
 
-## Compiler-options boundary
+## Delivery: installed alongside the binary
 
-Selecting the library follows the active dialect/edition, which the compiler
-already knows (`--dialect`). The **parser crate must not learn about libraries**
-— library location, loading, and selection live in the CLI/`sources` layer. No
-library option is added to the parser by this design. If library-related options
-are needed later, `CompilerOptions` should be restructured so the parser keeps
-only the minimal syntax-affecting subset and the CLI owns the rest (either by
-moving `CompilerOptions` into its own crate, or by the CLI defining the full
-option set with a mapping down to the parser's subset).
+Library files are shipped as files and installed next to the compiler, then
+loaded from disk at runtime. This keeps the library **visible and readable to
+users** and makes the set **extensible** — adding or adjusting a library is a
+file change, not a compiler rebuild.
 
-## Packaging and installers
+**REQ-LIB-sources-110** The compiler locates its library directory relative to
+the installed executable, independent of the current working directory and of the
+user's project directory.
+
+Because the library is read from disk as ordinary files, its elements carry
+normal file-based `FileId`s — no special builtin tagging is needed, and
+diagnostics and debug info point at the real library file on disk.
 
 The library tree is staged into each install layout the way `bom.cdx.json` is
 staged today:
@@ -154,19 +173,10 @@ staged today:
 - `compiler/install.sh`: after extraction, copy the library directory into
   `${INSTALL_DIR}/lib` (the script currently extracts only named binaries).
 - `compiler/homebrew/Formula/ironplc.rb`: `(share/"ironplc").install Dir["lib/*"]`.
-- Runtime path-resolution locates the library directory relative to the
-  executable (REQ-LIB-sources-110).
 
 The existing release workflows (`partial_compiler.yaml`,
 `partial_upload_release_artifacts.yaml`) manipulate whole artifacts and need no
 change.
-
-## Problem codes
-
-- `P4039` — the library for the active dialect could not be located or read
-  (REQ-LIB-sources-140). Next free code in the analyzer `P40xx` range; final
-  number allocated when implemented, documented under
-  `docs/reference/compiler/problems/`.
 
 ## Requirement ownership summary
 
@@ -174,9 +184,10 @@ One area code, `LIB`, partitioned by owning crate:
 
 | Block | Slug (crate) | Concern |
 |-------|--------------|---------|
-| `1xx` | `sources` | library location, dialect selection, disk delivery, runtime path resolution, load diagnostic, compile check |
+| `1xx` | `sources` | library location, explicit selection, disk delivery, runtime path resolution, `PI` content, compile check |
+| `2xx` | `parser` | per-file compiler-flag pragma |
 | `3xx` | `analyzer` | library exports in scope, duplicate-definition on collision |
-| `4xx` | `codegen` | reachability-pruned linking of library POUs |
+| `4xx` | `codegen` | reachability-pruned linking of POUs and global constants |
 
 Final slug placement for any requirement is confirmed when its slice wires the
 doc into that crate's `build.rs`.
@@ -190,32 +201,40 @@ enforcement is turned on once, up front.
 
 - **PR 1 — this document.** Design only; not wired into any `build.rs`.
 - **PR 2 — enforcement bootstrap.** Wire `library-support.md` into the `build.rs`
-  of every owning crate (`sources`, `analyzer`, `codegen`) and add `#[ignore]`d
-  `#[spec_test]` stubs for every requirement, so the requirements become
-  enforced-but-pending (mirrors how `reference-to-twincat.md` established
-  enforcement). Each later PR removes `#[ignore]` as it implements.
-- **PR 3 — library skeleton + compile check** (`sources`): create
-  `compiler/library/<dialect>/`, add one or two trivially-correct `.st` POUs, and
-  the REQ-LIB-sources-190 compile-check test. Small; locks in the guardrail first
-  and unblocks authoring.
-- **PR 4 — delivery + packaging** (`sources`): install the library alongside the
+  of every owning crate (`sources`, `parser`, `analyzer`, `codegen`) and add
+  `#[ignore]`d `#[spec_test]` stubs for every requirement (mirrors how
+  `reference-to-twincat.md` established enforcement). Each later PR removes
+  `#[ignore]` as it implements.
+- **PR 3 — per-file flag pragma** (`parser`): the pragma that lets a file enable
+  the flag `PI` needs (a global constant block); REQ-LIB-parser-200. Prerequisite
+  for the `PI` library.
+- **PR 4 — first library (`PI`) + compile check** (`sources`): create
+  `compiler/library/<name>/` defining `PI` with the pragma from PR 3, and the
+  REQ-LIB-sources-190 compile-check test; REQ-LIB-sources-100/102/180/190. Locks
+  in the guardrail and gives a concrete first library.
+- **PR 5 — delivery + packaging** (`sources`): install the library alongside the
   binary and resolve it at runtime relative to the executable; update all
-  installers; REQ-LIB-sources-110/140.
-- **PR 5 — pipeline integration** (`sources` + `analyzer` + `codegen`): load the
-  dialect's library into every compilation; exports resolve; duplicate-definition
-  on collision; reachability-pruned linking; REQ-LIB-analyzer-300/330,
+  installers; REQ-LIB-sources-110.
+- **PR 6 — selection + pipeline integration** (`sources` + `analyzer` +
+  `codegen`): opt-in selection by compiler flag and/or project-config reference;
+  merge selected libraries into the compilation; exports resolve;
+  duplicate-definition on collision; reachability pruning extended to global
+  constants; REQ-LIB-sources-130, REQ-LIB-analyzer-300/330,
   REQ-LIB-codegen-400/410.
-- **PR 6+ — library content**: port stdlib functions from Rust to library source
-  incrementally; user documentation.
+- **PR 7+ — additional libraries + docs.** Add further compatibility libraries as
+  needed and user documentation. (No porting of the Rust-baked stdlib — it
+  remains.)
 
-Rough order: PR 2 → PR 3 → PR 4 → PR 5 → PR 6+.
+Rough order: PR 2 → PR 3 → PR 4 → PR 5 → PR 6 → PR 7+.
 
 ## Relationship to existing work and ADRs
 
-- **Foundational for #1199 and reframes #1217.** Functions IronPLC lacks become
-  library content rather than per-function `--allow-*` flags. Functions that need
-  new compiler/VM primitives (`LTRUNC`/`LMOD`) are a follow-on design that builds
-  on this library foundation.
+- **Reframes #1219 and #1217.** `PI` (#1219) becomes this design's first library
+  (source, not a compiler flag). `LTRUNC`/`LMOD` (#1217) become library content
+  once the follow-on primitives design lands. Both stop being per-function
+  `--allow-*` flags.
+- **Additive, not a replacement.** The Rust-baked standard library remains; this
+  ships *additional* compatibility content as source.
 - Complements **[ADR-0012](../adrs/0012-accept-vendor-dialect-files-as-is.md)**
   (accept vendor dialect files as-is) — the library provides the compatibility
   counterpart in IronPLC-authored source.
@@ -225,9 +244,12 @@ Rough order: PR 2 → PR 3 → PR 4 → PR 5 → PR 6+.
 
 ### Decisions to ratify as ADRs
 
-1. IronPLC ships a **source** library compiled by the normal pipeline, replacing
-   the Rust-baked stdlib.
-2. IronPLC authors its own **compatibility libraries**; it does not redistribute
+1. IronPLC ships **source** compatibility libraries compiled by the normal
+   pipeline, **additive to** (not replacing) the Rust-baked standard library.
+2. IronPLC authors its own compatibility libraries; it does not redistribute
    third-party vendor libraries.
-3. Library files are **installed alongside the binary and loaded from disk**
-   (visible and extensible), not embedded.
+3. Libraries are opted into **explicitly** (compiler flag and/or project
+   reference); dialects do not select libraries.
+4. Library files are **installed alongside the binary and loaded from disk**.
+5. A library declares the compiler flags it needs via a **pragma** (general,
+   file-scoped).

--- a/specs/design/library-support.md
+++ b/specs/design/library-support.md
@@ -1,0 +1,353 @@
+# Design: Library Support
+
+## Status
+
+Design document for the library-support subsystem. This PR contains the design
+only — the requirement markers below are **not yet enforced** (the doc is not
+listed in any crate's `build.rs`, so the spec-conformance guard does not scan
+it). Each implementation slice wires the doc into its owning crate's `build.rs`
+and adds the `#[spec_test]` tests for the requirements it implements. See
+[Implementation Breakdown](#implementation-breakdown). This is expected to land
+as multiple PRs.
+
+## Overview
+
+IronPLC has no library mechanism. Its "standard library" (TON, CTU, string
+functions, …) is hand-written Rust baked into the compiler and registered
+programmatically (`analyzer/src/stages.rs`, `analyzer/src/stdlib.rs`). When a
+vendor function is missing — e.g. Beckhoff's `LTRUNC`/`LMOD`
+([#1217](https://github.com/ironplc/ironplc/pull/1217), part of #1199) — the
+current path is to register a single signature behind a per-function
+`--allow-*` flag. That approach does not scale (one flag and one code change per
+function), miscategorizes ordinary functions as compiler intrinsics, and ships
+no implementation (the signature type-checks, then codegen has nothing to emit).
+
+This design introduces a real **library** mechanism, following the approach used
+by other compilers: a **bundled standard library shipped as source**, implicitly
+available like a prelude; **additional libraries referenced explicitly** and
+resolved from a search path; all library code compiled through the **same
+pipeline** as user code; and a small set of **VM primitives** for the few
+operations that cannot be expressed in the language itself.
+
+### Goals
+
+- Ship IronPLC's own standard library as IEC 61131-3 **source** the compiler
+  reads, not Rust baked into the binary.
+- Let user programs use library POUs/types by **referencing** a library, with a
+  standard library available by default.
+- Verify in **CI that every bundled library file compiles**, so the library
+  cannot silently break.
+- Ship the library files with every installer.
+- Provide the **primitive opcodes** that let library functions like
+  `LTRUNC`/`LMOD` be authored outside the compiler.
+
+### Non-goals
+
+- **Redistributing third-party vendor libraries** (Beckhoff `Tc2_*`, etc.).
+  IronPLC ships only its own library. Consuming a user's *installed* vendor
+  libraries is a downstream extension that reuses this design's reference and
+  resolution mechanism; it is out of scope here.
+- A full namespace / version / transitive-dependency resolver. First cut is
+  name-based resolution of a flat set of bundles.
+
+### Approach: what other compilers do
+
+This mirrors the conventional model:
+
+- A **bundled standard library** ships with the toolchain and is implicitly in
+  scope (Rust's `std`/prelude, Go's `std`, the C runtime on the default include
+  path). `--no-stdlib` opts out, as `#![no_std]` does.
+- **Additional libraries are referenced explicitly** and resolved from a
+  **search path** (Rust `extern crate` + `-L`, C `#include` + `-I`, CODESYS/
+  TwinCAT library references + repository).
+- Library code is **ordinary source** compiled by the same front end. The
+  compiler already supports this: `analyze()` merges all units into one library
+  and `xform_toposort_declarations` prunes everything unreachable from a PROGRAM
+  root, so a large library can be supplied and only used POUs are emitted.
+- The rare function that the language cannot express (e.g. a float→float
+  truncation) binds to a **compiler/VM primitive**. Per ADR-0008 these are
+  `func_id`s under the single `BUILTIN` opcode, so the compiler grows
+  *primitives*, not *functions*.
+
+## Architecture
+
+### Library source location and authoring
+
+**REQ-LIB-sources-100** IronPLC ships a standard library of IEC 61131-3 source
+files under `compiler/library/`. Each immediate subdirectory of
+`compiler/library/` is one named library bundle (the directory name is the
+bundle name).
+
+**REQ-LIB-sources-101** The bundle named `standard` is available to every
+compilation by default, without an explicit reference, unless `--no-stdlib` is
+set.
+
+**REQ-LIB-sources-102** Library source files use the same Structured Text / IEC
+syntax and file extensions (`.st`, `.iec`) as user source and are parsed by the
+same parser with no library-only grammar.
+
+Keeping the files as real source under `compiler/library/` (rather than Rust
+string literals) makes them reviewable, diffable, editable by contributors, and
+— critically — **compilable by the same CI that builds user programs** (see
+[Build-time compile check](#build-time-compile-check)).
+
+### Delivery to the compiler — Open decision D1
+
+The library files must reach the *installed* compiler. Two mechanisms, both
+keeping the source under `compiler/library/`:
+
+- **Option A — Embed at build time (recommended).** A `build.rs` generator emits
+  the bundle contents into the binary via `include_str!` (the pattern already
+  used for embedded spec/schema text, e.g. `mcp/build.rs`). The installed
+  `ironplcc` carries the library with it; no runtime filesystem lookup; behaves
+  identically in tests, CI, and production; **no installer changes required**.
+- **Option B — Install alongside the binary.** Ship the `compiler/library/` tree
+  into the install layout (`$INSTDIR/lib`, `$HOME/.ironplc/lib`) and resolve it
+  at runtime relative to the executable. Requires **new runtime path-resolution
+  code** (none exists today) and edits to all four installers (see
+  [Packaging](#packaging-and-installers)).
+
+**Recommendation: Option A.** It matches how the compiler already ships and reads
+bundled files, eliminates a class of "library not found next to the binary"
+runtime failures, and needs no installer work. Option B's only advantages are
+post-install visibility and user-editability of the files, which a standard
+library does not need. This is the primary decision to confirm on this PR.
+
+The requirements below are written to hold under either option; those specific
+to Option A are marked.
+
+**REQ-LIB-sources-110** Library bundle sources are available to the compiler
+independent of the current working directory and of the user's project
+directory.
+
+**REQ-LIB-sources-111** *(Option A)* Library sources are embedded into the
+`ironplcc` binary at build time; the installed compiler loads them with no
+filesystem access.
+
+**REQ-LIB-sources-120** Elements originating from a library bundle are tagged
+with a builtin/library `FileId` (see `FileId::builtin()` in `dsl/src/core.rs`)
+distinct from any user `FileId`, so diagnostics and debug info attribute them to
+the library rather than to a user file.
+
+### Reference and resolution
+
+**REQ-LIB-sources-130** A library reference names a bundle. The compiler resolves
+the bundle by name against a **library search path**: the built-in/bundled set
+plus any directories added via `--library-path`.
+
+**REQ-LIB-sources-131** When a project is discovered from a `.plcproj`, each
+`<LibraryReference>` / placeholder entry in the project file is extracted as a
+library reference (discovery currently reads only `<Compile Include>`).
+
+**REQ-LIB-sources-140** Referencing a bundle that cannot be resolved on the
+search path produces a diagnostic (proposed `P4039`, "referenced library not
+found") naming the missing bundle, rather than a generic error.
+
+**REQ-LIB-parser-200** The `--no-stdlib` compiler option disables the implicit
+availability of the `standard` bundle.
+
+**REQ-LIB-parser-210** The `--library <name>` compiler option references an
+additional bundle by name; it is repeatable.
+
+**REQ-LIB-parser-220** The `--library-path <dir>` compiler option adds a
+directory to the library search path; it is repeatable.
+
+These three become fields on `CompilerOptions` (owned by the `parser` crate),
+wired through the CLI `FileArgs` alongside the existing `--allow-*` flags.
+
+### Semantic integration
+
+**REQ-LIB-analyzer-300** POUs, types, and global variables exported by an
+in-scope library bundle resolve in user code as if declared in the compilation,
+using the existing merge performed by `analyze()`.
+
+**REQ-LIB-analyzer-310** A bundle's exports are in scope only when the bundle is
+referenced. The `standard` bundle is implicitly referenced unless `--no-stdlib`;
+all other bundles are in scope only when referenced via `--library`,
+`--library-path`, or a project `<LibraryReference>`.
+
+**REQ-LIB-analyzer-320** A call to a function that exists only in a bundle that
+is **not** referenced produces a diagnostic (proposed `P4040`, "function
+requires an unreferenced library") that names the bundle providing it, distinct
+from the generic undeclared-function diagnostic (`P4017`).
+
+**REQ-LIB-analyzer-330** A user declaration whose name matches a library export
+shadows the library export within the user compilation (local-over-library
+precedence); it is not a redefinition error.
+
+**REQ-LIB-analyzer-340** A function declared with an external-binding attribute
+(see [Primitive-backed functions](#primitive-backed-library-functions)) is
+treated as declared — no undeclared-function diagnostic — and its signature is
+taken from the declaration.
+
+### Code generation and linking
+
+**REQ-LIB-codegen-400** Library POUs reachable from a PROGRAM root are compiled
+and linked into the output container; library POUs not reachable from any
+PROGRAM root are omitted (the existing `xform_toposort_declarations` reachability
+pass, applied to merged library + user code).
+
+**REQ-LIB-codegen-410** A call to a source-implemented library function is
+compiled as a `CALL` to the compiled library POU, using the same path as a call
+to a user-defined function.
+
+**REQ-LIB-codegen-420** A call to an external-binding library function emits the
+bound `BUILTIN` opcode inline at the call site (no `CALL` frame), the way
+`compile_trunc` already inlines its conversion.
+
+### Primitive-backed library functions
+
+Most of a library is ordinary ST. A few functions need an operation the language
+cannot express; those bind to a VM primitive. `LTRUNC`/`LMOD` are the motivating
+case — the VM today has no float→float truncation and no floating-point modulo.
+
+**REQ-LIB-container-500** The `BUILTIN` `func_id` table defines float truncation
+(`TRUNC_F32`, `TRUNC_F64`) and floating-point modulo (`MOD_F32`, `MOD_F64`)
+primitives, with corresponding `arg_count` entries (ADR-0008; no new opcode
+slots).
+
+**REQ-LIB-vm-550** Executing a float-truncation primitive removes the operand's
+fractional part toward zero and yields a float of the same width; the result is
+**not** clamped to any integer type's range.
+
+**REQ-LIB-vm-551** Executing a floating-point-modulo primitive yields the
+floating remainder such that `MOD_F64(400.56, 360.0) = 40.56`; a zero divisor
+yields NaN (consistent with float division).
+
+The binding surface has two tiers, matching the two categories of library
+function:
+
+| Kind | Declaration | Codegen |
+|------|-------------|---------|
+| External-binding alias (`LTRUNC`, `LMOD`) | `{external := 'TRUNC_F64'}`, no body | inline `BUILTIN` (REQ-LIB-codegen-420) |
+| Source POU (most functions) | ordinary ST body | compile + link + prune (REQ-LIB-codegen-400/410) |
+
+With these primitives in place, `LTRUNC`/`LMOD` are declared in the bundled
+library as external aliases — no per-function `--allow-*` flag, no bespoke
+codegen arm — and adding the next float-trunc/mod-based function is pure library
+content.
+
+### Build-time compile check
+
+**REQ-LIB-sources-190** Every source file under `compiler/library/` parses,
+analyzes, and compiles to a container without error. CI fails if any bundled
+library file does not compile.
+
+This is implemented as an integration test that runs the real `check()` +
+`compile()` entry points over the `compiler/library/` tree (directory input is
+already supported; see the existing `check(&[resource_path("set")], …)` test in
+`ironplc-cli/src/cli.rs`) and asserts success. It runs as part of `just`
+(`compile`/`coverage`) so a change that breaks a library file fails CI the same
+as any other test. It is the guardrail the current Rust-baked stdlib lacks.
+
+## Packaging and installers
+
+Under **Option A (embed)** no installer changes are needed — the library rides
+inside the binary. Under **Option B (install alongside)** the following change,
+staging `compiler/library/` into each install layout the way `bom.cdx.json` is
+staged today:
+
+- `compiler/justfile` `_package-macos` / `_package-linux`: `cp -r` the library
+  tree into `target/<target>/release/` and add it to the `tar` argument list
+  (alongside `ironplcc ironplcvm ironplcmcp bom.cdx.json`).
+- `compiler/setup.nsi`: a new section `SetOutPath "$INSTDIR\lib"` +
+  `File /r "..\library\*"`, mirroring the existing `$INSTDIR\examples` section.
+- `compiler/install.sh`: after extraction, copy the `lib` directory into
+  `${INSTALL_DIR}/lib` (the script currently extracts only named binaries).
+- `compiler/homebrew/Formula/ironplc.rb`: `(share/"ironplc").install Dir["lib/*"]`.
+- New runtime path-resolution to locate `lib` relative to the executable.
+
+The existing release workflows (`partial_compiler.yaml`,
+`partial_upload_release_artifacts.yaml`) manipulate whole artifacts and need no
+change under either option.
+
+## Problem codes
+
+Two new compiler diagnostics are introduced (next free codes in the analyzer
+`P40xx` range; final numbers allocated when implemented, documented under
+`docs/reference/compiler/problems/`):
+
+- `P4039` — referenced library not found on the search path (REQ-LIB-sources-140).
+- `P4040` — function requires a library that is not referenced (REQ-LIB-analyzer-320).
+
+## Requirement ownership summary
+
+One area code, `LIB`, partitioned by owning crate in hundreds-blocks per the
+`reference-to-twincat.md` convention:
+
+| Block | Slug (crate) | Concern |
+|-------|--------------|---------|
+| `1xx` | `sources` | bundle location, delivery, `FileId` tagging, search-path resolution, `.plcproj` reference extraction, not-found diagnostic, compile check |
+| `2xx` | `parser` | `CompilerOptions` (`--no-stdlib`, `--library`, `--library-path`) |
+| `3xx` | `analyzer` | reference-gated scoping, shadowing, external-binding recognition, unreferenced-library diagnostic |
+| `4xx` | `codegen` | reachability-pruned linking of library POUs, external-binding inlining |
+| `5xx` | `container` / `vm` | float trunc/mod `BUILTIN` primitives |
+
+Final slug placement for any requirement is confirmed when its slice wires the
+doc into that crate's `build.rs`.
+
+## Implementation Breakdown
+
+The work is large; it splits into independently reviewable PRs. Because the
+spec-conformance orphan guard treats a doc as "enforced" only once a `build.rs`
+lists it — and then requires **every** slug used in the doc to be claimed by a
+listing crate — enforcement is best turned on once, up front, rather than
+incrementally.
+
+- **PR 1 — this document.** Design only; not wired into any `build.rs`; CI-neutral.
+- **PR 2 — enforcement bootstrap.** Wire `library-support.md` into the `build.rs`
+  of every owning crate (`sources`, `parser`, `analyzer`, `codegen`, `container`,
+  `vm`) and add `#[ignore]`d `#[spec_test]` stubs for every requirement, so the
+  requirements become enforced-but-pending (mirrors how `reference-to-twincat.md`
+  established enforcement). Each later PR removes `#[ignore]` as it implements.
+- **PR 3 — library skeleton + compile check** (`sources`): create
+  `compiler/library/standard/`, add one or two trivially-correct `.st` POUs, and
+  the REQ-LIB-sources-190 compile-check test. Small, unblocks authoring.
+- **PR 4 — delivery** (`sources`): implement Option A embed generator (or Option
+  B install path + packaging), satisfying REQ-LIB-sources-110/111/120.
+- **PR 5 — pipeline loading + options** (`sources` + `parser`): `--no-stdlib` /
+  `--library` / `--library-path`; inject bundled sources into every compilation;
+  REQ-LIB-parser-2xx, REQ-LIB-sources-130.
+- **PR 6 — reference gating + diagnostics** (`analyzer` + `sources`):
+  reference-gated scoping, shadowing, `P4039`/`P4040`; `.plcproj`
+  `<LibraryReference>` extraction; REQ-LIB-analyzer-300/310/320/330,
+  REQ-LIB-sources-131/140.
+- **PR 7 — float primitives** (`container` + `vm`): `TRUNC_*`/`MOD_*`
+  `BUILTIN`s; REQ-LIB-container-500, REQ-LIB-vm-550/551. Independent — can land
+  in parallel with PRs 3–6.
+- **PR 8 — external binding + codegen** (`analyzer` + `codegen`): external-binding
+  attribute, inline-`BUILTIN` codegen; REQ-LIB-analyzer-340,
+  REQ-LIB-codegen-400/410/420.
+- **PR 9 — `LTRUNC`/`LMOD` as library content**: declare them in
+  `compiler/library/standard/` as external aliases to the PR 7 primitives; remove
+  the `--allow-extended-math-functions` flag and the analyzer/#1217 signature
+  registration. This is the end-to-end proof: the functions compile *and run*.
+- **PR 10+ — library content + docs**: port the rest of the Rust-baked stdlib to
+  library source incrementally; user documentation.
+
+Rough dependency order: PR 2 → (PR 3 → PR 4 → PR 5 → PR 6) and (PR 7) in
+parallel → PR 8 → PR 9 → PR 10+.
+
+## Relationship to existing work and ADRs
+
+- **Reframes #1217.** `LTRUNC`/`LMOD` become two VM primitives plus a library
+  alias (PRs 7 + 9), not a per-function flag. Recommendation: do not merge the
+  flag; land them via the library.
+- Builds on **[ADR-0008](../adrs/0008-unified-builtin-opcode.md)** (unified
+  `BUILTIN` opcode — the primitive-extension surface),
+  **[ADR-0003](../adrs/0003-plc-standard-function-blocks-as-intrinsics.md)**
+  (intrinsics recognized at dispatch), and
+  **[ADR-0012](../adrs/0012-accept-vendor-dialect-files-as-is.md)**.
+- Related conformance mechanics:
+  **[cross-crate-spec-conformance.md](cross-crate-spec-conformance.md)** and
+  **[ADR-0037](../adrs/0037-mandatory-crate-slug-in-requirement-ids.md)**.
+
+### Decisions to ratify as ADRs
+
+1. IronPLC ships a **source** standard library compiled by the normal pipeline,
+   replacing the Rust-baked stdlib.
+2. Library availability is expressed by **references** (with an implicit standard
+   library), not per-function `--allow-*` flags.
+3. External library functions bind to `BUILTIN` **primitives** — the compiler
+   grows opcodes, not functions.
+4. Delivery mechanism — embed vs install-alongside (Open decision D1).

--- a/specs/design/library-support.md
+++ b/specs/design/library-support.md
@@ -1,250 +1,149 @@
 # Design: Library Support
 
-## Status
-
-Design document for the library-support subsystem. This PR contains the design
-only — the requirement markers below are **not yet enforced** (the doc is not
-listed in any crate's `build.rs`, so the spec-conformance guard does not scan
-it). Each implementation slice wires the doc into its owning crate's `build.rs`
-and adds the `#[spec_test]` tests for the requirements it implements. See
-[Implementation Breakdown](#implementation-breakdown). This is expected to land
-as multiple PRs.
-
 ## Overview
 
 IronPLC has no library mechanism. Its "standard library" (TON, CTU, string
 functions, …) is hand-written Rust baked into the compiler and registered
-programmatically (`analyzer/src/stages.rs`, `analyzer/src/stdlib.rs`). When a
-vendor function is missing — e.g. Beckhoff's `LTRUNC`/`LMOD`
-([#1217](https://github.com/ironplc/ironplc/pull/1217), part of #1199) — the
-current path is to register a single signature behind a per-function
-`--allow-*` flag. That approach does not scale (one flag and one code change per
-function), miscategorizes ordinary functions as compiler intrinsics, and ships
-no implementation (the signature type-checks, then codegen has nothing to emit).
+programmatically (`analyzer/src/stages.rs`, `analyzer/src/stdlib.rs`). Every
+function IronPLC lacks — e.g. Beckhoff's `LTRUNC`/`LMOD`
+([#1217](https://github.com/ironplc/ironplc/pull/1217), part of #1199) — today
+requires new Rust and, often, a per-function `--allow-*` flag. That does not
+scale and pushes ordinary library functions into the compiler.
 
-This design introduces a real **library** mechanism, following the approach used
-by other compilers: a **bundled standard library shipped as source**, implicitly
-available like a prelude; **additional libraries referenced explicitly** and
-resolved from a search path; all library code compiled through the **same
-pipeline** as user code; and a small set of **VM primitives** for the few
-operations that cannot be expressed in the language itself.
+This design introduces a **library**: IronPLC's own IEC 61131-3 **source** that
+the compiler reads and compiles through the same pipeline as user code, shipped
+with the compiler and installed alongside it. It follows the conventional model
+— a library that ships with the toolchain and is available to every program,
+like a language's standard library.
+
+IronPLC provides its **own** libraries. It does **not** redistribute third-party
+vendor libraries (Beckhoff `Tc2_*`, etc.) — that is a licensing non-starter.
+Instead, to be compatible with vendor and edition dialects, IronPLC provides
+**compatibility libraries** it authors itself.
+
+### Scope
+
+**In scope:** shipping a single IronPLC-authored library as `.st` source,
+selected by the active dialect/edition, loaded from disk, compiled by the normal
+pipeline, verified by CI, and installed with the compiler.
+
+**Out of scope (future designs):**
+
+- *How to offer multiple or vendor-specific compatibility libraries* and
+  reference them individually. For now IronPLC offers a single dialect-matched
+  library.
+- Functions that require an operation the language cannot express (a float→float
+  truncation, etc.) and the compiler/VM support they need. `LTRUNC`/`LMOD` fall
+  here and are deferred to a follow-on design; this design builds the library
+  foundation they will use.
 
 ### Goals
 
-- Ship IronPLC's own standard library as IEC 61131-3 **source** the compiler
-  reads, not Rust baked into the binary.
-- Let user programs use library POUs/types by **referencing** a library, with a
-  standard library available by default.
-- Verify in **CI that every bundled library file compiles**, so the library
-  cannot silently break.
-- Ship the library files with every installer.
-- Provide the **primitive opcodes** that let library functions like
-  `LTRUNC`/`LMOD` be authored outside the compiler.
-
-### Non-goals
-
-- **Redistributing third-party vendor libraries** (Beckhoff `Tc2_*`, etc.).
-  IronPLC ships only its own library. Consuming a user's *installed* vendor
-  libraries is a downstream extension that reuses this design's reference and
-  resolution mechanism; it is out of scope here.
-- A full namespace / version / transitive-dependency resolver. First cut is
-  name-based resolution of a flat set of bundles.
+- Ship IronPLC's library as IEC 61131-3 `.st` source the compiler reads, not
+  Rust baked into the binary.
+- Make the dialect-appropriate library available to every compilation.
+- Install the library files alongside the compiler so users can see and read
+  them.
+- Verify in CI that every shipped library file compiles.
 
 ### Approach: what other compilers do
 
-This mirrors the conventional model:
-
-- A **bundled standard library** ships with the toolchain and is implicitly in
-  scope (Rust's `std`/prelude, Go's `std`, the C runtime on the default include
-  path). `--no-stdlib` opts out, as `#![no_std]` does.
-- **Additional libraries are referenced explicitly** and resolved from a
-  **search path** (Rust `extern crate` + `-L`, C `#include` + `-I`, CODESYS/
-  TwinCAT library references + repository).
+- A library ships with the toolchain and is available by default (Rust's
+  `std`/prelude, Go's `std`, the C runtime).
 - Library code is **ordinary source** compiled by the same front end. The
   compiler already supports this: `analyze()` merges all units into one library
   and `xform_toposort_declarations` prunes everything unreachable from a PROGRAM
-  root, so a large library can be supplied and only used POUs are emitted.
-- The rare function that the language cannot express (e.g. a float→float
-  truncation) binds to a **compiler/VM primitive**. Per ADR-0008 these are
-  `func_id`s under the single `BUILTIN` opcode, so the compiler grows
-  *primitives*, not *functions*.
+  root, so the library can be supplied and only used POUs are emitted.
 
 ## Architecture
 
-### Library source location and authoring
+### Library source
 
-**REQ-LIB-sources-100** IronPLC ships a standard library of IEC 61131-3 source
-files under `compiler/library/`. Each immediate subdirectory of
-`compiler/library/` is one named library bundle (the directory name is the
-bundle name).
-
-**REQ-LIB-sources-101** The bundle named `standard` is available to every
-compilation by default, without an explicit reference, unless `--no-stdlib` is
-set.
-
-**REQ-LIB-sources-102** Library source files use the same Structured Text / IEC
-syntax and file extensions (`.st`, `.iec`) as user source and are parsed by the
-same parser with no library-only grammar.
-
-Keeping the files as real source under `compiler/library/` (rather than Rust
-string literals) makes them reviewable, diffable, editable by contributors, and
-— critically — **compilable by the same CI that builds user programs** (see
-[Build-time compile check](#build-time-compile-check)).
-
-### Delivery to the compiler — Open decision D1
-
-The library files must reach the *installed* compiler. Two mechanisms, both
-keeping the source under `compiler/library/`:
-
-- **Option A — Embed at build time (recommended).** A `build.rs` generator emits
-  the bundle contents into the binary via `include_str!` (the pattern already
-  used for embedded spec/schema text, e.g. `mcp/build.rs`). The installed
-  `ironplcc` carries the library with it; no runtime filesystem lookup; behaves
-  identically in tests, CI, and production; **no installer changes required**.
-- **Option B — Install alongside the binary.** Ship the `compiler/library/` tree
-  into the install layout (`$INSTDIR/lib`, `$HOME/.ironplc/lib`) and resolve it
-  at runtime relative to the executable. Requires **new runtime path-resolution
-  code** (none exists today) and edits to all four installers (see
-  [Packaging](#packaging-and-installers)).
-
-**Recommendation: Option A.** It matches how the compiler already ships and reads
-bundled files, eliminates a class of "library not found next to the binary"
-runtime failures, and needs no installer work. Option B's only advantages are
-post-install visibility and user-editability of the files, which a standard
-library does not need. This is the primary decision to confirm on this PR.
-
-The requirements below are written to hold under either option; those specific
-to Option A are marked.
-
-**REQ-LIB-sources-110** Library bundle sources are available to the compiler
-independent of the current working directory and of the user's project
+**REQ-LIB-sources-100** IronPLC ships library source under `compiler/library/`.
+Each immediate subdirectory of `compiler/library/` is one library, named by the
 directory.
 
-**REQ-LIB-sources-111** *(Option A)* Library sources are embedded into the
-`ironplcc` binary at build time; the installed compiler loads them with no
-filesystem access.
+**REQ-LIB-sources-101** A library is named to match a dialect/edition (the same
+names the compiler uses for its dialects), so the standard library can differ by
+IEC 61131-3 edition. The library matching the active dialect is available to
+every compilation by default. IronPLC ships a single such library initially.
 
-**REQ-LIB-sources-120** Elements originating from a library bundle are tagged
-with a builtin/library `FileId` (see `FileId::builtin()` in `dsl/src/core.rs`)
-distinct from any user `FileId`, so diagnostics and debug info attribute them to
-the library rather than to a user file.
+**REQ-LIB-sources-102** Library source files are `.st` files, parsed by the same
+parser as user source with no library-only grammar.
 
-### Reference and resolution
+Keeping the files as real `.st` source (rather than Rust string literals) makes
+them reviewable, diffable, editable, **visible to users after install**, and —
+critically — compilable by the same CI that builds user programs (see
+[Build-time compile check](#build-time-compile-check)).
 
-**REQ-LIB-sources-130** A library reference names a bundle. The compiler resolves
-the bundle by name against a **library search path**: the built-in/bundled set
-plus any directories added via `--library-path`.
+### Delivery: installed alongside the binary
 
-**REQ-LIB-sources-131** When a project is discovered from a `.plcproj`, each
-`<LibraryReference>` / placeholder entry in the project file is extracted as a
-library reference (discovery currently reads only `<Compile Include>`).
+Library files are shipped as files and installed next to the compiler, then
+loaded from disk at runtime. This keeps the library **visible and readable to
+users** and makes the set **extensible** — adding or adjusting a library is a
+file change, not a compiler rebuild.
 
-**REQ-LIB-sources-140** Referencing a bundle that cannot be resolved on the
-search path produces a diagnostic (proposed `P4039`, "referenced library not
-found") naming the missing bundle, rather than a generic error.
+**REQ-LIB-sources-110** The compiler locates its library directory relative to
+the installed executable, independent of the current working directory and of
+the user's project directory.
 
-**REQ-LIB-parser-200** The `--no-stdlib` compiler option disables the implicit
-availability of the `standard` bundle.
+**REQ-LIB-sources-140** If the library for the active dialect cannot be located
+or read, the compiler emits a clear diagnostic (proposed `P4039`) identifying
+the missing library, rather than silently omitting standard functions.
 
-**REQ-LIB-parser-210** The `--library <name>` compiler option references an
-additional bundle by name; it is repeatable.
-
-**REQ-LIB-parser-220** The `--library-path <dir>` compiler option adds a
-directory to the library search path; it is repeatable.
-
-These three become fields on `CompilerOptions` (owned by the `parser` crate),
-wired through the CLI `FileArgs` alongside the existing `--allow-*` flags.
+Because the library is read from disk as ordinary files, its elements carry
+normal file-based `FileId`s — no special builtin tagging is needed, and
+diagnostics and debug info point at the real library file on disk.
 
 ### Semantic integration
 
-**REQ-LIB-analyzer-300** POUs, types, and global variables exported by an
-in-scope library bundle resolve in user code as if declared in the compilation,
-using the existing merge performed by `analyze()`.
+**REQ-LIB-analyzer-300** POUs, types, and global variables exported by the
+active library resolve in user code as if declared in the compilation, using the
+existing merge performed by `analyze()`.
 
-**REQ-LIB-analyzer-310** A bundle's exports are in scope only when the bundle is
-referenced. The `standard` bundle is implicitly referenced unless `--no-stdlib`;
-all other bundles are in scope only when referenced via `--library`,
-`--library-path`, or a project `<LibraryReference>`.
-
-**REQ-LIB-analyzer-320** A call to a function that exists only in a bundle that
-is **not** referenced produces a diagnostic (proposed `P4040`, "function
-requires an unreferenced library") that names the bundle providing it, distinct
-from the generic undeclared-function diagnostic (`P4017`).
-
-**REQ-LIB-analyzer-330** A user declaration whose name matches a library export
-shadows the library export within the user compilation (local-over-library
-precedence); it is not a redefinition error.
-
-**REQ-LIB-analyzer-340** A function declared with an external-binding attribute
-(see [Primitive-backed functions](#primitive-backed-library-functions)) is
-treated as declared — no undeclared-function diagnostic — and its signature is
-taken from the declaration.
+**REQ-LIB-analyzer-330** A user declaration whose name collides with a library
+export is a duplicate-definition error, reported with the existing
+duplicate-definition diagnostic — the same as colliding with any other
+declaration.
 
 ### Code generation and linking
 
 **REQ-LIB-codegen-400** Library POUs reachable from a PROGRAM root are compiled
-and linked into the output container; library POUs not reachable from any
-PROGRAM root are omitted (the existing `xform_toposort_declarations` reachability
-pass, applied to merged library + user code).
+and linked into the output container; library POUs not reachable from any PROGRAM
+root are omitted (the existing `xform_toposort_declarations` reachability pass,
+applied to merged library + user code).
 
-**REQ-LIB-codegen-410** A call to a source-implemented library function is
-compiled as a `CALL` to the compiled library POU, using the same path as a call
-to a user-defined function.
-
-**REQ-LIB-codegen-420** A call to an external-binding library function emits the
-bound `BUILTIN` opcode inline at the call site (no `CALL` frame), the way
-`compile_trunc` already inlines its conversion.
-
-### Primitive-backed library functions
-
-Most of a library is ordinary ST. A few functions need an operation the language
-cannot express; those bind to a VM primitive. `LTRUNC`/`LMOD` are the motivating
-case — the VM today has no float→float truncation and no floating-point modulo.
-
-**REQ-LIB-container-500** The `BUILTIN` `func_id` table defines float truncation
-(`TRUNC_F32`, `TRUNC_F64`) and floating-point modulo (`MOD_F32`, `MOD_F64`)
-primitives, with corresponding `arg_count` entries (ADR-0008; no new opcode
-slots).
-
-**REQ-LIB-vm-550** Executing a float-truncation primitive removes the operand's
-fractional part toward zero and yields a float of the same width; the result is
-**not** clamped to any integer type's range.
-
-**REQ-LIB-vm-551** Executing a floating-point-modulo primitive yields the
-floating remainder such that `MOD_F64(400.56, 360.0) = 40.56`; a zero divisor
-yields NaN (consistent with float division).
-
-The binding surface has two tiers, matching the two categories of library
-function:
-
-| Kind | Declaration | Codegen |
-|------|-------------|---------|
-| External-binding alias (`LTRUNC`, `LMOD`) | `{external := 'TRUNC_F64'}`, no body | inline `BUILTIN` (REQ-LIB-codegen-420) |
-| Source POU (most functions) | ordinary ST body | compile + link + prune (REQ-LIB-codegen-400/410) |
-
-With these primitives in place, `LTRUNC`/`LMOD` are declared in the bundled
-library as external aliases — no per-function `--allow-*` flag, no bespoke
-codegen arm — and adding the next float-trunc/mod-based function is pure library
-content.
+**REQ-LIB-codegen-410** A call to a library function is compiled as a `CALL` to
+the compiled library POU, using the same path as a call to a user-defined
+function.
 
 ### Build-time compile check
 
 **REQ-LIB-sources-190** Every source file under `compiler/library/` parses,
-analyzes, and compiles to a container without error. CI fails if any bundled
+analyzes, and compiles to a container without error. CI fails if any shipped
 library file does not compile.
 
-This is implemented as an integration test that runs the real `check()` +
-`compile()` entry points over the `compiler/library/` tree (directory input is
-already supported; see the existing `check(&[resource_path("set")], …)` test in
+Implemented as an integration test that runs the real `check()` + `compile()`
+entry points over the `compiler/library/` tree (directory input is already
+supported; see the existing `check(&[resource_path("set")], …)` test in
 `ironplc-cli/src/cli.rs`) and asserts success. It runs as part of `just`
 (`compile`/`coverage`) so a change that breaks a library file fails CI the same
 as any other test. It is the guardrail the current Rust-baked stdlib lacks.
 
+## Compiler-options boundary
+
+Selecting the library follows the active dialect/edition, which the compiler
+already knows (`--dialect`). The **parser crate must not learn about libraries**
+— library location, loading, and selection live in the CLI/`sources` layer. No
+library option is added to the parser by this design. If library-related options
+are needed later, `CompilerOptions` should be restructured so the parser keeps
+only the minimal syntax-affecting subset and the CLI owns the rest (either by
+moving `CompilerOptions` into its own crate, or by the CLI defining the full
+option set with a mapping down to the parser's subset).
+
 ## Packaging and installers
 
-Under **Option A (embed)** no installer changes are needed — the library rides
-inside the binary. Under **Option B (install alongside)** the following change,
-staging `compiler/library/` into each install layout the way `bom.cdx.json` is
+The library tree is staged into each install layout the way `bom.cdx.json` is
 staged today:
 
 - `compiler/justfile` `_package-macos` / `_package-linux`: `cp -r` the library
@@ -252,102 +151,83 @@ staged today:
   (alongside `ironplcc ironplcvm ironplcmcp bom.cdx.json`).
 - `compiler/setup.nsi`: a new section `SetOutPath "$INSTDIR\lib"` +
   `File /r "..\library\*"`, mirroring the existing `$INSTDIR\examples` section.
-- `compiler/install.sh`: after extraction, copy the `lib` directory into
+- `compiler/install.sh`: after extraction, copy the library directory into
   `${INSTALL_DIR}/lib` (the script currently extracts only named binaries).
 - `compiler/homebrew/Formula/ironplc.rb`: `(share/"ironplc").install Dir["lib/*"]`.
-- New runtime path-resolution to locate `lib` relative to the executable.
+- Runtime path-resolution locates the library directory relative to the
+  executable (REQ-LIB-sources-110).
 
 The existing release workflows (`partial_compiler.yaml`,
 `partial_upload_release_artifacts.yaml`) manipulate whole artifacts and need no
-change under either option.
+change.
 
 ## Problem codes
 
-Two new compiler diagnostics are introduced (next free codes in the analyzer
-`P40xx` range; final numbers allocated when implemented, documented under
-`docs/reference/compiler/problems/`):
-
-- `P4039` — referenced library not found on the search path (REQ-LIB-sources-140).
-- `P4040` — function requires a library that is not referenced (REQ-LIB-analyzer-320).
+- `P4039` — the library for the active dialect could not be located or read
+  (REQ-LIB-sources-140). Next free code in the analyzer `P40xx` range; final
+  number allocated when implemented, documented under
+  `docs/reference/compiler/problems/`.
 
 ## Requirement ownership summary
 
-One area code, `LIB`, partitioned by owning crate in hundreds-blocks per the
-`reference-to-twincat.md` convention:
+One area code, `LIB`, partitioned by owning crate:
 
 | Block | Slug (crate) | Concern |
 |-------|--------------|---------|
-| `1xx` | `sources` | bundle location, delivery, `FileId` tagging, search-path resolution, `.plcproj` reference extraction, not-found diagnostic, compile check |
-| `2xx` | `parser` | `CompilerOptions` (`--no-stdlib`, `--library`, `--library-path`) |
-| `3xx` | `analyzer` | reference-gated scoping, shadowing, external-binding recognition, unreferenced-library diagnostic |
-| `4xx` | `codegen` | reachability-pruned linking of library POUs, external-binding inlining |
-| `5xx` | `container` / `vm` | float trunc/mod `BUILTIN` primitives |
+| `1xx` | `sources` | library location, dialect selection, disk delivery, runtime path resolution, load diagnostic, compile check |
+| `3xx` | `analyzer` | library exports in scope, duplicate-definition on collision |
+| `4xx` | `codegen` | reachability-pruned linking of library POUs |
 
 Final slug placement for any requirement is confirmed when its slice wires the
 doc into that crate's `build.rs`.
 
 ## Implementation Breakdown
 
-The work is large; it splits into independently reviewable PRs. Because the
-spec-conformance orphan guard treats a doc as "enforced" only once a `build.rs`
-lists it — and then requires **every** slug used in the doc to be claimed by a
-listing crate — enforcement is best turned on once, up front, rather than
-incrementally.
+The work splits into independently reviewable PRs. Because the spec-conformance
+orphan guard treats a doc as "enforced" only once a `build.rs` lists it — and
+then requires **every** slug used in the doc to be claimed by a listing crate —
+enforcement is turned on once, up front.
 
-- **PR 1 — this document.** Design only; not wired into any `build.rs`; CI-neutral.
+- **PR 1 — this document.** Design only; not wired into any `build.rs`.
 - **PR 2 — enforcement bootstrap.** Wire `library-support.md` into the `build.rs`
-  of every owning crate (`sources`, `parser`, `analyzer`, `codegen`, `container`,
-  `vm`) and add `#[ignore]`d `#[spec_test]` stubs for every requirement, so the
-  requirements become enforced-but-pending (mirrors how `reference-to-twincat.md`
-  established enforcement). Each later PR removes `#[ignore]` as it implements.
+  of every owning crate (`sources`, `analyzer`, `codegen`) and add `#[ignore]`d
+  `#[spec_test]` stubs for every requirement, so the requirements become
+  enforced-but-pending (mirrors how `reference-to-twincat.md` established
+  enforcement). Each later PR removes `#[ignore]` as it implements.
 - **PR 3 — library skeleton + compile check** (`sources`): create
-  `compiler/library/standard/`, add one or two trivially-correct `.st` POUs, and
-  the REQ-LIB-sources-190 compile-check test. Small, unblocks authoring.
-- **PR 4 — delivery** (`sources`): implement Option A embed generator (or Option
-  B install path + packaging), satisfying REQ-LIB-sources-110/111/120.
-- **PR 5 — pipeline loading + options** (`sources` + `parser`): `--no-stdlib` /
-  `--library` / `--library-path`; inject bundled sources into every compilation;
-  REQ-LIB-parser-2xx, REQ-LIB-sources-130.
-- **PR 6 — reference gating + diagnostics** (`analyzer` + `sources`):
-  reference-gated scoping, shadowing, `P4039`/`P4040`; `.plcproj`
-  `<LibraryReference>` extraction; REQ-LIB-analyzer-300/310/320/330,
-  REQ-LIB-sources-131/140.
-- **PR 7 — float primitives** (`container` + `vm`): `TRUNC_*`/`MOD_*`
-  `BUILTIN`s; REQ-LIB-container-500, REQ-LIB-vm-550/551. Independent — can land
-  in parallel with PRs 3–6.
-- **PR 8 — external binding + codegen** (`analyzer` + `codegen`): external-binding
-  attribute, inline-`BUILTIN` codegen; REQ-LIB-analyzer-340,
-  REQ-LIB-codegen-400/410/420.
-- **PR 9 — `LTRUNC`/`LMOD` as library content**: declare them in
-  `compiler/library/standard/` as external aliases to the PR 7 primitives; remove
-  the `--allow-extended-math-functions` flag and the analyzer/#1217 signature
-  registration. This is the end-to-end proof: the functions compile *and run*.
-- **PR 10+ — library content + docs**: port the rest of the Rust-baked stdlib to
-  library source incrementally; user documentation.
+  `compiler/library/<dialect>/`, add one or two trivially-correct `.st` POUs, and
+  the REQ-LIB-sources-190 compile-check test. Small; locks in the guardrail first
+  and unblocks authoring.
+- **PR 4 — delivery + packaging** (`sources`): install the library alongside the
+  binary and resolve it at runtime relative to the executable; update all
+  installers; REQ-LIB-sources-110/140.
+- **PR 5 — pipeline integration** (`sources` + `analyzer` + `codegen`): load the
+  dialect's library into every compilation; exports resolve; duplicate-definition
+  on collision; reachability-pruned linking; REQ-LIB-analyzer-300/330,
+  REQ-LIB-codegen-400/410.
+- **PR 6+ — library content**: port stdlib functions from Rust to library source
+  incrementally; user documentation.
 
-Rough dependency order: PR 2 → (PR 3 → PR 4 → PR 5 → PR 6) and (PR 7) in
-parallel → PR 8 → PR 9 → PR 10+.
+Rough order: PR 2 → PR 3 → PR 4 → PR 5 → PR 6+.
 
 ## Relationship to existing work and ADRs
 
-- **Reframes #1217.** `LTRUNC`/`LMOD` become two VM primitives plus a library
-  alias (PRs 7 + 9), not a per-function flag. Recommendation: do not merge the
-  flag; land them via the library.
-- Builds on **[ADR-0008](../adrs/0008-unified-builtin-opcode.md)** (unified
-  `BUILTIN` opcode — the primitive-extension surface),
-  **[ADR-0003](../adrs/0003-plc-standard-function-blocks-as-intrinsics.md)**
-  (intrinsics recognized at dispatch), and
-  **[ADR-0012](../adrs/0012-accept-vendor-dialect-files-as-is.md)**.
-- Related conformance mechanics:
+- **Foundational for #1199 and reframes #1217.** Functions IronPLC lacks become
+  library content rather than per-function `--allow-*` flags. Functions that need
+  new compiler/VM primitives (`LTRUNC`/`LMOD`) are a follow-on design that builds
+  on this library foundation.
+- Complements **[ADR-0012](../adrs/0012-accept-vendor-dialect-files-as-is.md)**
+  (accept vendor dialect files as-is) — the library provides the compatibility
+  counterpart in IronPLC-authored source.
+- Conformance mechanics:
   **[cross-crate-spec-conformance.md](cross-crate-spec-conformance.md)** and
   **[ADR-0037](../adrs/0037-mandatory-crate-slug-in-requirement-ids.md)**.
 
 ### Decisions to ratify as ADRs
 
-1. IronPLC ships a **source** standard library compiled by the normal pipeline,
-   replacing the Rust-baked stdlib.
-2. Library availability is expressed by **references** (with an implicit standard
-   library), not per-function `--allow-*` flags.
-3. External library functions bind to `BUILTIN` **primitives** — the compiler
-   grows opcodes, not functions.
-4. Delivery mechanism — embed vs install-alongside (Open decision D1).
+1. IronPLC ships a **source** library compiled by the normal pipeline, replacing
+   the Rust-baked stdlib.
+2. IronPLC authors its own **compatibility libraries**; it does not redistribute
+   third-party vendor libraries.
+3. Library files are **installed alongside the binary and loaded from disk**
+   (visible and extensible), not embedded.


### PR DESCRIPTION
## Summary

Design document for a real **library** mechanism in IronPLC, to replace the per-function `--allow-*` flag approach currently used to add vendor functions (e.g. `LTRUNC`/`LMOD` in #1217). Part of the #1199 lineage.

The design follows the conventional compiler approach:

- Ship IronPLC's standard library as **IEC source** under `compiler/library/`, compiled by the normal pipeline (not Rust baked into the binary).
- Make library POUs/types available to user programs by **reference**, with a **standard library implicitly in scope** (prelude-style, `--no-stdlib` to opt out) and additional libraries resolved from a **search path**.
- Verify in **CI that every bundled library file compiles**, so the library can't silently break.
- Ship the library files with every installer.
- Add the **VM primitives** (float trunc/mod under the unified `BUILTIN` opcode, per ADR-0008) that let functions like `LTRUNC`/`LMOD` be authored as library content — the compiler grows *primitives*, not *functions*.

## What's in this PR

Just the design doc: `specs/design/library-support.md`. No code.

- Annotated with `LIB`-area spec requirements partitioned by owning crate (`sources` / `parser` / `analyzer` / `codegen` / `container` / `vm`), following the `reference-to-twincat.md` hundreds-block convention.
- **Design-only / CI-neutral:** the doc is intentionally *not* wired into any `build.rs`, so the spec-conformance guard does not enforce it yet (verified: `spec_conformance_guard` passes 10/10). Each implementation slice wires the doc into its crate's `build.rs` and adds its `#[spec_test]` tests.

## Notable design points to review

- **Open decision D1 — delivery mechanism:** embed the library into the binary via `include_str!` (recommended; no installer changes, no runtime path lookup) vs. install the files alongside the binary and resolve at runtime (needs new path-resolution code + edits to all four installers). Both keep the source under `compiler/library/`.
- Reframes #1217: `LTRUNC`/`LMOD` become two VM primitives + a library alias, not a per-function flag.
- Two new problem codes proposed: `P4039` (referenced library not found), `P4040` (function requires an unreferenced library).
- A **10-PR implementation breakdown** for landing this in digestible pieces, including an up-front "enforcement bootstrap" PR (mirroring how `reference-to-twincat.md` turned on conformance).

## Test plan

- [x] `spec_conformance_guard` passes (design doc is not enforced; no unclaimed slugs).
- [ ] Design review / feedback on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TmDFQKZDRLasYiYREHXRx)_