### PR TITLE
docs: move dialect-enablement lists onto the dialects

### DIFF
--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -16,6 +16,8 @@ Supported Dialects
    Strict IEC 61131-3:2003 (Edition 2). No vendor extensions are enabled.
    This is the default when no dialect is specified.
 
+   **Enables:** nothing beyond strict IEC 61131-3 (no vendor extensions).
+
 **iec61131-3-ed3**
    Strict IEC 61131-3:2013 (Edition 3). Enables Edition 3 keywords
    including :doc:`LTIME </reference/language/data-types/elementary/ltime>`,
@@ -26,10 +28,25 @@ Supported Dialects
    :doc:`REF </reference/language/data-types/derived/reference-types>`, and
    :doc:`NULL </reference/language/data-types/derived/reference-types>`. No vendor extensions.
 
+   **Enables:** Edition 3 keywords, plus ``--allow-partial-access-syntax``.
+
 **rusty**
    RuSTy-compatible dialect. Uses Edition 2 as a base (so Edition 3 type
    names like :doc:`LDT </reference/language/data-types/elementary/ldate-and-time>` remain available as identifiers) and enables
    :doc:`REF_TO </reference/language/data-types/derived/reference-types>` support plus all vendor extensions.
+
+   **Enables:** ``--allow-c-style-comments``, ``--allow-missing-semicolon``,
+   ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
+   ``--allow-empty-var-blocks``, ``--allow-time-as-function-name``,
+   ``--allow-ref-to``, ``--allow-ref-arithmetic``,
+   ``--allow-ref-stack-variables``, ``--allow-ref-type-punning``,
+   ``--allow-int-to-bool-initializer``, ``--allow-sizeof``,
+   ``--allow-system-uptime-global``, ``--allow-cross-family-widening``,
+   ``--allow-partial-access-syntax``, ``--allow-pragmas``,
+   ``--allow-short-circuit-operators``,
+   ``--allow-mixed-located-var-declarations``,
+   ``--allow-constant-initializer-expressions``, and
+   ``--allow-bit-string-case-labels``.
 
 **codesys**
    CODESYS-compatible dialect. Uses Edition 2 as a base (so identifiers like
@@ -40,6 +57,18 @@ Supported Dialects
    implicit :doc:`__SYSTEM_UP_TIME </reference/extension-library/variables/system-uptime>`
    globals are not pre-bound under this dialect, since they are an IronPLC
    runtime convention rather than a CODESYS feature.
+
+   **Enables:** ``--allow-c-style-comments``, ``--allow-missing-semicolon``,
+   ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
+   ``--allow-empty-var-blocks``, ``--allow-time-as-function-name``,
+   ``--allow-ref-to``, ``--allow-reference-to``, ``--allow-ref-arithmetic``,
+   ``--allow-ref-stack-variables``, ``--allow-ref-type-punning``,
+   ``--allow-int-to-bool-initializer``, ``--allow-sizeof``,
+   ``--allow-cross-family-widening``, ``--allow-partial-access-syntax``,
+   ``--allow-pragmas``, ``--allow-short-circuit-operators``,
+   ``--allow-mixed-located-var-declarations``,
+   ``--allow-constant-initializer-expressions``, and
+   ``--allow-bit-string-case-labels``.
 
 **twincat**
    Beckhoff TwinCAT-compatible dialect. TwinCAT 3 is built on the CODESYS V3
@@ -56,6 +85,16 @@ Supported Dialects
    :doc:`__SYSTEM_UP_TIME </reference/extension-library/variables/system-uptime>`
    globals are not pre-bound, since they are an IronPLC runtime convention
    rather than a TwinCAT feature.
+
+   **Enables:** ``--allow-c-style-comments``, ``--allow-missing-semicolon``,
+   ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
+   ``--allow-empty-var-blocks``, ``--allow-time-as-function-name``,
+   ``--allow-reference-to``, ``--allow-int-to-bool-initializer``,
+   ``--allow-sizeof``, ``--allow-cross-family-widening``,
+   ``--allow-partial-access-syntax``, ``--allow-pragmas``,
+   ``--allow-short-circuit-operators``,
+   ``--allow-mixed-located-var-declarations``, and
+   ``--allow-bit-string-case-labels``.
 
 Editions are additive — enabling a later edition includes all features from
 earlier editions.
@@ -113,7 +152,8 @@ Enabling Specific Features
 
 Individual ``--allow-*`` flags can be combined with any dialect to enable
 additional features on top of the dialect's defaults. Flags can only enable
-features — they never disable features that a dialect already includes.
+features — they never disable features that a dialect already includes. To see
+which flags a dialect already enables by default, see `Supported Dialects`_.
 
 ``--allow-c-style-comments``
    Allow C-style comments (``//`` line comments and ``/* */`` block comments).
@@ -156,10 +196,8 @@ features — they never disable features that a dialect already includes.
    Allow the Beckhoff TwinCAT / CODESYS ``REFERENCE TO`` reference type and the
    ``REF=`` binding operator. This is the TwinCAT/CODESYS-facing alternative to
    ``--allow-ref-to``: the two describe the same underlying reference but with
-   different surface syntax. ``REFERENCE TO`` is bundled by the ``twincat`` and
-   ``codesys`` dialects. The compiler does not restrict flag combinations, so
-   ``--allow-ref-to`` and ``--allow-reference-to`` may be set at once, though no
-   single real dialect bundles both. See
+   different surface syntax. The compiler does not restrict flag combinations, so
+   ``--allow-ref-to`` and ``--allow-reference-to`` may be set at once. See
    :doc:`/reference/language/data-types/derived/reference-types`.
 
 ``--allow-ref-arithmetic``
@@ -192,8 +230,7 @@ features — they never disable features that a dialect already includes.
 ``--allow-system-uptime-global``
    Expose ``__SYSTEM_UP_TIME`` (``TIME``) and ``__SYSTEM_UP_LTIME``
    (``LTIME``) as implicit ``VAR_GLOBAL`` values holding the VM's monotonic
-   uptime. This is an IronPLC runtime convention enabled by
-   ``--dialect=rusty``.
+   uptime. This is an IronPLC runtime convention.
 
 ``--allow-cross-family-widening``
    Allow implicit widening between bit-string and integer type families.
@@ -205,8 +242,7 @@ features — they never disable features that a dialect already includes.
 ``--allow-partial-access-syntax``
    Allow IEC 61131-3:2013 partial-access bit syntax ``.%Xn`` (e.g.,
    ``myByte.%X3`` to access bit 3 of a ``BYTE``). Semantically equivalent to
-   the short form ``.n``. Enabled by ``--dialect=iec61131-3-ed3`` and
-   ``--dialect=rusty``. Byte/word/dword/lword partial access (``.%Bn``,
+   the short form ``.n``. Byte/word/dword/lword partial access (``.%Bn``,
    ``.%Wn``, ``.%Dn``, ``.%Ln``) is not yet supported.
 
 ``--allow-pragmas``
@@ -216,7 +252,7 @@ features — they never disable features that a dialect already includes.
    including Beckhoff TwinCAT and Schneider Electric Machine Expert). A
    pragma is parsed and discarded like a comment — its contents are not yet
    interpreted. Pragmas do not nest; an unclosed ``{`` still produces a parse
-   error. Enabled by ``--dialect=rusty`` and ``--dialect=codesys``.
+   error.
 
 ``--allow-short-circuit-operators``
    Allow the ``AND_THEN`` short-circuit boolean operator, a
@@ -232,7 +268,6 @@ features — they never disable features that a dialect already includes.
    evaluation this operator requires and refuses to compile it
    (problem :doc:`P9999 </reference/compiler/problems/P9999>`) rather
    than silently emitting eager (behaviorally incorrect) bytecode.
-   Enabled by ``--dialect=rusty`` and ``--dialect=codesys``.
 
 ``--allow-mixed-located-var-declarations``
    Allow an ``AT``-located variable (complete address like ``AT %IX0.0``,
@@ -244,8 +279,7 @@ features — they never disable features that a dialect already includes.
    this flag, mixing produces problem
    :doc:`P4036 </reference/compiler/problems/P4036>`. A block containing
    *only* located variables is unaffected by this flag — it is standard
-   syntax and always allowed. Enabled by ``--dialect=rusty``,
-   ``--dialect=codesys``, and ``--dialect=twincat``.
+   syntax and always allowed.
 
 ``--allow-constant-initializer-expressions``
    Allow a ``VAR`` initializer to be a constant *expression* — arithmetic
@@ -258,7 +292,6 @@ features — they never disable features that a dialect already includes.
    does not fully reduce to a constant (e.g. it references a
    non-``CONSTANT`` variable), it produces
    :doc:`P4038 </reference/compiler/problems/P4038>`.
-   Enabled by ``--dialect=rusty`` and ``--dialect=codesys``.
 
 ``--allow-bit-string-case-labels``
    Allow a hex, binary, or octal bit-string literal (e.g. ``16#D012``,
@@ -268,8 +301,7 @@ features — they never disable features that a dialect already includes.
    separate productions the standard does not include here. Real
    TwinCAT/CODESYS code uses them. Without this flag, such a label produces
    :doc:`P4041 </reference/compiler/problems/P4041>`. A plain decimal label
-   (``5:``) is standard syntax and is always allowed. Enabled by
-   ``--dialect=rusty``, ``--dialect=codesys``, and ``--dialect=twincat``.
+   (``5:``) is standard syntax and is always allowed.
 
 Pass the flag when running :program:`ironplcc`:
 

--- a/docs/extensions/ironplc_flags.py
+++ b/docs/extensions/ironplc_flags.py
@@ -5,7 +5,13 @@ This extension reads the source of truth (compiler/parser/src/options.rs),
 extracts all allow_* CLI flags and every Dialect::cli_name(), and verifies each
 one appears in the relevant doc pages.
 
-The build fails if any flag or dialect is missing from its doc file(s), ensuring
+It also verifies that each dialect's **Enables:** list in the explanation page
+matches exactly the flags that dialect turns on in options.rs. The per-dialect
+lists are the canonical place to learn which flags a dialect enables (the
+individual flag entries no longer repeat this), so they must not drift.
+
+The build fails if any flag or dialect is missing from its doc file(s), or if a
+dialect's documented flag list disagrees with the source of truth, ensuring
 documentation stays in sync when new flags or dialects are added.
 '''
 import re
@@ -18,6 +24,62 @@ def _options_text(app):
     srcdir = Path(app.srcdir)
     options_path = srcdir / '..' / 'compiler' / 'parser' / 'src' / 'options.rs'
     return srcdir, options_path.read_text()
+
+
+# Maps the `Dialect` enum variant idents used in options.rs to the CLI names
+# (and **bold** section headers) used in the explanation page.
+DIALECT_IDENT_TO_CLI = {
+    'Iec61131_3Ed2': 'iec61131-3-ed2',
+    'Iec61131_3Ed3': 'iec61131-3-ed3',
+    'Rusty': 'rusty',
+    'Codesys': 'codesys',
+    'TwinCat': 'twincat',
+}
+
+EXPLANATION_DOC = 'explanation/enabling-dialects-and-features.rst'
+
+
+def source_of_truth_dialect_flags(options_text):
+    """Map each dialect CLI name to the set of --allow-* flags it enables.
+
+    Parses the ``define_compiler_options!`` macro entries, each of which pairs
+    a ``"--allow-*"`` CLI-flag literal with a ``[Dialect, ...]`` list of the
+    dialects that enable it.
+    """
+    truth = {cli: set() for cli in DIALECT_IDENT_TO_CLI.values()}
+    entry_re = re.compile(r'"(--allow-[a-z0-9-]+)"\s*,\s*\[([^\]]*)\]')
+    for cli_flag, dialect_group in entry_re.findall(options_text):
+        for ident in re.findall(r'[A-Za-z0-9_]+', dialect_group):
+            cli = DIALECT_IDENT_TO_CLI.get(ident)
+            if cli is not None:
+                truth[cli].add(cli_flag)
+    return truth
+
+
+def documented_dialect_flags(doc_text, problems):
+    """Map each dialect to the flags listed after its **Enables:** label.
+
+    Each dialect appears as a ``**<cli-name>**`` bold header in the "Supported
+    Dialects" section, followed by prose and then a ``**Enables:**`` paragraph
+    that lists the flags. Only that paragraph (up to the next blank line) is
+    read, so flag names mentioned in the surrounding prose are not counted.
+    """
+    documented = {}
+    for cli in DIALECT_IDENT_TO_CLI.values():
+        header_idx = doc_text.find(f'**{cli}**')
+        if header_idx == -1:
+            problems.append(f'dialect header **{cli}** missing in {EXPLANATION_DOC}')
+            continue
+        enables_idx = doc_text.find('**Enables:**', header_idx)
+        if enables_idx == -1:
+            problems.append(f'**Enables:** list missing for dialect {cli} in {EXPLANATION_DOC}')
+            continue
+        end_idx = doc_text.find('\n\n', enables_idx)
+        if end_idx == -1:
+            end_idx = len(doc_text)
+        region = doc_text[enables_idx:end_idx]
+        documented[cli] = set(re.findall(r'--allow-[a-z0-9-]+', region))
+    return documented
 
 
 def validate_flags(app, config):
@@ -41,7 +103,7 @@ def validate_flags(app, config):
 
     # Verify each flag appears in both doc files
     doc_files = [
-        'explanation/enabling-dialects-and-features.rst',
+        EXPLANATION_DOC,
         'reference/compiler/ironplcc.rst',
     ]
     missing = []
@@ -51,6 +113,25 @@ def validate_flags(app, config):
         for cli_flag in cli_flags:
             if cli_flag not in doc_text:
                 missing.append(f'{cli_flag} missing in {doc_rel}')
+
+    # Verify each dialect's **Enables:** list matches the source of truth.
+    truth = source_of_truth_dialect_flags(options_text)
+    explanation_text = (srcdir / EXPLANATION_DOC).read_text()
+    documented = documented_dialect_flags(explanation_text, missing)
+    for cli, expected in truth.items():
+        if cli not in documented:
+            continue  # a structural problem was already reported above
+        actual = documented[cli]
+        for extra in sorted(actual - expected):
+            missing.append(
+                f'{cli}: {extra} is listed under **Enables:** but the source of '
+                f'truth does not enable it for this dialect'
+            )
+        for absent in sorted(expected - actual):
+            missing.append(
+                f'{cli}: {absent} is enabled by this dialect in options.rs but '
+                f'is missing from its **Enables:** list'
+            )
 
     if missing:
         for m in missing:

--- a/docs/reference/compiler/ironplcc.rst
+++ b/docs/reference/compiler/ironplcc.rst
@@ -136,7 +136,7 @@ Options
 ``--allow-reference-to``
    Allow the Beckhoff TwinCAT / CODESYS ``REFERENCE TO`` reference type and the
    ``REF=`` binding operator — the TwinCAT/CODESYS-facing alternative to
-   ``--allow-ref-to``. Enabled by the ``twincat`` and ``codesys`` dialects.
+   ``--allow-ref-to``.
 
 ``--allow-ref-arithmetic``
    Allow arithmetic (``+``, ``-``) and ordering comparisons (``<``, ``>``,
@@ -166,8 +166,7 @@ Options
 ``--allow-system-uptime-global``
    Expose ``__SYSTEM_UP_TIME`` (``TIME``) and ``__SYSTEM_UP_LTIME``
    (``LTIME``) as implicit ``VAR_GLOBAL`` values holding the VM's monotonic
-   uptime. This is an IronPLC runtime convention enabled by
-   ``--dialect=rusty``.
+   uptime. This is an IronPLC runtime convention.
 
 ``--allow-cross-family-widening``
    Allow implicit widening between bit-string and integer type families
@@ -176,31 +175,28 @@ Options
 
 ``--allow-partial-access-syntax``
    Allow IEC 61131-3:2013 partial-access bit syntax (``.%Xn``) as an alias
-   for the short form ``.n``. Enabled by ``--dialect=iec61131-3-ed3`` and
-   ``--dialect=rusty``. Byte/word/dword/lword partial access (``.%Bn``,
+   for the short form ``.n``. Byte/word/dword/lword partial access (``.%Bn``,
    ``.%Wn``, ``.%Dn``, ``.%Ln``) is not yet supported.
 
 ``--allow-pragmas``
    Allow curly-brace pragmas such as ``{attribute 'qualified_only'}``. This
    is CODESYS-core syntax, inherited by TwinCAT and other CODESYS-based
    IDEs. A pragma is parsed and discarded like a comment; its contents are
-   not interpreted. Enabled by ``--dialect=rusty`` and ``--dialect=codesys``.
+   not interpreted.
 
 ``--allow-short-circuit-operators``
    Allow the ``AND_THEN`` short-circuit boolean operator, a Beckhoff/CODESYS
    extension that only evaluates its right operand when the left operand is
    ``TRUE``. ``ironplcc check`` fully supports it; codegen
    (``ironplcc compile``) does not yet implement short-circuit evaluation and
-   refuses to compile it. Enabled by ``--dialect=rusty`` and
-   ``--dialect=codesys``.
+   refuses to compile it.
 
 ``--allow-mixed-located-var-declarations``
    Allow an ``AT``-located variable (e.g. ``AT %I*``) inside an otherwise
    plain ``VAR``/``VAR_INPUT``/``VAR_OUTPUT`` block, instead of requiring
    its own dedicated block. Produces
    :doc:`P4036 </reference/compiler/problems/P4036>` when mixed without
-   this flag. Enabled by ``--dialect=rusty``, ``--dialect=codesys``, and
-   ``--dialect=twincat``.
+   this flag.
 
 ``--allow-constant-initializer-expressions``
    Allow a ``VAR`` initializer to be a constant expression (e.g.
@@ -208,16 +204,14 @@ Options
    Folded to a literal at compile time; produces
    :doc:`P4037 </reference/compiler/problems/P4037>` when used without this
    flag, or :doc:`P4038 </reference/compiler/problems/P4038>` if the
-   expression does not fully reduce to a constant. Enabled by
-   ``--dialect=rusty`` and ``--dialect=codesys``.
+   expression does not fully reduce to a constant.
 
 ``--allow-bit-string-case-labels``
    Allow a hex, binary, or octal bit-string literal (e.g. ``16#D012``,
    ``2#1010``) as a ``CASE`` label. The IEC 61131-3 standard permits only a
    subrange, decimal integer, or enumerated value here. Produces
    :doc:`P4041 </reference/compiler/problems/P4041>` when used without this
-   flag. Enabled by ``--dialect=rusty``, ``--dialect=codesys``, and
-   ``--dialect=twincat``.
+   flag.
 
 Examples
 ========


### PR DESCRIPTION
The allow-flag reference previously repeated, on each individual
--allow-* flag, which dialects enable it. That mapping is easier to
consult from the dialect: to learn what a dialect turns on, read the
dialect entry rather than scanning every flag.

- Add a **Enables:** list to each dialect in Supported Dialects, listing
  exactly the --allow-* flags that dialect enables (from options.rs).
- Remove the per-flag "Enabled by --dialect=..." sentences from both the
  explanation page and the ironplcc CLI reference.
- Extend the ironplc_flags Sphinx guard to validate each dialect's
  **Enables:** list against options.rs, so the lists cannot drift (the
  old prose was already stale for several flags).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JyL5FZr2WtjzUT6XeG1QjL