### PR TITLE
test(vm): bind CALL_DEPTH_EXCEEDED to a spec-conformance requirement

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1127,8 +1127,10 @@ version = "0.232.0"
 dependencies = [
  "csv",
  "ironplc-container",
+ "ironplc-spec-requirements-gen",
  "ironplc-vm",
  "proptest",
+ "spec_test_macro",
 ]
 
 [[package]]

--- a/compiler/vm/Cargo.toml
+++ b/compiler/vm/Cargo.toml
@@ -17,9 +17,11 @@ ironplc-container = { path = "../container", version = "0.232.0" }
 [dev-dependencies]
 ironplc-vm = { path = ".", features = ["test-support"] }
 proptest = "1"
+spec_test_macro = { path = "../spec_test_macro" }
 
 [build-dependencies]
 csv = "1"
+ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
 
 # All integration tests live in a single binary so compile/link work (and
 # llvm-cov instrumentation) is amortized across the whole suite instead of

--- a/compiler/vm/build.rs
+++ b/compiler/vm/build.rs
@@ -126,4 +126,5 @@ fn main() {
         eprintln!("problem generating trap_codes.rs: {err}");
         process::exit(1);
     }
+    ironplc_spec_requirements_gen::generate(&["runtime-execution-model.md"]);
 }

--- a/compiler/vm/tests/it/execute_stack_overflow.rs
+++ b/compiler/vm/tests/it/execute_stack_overflow.rs
@@ -3,6 +3,7 @@
 use ironplc_container::opcode;
 use ironplc_container::{ContainerBuilder, FunctionId};
 use ironplc_vm::error::Trap;
+use spec_test_macro::spec_test;
 
 #[test]
 fn execute_when_stack_overflow_then_traps() {
@@ -52,11 +53,16 @@ fn execute_when_stack_underflow_then_traps() {
     crate::common::assert_trap(&mut vm, Trap::StackUnderflow);
 }
 
-#[test]
-fn execute_when_call_recursion_exceeds_max_depth_then_traps_call_stack_overflow() {
-    // SCAN unconditionally calls itself. Without a depth guard this would
-    // exhaust the Rust thread stack and abort the process; with the guard
-    // it must trap cleanly as Trap::CallStackOverflow.
+/// Builds a container whose SCAN function unconditionally calls itself and
+/// declares the given per-program `max_call_depth`, then asserts that running
+/// it traps cleanly with `Trap::CallStackOverflow`.
+///
+/// The frame buffer is sized from the container's `max_call_depth`
+/// (`VmBuffers::from_container`), so unbounded self-recursion fills exactly
+/// that many frames and the next CALL traps. Because the bound comes from the
+/// container header — not a VM-wide constant — a small declared depth traps
+/// after only a few frames, which is what makes this a per-program contract.
+fn assert_self_recursion_traps_at_depth(max_call_depth: u16) {
     let init_bytecode: Vec<u8> = vec![opcode::RET_VOID];
     let scan_id = FunctionId::SCAN.to_le_bytes();
     #[rustfmt::skip]
@@ -64,19 +70,30 @@ fn execute_when_call_recursion_exceeds_max_depth_then_traps_call_stack_overflow(
         opcode::CALL, scan_id[0], scan_id[1], 0x00, 0x00, // CALL SCAN, var_offset=0
         opcode::RET_VOID,
     ];
-    // The frame buffer holds 4 frames; unbounded self-recursion fills it
-    // and the 5th CALL traps Trap::CallStackOverflow.
     let c = ContainerBuilder::new()
         .num_variables(1)
         .add_function(FunctionId::INIT, &init_bytecode, 0, 1, 0)
         .add_function(FunctionId::SCAN, &bytecode, 4, 1, 0)
         .init_function_id(FunctionId::INIT)
         .entry_function_id(FunctionId::SCAN)
-        .max_call_depth(4)
+        .max_call_depth(max_call_depth)
         .build();
     let mut b = crate::common::VmBuffers::from_container(&c);
     let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
     crate::common::assert_trap(&mut vm, Trap::CallStackOverflow);
+}
+
+/// REQ-RT-vm-001: a CALL that would push a frame beyond the container's
+/// declared `max_call_depth` traps with `CALL_DEPTH_EXCEEDED`
+/// (`Trap::CallStackOverflow`). Parameterised over several declared depths so
+/// the test binds to the per-program contract rather than a hardcoded value:
+/// a small declared depth (2) traps after only a few frames — impossible if
+/// the guard were still the old VM-wide `MAX_CALL_DEPTH = 32` constant.
+#[spec_test(REQ_RT_vm_001)]
+fn vm_spec_req_rt_vm_001_call_recursion_exceeds_declared_depth_then_traps() {
+    for max_call_depth in [2, 4, 8, 32] {
+        assert_self_recursion_traps_at_depth(max_call_depth);
+    }
 }
 
 #[test]

--- a/compiler/vm/tests/it/main.rs
+++ b/compiler/vm/tests/it/main.rs
@@ -11,6 +11,26 @@
 
 mod common;
 
+/// Spec-conformance requirements generated from `specs/design/runtime-execution-model.md`.
+/// Referenced by `#[spec_test(REQ_RT_vm_NNN)]`. See `vm/build.rs`.
+#[allow(dead_code)]
+mod spec_requirements {
+    include!(concat!(env!("OUT_DIR"), "/spec_requirements.rs"));
+}
+
+/// Meta-test: every `REQ-RT-vm-NNN` requirement in
+/// `specs/design/runtime-execution-model.md` has a `#[spec_test(...)]`
+/// somewhere in this crate's `src/` or `tests/`. The build script populates
+/// `UNTESTED` from the files it scans.
+#[test]
+fn all_spec_requirements_have_tests() {
+    assert!(
+        spec_requirements::UNTESTED.is_empty(),
+        "Requirements in spec with no conformance test: {:?}",
+        spec_requirements::UNTESTED
+    );
+}
+
 mod debug_engine;
 mod execute_add_i32;
 mod execute_arith_f32;

--- a/compiler/vm/tests/it/main.rs
+++ b/compiler/vm/tests/it/main.rs
@@ -12,8 +12,9 @@
 mod common;
 
 /// Spec-conformance requirements generated from `specs/design/runtime-execution-model.md`.
-/// Referenced by `#[spec_test(REQ_RT_vm_NNN)]`. See `vm/build.rs`.
-#[allow(dead_code)]
+/// Referenced by `#[spec_test(REQ_RT_vm_NNN)]`. See `vm/build.rs`. Every item the
+/// build script emits carries its own targeted `#[allow(dead_code)]`, so no
+/// module-level blanket allow is needed.
 mod spec_requirements {
     include!(concat!(env!("OUT_DIR"), "/spec_requirements.rs"));
 }

--- a/specs/design/runtime-execution-model.md
+++ b/specs/design/runtime-execution-model.md
@@ -398,16 +398,16 @@ A trap is an unrecoverable error detected during the EXECUTE phase. The VM canno
 
 ### Trap Sources
 
-| Trap code | Source | Description |
-|-----------|--------|-------------|
-| DIVIDE_BY_ZERO | DIV_I32, DIV_U32, DIV_I64, DIV_U64, MOD_I32, MOD_U32, MOD_I64, MOD_U64 | Integer division or modulo with zero divisor |
-| OVERFLOW | ADD_*, SUB_*, MUL_*, NEG_*, NARROW_*, F*_TO_I*, F*_TO_U* | Overflow under the `fault` overflow policy (ADR-0002) |
-| ARRAY_OUT_OF_BOUNDS | LOAD_ARRAY, STORE_ARRAY | Array index outside declared bounds |
-| STACK_OVERFLOW | any instruction | Operand stack depth exceeds `max_stack_depth` |
-| CALL_DEPTH_EXCEEDED | CALL, FB_CALL | Call stack depth exceeds `max_call_depth` |
-| STRING_POOL_EXHAUSTED | BUILTIN (string), LOAD_CONST_STR, LOAD_CONST_WSTR | Temporary string buffer pool has no free slots |
-| WATCHDOG_EXPIRED | (external) | EXECUTE phase exceeded `max_scan_time` |
-| INVALID_INSTRUCTION | any | Undefined opcode encountered at runtime (should never happen if verifier ran, but defense-in-depth) |
+| Requirement | Trap code | Source | Description |
+|-------------|-----------|--------|-------------|
+| | DIVIDE_BY_ZERO | DIV_I32, DIV_U32, DIV_I64, DIV_U64, MOD_I32, MOD_U32, MOD_I64, MOD_U64 | Integer division or modulo with zero divisor |
+| | OVERFLOW | ADD_*, SUB_*, MUL_*, NEG_*, NARROW_*, F*_TO_I*, F*_TO_U* | Overflow under the `fault` overflow policy (ADR-0002) |
+| | ARRAY_OUT_OF_BOUNDS | LOAD_ARRAY, STORE_ARRAY | Array index outside declared bounds |
+| | STACK_OVERFLOW | any instruction | Operand stack depth exceeds `max_stack_depth` |
+| **REQ-RT-vm-001** | CALL_DEPTH_EXCEEDED | CALL, FB_CALL | A CALL or FB_CALL that would push a call frame beyond the container's per-program `max_call_depth` traps with `CALL_DEPTH_EXCEEDED`. The limit is the container's declared depth, not a VM-wide constant. |
+| | STRING_POOL_EXHAUSTED | BUILTIN (string), LOAD_CONST_STR, LOAD_CONST_WSTR | Temporary string buffer pool has no free slots |
+| | WATCHDOG_EXPIRED | (external) | EXECUTE phase exceeded `max_scan_time` |
+| | INVALID_INSTRUCTION | any | Undefined opcode encountered at runtime (should never happen if verifier ran, but defense-in-depth) |
 
 ### Trap Sequence
 

--- a/specs/plans/2026-08-01-call-depth-spec-conformance.md
+++ b/specs/plans/2026-08-01-call-depth-spec-conformance.md
@@ -1,0 +1,57 @@
+# Bind `CALL_DEPTH_EXCEEDED` to a spec-conformance requirement
+
+## Goal
+
+Close out the remaining spec-test half of issue #962. The VM already honours
+the per-program `container.max_call_depth` (the hardcoded `MAX_CALL_DEPTH`
+constant is gone and a zero depth is rejected at load), but the
+`CALL_DEPTH_EXCEEDED` trap contract in `runtime-execution-model.md` still has
+no `REQ-` ID and no `#[spec_test]` binding. This plan adds that binding so the
+per-program call-depth limit is enforced bidirectionally by the
+spec-conformance machinery.
+
+## Architecture
+
+Wire the `ironplc-vm` crate into the existing spec-conformance pipeline
+(`spec_requirements_gen` + `spec_test_macro`), following the `vm-cli` pattern
+where the `#[spec_test]` lives in the integration-test binary:
+
+1. Add a single testable requirement `REQ-RT-vm-001` to the Trap Sources table
+   in `runtime-execution-model.md` (new area code `RT` = runtime, owning crate
+   slug `vm`), via a dedicated `Requirement` first column (matching the
+   partially-filled-column house style in `bytecode-container-format.md`).
+2. Have `vm/build.rs` list `runtime-execution-model.md` through
+   `ironplc_spec_requirements_gen::generate`, and add the `spec_requirements`
+   module + completeness meta-test to the `it` integration-test binary.
+3. Convert the existing self-recursion trap test to `#[spec_test(REQ_RT_vm_001)]`,
+   parameterised over `max_call_depth` so it verifies the per-program contract
+   at several depths rather than one hardcoded value.
+
+The workspace orphan guard (`compiler/test/tests/spec_conformance_guard.rs`)
+already passes for this shape: `vm/build.rs` listing the doc claims
+`(vm, runtime-execution-model.md)`, which matches the `REQ-RT-vm-001` slug.
+
+## Design doc reference
+
+- `specs/design/runtime-execution-model.md` (Trap Sources / trap contract)
+- `specs/design/cross-crate-spec-conformance.md` (ID grammar, ownership)
+- `specs/design/spec-conformance-testing.md` (enforcement mechanism)
+
+## File map
+
+- `specs/design/runtime-execution-model.md` — add `Requirement` column to the
+  Trap Sources table; fill `REQ-RT-vm-001` on the `CALL_DEPTH_EXCEEDED` row.
+- `compiler/vm/build.rs` — call `ironplc_spec_requirements_gen::generate`.
+- `compiler/vm/Cargo.toml` — add `ironplc-spec-requirements-gen` build-dep and
+  `spec_test_macro` dev-dep.
+- `compiler/vm/tests/it/main.rs` — add `spec_requirements` module + meta-test.
+- `compiler/vm/tests/it/execute_stack_overflow.rs` — convert the recursion test
+  to `#[spec_test(REQ_RT_vm_001)]`, parameterised over depth.
+
+## Tasks
+
+- [ ] Add `REQ-RT-vm-001` to the Trap Sources table.
+- [ ] Wire `vm/build.rs` + `vm/Cargo.toml` dependencies.
+- [ ] Add `spec_requirements` module and meta-test to the `it` binary.
+- [ ] Convert + parameterise the recursion spec test.
+- [ ] `cargo test -p ironplc-vm` green; full `cd compiler && just` green.


### PR DESCRIPTION
The VM already honours the per-program container `max_call_depth` (the
hardcoded `MAX_CALL_DEPTH` constant is gone and a zero depth is rejected
at load), but the `CALL_DEPTH_EXCEEDED` trap contract had no `REQ-` ID
and no `#[spec_test]` binding, so issue #962's spec-test half was still
open.

- Add `REQ-RT-vm-001` to the Trap Sources table in
  runtime-execution-model.md (new `RT` area, `vm` crate slug), via a
  Requirement column matching the existing house style.
- Wire the `ironplc-vm` crate into the spec-conformance pipeline:
  `build.rs` lists the doc through `spec_requirements_gen`; add the
  `spec_requirements` module and `all_spec_requirements_have_tests`
  meta-test to the `it` integration binary.
- Convert the self-recursion trap test to `#[spec_test(REQ_RT_vm_001)]`,
  parameterised over declared depths [2, 4, 8, 32] so it verifies the
  per-program contract rather than a hardcoded value.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011QBGNjb5bsPcbxA3v8g9Nv