### PR TITLE
fix(analyzer): order referenced FB type before referencer in toposort

### DIFF
--- a/compiler/analyzer/src/xform_toposort_declarations.rs
+++ b/compiler/analyzer/src/xform_toposort_declarations.rs
@@ -501,12 +501,16 @@ impl Visitor<Diagnostic> for RuleGraphReferenceableElements {
         &mut self,
         init: &FunctionBlockInitialValueAssignment,
     ) -> Result<Self::Value, Diagnostic> {
-        // Current context has a reference to this function block
+        // Current context has a reference to this function block. The
+        // referenced type must be ordered before the containing POU (same
+        // convention as the Structure/LateResolvedType arms in
+        // visit_initial_value_assignment_kind below), so the edge points
+        // from the referenced type to the containing POU, not the reverse.
         match &self.current_from {
             Some(from) => {
                 let from = self.declarations.add_node(from);
                 let to = self.declarations.add_node(&init.type_name.name);
-                self.declarations.graph.add_edge(from, to, ());
+                self.declarations.graph.add_edge(to, from, ());
             }
             None => return Err(Diagnostic::todo(file!(), line!())),
         }
@@ -527,10 +531,12 @@ impl Visitor<Diagnostic> for RuleGraphReferenceableElements {
                     InitialValueAssignmentKind::EnumeratedValues(_) => {}
                     InitialValueAssignmentKind::EnumeratedType(_) => {}
                     InitialValueAssignmentKind::FunctionBlock(fb) => {
-                        // We only care about these because these may be references to a function block
+                        // Same ordering convention as the Structure/LateResolvedType
+                        // arms below: the referenced type must come before the
+                        // containing POU.
                         let from = self.declarations.add_node(from);
                         let to = self.declarations.add_node(&fb.type_name.name);
-                        self.declarations.graph.add_edge(from, to, ());
+                        self.declarations.graph.add_edge(to, from, ());
                     }
                     InitialValueAssignmentKind::Subrange(_) => {}
                     InitialValueAssignmentKind::Structure(struct_init) => {
@@ -611,6 +617,68 @@ mod tests {
         let library = parse_only(program);
         let (library, _reachable) = apply(library).unwrap();
 
+        let decl = library.elements.first().unwrap();
+        let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
+        assert_eq!(decl.name, TypeName::from("Callee"));
+
+        let decl = library.elements.get(1).unwrap();
+        let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
+        assert_eq!(decl.name, TypeName::from("Caller"));
+    }
+
+    #[test]
+    fn apply_when_eager_function_block_initializer_forward_reference_then_referenced_type_ordered_first(
+    ) {
+        // Regression for a dependency-graph edge-direction bug: the
+        // FunctionBlock arms (both this dedicated visitor and the inline
+        // arm in visit_initial_value_assignment_kind) previously added the
+        // edge in the opposite direction to the Structure/LateResolvedType
+        // arms, ordering a referenced type *after* its referencing POU and
+        // producing a spurious P2011 "Parent type is not declared"
+        // downstream.
+        //
+        // A bare `CalleeInstance : Callee;` declaration parses to
+        // LateResolvedType (the correct arm, already covered above), so it
+        // does not exercise this. An *eager* InitialValueAssignmentKind::
+        // FunctionBlock initializer is what the CODESYS/TwinCAT call-style
+        // instance initializer (`name : FB_Type(args);`) constructs at
+        // parse time -- but that grammar lands in a separate PR. To keep
+        // this regression independent of it, construct the eager
+        // FunctionBlock initializer directly on the parsed AST.
+        let mut library = parse_only(
+            "
+        FUNCTION_BLOCK Caller
+            VAR
+                CalleeInstance : Callee;
+            END_VAR
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Callee
+            VAR
+               IN1: BOOL;
+            END_VAR
+        END_FUNCTION_BLOCK",
+        );
+
+        // Rewrite Caller's forward reference to Callee into the eager
+        // FunctionBlock form. Caller is declared first, so the referenced
+        // type Callee must be reordered before it.
+        for element in library.elements.iter_mut() {
+            if let LibraryElementKind::FunctionBlockDeclaration(fb) = element {
+                if fb.name == TypeName::from("Caller") {
+                    fb.variables[0].initializer = InitialValueAssignmentKind::FunctionBlock(
+                        FunctionBlockInitialValueAssignment {
+                            type_name: TypeName::from("Callee"),
+                            init: vec![],
+                        },
+                    );
+                }
+            }
+        }
+
+        let (library, _reachable) = apply(library).unwrap();
+
+        // Callee (the referenced type) must come before Caller.
         let decl = library.elements.first().unwrap();
         let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
         assert_eq!(decl.name, TypeName::from("Callee"));

--- a/specs/plans/2026-07-31-toposort-fb-edge-direction-fix.md
+++ b/specs/plans/2026-07-31-toposort-fb-edge-direction-fix.md
@@ -1,0 +1,78 @@
+# Plan: Fix toposort dependency-graph edge direction for eager FunctionBlock initializers
+
+## Context
+
+Split out of PR #1222, which bundled this pre-existing correctness fix with
+a new feature (the CODESYS/TwinCAT call-style FB instance initializer,
+`name : FB_Type(args);`). The maintainer asked to separate the two. This PR
+is only the toposort fix; the feature that first makes the bug reachable
+through user-facing syntax rides along in a separate PR.
+
+## The bug
+
+`compiler/analyzer/src/xform_toposort_declarations.rs` builds a directed
+dependency graph and topologically sorts declarations so that a referenced
+type is always emitted before the POU that references it
+(referenced-type-before-referencer). Toposort orders an edge's source
+before its target, so the established convention across the arms is
+`add_edge(referenced, referencer)`:
+
+- `visit_late_bound_declaration`: `add_edge(base_type, alias)`
+- `visit_function` (call): `add_edge(callee, caller)`
+- `visit_initial_value_assignment_kind`, `Structure` arm:
+  `add_edge(referenced_struct, container)`
+- `visit_initial_value_assignment_kind`, `LateResolvedType` arm:
+  `add_edge(referenced, referencer)`
+
+Two arms for `InitialValueAssignmentKind::FunctionBlock` had the edge
+reversed (`add_edge(referencer, referenced)`):
+
+1. `visit_function_block_initial_value_assignment` (the dedicated visitor)
+2. the `InitialValueAssignmentKind::FunctionBlock(fb)` arm of
+   `visit_initial_value_assignment_kind`
+
+Both fire for the same eager FunctionBlock initializer. The reversed edge
+can order a referenced FB type *after* its referencer, which surfaces
+downstream as a spurious `P2011` "Parent type is not declared".
+
+## Reachability note
+
+At parse time, no current user-facing syntax produces an eager
+`InitialValueAssignmentKind::FunctionBlock` in this codebase:
+
+- A bare `inst : FB_Type;` inside a POU parses to `LateResolvedType` (the
+  correct arm).
+- A top-level `VAR_GLOBAL inst : FB_Type;` parses to `Simple`
+  (`located_var_spec_init()` matches first, so `global_var_decl()`'s
+  FunctionBlock alternative is dead code).
+- A `TYPE FB_Alias : FB_Type;` alias parses to `LateBound`.
+- `fb_name_decl()`'s FunctionBlock construction is unreachable (its
+  `commasep_oneplus()` combinator requires a spurious trailing comma).
+
+The eager form is produced at parse time only by the call-style grammar
+(separate PR), and by the late-bound resolver — which runs *after* toposort
+in `resolve_types`, so it doesn't feed toposort. The fix is still correct
+and worth landing first: it makes the transform obey its own convention for
+every eager FunctionBlock initializer, so the call-style feature is safe the
+moment it lands.
+
+## Change
+
+Flip both edges to `add_edge(to, from)` (referenced → referencer) and update
+the two comments to state the convention.
+
+## Test
+
+Because no parser path produces the eager form without the call-style
+grammar, the regression test constructs the eager
+`InitialValueAssignmentKind::FunctionBlock` initializer directly on a parsed
+AST (a `Caller` FB forward-referencing a later-declared `Callee` FB) and
+asserts `apply` orders `Callee` before `Caller`. Verified fail-before /
+pass-after: the test fails with the original reversed edges and passes with
+the flip. It deliberately avoids the `FB_Type(args)` call-style grammar,
+which is not part of this PR.
+
+## Non-goals
+
+No DSL, parser-grammar, or renderer changes — those all belong to the
+call-style feature PR.


### PR DESCRIPTION
## Summary

Split out of #1222 (per the request to separate the pre-existing bug fix from the new feature). This PR is **only** the toposort correctness fix — no DSL, parser-grammar, or renderer changes.

In `compiler/analyzer/src/xform_toposort_declarations.rs`, the dependency-graph edges for `InitialValueAssignmentKind::FunctionBlock` pointed the opposite direction to the `Structure` and `LateResolvedType` arms. Because `toposort` orders an edge's source before its target, the established convention is `add_edge(referenced_type, referencer)`. The two FunctionBlock arms had it reversed, which can order a referenced function-block type **after** the POU that references it, surfacing downstream as a spurious `P2011` "Parent type is not declared".

## Changes

- `visit_function_block_initial_value_assignment` (dedicated visitor): `add_edge(from, to)` → `add_edge(to, from)`.
- `visit_initial_value_assignment_kind`, `InitialValueAssignmentKind::FunctionBlock(fb)` arm: same flip.
- Both comments updated to state the referenced-type-before-containing-POU convention.

## Test

At parse time, no current user-facing syntax in this branch produces an eager `InitialValueAssignmentKind::FunctionBlock`:

- A bare `inst : FB_Type;` inside a POU parses to `LateResolvedType` (the already-correct arm).
- A top-level `VAR_GLOBAL inst : FB_Type;` parses to `Simple` (`located_var_spec_init()` matches first, so `global_var_decl()`'s FunctionBlock alternative is dead code).
- A `TYPE FB_Alias : FB_Type;` alias parses to `LateBound`.

The eager form is produced at parse time only by the call-style FB instance grammar (`name : FB_Type(args);`), which is not part of this PR, and by the late-bound resolver (which runs *after* toposort). So the regression test constructs the eager `FunctionBlock` initializer directly on a parsed AST — a `Caller` FB forward-referencing a later-declared `Callee` FB — and asserts `apply` orders `Callee` first. Verified fail-before / pass-after: it fails with the original reversed edges and passes with the flip, without depending on the call-style grammar.

## Dependency note for the maintainer

**This fix should merge before the FB call-style instance-init PR.** That feature is what first makes this bug reachable through user-facing syntax, and its tests depend on this fix.

## Verification

`cd compiler && just` passes locally (compile, coverage ≥ 85% incl. tests, clippy, fmt, dupes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJrtwYJjPwhftx4EqeBiQw)_