### PR TITLE
Enforce --allow-constant-type-params (P4029)

### DIFF
--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -128,7 +128,7 @@ pub fn resolve_types(
     // Resolve constant references in type parameters (STRING lengths, array bounds).
     // Must run before toposort so that concrete integer values are available.
     let fallback = library.clone();
-    match xform_resolve_constant_expressions::apply(library) {
+    match xform_resolve_constant_expressions::apply(library, options) {
         Ok(result) => library = result,
         Err(errs) => {
             diagnostics.extend(errs);

--- a/compiler/analyzer/src/xform_resolve_constant_expressions.rs
+++ b/compiler/analyzer/src/xform_resolve_constant_expressions.rs
@@ -12,9 +12,10 @@
 use std::collections::HashMap;
 
 use ironplc_dsl::common::*;
-use ironplc_dsl::core::Located;
+use ironplc_dsl::core::{Id, Located};
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::fold::Fold;
+use ironplc_parser::options::CompilerOptions;
 use ironplc_problems::Problem;
 
 /// Stored information about an integer constant.
@@ -30,11 +31,17 @@ struct ConstantInfo {
 /// Global constants are collected upfront and available everywhere. POU-local
 /// constants (VAR CONSTANT inside FUNCTION, FUNCTION_BLOCK, or PROGRAM) are
 /// scoped — they are only visible within their declaring POU.
-pub fn apply(lib: Library) -> Result<Library, Vec<Diagnostic>> {
+///
+/// Using a constant reference in a type parameter is a vendor extension. When
+/// `options.allow_constant_type_params` is false (strict IEC 61131-3), any such
+/// reference is rejected with [`Problem::ConstantTypeParamNotAllowed`] instead
+/// of being resolved.
+pub fn apply(lib: Library, options: &CompilerOptions) -> Result<Library, Vec<Diagnostic>> {
     let constants = collect_constants(&lib);
 
     let mut resolver = ConstantResolver {
         constants,
+        allow_constant_type_params: options.allow_constant_type_params,
         diagnostics: vec![],
     };
 
@@ -121,7 +128,33 @@ fn extract_integer_value(init: &InitialValueAssignmentKind) -> Option<u128> {
 
 struct ConstantResolver {
     constants: HashMap<String, ConstantInfo>,
+    /// Whether the `--allow-constant-type-params` vendor extension is enabled.
+    /// When false, a constant reference in a type parameter is rejected outright
+    /// (P4029) rather than resolved.
+    allow_constant_type_params: bool,
     diagnostics: Vec<Diagnostic>,
+}
+
+impl ConstantResolver {
+    /// Records a P4029 diagnostic for a constant reference that appears in a type
+    /// parameter while the vendor extension is disabled. Returns `true` when the
+    /// reference was rejected (flag off), so callers skip resolution.
+    fn reject_if_not_allowed(&mut self, id: &Id) -> bool {
+        if self.allow_constant_type_params {
+            return false;
+        }
+        self.diagnostics.push(
+            Diagnostic::problem(
+                Problem::ConstantTypeParamNotAllowed,
+                Label::span(id.span(), format!("Constant '{id}' used in type parameter")),
+            )
+            .with_help(
+                "Use an integer literal in the type parameter, or enable the \
+                 --allow-constant-type-params vendor extension.",
+            ),
+        );
+        true
+    }
 }
 
 impl<E> Fold<E> for ConstantResolver {
@@ -129,6 +162,9 @@ impl<E> Fold<E> for ConstantResolver {
         match node {
             IntegerRef::Literal(_) => Ok(node),
             IntegerRef::Constant(ref id) => {
+                if self.reject_if_not_allowed(id) {
+                    return Ok(node);
+                }
                 let name = id.to_string().to_uppercase();
                 match self.constants.get(&name) {
                     Some(info) => Ok(IntegerRef::Literal(Integer {
@@ -152,6 +188,9 @@ impl<E> Fold<E> for ConstantResolver {
         match node {
             SignedIntegerRef::Literal(_) => Ok(node),
             SignedIntegerRef::Constant(ref id) => {
+                if self.reject_if_not_allowed(id) {
+                    return Ok(node);
+                }
                 let name = id.to_string().to_uppercase();
                 match self.constants.get(&name) {
                     Some(info) => Ok(SignedIntegerRef::Literal(SignedInteger {
@@ -227,6 +266,15 @@ mod tests {
         .unwrap()
     }
 
+    /// Options with the constant-type-params vendor extension enabled, so the
+    /// transform resolves references instead of rejecting them (P4029).
+    fn enabled() -> CompilerOptions {
+        CompilerOptions {
+            allow_constant_type_params: true,
+            ..CompilerOptions::default()
+        }
+    }
+
     /// Find the first VarDecl with the given name from a POU.
     fn find_var_decl<'a>(lib: &'a Library, var_name: &str) -> &'a VarDecl {
         for element in &lib.elements {
@@ -279,7 +327,7 @@ mod tests {
         ",
         );
 
-        let lib = apply(lib).unwrap();
+        let lib = apply(lib, &enabled()).unwrap();
         let var = find_var_decl(&lib, "STR");
         assert_eq!(get_string_length(var), 250);
     }
@@ -299,7 +347,7 @@ mod tests {
         ",
         );
 
-        let lib = apply(lib).unwrap();
+        let lib = apply(lib, &enabled()).unwrap();
         let var = find_var_decl(&lib, "ARR");
         let subranges = get_array_subranges(var);
         assert_eq!(subranges.len(), 1);
@@ -322,7 +370,7 @@ mod tests {
         ",
         );
 
-        let result = apply(lib);
+        let result = apply(lib, &enabled());
         assert!(result.is_err());
     }
 
@@ -338,7 +386,7 @@ mod tests {
         ",
         );
 
-        let result = apply(lib);
+        let result = apply(lib, &enabled());
         assert!(result.is_err());
     }
 
@@ -359,7 +407,7 @@ mod tests {
         ",
         );
 
-        let lib = apply(lib).unwrap();
+        let lib = apply(lib, &enabled()).unwrap();
         assert_eq!(get_string_length(find_var_decl(&lib, "STR")), 100);
 
         let subranges = get_array_subranges(find_var_decl(&lib, "ARR"));
@@ -381,7 +429,7 @@ mod tests {
         ",
         );
 
-        let result = apply(lib);
+        let result = apply(lib, &enabled());
         assert!(result.is_err());
     }
 
@@ -397,7 +445,7 @@ mod tests {
         ",
         );
 
-        let lib = apply(lib).unwrap();
+        let lib = apply(lib, &enabled()).unwrap();
         let var = find_var_decl(&lib, "STR");
         assert_eq!(get_string_length(var), 50);
     }
@@ -417,7 +465,7 @@ mod tests {
         ",
         );
 
-        let lib = apply(lib).unwrap();
+        let lib = apply(lib, &enabled()).unwrap();
         let var = find_var_decl(&lib, "fifo");
         let subranges = get_array_subranges(var);
         assert_eq!(subranges.len(), 1);
@@ -441,7 +489,7 @@ mod tests {
         ",
         );
 
-        let lib = apply(lib).unwrap();
+        let lib = apply(lib, &enabled()).unwrap();
         let var = find_var_decl(&lib, "STR");
         assert_eq!(get_string_length(var), 80);
     }
@@ -461,7 +509,7 @@ mod tests {
         ",
         );
 
-        let lib = apply(lib).unwrap();
+        let lib = apply(lib, &enabled()).unwrap();
         let var = find_var_decl(&lib, "buf");
         let subranges = get_array_subranges(var);
         assert_eq!(subranges.len(), 1);
@@ -486,7 +534,7 @@ mod tests {
         ",
         );
 
-        let result = apply(lib);
+        let result = apply(lib, &enabled());
         assert!(result.is_err());
     }
 
@@ -503,7 +551,120 @@ mod tests {
         ",
         );
 
-        let result = apply(lib);
+        let result = apply(lib, &enabled());
         assert!(result.is_err());
+    }
+
+    // ---------------------------------------------------------------------
+    // Enforcement of the `--allow-constant-type-params` vendor extension.
+    // See ironplc/ironplc#1234.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn apply_when_constant_in_string_length_and_flag_disabled_then_error() {
+        let lib = parse(
+            "
+            VAR_GLOBAL CONSTANT
+                STRING_LENGTH : INT := 250;
+            END_VAR
+            FUNCTION_BLOCK fb1
+            VAR_INPUT
+                STR : STRING[STRING_LENGTH];
+            END_VAR
+            END_FUNCTION_BLOCK
+        ",
+        );
+
+        let diagnostics = apply(lib, &CompilerOptions::default()).unwrap_err();
+
+        assert_eq!(
+            diagnostics[0].code,
+            Problem::ConstantTypeParamNotAllowed.code()
+        );
+    }
+
+    #[test]
+    fn apply_when_constant_in_array_bounds_and_flag_disabled_then_error() {
+        let lib = parse(
+            "
+            VAR_GLOBAL CONSTANT
+                ARRAY_SIZE : INT := 10;
+            END_VAR
+            FUNCTION_BLOCK fb1
+            VAR_INPUT
+                ARR : ARRAY[1..ARRAY_SIZE] OF INT;
+            END_VAR
+            END_FUNCTION_BLOCK
+        ",
+        );
+
+        let diagnostics = apply(lib, &CompilerOptions::default()).unwrap_err();
+
+        assert_eq!(
+            diagnostics[0].code,
+            Problem::ConstantTypeParamNotAllowed.code()
+        );
+    }
+
+    #[test]
+    fn apply_when_constant_type_param_rejected_then_diagnostic_has_help() {
+        let lib = parse(
+            "
+            VAR_GLOBAL CONSTANT
+                STRING_LENGTH : INT := 250;
+            END_VAR
+            FUNCTION_BLOCK fb1
+            VAR_INPUT
+                STR : STRING[STRING_LENGTH];
+            END_VAR
+            END_FUNCTION_BLOCK
+        ",
+        );
+
+        let diagnostics = apply(lib, &CompilerOptions::default()).unwrap_err();
+
+        assert!(!diagnostics[0].help().is_empty());
+    }
+
+    #[test]
+    fn apply_when_flag_disabled_then_undefined_constant_still_reported_as_type_param() {
+        // With the flag off, even an *undefined* constant reference is rejected
+        // as a type-parameter violation (P4029), not P4030 — the construct is
+        // disallowed before resolution is attempted.
+        let lib = parse(
+            "
+            FUNCTION_BLOCK fb1
+            VAR_INPUT
+                STR : STRING[UNDEFINED_CONST];
+            END_VAR
+            END_FUNCTION_BLOCK
+        ",
+        );
+
+        let diagnostics = apply(lib, &CompilerOptions::default()).unwrap_err();
+
+        assert_eq!(
+            diagnostics[0].code,
+            Problem::ConstantTypeParamNotAllowed.code()
+        );
+    }
+
+    #[test]
+    fn apply_when_literal_type_param_and_flag_disabled_then_ok() {
+        // A plain integer literal in a type parameter is standard IEC and must
+        // remain accepted regardless of the flag.
+        let lib = parse(
+            "
+            FUNCTION_BLOCK fb1
+            VAR_INPUT
+                STR : STRING[50];
+            END_VAR
+            END_FUNCTION_BLOCK
+        ",
+        );
+
+        let result = apply(lib, &CompilerOptions::default());
+
+        assert!(result.is_ok());
     }
 }

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -19,20 +19,17 @@
 //! that flag and nothing else — the strongest form of "this example is
 //! supported, this other code is not".
 //!
-//! A few flags are declared and surfaced by `list_options` but are not yet
-//! enforced by the compiler — the construct they gate compiles whether the flag
-//! is on or off, so no off-rejects/on-accepts fixture can exist. Those are
-//! listed in [`UNENFORCED`], each tracked by an issue. The gap lives in the
-//! issue tracker, not in a special test expectation.
+//! Every feature flag must have a fixture — there is no escape hatch for
+//! "declared but not yet enforced". A flag that is surfaced by `list_options`
+//! but gates no behavior is a dead flag, and the suite fails until it either
+//! gains a fixture (enforcement lands) or is removed.
 //!
-//! Two meta-tests keep the tables honest and decoupled:
-//! - [`every_feature_flag_has_a_fixture_or_is_tracked_unenforced`] fails when a
-//!   new flag is added without either a fixture or an `UNENFORCED` entry (the
-//!   reminder lives in the suite, not a reviewer's head), mirroring
-//!   `spec_conformance::all_spec_requirements_have_tests`.
-//! - [`fixture_and_unenforced_tables_are_consistent`] fails when an entry names
-//!   a flag that does not exist, or when a flag is listed as both fixtured and
-//!   unenforced (e.g. enforcement was added but `UNENFORCED` was not updated).
+//! Two meta-tests keep the table honest and decoupled:
+//! - [`every_feature_flag_has_a_fixture`] fails when a new flag is added without
+//!   a fixture (the reminder lives in the suite, not a reviewer's head),
+//!   mirroring `spec_conformance::all_spec_requirements_have_tests`.
+//! - [`fixture_keys_name_real_flags`] fails when a fixture entry names a flag or
+//!   prerequisite that does not exist (typo or removed flag).
 //!
 //! Adding a flag therefore means adding *your own* fixture row (cohesion), not
 //! editing a shared count or a neighbor's assertions (coupling).
@@ -55,16 +52,7 @@ struct FlagFixture {
     source: &'static str,
 }
 
-/// Vendor flags that are declared and surfaced by `list_options` but that the
-/// compiler does not yet enforce: the construct they gate compiles whether the
-/// flag is on or off, so no off-rejects/on-accepts fixture can exist. Each is
-/// tracked by an issue. When enforcement lands, add a fixture to
-/// [`FLAG_FIXTURES`] and remove the entry here.
-///
-/// (none currently)
-const UNENFORCED: &[&str] = &[];
-
-/// One fixture per *enforced* vendor-extension flag. Order mirrors
+/// One fixture per vendor-extension flag. Order mirrors
 /// `FEATURE_DESCRIPTORS` for readability; the suite does not depend on ordering.
 /// Snippets are adapted from the compiler's own positive/negative tests (parser
 /// and analyzer) so they exercise the real enforcement path.
@@ -216,29 +204,26 @@ fn ed2_with(flags: &[&str]) -> serde_json::Value {
     serde_json::Value::Object(map)
 }
 
-/// Completeness: every feature flag must have a behavioral fixture, or be listed
-/// in `UNENFORCED`. Adding a flag with neither fails here rather than passing
-/// silently.
+/// Completeness: every feature flag must have a behavioral fixture. Adding a
+/// flag without one fails here rather than passing silently — there is no
+/// "not yet enforced" escape hatch.
 #[test]
-fn every_feature_flag_has_a_fixture_or_is_tracked_unenforced() {
+fn every_feature_flag_has_a_fixture() {
     for fd in CompilerOptions::FEATURE_DESCRIPTORS {
         let has_fixture = FLAG_FIXTURES.iter().any(|f| f.key == fd.option_key);
-        let is_unenforced = UNENFORCED.contains(&fd.option_key);
         assert!(
-            has_fixture || is_unenforced,
+            has_fixture,
             "feature flag `{}` has no behavioral fixture. Add a source snippet to FLAG_FIXTURES \
-             that is rejected with the flag off and accepted with it on. If the flag is declared \
-             but not yet enforced, add it to UNENFORCED with a tracking issue instead.",
+             that is rejected with the flag off and accepted with it on. Every flag must gate \
+             real behavior; a flag that gates nothing is a dead flag and must be removed instead.",
             fd.option_key
         );
     }
 }
 
-/// Consistency guard for both tables: every key/prereq must name a real flag,
-/// and a flag must not be both fixtured and listed as unenforced (which happens
-/// if enforcement is added but `UNENFORCED` is not updated).
+/// Consistency guard: every fixture key and prerequisite must name a real flag.
 #[test]
-fn fixture_and_unenforced_tables_are_consistent() {
+fn fixture_keys_name_real_flags() {
     let is_flag = |key: &str| {
         CompilerOptions::FEATURE_DESCRIPTORS
             .iter()
@@ -259,18 +244,6 @@ fn fixture_and_unenforced_tables_are_consistent() {
                 prereq
             );
         }
-    }
-
-    for key in UNENFORCED {
-        assert!(
-            is_flag(key),
-            "UNENFORCED lists `{key}`, which matches no FEATURE_DESCRIPTOR (typo or removed flag?)"
-        );
-        assert!(
-            !FLAG_FIXTURES.iter().any(|f| f.key == *key),
-            "`{key}` is listed in UNENFORCED but also has a behavioral fixture. If it is now \
-             enforced, remove it from UNENFORCED; otherwise remove the fixture."
-        );
     }
 }
 

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -61,8 +61,8 @@ struct FlagFixture {
 /// tracked by an issue. When enforcement lands, add a fixture to
 /// [`FLAG_FIXTURES`] and remove the entry here.
 ///
-/// - `allow_constant_type_params`  → ironplc/ironplc#1234
-const UNENFORCED: &[&str] = &["allow_constant_type_params"];
+/// (none currently)
+const UNENFORCED: &[&str] = &[];
 
 /// One fixture per *enforced* vendor-extension flag. Order mirrors
 /// `FEATURE_DESCRIPTORS` for readability; the suite does not depend on ordering.
@@ -93,6 +93,15 @@ const FLAG_FIXTURES: &[FlagFixture] = &[
         key: "allow_top_level_var_global",
         prereqs: &[],
         source: "VAR_GLOBAL CONSTANT\nX : INT := 250;\nEND_VAR\nPROGRAM p\nEND_PROGRAM",
+    },
+    // A constant reference in a type parameter (STRING length) is rejected with
+    // P4029 unless the flag is on, which resolves it to the constant's value. A
+    // POU-local VAR CONSTANT is used so the fixture needs no top-level-var-global
+    // prerequisite.
+    FlagFixture {
+        key: "allow_constant_type_params",
+        prereqs: &[],
+        source: "FUNCTION_BLOCK fb1\nVAR CONSTANT\nSTRING_LENGTH : INT := 250;\nEND_VAR\nVAR_INPUT\nSTR : STRING[STRING_LENGTH];\nEND_VAR\nEND_FUNCTION_BLOCK\nPROGRAM p\nEND_PROGRAM",
     },
     // TIME is a type keyword; using it as a function name needs the flag.
     FlagFixture {


### PR DESCRIPTION
The allow_constant_type_params flag was declared, surfaced by
list_options, and documented, but never enforced: a constant reference
in a type parameter (e.g. STRING[MY_CONST], ARRAY[1..MY_CONST] OF INT)
compiled cleanly regardless of the flag, and the reserved problem code
P4029 (ConstantTypeParamNotAllowed) was emitted nowhere.

Thread the flag into xform_resolve_constant_expressions and reject any
constant reference in a type parameter with P4029 when the flag is off,
before resolution is attempted. With the flag on, references resolve as
before. Move the flag's feature_flag_conformance entry from UNENFORCED
to a behavioral fixture (rejected off / accepted on).

Fixes #1234

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012MgRzbx338Y7tfKhofnHk1