### PR TITLE
Override displayName for Marketplace VSIX build

### DIFF
--- a/integrations/vscode/justfile
+++ b/integrations/vscode/justfile
@@ -60,11 +60,15 @@ package filename:
 
 # Build the Marketplace VSIX package. The Visual Studio Marketplace uses the
 # extension ID ironplc.ironplc-vscode because the original ironplc.ironplc ID
-# cannot be reused; Open VSX keeps ironplc.ironplc. Only the `name` differs, so
-# `displayName` and publisher remain identical on both registries. Overriding
-# the name here mutates package.json in the (ephemeral) build tree only.
+# cannot be reused; Open VSX keeps ironplc.ironplc. The `displayName` is also
+# overridden to "IronPLC IDE" because the Marketplace still reserves the bare
+# "IronPLC" display name from the removed listing and rejects it as in use; the
+# publisher (ironplc) is unchanged. Open VSX keeps `name: ironplc` and
+# `displayName: IronPLC`. Both overrides mutate package.json in the (ephemeral)
+# build tree only.
 package-marketplace filename:
   npm pkg set name=ironplc-vscode
+  npm pkg set 'displayName=IronPLC IDE'
   npx vsce package --out {{filename}}
 
 # Generate a CycloneDX JSON SBOM (bom.cdx.json) for the VS Code extension.

--- a/specs/plans/vscode-marketplace-extension-id.md
+++ b/specs/plans/vscode-marketplace-extension-id.md
@@ -18,13 +18,21 @@ across them.
 
 ## Decision
 
-- **Open VSX** keeps `ironplc.ironplc` (unchanged) — protects existing users.
-- **Marketplace** publishes as `ironplc.ironplc-vscode` — same publisher and
-  same `displayName` ("IronPLC"), only the machine `name` differs. The differing
-  internal ID is invisible in the store UI.
+- **Open VSX** keeps `ironplc.ironplc` and `displayName` "IronPLC" (unchanged) —
+  protects existing users.
+- **Marketplace** publishes as `ironplc.ironplc-vscode` with `displayName`
+  "IronPLC IDE" — same publisher (`ironplc`); the machine `name` differs because
+  `ironplc.ironplc` is retired, and the `displayName` differs because the
+  Marketplace still reserves the bare "IronPLC" display name from the removed
+  listing and rejects a new upload with it as already in use. Adding a neutral
+  qualifier ("IDE" — deliberately not tied to Structured Text or IEC 61131-3, so
+  the name still fits if other languages/standards are added later) follows the
+  common `<Brand> <Descriptor>` convention used by peer PLC extensions on the
+  Marketplace. The differing internal ID is invisible in the store UI.
 
-Only the `name` field changes for the Marketplace build. Command IDs, language
-IDs, and activation events are literal strings unaffected by `name`.
+Only the `name` and `displayName` fields change for the Marketplace build.
+Command IDs, language IDs, and activation events are literal strings unaffected
+by `name`.
 
 ## Rollout
 
@@ -42,10 +50,12 @@ manually tested. This plan is delivered in two stages.
    prerequisite for the new ID to report its version correctly.
 
 2. **Add a `package-marketplace` justfile recipe** that overrides `name` to
-   `ironplc-vscode` and packages a VSIX with extension ID `ironplc.ironplc-vscode`.
-   Run `just package-marketplace <file>.vsix` locally to build a VSIX for manual
-   install (`code --install-extension <file>.vsix`) or a manual `vsce publish`
-   test. The Open VSX / GitHub-release VSIX is unchanged (`name: ironplc`).
+   `ironplc-vscode` and `displayName` to "IronPLC IDE", then packages a VSIX with
+   extension ID `ironplc.ironplc-vscode`. Run `just package-marketplace
+   <file>.vsix` locally to build a VSIX for manual install (`code
+   --install-extension <file>.vsix`) or a manual `vsce publish` test. The Open
+   VSX / GitHub-release VSIX is unchanged (`name: ironplc`, `displayName:
+   IronPLC`).
 
 ### Stage 1.5 — package and upload the Marketplace VSIX in CI, no publish (this change)
 


### PR DESCRIPTION
## Summary

Updates the Marketplace VSIX packaging to override both the extension `name` and `displayName` fields, addressing a constraint where the Visual Studio Marketplace reserves the bare "IronPLC" display name from the removed listing and rejects it as already in use.

## Changes

- **Decision documentation** (`specs/plans/vscode-marketplace-extension-id.md`):
  - Clarified that the Marketplace build uses `displayName: "IronPLC IDE"` in addition to the already-documented `name: ironplc-vscode`
  - Explained the rationale: the Marketplace still reserves "IronPLC" from the removed listing, so a neutral qualifier ("IDE") is added following the `<Brand> <Descriptor>` convention used by peer PLC extensions
  - Updated rollout plan to reflect both field overrides in the `package-marketplace` recipe

- **Build configuration** (`integrations/vscode/justfile`):
  - Added `npm pkg set 'displayName=IronPLC IDE'` to the `package-marketplace` recipe
  - Updated recipe comments to document both the `name` and `displayName` overrides and their rationale
  - Clarified that Open VSX retains the original values (`name: ironplc`, `displayName: IronPLC`)

## Implementation Details

The `package-marketplace` recipe now performs two mutations on `package.json` in the ephemeral build tree:
1. `name: ironplc-vscode` (already present)
2. `displayName: IronPLC IDE` (newly added)

These overrides are invisible to end users in the store UI but ensure the Marketplace listing can be published without conflicts while maintaining a distinct, descriptive display name that remains applicable if additional languages or standards are supported in the future.

https://claude.ai/code/session_01R6mZFWdVev6SSXKvt1AskV