### PR TITLE
docs: plan + include for consistent dialect references

### DIFF
--- a/docs/explanation/references.rst
+++ b/docs/explanation/references.rst
@@ -8,10 +8,9 @@ list, see the :doc:`/reference/language/data-types/derived/reference-types`.
 
 .. note::
 
-   References require enabling through a dialect or flag. You can select a
-   dialect that includes references (``--dialect iec61131-3-ed3`` or
-   ``--dialect rusty``) or enable references directly with ``--allow-ref-to``.
-   See :doc:`enabling-dialects-and-features` for details.
+   References require enabling through a dialect or flag. Enable them directly
+   with ``--allow-ref-to``, or select a dialect that includes them. See
+   :doc:`enabling-dialects-and-features` for details.
 
 --------------------------------------
 What Is a Reference?

--- a/docs/includes/enabled-by-flag.rst
+++ b/docs/includes/enabled-by-flag.rst
@@ -1,0 +1,3 @@
+Pass the |flag| flag to enable it, or select a dialect that includes it. See
+:doc:`/explanation/enabling-dialects-and-features` for the dialects and flags
+reference.

--- a/docs/includes/requires-edition3.rst
+++ b/docs/includes/requires-edition3.rst
@@ -1,5 +1,5 @@
 .. note::
 
    This feature requires IEC 61131-3 Edition 3. Use
-   ``--dialect iec61131-3-ed3`` or the ``rusty`` dialect to enable it.
-   See :doc:`/explanation/enabling-dialects-and-features` for details.
+   ``--dialect iec61131-3-ed3`` to enable it. See
+   :doc:`/explanation/enabling-dialects-and-features` for details.

--- a/docs/reference/compiler/problems/P0004.rst
+++ b/docs/reference/compiler/problems/P0004.rst
@@ -39,10 +39,9 @@ To fix this error, you have two options:
    Counter := Counter + 1;
    END_FUNCTION_BLOCK
 
-**Option 2: Choose a dialect that supports C-style comments**
+**Option 2: Enable C-style comments**
 
-If you prefer to use C-style comments, select a dialect that supports them.
-The ``rusty`` and ``codesys`` dialects both enable C-style comments (choose one
-from the dialect selector in the playground, or pass ``--dialect rusty`` on the
-command line). You can also enable just this feature with the
-``--allow-c-style-comments`` command line option.
+If you prefer to use C-style comments, enable them.
+
+.. |flag| replace:: ``--allow-c-style-comments``
+.. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4033.rst
+++ b/docs/reference/compiler/problems/P4033.rst
@@ -7,8 +7,7 @@ P4033
 This error occurs when a source uses the IEC 61131-3:2013 partial-access bit
 syntax (``.%Xn``) without enabling it. Partial-access syntax is standardized
 in Edition 3 of IEC 61131-3 but is not part of Edition 2, so it is gated
-behind the ``--allow-partial-access-syntax`` flag (also enabled by the
-``rusty`` and ``iec61131-3-ed3`` dialect presets).
+behind the ``--allow-partial-access-syntax`` flag.
 
 Example
 -------
@@ -31,11 +30,10 @@ To fix this error, either use the Edition 2 short form ``.n``:
 
    r := b.0;
 
-Or enable partial-access syntax with one of:
+Or enable partial-access syntax:
 
-- ``--allow-partial-access-syntax``
-- ``--dialect=iec61131-3-ed3``
-- ``--dialect=rusty``
+.. |flag| replace:: ``--allow-partial-access-syntax``
+.. include:: /includes/enabled-by-flag.rst
 
 Scope
 -----

--- a/docs/reference/compiler/problems/P4036.rst
+++ b/docs/reference/compiler/problems/P4036.rst
@@ -42,6 +42,7 @@ To fix this error, either move the located variable into its own block:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the vendor extension with the
-``--allow-mixed-located-var-declarations`` flag (also enabled by
-``--dialect=rusty``, ``--dialect=codesys``, and ``--dialect=twincat``).
+Or enable the vendor extension:
+
+.. |flag| replace:: ``--allow-mixed-located-var-declarations``
+.. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4037.rst
+++ b/docs/reference/compiler/problems/P4037.rst
@@ -38,6 +38,7 @@ To fix this error, either use a literal value directly:
    END_VAR
    END_PROGRAM
 
-Or enable the vendor extension with the
-``--allow-constant-initializer-expressions`` flag (also enabled by
-``--dialect=rusty`` and ``--dialect=codesys``).
+Or enable the vendor extension:
+
+.. |flag| replace:: ``--allow-constant-initializer-expressions``
+.. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4041.rst
+++ b/docs/reference/compiler/problems/P4041.rst
@@ -48,6 +48,7 @@ To fix this error, either use a decimal label:
    END_CASE;
    END_FUNCTION_BLOCK
 
-Or enable the vendor extension with the ``--allow-bit-string-case-labels``
-flag (also enabled by ``--dialect=rusty``, ``--dialect=codesys``, and
-``--dialect=twincat``).
+Or enable the vendor extension:
+
+.. |flag| replace:: ``--allow-bit-string-case-labels``
+.. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/extension-library/functions/isvalidref.rst
+++ b/docs/reference/extension-library/functions/isvalidref.rst
@@ -11,7 +11,7 @@ target.
    * - **IEC 61131-3**
      - Not part of the standard (Beckhoff TwinCAT / CODESYS extension)
    * - **Support**
-     - Supported (requires ``--allow-reference-to`` or ``--dialect twincat`` / ``--dialect codesys``)
+     - Supported (requires ``--allow-reference-to``)
 
 Signatures
 ----------
@@ -58,14 +58,8 @@ Enabling
 
    ironplcc check --allow-reference-to main.st
 
-Or use a dialect that enables ``REFERENCE TO`` support:
-
-.. code-block:: shell
-
-   ironplcc check --dialect twincat main.st
-
-See :doc:`/explanation/enabling-dialects-and-features` for more information
-about dialects and feature flags.
+.. |flag| replace:: ``--allow-reference-to``
+.. include:: /includes/enabled-by-flag.rst
 
 Example
 -------

--- a/docs/reference/extension-library/functions/sizeof.rst
+++ b/docs/reference/extension-library/functions/sizeof.rst
@@ -10,7 +10,7 @@ Returns the size in bytes of a variable or type.
    * - **IEC 61131-3**
      - Not part of the standard (vendor extension)
    * - **Support**
-     - Supported (requires ``--allow-sizeof`` or ``--dialect rusty``)
+     - Supported (requires ``--allow-sizeof``)
 
 Signatures
 ----------
@@ -57,14 +57,8 @@ Enabling
 
    ironplcc check --allow-sizeof main.st
 
-Or use the RuSTy dialect which enables all vendor extensions:
-
-.. code-block:: shell
-
-   ironplcc check --dialect rusty main.st
-
-See :doc:`/explanation/enabling-dialects-and-features` for more information
-about dialects and feature flags.
+.. |flag| replace:: ``--allow-sizeof``
+.. include:: /includes/enabled-by-flag.rst
 
 Example
 -------

--- a/docs/reference/extension-library/index.rst
+++ b/docs/reference/extension-library/index.rst
@@ -8,9 +8,9 @@ supported by other PLC environments such as CODESYS, TwinCAT, and RuSTy.
 
 .. tip::
 
-   Extension library items require explicit opt-in via ``--allow-*`` flags
-   or ``--dialect rusty``. See :doc:`/explanation/enabling-dialects-and-features`
-   for details.
+   Extension library items require explicit opt-in via ``--allow-*`` flags,
+   or a dialect that enables them. See
+   :doc:`/explanation/enabling-dialects-and-features` for details.
 
 Functions
 ---------

--- a/docs/reference/extension-library/variables/system-uptime.rst
+++ b/docs/reference/extension-library/variables/system-uptime.rst
@@ -10,7 +10,7 @@ Implicit global variables that expose the VM's monotonic uptime counter.
    * - **IEC 61131-3**
      - Not part of the standard (vendor extension)
    * - **Support**
-     - Supported (requires ``--allow-system-uptime-global`` or ``--dialect rusty``)
+     - Supported (requires ``--allow-system-uptime-global``)
 
 Variables
 ---------
@@ -62,14 +62,8 @@ System uptime variables are a vendor extension and must be explicitly enabled:
 
    ironplcc check --allow-system-uptime-global main.st
 
-Or use the RuSTy dialect which enables all vendor extensions:
-
-.. code-block:: shell
-
-   ironplcc check --dialect rusty main.st
-
-See :doc:`/explanation/enabling-dialects-and-features` for more information
-about dialects and feature flags.
+.. |flag| replace:: ``--allow-system-uptime-global``
+.. include:: /includes/enabled-by-flag.rst
 
 Usage
 -----

--- a/docs/reference/language/data-types/derived/reference-types.rst
+++ b/docs/reference/language/data-types/derived/reference-types.rst
@@ -11,15 +11,15 @@ variable.
 .. tip::
 
    References can also be enabled without full Edition 3 by passing
-   ``--allow-ref-to`` or by selecting the ``rusty`` dialect.
+   ``--allow-ref-to``, or by selecting a dialect that includes it.
    See :doc:`/explanation/enabling-dialects-and-features`.
 
 .. note::
 
    Beckhoff TwinCAT and CODESYS spell references ``REFERENCE TO`` and bind them
    with the ``REF=`` operator (``r REF= x;``) rather than ``REF_TO`` and
-   ``r := REF(x);``. Enable this variant with ``--allow-reference-to`` or the
-   ``twincat`` or ``codesys`` dialect. It describes the same underlying reference,
+   ``r := REF(x);``. Enable this variant with ``--allow-reference-to``, or a
+   dialect that includes it. It describes the same underlying reference,
    but — unlike ``REF_TO`` — a ``REFERENCE TO`` variable *auto-dereferences*: a
    bare use reads through the reference and a bare ``:=`` writes through it, with
    no ``^`` needed. Only the binding operator ``REF=`` and ``__ISVALIDREF(r)``

--- a/docs/reference/language/structured-text/bit-access.rst
+++ b/docs/reference/language/structured-text/bit-access.rst
@@ -100,8 +100,7 @@ Edition 3 Partial-Access Syntax
 IEC 61131-3:2013 adds the explicit form ``variable.%Xn`` for bit access.
 Semantically it is identical to the ``.n`` short form — IronPLC lowers both
 to the same representation. The Edition 3 form is gated behind
-``--allow-partial-access-syntax`` and is enabled by default under
-``--dialect=iec61131-3-ed3`` and ``--dialect=rusty``.
+``--allow-partial-access-syntax``.
 
 Using ``.%Xn`` without the flag raises
 :doc:`P4033 </reference/compiler/problems/P4033>`.

--- a/specs/plans/dialect-reference-consistency.md
+++ b/specs/plans/dialect-reference-consistency.md
@@ -1,0 +1,89 @@
+# Consistent Dialect References in the Docs Website
+
+## Context
+
+The documentation website (`docs/`) should have exactly two canonical places
+that describe IronPLC's dialects and how to select them:
+
+- `docs/explanation/enabling-dialects-and-features.rst` — the dialects and
+  flags reference.
+- `docs/reference/editor/settings.rst` — the VS Code `ironplc.dialect` setting.
+
+Throughout the rest of the site, individual feature/problem pages should **not**
+enumerate which dialect presets (`rusty`, `codesys`, `twincat`,
+`iec61131-3-ed3`) happen to enable a given feature. That duplication is
+inconsistent from page to page and drifts as dialect definitions change. A
+feature that is gated behind a `--allow-*` flag should name **the flag** and
+then point the reader to the dialects-and-flags page.
+
+For example, `P4033.rst` currently says the partial-access flag is "also
+enabled by the `rusty` and `iec61131-3-ed3` dialect presets" and lists
+`--dialect=iec61131-3-ed3` / `--dialect=rusty` as fixes. We want it to name
+`--allow-partial-access-syntax` and link to the dialect page instead.
+
+## Approach
+
+### 1. New reusable include: `docs/includes/enabled-by-flag.rst`
+
+reStructuredText `include` directives cannot take positional arguments, but the
+including document's substitution definitions are in scope inside the included
+file. The include therefore reads a `|flag|` substitution that each caller
+defines immediately before the include:
+
+```rst
+.. |flag| replace:: ``--allow-bit-string-case-labels``
+.. include:: /includes/enabled-by-flag.rst
+```
+
+The include contains the standard text (name the flag, mention dialects
+generically, link to the dialects-and-flags page). This mirrors the existing
+`requires-vendor-extension.rst` / `requires-edition3.rst` includes.
+
+### 2. Trim the edition-3 include
+
+`requires-edition3.rst` currently names the `rusty` dialect specifically. Trim
+it to name only `--dialect iec61131-3-ed3` (the edition enabler) and point to
+the dialect page, so the shared edition note stops enumerating vendor dialects.
+
+### 3. Fix the violation pages
+
+Replace per-page dialect enumerations with the flag + include (or, for
+table cells where a directive can't be inserted, drop the `or --dialect X`
+suffix and rely on the page's prose/"Enabling" section to link out):
+
+- `reference/compiler/problems/P4033.rst` — `--allow-partial-access-syntax`
+- `reference/compiler/problems/P4036.rst` — `--allow-mixed-located-var-declarations`
+- `reference/compiler/problems/P4037.rst` — `--allow-constant-initializer-expressions`
+- `reference/compiler/problems/P4041.rst` — `--allow-bit-string-case-labels`
+- `reference/compiler/problems/P0004.rst` — `--allow-c-style-comments`
+- `reference/extension-library/functions/sizeof.rst` — `--allow-sizeof`
+- `reference/extension-library/variables/system-uptime.rst` — `--allow-system-uptime-global`
+- `reference/extension-library/functions/isvalidref.rst` — `--allow-reference-to`
+- `reference/extension-library/index.rst`
+- `reference/language/data-types/derived/reference-types.rst`
+- `explanation/references.rst`
+- `reference/language/structured-text/bit-access.rst`
+
+## Not in scope (legitimate references — left unchanged)
+
+- The two canonical pages above, plus `reference/compiler/ironplcc.rst`
+  (compiler-flag reference) — all required by the `ironplc_flags.py` doc guard.
+- `trademarks.rst` — trademark attribution.
+- `reference/language/edition-support.rst` — the edition reference page itself.
+- `reference/compiler/problems/P0010.rst` — the canonical "enable Edition 3"
+  page; editions have no `--allow-*` flag, and it already links to the dialect
+  page.
+- `reference/mcp/tools.rst` — documents the `dialect` API parameter's valid
+  values ("for example …; call `list_options` for the authoritative list").
+- `how-to-guides/ai-agents/write-plc-programs-with-an-ai-agent.rst` — a passing
+  example of what to tell an AI agent.
+- `:dialect:` options on `playground*` example directives — these configure the
+  runnable example.
+- `CODESYS: <url>` "See also" citation links, and prose naming real PLC
+  environments (CODESYS/TwinCAT/RuSTy) as the *origin* of a vendor extension —
+  these describe provenance, not IronPLC dialect selection.
+
+## Validation
+
+`cd docs && just` (runs `sphinx-build -a -W -n`). The `ironplc_flags.py` guard
+still passes because no flag or dialect is removed from the two canonical pages.


### PR DESCRIPTION
Add specs/plans/dialect-reference-consistency.md and a reusable
docs/includes/enabled-by-flag.rst include that names a --allow-* flag
(via a |flag| substitution) and links to the dialects-and-flags page,
so feature/problem pages stop enumerating specific dialect presets.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0145iEtxqeQnG4uhQsLsQRFE