### PR TITLE
feat(parser): inline FB-instance call-style initializer

### DIFF
--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -453,4 +453,41 @@ END_FUNCTION_BLOCK";
 
         assert!(context.has_diagnostics());
     }
+
+    // ---------------------------------------------------------------------
+    // FB-instance call-style initializer.
+    // See specs/plans/2026-07-31-twincat-inline-fb-call-style-initializer.md.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn analyze_when_fb_call_style_init_references_earlier_declared_fb_then_no_diagnostics() {
+        // End-to-end regression for the toposort edge-direction bug found
+        // while adding this feature: `comm : FB_Comm(retries := 3);`
+        // constructs InitialValueAssignmentKind::FunctionBlock directly at
+        // parse time (unlike a bare declaration, which defers to
+        // LateResolvedType). Before the xform_toposort_declarations.rs fix,
+        // this produced a spurious P2011 "Parent type is not declared"
+        // because the referenced type was ordered after its referencing
+        // POU instead of before it.
+        let program = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm(retries := 3);
+END_VAR
+END_FUNCTION_BLOCK";
+        let lib = parse_program(program, &FileId::default(), &CompilerOptions::default()).unwrap();
+        let (_library, context) = analyze(&[&lib], &CompilerOptions::default()).unwrap();
+
+        assert!(
+            !context.has_diagnostics(),
+            "unexpected diagnostics: {:?}",
+            context.diagnostics()
+        );
+    }
 }

--- a/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
@@ -158,6 +158,7 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                             FunctionBlockInitialValueAssignment {
                                 type_name: name,
                                 init: vec![],
+                                call_params: None,
                             },
                         ));
                     }
@@ -176,6 +177,7 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                         FunctionBlockInitialValueAssignment {
                             type_name: name,
                             init: vec![],
+                            call_params: None,
                         },
                     ));
                 }
@@ -197,6 +199,7 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                                 FunctionBlockInitialValueAssignment {
                                     type_name: name,
                                     init: vec![],
+                                    call_params: None,
                                 },
                             ))
                         }

--- a/compiler/analyzer/src/xform_toposort_declarations.rs
+++ b/compiler/analyzer/src/xform_toposort_declarations.rs
@@ -670,6 +670,7 @@ mod tests {
                         FunctionBlockInitialValueAssignment {
                             type_name: TypeName::from("Callee"),
                             init: vec![],
+                            call_params: None,
                         },
                     );
                 }
@@ -679,6 +680,46 @@ mod tests {
         let (library, _reachable) = apply(library).unwrap();
 
         // Callee (the referenced type) must come before Caller.
+        let decl = library.elements.first().unwrap();
+        let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
+        assert_eq!(decl.name, TypeName::from("Callee"));
+
+        let decl = library.elements.get(1).unwrap();
+        let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
+        assert_eq!(decl.name, TypeName::from("Caller"));
+    }
+
+    #[test]
+    fn apply_when_function_block_call_style_init_then_return_ok() {
+        // Regression for a toposort edge-direction bug found while adding
+        // the CODESYS/TwinCAT call-style FB instance initializer
+        // (`name : FB_Type(args);`): unlike a bare declaration (which
+        // resolves via LateResolvedType, exercised by the test above),
+        // this syntax constructs InitialValueAssignmentKind::FunctionBlock
+        // directly at parse time. The FunctionBlock arms in this file
+        // previously added the dependency edge backwards relative to the
+        // Structure/LateResolvedType arms, so the referenced type
+        // (Callee) was ordered *after* the referencing POU (Caller)
+        // instead of before it, causing a spurious P2011 "Parent type is
+        // not declared" error downstream.
+        let program = "
+        FUNCTION_BLOCK Callee
+            VAR_INPUT
+               IN1: BOOL;
+            END_VAR
+
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Caller
+            VAR
+                CalleeInstance : Callee(IN1 := TRUE);
+            END_VAR
+
+        END_FUNCTION_BLOCK";
+
+        let library = parse_only(program);
+        let (library, _reachable) = apply(library).unwrap();
+
         let decl = library.elements.first().unwrap();
         let decl = cast!(decl, LibraryElementKind::FunctionBlockDeclaration);
         assert_eq!(decl.name, TypeName::from("Callee"));

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -2011,6 +2011,7 @@ impl VarDecl {
                 FunctionBlockInitialValueAssignment {
                     type_name: TypeName::from(type_name),
                     init: vec![],
+                    call_params: None,
                 },
             ),
             block: next_block_id(),
@@ -2592,6 +2593,16 @@ pub struct FunctionBlockInitialValueAssignment {
     pub type_name: TypeName,
     // The initializer may be empty
     pub init: Vec<StructureElementInit>,
+    /// Present for the CODESYS/TwinCAT call-style instance initializer
+    /// (`name : FB_Type(args);`, no `:=`) -- `args` uses the same
+    /// positional-or-named shape as an ordinary FB call. `None` for the
+    /// standard `:= (member := value, ...)` form or no initializer at all.
+    /// Mutually exclusive with `init` being non-empty. Not yet wired into
+    /// codegen, matching `init`'s own pre-existing status (parsed and
+    /// stored, but instance field/input values are not yet applied from
+    /// either form).
+    #[recurse(ignore)]
+    pub call_params: Option<Vec<ParamAssignmentKind>>,
 }
 
 /// See section 2.4.3.2. #6

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -930,7 +930,7 @@ parser! {
     // We have to first handle the special case of enumeration or fb_name without an initializer
     // because these share the same syntax. We only know the type after trying to resolve the
     // type name.
-    rule var_init_decl() -> Vec<UntypedVarDecl> = located_var1_init_decl() / structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() /  fb_name_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
+    rule var_init_decl() -> Vec<UntypedVarDecl> = located_var1_init_decl() / structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() /  fb_name_decl() / fb_call_style_var_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
     // CODESYS/TwinCAT vendor extension: a located variable (complete or
     // incomplete/wildcard address) declared inside an otherwise plain
     // VAR/VAR_INPUT/VAR_OUTPUT block, instead of requiring its own
@@ -990,12 +990,36 @@ parser! {
         UntypedVarDecl {
           location: None,
           name,
-          initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: init.clone().unwrap_or_else(Vec::new) }),
+          initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: init.clone().unwrap_or_else(Vec::new), call_params: None }),
         }
       }).collect()
     }
     rule fb_name_list() -> Vec<Id> = commasep_oneplus(<fb_name()>)
     rule fb_name() -> Id = i:identifier() { i }
+    // CODESYS/TwinCAT FB instance declaration with a call-style
+    // initialization parameter list (`FB_Type(args)`, no `:=`), using the
+    // same positional-or-named shape as an ordinary FB call -- e.g.
+    // `comm : FB_Comm(retries := 3, THIS);`. Deliberately uses var1_list()
+    // (not fb_name_list(), which has a pre-existing, unrelated bug --
+    // commasep_oneplus() requires a spurious trailing comma, making
+    // fb_name_decl() above unreachable in practice) and requires the
+    // parens unconditionally (not optional) so this rule can never match
+    // a bare "name : Type;" declaration -- that continues to flow through
+    // the existing late-bound-resolution fallback unchanged. No ordering
+    // hazard: every earlier alternative in var_init_decl() requires its
+    // own mandatory leading token (ARRAY, REF_TO, STRING/WSTRING, or a
+    // literal `:=`) and fails outright (not a partial match) on a bare
+    // type name followed by `(`.
+    rule fb_call_style_var_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ type_name:function_block_type_name() _ params:fb_call_style_init_params() {
+      names.into_iter().map(|name| {
+        UntypedVarDecl {
+          location: None,
+          name,
+          initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: Vec::new(), call_params: Some(params.clone()) }),
+        }
+      }).collect()
+    }
+    rule fb_call_style_init_params() -> Vec<ParamAssignmentKind> = tok(TokenType::LeftParen) _ params:param_assignment() ** (_ tok(TokenType::Comma) _) _ tok(TokenType::RightParen) { params }
     rule ref_to_var_init_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ syntax:ref_to_keyword() _ ref_target:ref_to_target() _ init:(tok(TokenType::Assignment) _ v:ref_initial_value() { v })? {
       names.into_iter().map(|name| {
         UntypedVarDecl {
@@ -1138,7 +1162,7 @@ parser! {
       }).collect()
     }
     // TODO this doesn't pass all information. I suspect the rule from the description is not right
-    rule global_var_decl() -> (Vec<VarDecl>) = vs:global_var_spec() _ tok:tok(TokenType::Colon) _ initializer:(l:located_var_spec_init() { l } / f:function_block_type_name() { InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment{type_name: f, init: vec![] })})? {
+    rule global_var_decl() -> (Vec<VarDecl>) = vs:global_var_spec() _ tok:tok(TokenType::Colon) _ initializer:(l:located_var_spec_init() { l } / f:function_block_type_name() { InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment{type_name: f, init: vec![], call_params: None })})? {
       vs.0.into_iter().map(|name| {
         let init = initializer.clone().unwrap_or(InitialValueAssignmentKind::None(SourceSpan::join(&tok.span, &tok.span)));
         VarDecl {

--- a/compiler/parser/src/tests/var_declarations.rs
+++ b/compiler/parser/src/tests/var_declarations.rs
@@ -168,3 +168,129 @@ END_PROGRAM",
         VariableIdentifier::Direct(_)
     ));
 }
+
+// ---------------------------------------------------------------------
+// CODESYS/TwinCAT FB-instance call-style initializer.
+// See specs/plans/2026-07-31-twincat-inline-fb-call-style-initializer.md.
+// ---------------------------------------------------------------------
+
+#[test]
+fn parse_when_fb_call_style_init_named_and_positional_then_parses_call_params() {
+    // Matches real usage found in a private test corpus: both named
+    // (comm := comm) and positional (THIS) arguments in the same
+    // call-style initializer.
+    let source = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm(retries := 3, THIS);
+END_VAR
+END_FUNCTION_BLOCK";
+    let library = parse_text(source);
+
+    let fb = cast!(
+        &library.elements[1],
+        LibraryElementKind::FunctionBlockDeclaration
+    );
+    assert_eq!(fb.variables.len(), 1);
+    let fb_init = cast!(
+        &fb.variables[0].initializer,
+        InitialValueAssignmentKind::FunctionBlock
+    );
+    assert_eq!(fb_init.type_name.to_string(), "FB_Comm");
+    assert!(fb_init.init.is_empty());
+    let call_params = fb_init
+        .call_params
+        .as_ref()
+        .expect("call_params must be Some");
+    assert_eq!(call_params.len(), 2);
+    assert!(matches!(call_params[0], ParamAssignmentKind::NamedInput(_)));
+    assert!(matches!(
+        call_params[1],
+        ParamAssignmentKind::PositionalInput(_)
+    ));
+}
+
+#[test]
+fn parse_when_fb_call_style_init_empty_parens_then_parses() {
+    let source = "
+FUNCTION_BLOCK FB_Comm
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm();
+END_VAR
+END_FUNCTION_BLOCK";
+    let library = parse_text(source);
+
+    let fb = cast!(
+        &library.elements[1],
+        LibraryElementKind::FunctionBlockDeclaration
+    );
+    let fb_init = cast!(
+        &fb.variables[0].initializer,
+        InitialValueAssignmentKind::FunctionBlock
+    );
+    assert_eq!(fb_init.call_params.as_ref().map(|p| p.len()), Some(0));
+}
+
+#[test]
+fn parse_when_fb_bare_decl_then_no_call_params() {
+    // Regression: an ordinary bare FB instance declaration (no
+    // initializer at all) must be unaffected -- it continues to flow
+    // through the existing late-bound-resolution path, not the new
+    // call-style rule (which requires the parens unconditionally).
+    let source = "
+FUNCTION_BLOCK FB_Comm
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm;
+END_VAR
+END_FUNCTION_BLOCK";
+    let library = parse_text(source);
+
+    let fb = cast!(
+        &library.elements[1],
+        LibraryElementKind::FunctionBlockDeclaration
+    );
+    // Bare declarations resolve to LateResolvedType at parse time
+    // (kind is only known once the type environment is built), not
+    // eagerly to FunctionBlock.
+    assert!(matches!(
+        &fb.variables[0].initializer,
+        InitialValueAssignmentKind::LateResolvedType(_)
+    ));
+}
+
+#[test]
+fn parse_when_fb_struct_init_then_still_parses() {
+    // Regression: the standard `:= (member := value)` named-struct-init
+    // form must still parse unchanged.
+    let source = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm := (retries := 3);
+END_VAR
+END_FUNCTION_BLOCK";
+    let library = parse_text(source);
+
+    let fb = cast!(
+        &library.elements[1],
+        LibraryElementKind::FunctionBlockDeclaration
+    );
+    assert_eq!(fb.variables.len(), 1);
+}

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -811,7 +811,17 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         &mut self,
         node: &FunctionBlockInitialValueAssignment,
     ) -> Result<Self::Value, Diagnostic> {
-        self.visit_type_name(&node.type_name)
+        self.visit_type_name(&node.type_name)?;
+
+        // CODESYS/TwinCAT call-style instance initializer
+        // (`name : FB_Type(args);`) -- see call_params' doc comment.
+        if let Some(params) = &node.call_params {
+            self.write_ws("(");
+            visit_comma_separated!(self, params.iter(), ParamAssignmentKind);
+            self.write_ws(")");
+        }
+
+        Ok(())
     }
 
     // 2.4.3.2

--- a/compiler/plc2plc/src/tests/declarations.rs
+++ b/compiler/plc2plc/src/tests/declarations.rs
@@ -48,3 +48,35 @@ fn write_to_string_when_array_of_string_with_size_then_renders_size() {
     let expected = read_resource("array_of_string_rendered.st");
     assert_eq!(rendered, expected);
 }
+
+// ---------------------------------------------------------------------
+// CODESYS/TwinCAT FB-instance call-style initializer.
+// See specs/plans/2026-07-31-twincat-inline-fb-call-style-initializer.md.
+// ---------------------------------------------------------------------
+
+#[test]
+fn write_to_string_when_fb_instance_call_style_init_then_round_trips() {
+    let source = "
+FUNCTION_BLOCK FB_Comm
+VAR_INPUT
+    retries : INT;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm(retries := 3, THIS);
+END_VAR
+END_FUNCTION_BLOCK
+";
+    let library_original =
+        parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
+    let rendered = write_to_string(&library_original).unwrap();
+
+    assert!(rendered.contains("FB_Comm ( retries := 3 , THIS )"));
+
+    let library_rendered =
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
+            .expect("rendered output must parse");
+    assert_eq!(library_original, library_rendered);
+}

--- a/specs/plans/2026-07-31-twincat-inline-fb-call-style-initializer.md
+++ b/specs/plans/2026-07-31-twincat-inline-fb-call-style-initializer.md
@@ -1,0 +1,181 @@
+# Plan: Inline FB-Instance Call-Style Initializer (`name : FB_Type(args);`)
+
+## Goal
+
+Add support for the CODESYS/TwinCAT call-style function-block instance
+initializer: passing an initialization parameter list directly after the
+type name, instead of the only currently-accepted `name : FB_Type :=
+(member := value, ...);` named-struct-init form.
+
+```
+FUNCTION_BLOCK FB_Example
+VAR
+    comm : FB_Comm(retries := 3, THIS);   // currently a parse error -- only FB_Comm := (...) parses
+END_VAR
+END_FUNCTION_BLOCK
+```
+
+This is split out of #1222 (which bundled two unrelated syntax gaps) and is
+part of the TwinCAT dialect work tracked in #1199. The
+`STRING(n)`/`WSTRING(n)` parenthesis-length half of #1222 is a separate PR
+(Agent 1). The toposort edge-direction fix that this feature depends on is
+also a separate, already-merged PR (#1269, Agent 2).
+
+## Verification against real files
+
+Per the "verify before assuming" habit, #1222 checked a private local
+checkout of a real TwinCAT codebase before designing anything:
+
+- Inline FB-constructor-call: 24 occurrences across several `.TcPOU`
+  files, using **both** named args (`FB_Comm(comm := comm)`) **and**
+  positional args (`FB_IdleState(THIS)`) — confirming this needs the same
+  positional-or-named parameter grammar as an ordinary FB call
+  (`param_assignment()`), not the named-only `member := value` shape that
+  `structure_initialization()` already provides for the `:=` form.
+
+## Dependency: toposort edge-direction fix (#1269, merged)
+
+Constructing an eager `InitialValueAssignmentKind::FunctionBlock`
+initializer for a real, user-declared FB type — which the call-style
+grammar does at parse time — surfaced a pre-existing bug in
+`xform_toposort_declarations.rs`: the `FunctionBlock` dependency-graph
+edges pointed the opposite direction to the `Structure`/`LateResolvedType`
+arms, ordering a referenced type *after* its referencing POU and producing
+a spurious `P2011` "Parent type is not declared". That fix (flipping both
+`FunctionBlock` edges to `add_edge(referenced, referencer)`) landed
+separately in #1269 and must be merged before this branch, or this
+branch's end-to-end tests fail. This PR does **not** re-include the edge
+flips; it does include the call-style-syntax tests that exercise the fix.
+
+## Design: why this needs no new dialect flag
+
+Following the qualified-method-call precedent: a construct needs a dialect
+gate only when it introduces a new keyword to demote/promote at the lexer
+level (`EXTENDS`, pragmas, `PI`). This construct introduces no new keyword
+— `(` is already a token used everywhere. Flag-gating isn't the right shape
+here either: codegen **already silently ignores** FB instance initializer
+values for the existing, standard `:= (member := value, ...)` form
+(`fb_init.init` is parsed and stored on the AST but never read by
+`compile_setup`; only `fb_init.type_name` is used to determine the
+instance's memory layout). Flagging *only* the new call-style form as
+"recognized but unsupported" would be inconsistent: the old form is equally
+not wired into codegen today, and isn't flagged. So: parse both forms the
+same permissive way, store the call-style argument list on the AST, and
+leave codegen's behavior exactly as it already is — this is a pure parser
+fix unblocking files that today fail to parse at all.
+
+## DSL: new optional field on `FunctionBlockInitialValueAssignment`
+
+```rust
+// compiler/dsl/src/common.rs
+pub struct FunctionBlockInitialValueAssignment {
+    pub type_name: TypeName,
+    pub init: Vec<StructureElementInit>,
+    /// Present for the CODESYS/TwinCAT call-style instance initializer
+    /// (`name : FB_Type(args);`, no `:=`) -- `args` uses the same
+    /// positional-or-named shape as an ordinary FB call. `None` for the
+    /// standard `:= (member := value, ...)` form or no initializer at all.
+    /// Mutually exclusive with `init` being non-empty. Not yet wired into
+    /// codegen.
+    #[recurse(ignore)]
+    pub call_params: Option<Vec<ParamAssignmentKind>>,
+}
+```
+
+`#[recurse(ignore)]` matches the existing treatment of non-recursable
+auxiliary fields on the DSL structs. Construction sites that need the new
+field added (`call_params: None` for all but the new grammar path):
+`compiler/dsl/src/common.rs` (1: `VarDecl::function_block`),
+`compiler/parser/src/parser.rs` (2: `fb_name_decl()`, `global_var_decl()`),
+`compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs` (3).
+`compiler/mcp/src/tools/pou_lineage.rs` pattern-matches with `..` and needs
+no change.
+
+## Grammar: new dedicated rule in `var_init_decl()`
+
+`fb_name_decl()` — the rule that *looks* like it should host this — is
+pre-existing dead code: `fb_name_list()` uses `commasep_oneplus()`, which
+requires a spurious trailing comma, so `fb_name_decl()` has never matched
+real input (every FB instance declaration is actually handled by the
+`var1_init_decl__with_ambiguous_struct()` fallback). Fixing
+`commasep_oneplus()` is deliberately out of scope: `fb_name_decl()` being
+unreachable is load-bearing (it eagerly commits a bare type name to
+`FunctionBlock` with no way to check the type actually *is* a function
+block — precisely why the `LateResolvedType`-then-resolve deferral exists).
+
+Instead, add a new, narrowly-scoped rule using the *working* `var1_list()`
+combinator, requiring the call-style parens **unconditionally** (not
+optional):
+
+```
+rule fb_call_style_var_decl() -> Vec<UntypedVarDecl> =
+  names:var1_list() _ tok(Colon) _ type_name:function_block_type_name() _
+  params:fb_call_style_init_params() { ... call_params: Some(params) ... }
+
+rule fb_call_style_init_params() -> Vec<ParamAssignmentKind> =
+  tok(LeftParen) _ params:param_assignment() ** (_ tok(Comma) _) _ tok(RightParen) { params }
+```
+
+Added to `var_init_decl()`'s ordered choice immediately after
+`fb_name_decl()`. The mandatory parens make this syntax unambiguous (no
+other declaration shape can be followed directly by `(`), so it never needs
+to defer to late-bound resolution the way a bare type name does. No PEG
+ordering hazard: every earlier alternative in `var_init_decl()` requires
+its own mandatory leading token (`ARRAY`, `REF_TO`, `STRING`/`WSTRING`, or
+a literal `:=`) and fails outright (not a partial match) on a bare type
+name followed by `(`.
+
+## Renderer
+
+`plc2plc`'s `visit_function_block_initial_value_assignment` renders the
+call params in parentheses when `call_params` is `Some`, using
+`visit_comma_separated!` (same as the ordinary FB-call param rendering).
+`write_ws` inserts spaces, so `FB_Comm(retries := 3, THIS)` round-trips to
+`FB_Comm ( retries := 3 , THIS )` (spaced) — normalization, not a bug,
+matching the renderer's existing convention.
+
+## Non-goals
+
+- Any codegen change — `call_params` is stored on the AST and otherwise
+  unused, matching the pre-existing behavior of `init` today.
+- Fixing `commasep_oneplus()` / making `fb_name_decl()` reachable — see
+  above; deliberately out of scope.
+- The `STRING(n)`/`WSTRING(n)` parenthesis-length grammar (Agent 1's PR).
+- The toposort edge-direction fix itself (Agent 2's PR #1269, merged).
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `compiler/dsl/src/common.rs` | `FunctionBlockInitialValueAssignment.call_params` field + `VarDecl::function_block` site |
+| `compiler/parser/src/parser.rs` | New `fb_call_style_var_decl()`/`fb_call_style_init_params()` rules; add to `var_init_decl()`; `call_params: None` in `fb_name_decl()` and `global_var_decl()` |
+| `compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs` | `call_params: None` at 3 construction sites |
+| `compiler/plc2plc/src/renderer.rs` | Render call params in parentheses when `Some` |
+
+## Testing Strategy
+
+- Parser (`compiler/parser/src/tests/var_declarations.rs`): mixed
+  named+positional call params populate `call_params`; empty parens →
+  `Some(vec![])`; bare declaration (no init) still resolves to
+  `LateResolvedType` (`call_params` path not taken); `:= (member := value)`
+  struct-init form still parses (regression).
+- plc2plc (`compiler/plc2plc/src/tests/declarations.rs`): call-style
+  initializer round-trips through parse → render → parse.
+- Analyzer (`compiler/analyzer/src/stages.rs`): end-to-end confirmation
+  that a call-style initializer referencing an earlier-declared FB produces
+  no diagnostics (the P2011 regression, green with #1269 merged).
+- Toposort (`compiler/analyzer/src/xform_toposort_declarations.rs`): a
+  call-style-grammar-driven test asserting the referenced type is ordered
+  first (test only — the production edge flip is #1269's).
+
+## Tasks
+
+- [x] Write plan (this document)
+- [x] DSL: add `call_params` field + update `VarDecl` construction site
+- [x] Parser: new rules + `var_init_decl()` alternative + `call_params: None`
+      at existing sites
+- [x] Analyzer: `call_params: None` at 3 `xform_resolve_late_bound` sites
+- [x] Renderer: render call params
+- [x] Tests (parser, plc2plc, analyzer stages, toposort)
+- [x] Run full CI pipeline (`cd compiler && just`)
+- [ ] Open PR against `ironplc/ironplc:main`


### PR DESCRIPTION
## Summary

Adds support for the CODESYS/TwinCAT **call-style function-block instance initializer** — passing an initialization parameter list directly after the type name, using the same positional-or-named parameter shape as an ordinary FB call:

```iecst
FUNCTION_BLOCK FB_Example
VAR
    comm : FB_Comm(retries := 3, THIS);   // previously a parse error -- only `FB_Comm := (...)` parsed
END_VAR
END_FUNCTION_BLOCK
```

This is **split out of #1222** (which bundled two unrelated syntax gaps) and is **part of #1199** (TwinCAT dialect support). The `STRING(n)`/`WSTRING(n)` parenthesis-length half of #1222 is a separate PR.

## Design notes

- **No new dialect flag.** `(` is already a token, and codegen already silently ignores FB instance initializer values for the existing `:= (member := value, ...)` form (only `type_name` drives memory layout). Gating *only* the new form as "recognized but unsupported" would be inconsistent — so both forms parse the same permissive way. The call-style argument list is parsed and stored but not yet wired into codegen, matching `init`'s own pre-existing status.
- **New optional DSL field** `FunctionBlockInitialValueAssignment.call_params: Option<Vec<ParamAssignmentKind>>` (`#[recurse(ignore)]`) — `Some` only for the call-style form, `None` for the `:=` struct-init form or a bare declaration.
- **Dedicated grammar rule.** Uses a new `fb_call_style_var_decl()` built on the working `var1_list()` combinator and requiring the parens unconditionally (so it can never match a bare `name : Type;`, which continues through the late-bound path). It deliberately does **not** use the pre-existing dead `fb_name_decl()` rule, whose `commasep_oneplus()`-based name list requires a spurious trailing comma and never matches real input — fixing that combinator is out of scope.
- **plc2plc** renders the call params back in parentheses; round-trips through parse → render → parse.

## Dependency

Depends on the toposort edge-direction fix **#1269** (also split from #1222, now merged into `main`). Constructing an eager `InitialValueAssignmentKind::FunctionBlock` for a user-declared FB type — which the call-style grammar does at parse time — surfaces a spurious `P2011` "Parent type is not declared" without that fix. This PR **does not** re-include the production edge flip; it **does** include the call-style-syntax tests that exercise the fixed ordering (an end-to-end test in `stages.rs` and a toposort-level test).

## Changes

| File | Change |
|------|--------|
| `compiler/dsl/src/common.rs` | New `call_params` field + `VarDecl::function_block` construction site |
| `compiler/parser/src/parser.rs` | New `fb_call_style_var_decl()` / `fb_call_style_init_params()` rules; added to `var_init_decl()`; `call_params: None` at existing sites |
| `compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs` | `call_params: None` at 3 construction sites |
| `compiler/plc2plc/src/renderer.rs` | Render call params when `Some` |
| `specs/plans/2026-07-31-twincat-inline-fb-call-style-initializer.md` | Implementation plan |

## Tests

- **Parser:** mixed named+positional call params; empty parens; bare declaration still `LateResolvedType` (regression); `:= (...)` struct-init still parses (regression).
- **plc2plc:** call-style initializer round-trips.
- **Analyzer:** end-to-end no-diagnostics for a call-style initializer referencing an earlier-declared FB (P2011 regression, green with #1269 merged); toposort ordering test.

Full CI pipeline (`cd compiler && just` — compile, coverage ≥85%, clippy, fmt, dupes) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVvRfY3XHuutbjewWKX5v3

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVvRfY3XHuutbjewWKX5v3)_