### PR TITLE
Fix commasep_oneplus trailing-comma grammar bug

### DIFF
--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -291,7 +291,7 @@ parser! {
     rule semisep<T>(x: rule<T>) -> Vec<T> = v:(x() ** (_ semicolon() _)) _ semicolon() {v}
     rule semisep_oneplus<T>(x: rule<T>) -> Vec<T> = v:(x() ++ (_ semicolon() _)) semicolon() {v}
     rule semisep_or_empty<T>(x: rule<T>) -> Vec<T> = v:(x() ** (_ semicolon() _)) _ semicolon() {v} / { vec![] }
-    rule commasep_oneplus<T>(x: rule<T>) -> Vec<T> = v:(x() ++ (_ comma() _)) comma() {v}
+    rule commasep_oneplus<T>(x: rule<T>) -> Vec<T> = v:(x() ++ (_ comma() _)) {v}
 
 
     pub rule library() -> Vec<LibraryElementKind> = traced(<library__impl()>)
@@ -930,7 +930,7 @@ parser! {
     // We have to first handle the special case of enumeration or fb_name without an initializer
     // because these share the same syntax. We only know the type after trying to resolve the
     // type name.
-    rule var_init_decl() -> Vec<UntypedVarDecl> = located_var1_init_decl() / structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() /  fb_name_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
+    rule var_init_decl() -> Vec<UntypedVarDecl> = located_var1_init_decl() / structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
     // CODESYS/TwinCAT vendor extension: a located variable (complete or
     // incomplete/wildcard address) declared inside an otherwise plain
     // VAR/VAR_INPUT/VAR_OUTPUT block, instead of requiring its own
@@ -985,16 +985,6 @@ parser! {
         }
       }).collect()
     }
-    rule fb_name_decl() -> Vec<UntypedVarDecl> = names:fb_name_list() _ tok(TokenType::Colon) _ type_name:function_block_type_name() _ init:(tok(TokenType::Assignment) _ init:structure_initialization() { init })? {
-      names.into_iter().map(|name| {
-        UntypedVarDecl {
-          location: None,
-          name,
-          initializer: InitialValueAssignmentKind::FunctionBlock(FunctionBlockInitialValueAssignment { type_name: type_name.clone(), init: init.clone().unwrap_or_else(Vec::new) }),
-        }
-      }).collect()
-    }
-    rule fb_name_list() -> Vec<Id> = commasep_oneplus(<fb_name()>)
     rule fb_name() -> Id = i:identifier() { i }
     rule ref_to_var_init_decl() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ syntax:ref_to_keyword() _ ref_target:ref_to_target() _ init:(tok(TokenType::Assignment) _ v:ref_initial_value() { v })? {
       names.into_iter().map(|name| {
@@ -1044,7 +1034,7 @@ parser! {
     pub rule input_output_declarations() -> Vec<VarDecl> = tok(TokenType::VarInOut) _ declarations:semisep_or_empty(<var_declaration()>) _ tok(TokenType::EndVar) {
       VarDeclarations::flat_map(declarations, VariableType::InOut,  None)
     }
-    rule var_declaration() -> Vec<UntypedVarDecl> = temp_var_decl() / fb_name_decl()
+    rule var_declaration() -> Vec<UntypedVarDecl> = temp_var_decl()
     rule temp_var_decl() -> Vec<UntypedVarDecl> = string_var_declaration() / var1_declaration() / array_var_declaration() / structured_var_declaration()
     rule var1_declaration() -> Vec<UntypedVarDecl> = names:var1_list() _ tok(TokenType::Colon) _ init:(spec:subrange_specification__with_range() {InitialValueAssignmentKind::Subrange(spec)} / values:enumerated_specification__only_values()  {InitialValueAssignmentKind::EnumeratedValues(EnumeratedValuesInitializer{ values, initial_value: None})} / spec:simple_specification() { InitialValueAssignmentKind::LateResolvedType(spec)} ) {
       // TODO this could eventually cause duplicated definitions because

--- a/compiler/parser/src/tests/tasks.rs
+++ b/compiler/parser/src/tests/tasks.rs
@@ -92,6 +92,29 @@ fn parse_when_task_with_priority_only_then_builds_structure() {
 }
 
 #[test]
+fn parse_when_program_configuration_has_conf_elements_then_no_trailing_comma_required() {
+    // Regression test for the `commasep_oneplus` trailing-comma bug: a program
+    // configuration with conf elements must parse WITHOUT a trailing comma. The
+    // `(someVar := 5)` element is a program connection source.
+    let source = "
+        CONFIGURATION config
+            RESOURCE resource1 ON PLC
+                TASK my_task(PRIORITY := 1);
+                PROGRAM instance1 WITH my_task : my_prg (someVar := 5);
+            END_RESOURCE
+        END_CONFIGURATION";
+
+    let lib = parse_text(source);
+    let config = cast!(
+        &lib.elements[0],
+        LibraryElementKind::ConfigurationDeclaration
+    );
+    let program = &config.resource_decl[0].programs[0];
+    assert_eq!(program.name, Id::from("instance1"));
+    assert_eq!(program.sources.len(), 1);
+}
+
+#[test]
 fn parse_when_task_with_interval_non_duration_then_parse_error() {
     let source = "
         CONFIGURATION config

--- a/specs/plans/commasep-oneplus-trailing-comma.md
+++ b/specs/plans/commasep-oneplus-trailing-comma.md
@@ -1,0 +1,68 @@
+# Fix `commasep_oneplus` Trailing-Comma Grammar Bug
+
+## Context
+
+`compiler/parser/src/parser.rs` defines a family of separated-list combinators.
+`commasep_oneplus` is broken:
+
+```
+rule commasep_oneplus<T>(x: rule<T>) -> Vec<T> = v:(x() ++ (_ comma() _)) comma() {v}
+```
+
+The `x() ++ (_ comma() _)` fragment already matches a one-or-more
+comma-separated list. The trailing `comma()` demands a *spurious* trailing
+comma, so the combinator only matches input that ends in a comma. IEC 61131-3
+does not allow a trailing comma in these lists, so the fix is to remove the
+trailing `comma()` (not make it optional):
+
+```
+rule commasep_oneplus<T>(x: rule<T>) -> Vec<T> = v:(x() ++ (_ comma() _)) {v}
+```
+
+## Callers
+
+`commasep_oneplus` has exactly two callers:
+
+1. **`prog_conf_elements()`** (used by `program_configuration()`), the `( ... )`
+   element list of `PROGRAM inst WITH task : ptype ( elem, ... )`. This is a
+   genuine user-facing parse failure: any program configuration with conf
+   elements currently requires an illegal trailing comma. No test covers it
+   today — all program-config tests in `tests/tasks.rs` use the no-element
+   form.
+
+2. **`fb_name_list()`**, used only by `fb_name_decl()`, which is dead code
+   because of the trailing-comma bug.
+
+## Why the one-line fix alone regresses tests
+
+Removing the trailing comma makes `fb_name_decl()` reachable. It is tried
+before the late-bound fallback in `var_init_decl()` and `var_declaration()`,
+so it eagerly commits bare `x : SomeType` declarations to
+`InitialValueAssignmentKind::FunctionBlock` instead of deferring via
+`LateResolvedType`. This misclassifies non-FB types (structs, enums, aliases)
+as function blocks and regresses ~6 parser tests.
+
+`fb_name_decl` is fundamentally unsound: at parse time we cannot know a bare
+type name refers to a function block — that is exactly why the
+`LateResolvedType` placeholder + `xform_resolve_late_bound_type_initializer`
+pipeline exists.
+
+## Changes
+
+1. Fix `commasep_oneplus` — remove the trailing `comma()`.
+2. Remove `fb_name_decl()` and `fb_name_list()`, and remove the
+   `fb_name_decl()` alternative from `var_init_decl()` and `var_declaration()`.
+   Bare and `:=`-initialized FB declarations already flow correctly through
+   `structured_var_init_decl__without_ambiguous()` (`:=`) and
+   `var1_init_decl__with_ambiguous_struct()` -> `LateResolvedType` (bare).
+   Keep the `fb_name()` rule — still used by `fb_task()`, `fb_invocation()`,
+   and the config data-source path.
+3. Add a regression test in `tests/tasks.rs` proving a program configuration
+   WITH conf elements parses without a trailing comma.
+4. Run `cd compiler && just`; all checks must pass (the previously-failing
+   tests pass once the misclassification path is gone).
+
+## Notes
+
+Unblocks #1273 (the call-style FB initializer PR), which currently sidesteps
+this bug by using `var1_list()` in its call-style rule.


### PR DESCRIPTION
## Summary

Fixes a parser grammar bug in `commasep_oneplus` that incorrectly required a trailing comma in comma-separated lists. This bug made program configurations with conf elements unparseable and blocked dead code (`fb_name_decl`) from being removed.

## Changes

- **Fix `commasep_oneplus` rule**: Removed the spurious trailing `comma()` requirement. The `x() ++ (_ comma() _)` fragment already matches a complete one-or-more comma-separated list; the trailing comma was non-standard and prevented valid IEC 61131-3 syntax from parsing.

- **Remove dead code**: Deleted `fb_name_decl()` and `fb_name_list()` rules that were unreachable due to the trailing-comma bug. These rules were fundamentally unsound—they attempted to classify bare type names as function blocks at parse time, which is impossible without semantic analysis. Removed the `fb_name_decl()` alternative from `var_init_decl()` and `var_declaration()`. Function block declarations already flow correctly through existing paths (`structured_var_init_decl__without_ambiguous()` for `:=`-initialized, and `var1_init_decl__with_ambiguous_struct()` → `LateResolvedType` for bare).

- **Kept `fb_name()` rule**: Still used by `fb_task()`, `fb_invocation()`, and config data-source paths.

- **Added regression test**: New test in `tests/tasks.rs` verifies that a program configuration WITH conf elements parses correctly without a trailing comma.

## Implementation Details

The one-line grammar fix alone would have regressed ~6 parser tests because `fb_name_decl()` would become reachable and eagerly misclassify non-FB types (structs, enums, aliases) as function blocks. Removing the dead code path eliminates this misclassification, allowing the fix to pass all tests.

This unblocks #1273 (call-style FB initializer PR), which currently works around this bug by using `var1_list()` in its call-style rule.

https://claude.ai/code/session_018KTQBvgrE3Q5SUMdUecqVp