### PR TITLE
Parallelize compiler quality and package builds in CI

### DIFF
--- a/.github/workflows/partial_compiler.yaml
+++ b/.github/workflows/partial_compiler.yaml
@@ -63,21 +63,16 @@ jobs:
   # (neither job depends on the other) so the coverage build and the release
   # build no longer happen serially.
   #
-  # `just ci` exercises the host toolchain only -- it never uses the release
-  # `rust_target`, and nothing consumes its coverage output (lcov.info is a
-  # pass/fail gate, not an artifact). So it runs once per unique CI host rather
-  # than once per release target: the two Windows release targets share one
-  # x86_64 Windows host and the two macOS targets share one arm64 host.
+  # Coverage/lint/dupes are host-independent, and `just ci` never uses the
+  # release `rust_target`. Cross-platform test execution is provided instead by
+  # the per-target test step in compiler-package, so this gate runs on Linux
+  # only.
   compiler-quality:
     name: Compiler Quality Checks
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./compiler
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest, windows-2025, macos-latest]
 
     steps:
       # Checkout the repository/fetch input artifacts
@@ -99,7 +94,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "compiler -> target"
-          key: quality-${{ matrix.os }}
+          key: quality-ubuntu-latest
       - uses: taiki-e/install-action@03e268b84870ac3cfa58a44d9b504511b732a857 # cargo-llvm-cov
       - name: Install cargo-dupes
         run: cargo install cargo-dupes
@@ -182,6 +177,12 @@ jobs:
         with:
           name: ironplc-compiler-sbom
           path: compiler/
+
+      # Run the full test suite on this host. compiler-quality runs coverage
+      # (and thus the tests) on Linux only, so this is where cross-platform
+      # test execution happens -- tests run on the Windows and macOS hosts too.
+      - name: Run tests
+        run: just test
 
       # Execute build recipe. This is the release build only; the debug /
       # coverage / lint build runs in parallel in compiler-quality.

--- a/.github/workflows/partial_compiler.yaml
+++ b/.github/workflows/partial_compiler.yaml
@@ -58,7 +58,57 @@ jobs:
             compiler/bom.cdx.json.sha256
           if-no-files-found: error
 
-  compiler:
+  # Quality gate: debug build, coverage (which runs all tests), lint, and
+  # duplicate-code checks via `just ci`. Runs in parallel with compiler-package
+  # (neither job depends on the other) so the coverage build and the release
+  # build no longer happen serially.
+  #
+  # `just ci` exercises the host toolchain only -- it never uses the release
+  # `rust_target`, and nothing consumes its coverage output (lcov.info is a
+  # pass/fail gate, not an artifact). So it runs once per unique CI host rather
+  # than once per release target: the two Windows release targets share one
+  # x86_64 Windows host and the two macOS targets share one arm64 host.
+  compiler-quality:
+    name: Compiler Quality Checks
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./compiler
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-2025, macos-latest]
+
+    steps:
+      # Checkout the repository/fetch input artifacts
+      - name: Checkout branch or tag ${{ inputs.commit-ref }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ inputs.commit-ref }}
+        with:
+          ref: ${{ inputs.commit-ref  }}
+      - name: Checkout HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ !inputs.commit-ref }}
+
+      # Configure the execution environment. Only the tools `just ci` needs;
+      # no cross-compile target, SBOM, or NSIS.
+      - uses: taiki-e/install-action@01159adff8f38113be7211e869405f6f6abf02d7 # just
+      - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: "compiler -> target"
+          key: quality-${{ matrix.os }}
+      - uses: taiki-e/install-action@03e268b84870ac3cfa58a44d9b504511b732a857 # cargo-llvm-cov
+      - name: Install cargo-dupes
+        run: cargo install cargo-dupes
+
+      # Compile, run coverage (all tests, 85% gate), lint, and dupe checks.
+      - name: Run quality checks
+        run: just ci
+
+  compiler-package:
     name: Build Compiler and Associated Installers
     needs: [compiler-sbom]
     runs-on:  ${{ matrix.os }}
@@ -96,20 +146,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ !inputs.commit-ref }}
 
-      # Configure the execution environment
+      # Configure the execution environment. Only the tools `just package`
+      # needs; lint/coverage tooling lives in compiler-quality.
       - uses: taiki-e/install-action@01159adff8f38113be7211e869405f6f6abf02d7 # just
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
-          components: rustfmt, clippy
           target: ${{ matrix.rust_target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "compiler -> target"
           # Include target triple in cache key for cross-compilation
           key: ${{ matrix.rust_target }}
-      - uses: taiki-e/install-action@03e268b84870ac3cfa58a44d9b504511b732a857 # cargo-llvm-cov
-      - name: Install cargo-dupes
-        run: cargo install cargo-dupes
       - name: Cache NSIS
         if: ${{ matrix.os == 'windows-2025' }}
         id: cache-nsis
@@ -136,9 +183,8 @@ jobs:
           name: ironplc-compiler-sbom
           path: compiler/
 
-      # Execute build recipe
-      - name: Build the Compiler
-        run: just ci
+      # Execute build recipe. This is the release build only; the debug /
+      # coverage / lint build runs in parallel in compiler-quality.
       - name: Create installer package
         run: just package ${{ inputs.version }} ${{ matrix.artifact }} ${{ matrix.rust_target }}
 

--- a/compiler/justfile
+++ b/compiler/justfile
@@ -13,7 +13,7 @@ compile:
   cargo build
 
 test:
-  cargo test --quiet --all-targets
+  cargo test --quiet --all-targets --features ironplc-vm-cli/dap
 
 # Run tests and produce coverage report
 coverage:

--- a/compiler/justfile
+++ b/compiler/justfile
@@ -12,8 +12,12 @@ setup:
 compile:
   cargo build
 
+# Run the test suite. Excludes benchmarks (which `--all-targets` would run as
+# tests, since st_benchmark uses `harness = false`); benches are compile-checked
+# by `just lint` and run via `just bench`. Mirrors the targets `just coverage`
+# exercises.
 test:
-  cargo test --quiet --all-targets --features ironplc-vm-cli/dap
+  cargo test --quiet --workspace --features ironplc-vm-cli/dap
 
 # Run tests and produce coverage report
 coverage:

--- a/specs/plans/2026-08-02-parallel-compiler-builds.md
+++ b/specs/plans/2026-08-02-parallel-compiler-builds.md
@@ -1,0 +1,78 @@
+# Parallelize the compiler quality and package builds in CI/release
+
+## Goal
+
+Cut the wall-clock time of the compiler build stage (used by both CI and the
+release/deployment workflows) by running the coverage/quality build and the
+release/installer build **in parallel** instead of serially.
+
+## Problem
+
+`.github/workflows/partial_compiler.yaml` has a single matrix job (`compiler`,
+5 target legs) that runs two independent builds one after the other:
+
+1. `just ci` — `compile` (debug build) + `coverage` (a second,
+   instrumentation-flagged build that runs all tests, gated at 85% lines) +
+   `lint` + `dupes`.
+2. `just package` — a third build (`cargo build --release --target <triple>`)
+   that produces the actual installer.
+
+Per leg the wall-clock is `ci_time + package_time`. Two facts make splitting
+these clean:
+
+- **Nothing consumes the coverage output.** `lcov.info` is never uploaded; the
+  `coverage` recipe is purely a pass/fail gate. There is no artifact to reuse
+  between the two builds (a coverage-instrumented binary is unusable for
+  release anyway).
+- **`just ci` is run redundantly today.** `just ci` builds/tests on the *host*
+  and never uses `matrix.rust_target` (only `just package` cross-compiles). The
+  two Windows legs share one x86_64 Windows host and the two macOS legs share
+  one arm64 host, so `just ci` runs 5× across only **3 unique hosts**.
+
+## Approach
+
+Split the single `compiler` job into two jobs that do not depend on each other,
+so they run concurrently:
+
+- **`compiler-quality`** — runs `just ci` on a 3-host matrix
+  (`ubuntu-latest`, `windows-2025`, `macos-latest`): exactly the host arch/OS
+  combinations `just ci` executes on today, deduplicated. Installs only what
+  `just ci` needs (rustfmt, clippy, cargo-llvm-cov, cargo-dupes). No SBOM
+  download, no cross-compile target, no NSIS.
+- **`compiler-package`** — keeps the existing 5-target matrix, the
+  `compiler-sbom` dependency, the SBOM download, and the NSIS install. Runs
+  only `just package` and uploads the installer + sha256 artifacts. Drops the
+  clippy/rustfmt/cargo-llvm-cov/cargo-dupes setup it no longer needs.
+
+Per stage the wall-clock drops from `ci + package` to roughly
+`max(ci, package)`.
+
+### Correctness / gating
+
+- The reusable workflow (partial) succeeds only if **both** jobs pass, so the
+  existing gates are preserved: `upload-release-artifacts` and the release
+  publish steps in `deployment.yaml` still block on coverage + lint passing.
+- No caller (`deployment.yaml`, `integration.yaml`, `update.yaml`) references
+  the partial's internal job names or any output; they gate on the caller-level
+  `uses:` job. The partial exposes no `outputs`.
+- Artifact names are unchanged: `ironplc-compiler-sbom`, and the per-target
+  installer + `.sha256` names.
+
+### Accepted trade-off
+
+Because the two jobs are now independent, `just package` runs even when
+`just ci` is failing (it will simply never publish, since the partial still
+fails overall). This wasted-compute-on-failure is the inherent cost of the
+parallelism.
+
+## File map
+
+- `.github/workflows/partial_compiler.yaml` — split `compiler` into
+  `compiler-quality` and `compiler-package`.
+
+## Tasks
+
+- [ ] Add `compiler-quality` job (3-host matrix, `just ci`, no SBOM/target/NSIS).
+- [ ] Rework `compiler` → `compiler-package` (5-target matrix, `just package`
+      only, drop lint/coverage tool installs).
+- [ ] Verify workflow YAML parses and callers are unaffected.

--- a/specs/plans/2026-08-02-parallel-compiler-builds.md
+++ b/specs/plans/2026-08-02-parallel-compiler-builds.md
@@ -34,15 +34,20 @@ these clean:
 Split the single `compiler` job into two jobs that do not depend on each other,
 so they run concurrently:
 
-- **`compiler-quality`** — runs `just ci` on a 3-host matrix
-  (`ubuntu-latest`, `windows-2025`, `macos-latest`): exactly the host arch/OS
-  combinations `just ci` executes on today, deduplicated. Installs only what
-  `just ci` needs (rustfmt, clippy, cargo-llvm-cov, cargo-dupes). No SBOM
-  download, no cross-compile target, no NSIS.
+- **`compiler-quality`** — runs `just ci` (compile, coverage at 85%, lint,
+  dupes) on **Linux only**. Coverage/lint/dupes are host-independent, so a
+  single host is sufficient for the gate. Installs only what `just ci` needs
+  (rustfmt, clippy, cargo-llvm-cov, cargo-dupes). No SBOM download, no
+  cross-compile target, no NSIS.
 - **`compiler-package`** — keeps the existing 5-target matrix, the
-  `compiler-sbom` dependency, the SBOM download, and the NSIS install. Runs
-  only `just package` and uploads the installer + sha256 artifacts. Drops the
+  `compiler-sbom` dependency, the SBOM download, and the NSIS install. Runs the
+  full test suite (`just test`) on each host and then `just package`, and
+  uploads the installer + sha256 artifacts. Drops the
   clippy/rustfmt/cargo-llvm-cov/cargo-dupes setup it no longer needs.
+
+Cross-platform test execution is preserved by the `just test` step in
+`compiler-package`: tests run on the Windows and macOS hosts (as well as Linux)
+even though coverage/lint only run on Linux.
 
 Per stage the wall-clock drops from `ci + package` to roughly
 `max(ci, package)`.
@@ -72,7 +77,7 @@ parallelism.
 
 ## Tasks
 
-- [ ] Add `compiler-quality` job (3-host matrix, `just ci`, no SBOM/target/NSIS).
-- [ ] Rework `compiler` → `compiler-package` (5-target matrix, `just package`
-      only, drop lint/coverage tool installs).
-- [ ] Verify workflow YAML parses and callers are unaffected.
+- [x] Add `compiler-quality` job (Linux only, `just ci`, no SBOM/target/NSIS).
+- [x] Rework `compiler` → `compiler-package` (5-target matrix, `just test` +
+      `just package`, drop lint/coverage tool installs).
+- [x] Verify workflow YAML parses (actionlint clean) and callers are unaffected.


### PR DESCRIPTION
## Summary

Split the single `compiler` job in the CI workflow into two independent, parallel jobs (`compiler-quality` and `compiler-package`) to reduce wall-clock build time. The quality checks (coverage, lint, dupes) now run on Linux only, while the release builds continue across all target platforms.

## Changes

- **New `compiler-quality` job**: Runs `just ci` (compile, coverage at 85%, lint, dupes) on Linux only. Installs only the tools needed for quality checks (rustfmt, clippy, cargo-llvm-cov, cargo-dupes). No SBOM download, cross-compile targets, or NSIS setup.

- **Renamed `compiler` → `compiler-package`**: Keeps the existing 5-target matrix and `compiler-sbom` dependency. Now runs `just test` on each host (preserving cross-platform test execution) followed by `just package`. Removes lint/coverage tool installation since those now live in `compiler-quality`.

- **Updated `compiler/justfile`**: Modified `test` recipe to include the `ironplc-vm-cli/dap` feature flag (aligning with what the full CI pipeline expects).

## Implementation Details

- Both jobs run in parallel with no dependency between them; the workflow succeeds only if both pass, preserving all existing gates for release and deployment.
- Cross-platform test execution is preserved: tests run on Windows and macOS hosts via the `just test` step in `compiler-package`, while coverage/lint run on Linux only in `compiler-quality`.
- No artifact names or caller-level interfaces change; internal job names are not exposed to callers (`deployment.yaml`, `integration.yaml`, `update.yaml`).
- Accepted trade-off: `just package` runs even when `just ci` fails (wasted compute on failure), but the partial workflow still fails overall and prevents publication.

Wall-clock time per stage drops from `ci_time + package_time` to roughly `max(ci_time, package_time)`.

https://claude.ai/code/session_01WRNepUNdViCkSvccfZEtS8