### PR TITLE
feat(vm-cli): minimal DAP run/stop loop (Phase 4, commit 4)

### DIFF
--- a/compiler/vm-cli/src/dap/debug_info.rs
+++ b/compiler/vm-cli/src/dap/debug_info.rs
@@ -7,15 +7,10 @@
 //! section (line map, VAR_NAME, `debug_format`) is a dependency of exactly one
 //! module.
 //!
-//! This first cut ships **passthrough** resolvers (see the plan,
-//! `specs/plans/2026-06-25-dap-server-scaffold.md` §"Debug-info coupling,
-//! isolated"): the DAP `line` is treated as a raw bytecode offset and slots are
-//! rendered by index with no names. The two function signatures are the stable
-//! seam — commit 5 swaps real line-map / `debug_format` lookups in behind them
-//! without touching any other module.
-//!
-//! Both resolvers are consumed by the minimal Phase 4 run/stop loop
-//! (`setBreakpoints` and `variables`) in [`super::server`].
+//! This first cut ships **passthrough** resolvers: the DAP `line` is treated
+//! as a raw bytecode offset and slots are rendered by index with no names. The
+//! two function signatures are the stable seam — real line-map / `debug_format`
+//! lookups swap in behind them without touching any other module.
 
 use ironplc_container::debug_section::DebugSection;
 use ironplc_container::FunctionId;
@@ -27,9 +22,9 @@ use super::types::Variable;
 ///
 /// **Passthrough:** the DAP `line` is interpreted directly as a bytecode offset
 /// in the scan function, ignoring `debug` and `source_path`. A negative line
-/// (never produced by a conformant client) resolves to nothing. Commit 5
-/// replaces the body with a real line-map + SOURCE_FILE lookup keyed off
-/// `source_path`; this signature stays fixed.
+/// (never produced by a conformant client) resolves to nothing. A real
+/// line-map + SOURCE_FILE lookup keyed off `source_path` will replace the
+/// body; this signature stays fixed.
 pub fn resolve_breakpoint(
     _debug: Option<&DebugSection>,
     _source_path: &str,
@@ -45,8 +40,8 @@ pub fn resolve_breakpoint(
 ///
 /// `values[i]` is the raw 64-bit slot for variable index `i`. **Passthrough:**
 /// each slot is named `var[i]` and rendered as a signed 32-bit decimal, with no
-/// type — `debug` is ignored. Commit 5 replaces the body with VAR_NAME lookups
-/// for names/types and `debug_format::format_variable_value` for the value;
+/// type — `debug` is ignored. VAR_NAME lookups for names/types and
+/// `debug_format::format_variable_value` for the value will replace the body;
 /// this signature stays fixed.
 pub fn render_variables(_debug: Option<&DebugSection>, values: &[u64]) -> Vec<Variable> {
     values

--- a/compiler/vm-cli/src/dap/debug_info.rs
+++ b/compiler/vm-cli/src/dap/debug_info.rs
@@ -14,10 +14,8 @@
 //! seam — commit 5 swaps real line-map / `debug_format` lookups in behind them
 //! without touching any other module.
 //!
-//! Both resolvers are consumed by the run/stop loop that lands in commit 4
-//! (`setBreakpoints` and `variables`); until then they are exercised only by
-//! the unit tests below, hence the module-level `dead_code` allowance.
-#![allow(dead_code)]
+//! Both resolvers are consumed by the minimal Phase 4 run/stop loop
+//! (`setBreakpoints` and `variables`) in [`super::server`].
 
 use ironplc_container::debug_section::DebugSection;
 use ironplc_container::FunctionId;

--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -1,11 +1,12 @@
 //! The single-threaded DAP event loop.
 //!
-//! This module implements the minimal Phase 4 debugger: the `initialize` →
-//! `launch` → `setBreakpoints` → `configurationDone` → (run) → `stopped` →
-//! inspect → `continue` → `terminated` → `disconnect` lifecycle against the
-//! Phase 3 VM engine. Every request is gated through the [`state::legal`]
-//! table; an illegal or not-yet-supported request is answered with a DAP error
-//! whose message is `requestNotApplicable`.
+//! This module drives the `initialize` → `launch` → `setBreakpoints` →
+//! `configurationDone` → (run) → `stopped` → inspect → `continue` →
+//! `terminated` → `disconnect` lifecycle against the VM debug engine. Every
+//! request is gated through the [`state::legal`] table; an illegal or
+//! not-yet-supported request is answered with a DAP error whose message is
+//! `requestNotApplicable`. The single-threaded design is described in
+//! `specs/design/debugger-support.md` §"Single-threaded DAP loop (v1)".
 //!
 //! The loop is split at the launch boundary so lifetimes stay simple: the
 //! *pre-launch* loop ([`serve`]) handles `initialize` / `disconnect` and the
@@ -14,10 +15,9 @@
 //! buffers, starts the VM, and runs the *post-launch* run/stop loop borrowing
 //! them.
 //!
-//! **Deferred to Phase 4b** (see the plan,
-//! `specs/plans/2026-06-25-dap-server-scaffold.md`): single-stepping
-//! (`next`/`stepIn`/`stepOut`) and trap→`stopped{reason:"exception"}`. Both are
-//! refused with `requestNotApplicable` / reported as `terminated` for now.
+//! Not yet implemented: single-stepping (`next`/`stepIn`/`stepOut`) is refused
+//! with `requestNotApplicable`, and a trap ends the session as `terminated`
+//! rather than surfacing a `stopped{reason:"exception"}`.
 
 use std::io::{self, BufRead, Write};
 use std::path::Path;
@@ -156,22 +156,22 @@ fn load_and_check(request: &Request) -> Result<Container, String> {
 }
 
 /// Owns the loaded `container`, starts the VM, answers the `launch` request,
-/// and runs the post-launch run/stop loop (minimal Phase 4).
+/// and runs the post-launch run/stop loop.
 ///
 /// The `container` and the buffers sized from it live here so the [`VmRunning`]
 /// can borrow them for the remainder of the session.
 ///
-/// The loop alternates between two modes (see the plan,
-/// `specs/plans/2026-06-25-dap-server-scaffold.md` §"Single-threaded event
-/// loop"): when `Running`, it drives one `run_round_debug` and reacts to the
-/// outcome; otherwise it reads and services one client request. Because the
+/// The loop alternates between two modes (see
+/// `specs/design/debugger-support.md` §"Single-threaded DAP loop (v1)"): when
+/// `Running`, it drives one `run_round_debug` and reacts to the outcome;
+/// otherwise it reads and services one client request. Because the
 /// [`BreakpointTable`] is mutated between rounds (a `setBreakpoints` at a
 /// pause) while the [`DebuggerHook`] borrows it during a round, the hook is
 /// built fresh per round; after a breakpoint pause the next hook is told to
 /// suppress that location once so `continue` makes forward progress.
 ///
-/// **Minimal cut:** `continue` is the only execution control (stepping and
-/// trap→`exception` are Phase 4b); one completed scan is reported as
+/// Current limitations: `continue` is the only execution control (stepping and
+/// trap→`exception` are not yet implemented); one completed scan is reported as
 /// `terminated`; `stopOnEntry`/`scanLimit` launch options are accepted but not
 /// yet acted on.
 fn launched_session<R: BufRead, W: Write>(
@@ -242,8 +242,8 @@ fn launched_session<R: BufRead, W: Write>(
                             suppress_bp = true;
                             "breakpoint"
                         }
-                        // Neither is produced in minimal Phase 4 (no stepping,
-                        // no stop-on-entry), but map them so the loop is total.
+                        // Neither is produced yet (no stepping, no
+                        // stop-on-entry), but map them so the loop is total.
                         PauseReason::Step => {
                             suppress_bp = true;
                             "step"
@@ -253,8 +253,9 @@ fn launched_session<R: BufRead, W: Write>(
                     send(writer, &stopped_event(take_seq(seq), dap_reason))?;
                     phase = Phase::Paused;
                 }
-                // Trap-stop is Phase 4b; for now a trap ends the session like a
-                // normal termination rather than surfacing an `exception` stop.
+                // Trap-stop is not yet implemented; for now a trap ends the
+                // session like a normal termination rather than surfacing an
+                // `exception` stop.
                 Err(_fault) => {
                     send(writer, &Event::new(take_seq(seq), "terminated", None))?;
                     phase = Phase::Terminated;
@@ -325,7 +326,7 @@ fn launched_session<R: BufRead, W: Write>(
                 phase = Phase::Running;
             }
             _ => {
-                // Illegal in this phase, unknown, or deferred to Phase 4b
+                // Illegal in this phase, unknown, or not yet implemented
                 // (`next`/`stepIn`/`stepOut`).
                 send(
                     writer,
@@ -354,7 +355,7 @@ fn stopped_event(seq: i64, reason: &'static str) -> Event {
 /// DAP `setBreakpoints` carries the full set for one source, so the table is
 /// cleared and rebuilt. v1 debugs a single source, so a table-wide clear is
 /// correct. Line→location resolution is delegated to [`debug_info`] (a
-/// passthrough until the Layer-1 swap in commit 5).
+/// passthrough until the Layer-1 line-map swap).
 fn set_breakpoints(
     request: &Request,
     debug: Option<&DebugSection>,
@@ -756,7 +757,7 @@ mod tests {
         assert_eq!(out.len(), 2);
     }
 
-    // -- run/stop loop (minimal Phase 4) ------------------------------------
+    // -- run/stop loop ------------------------------------------------------
 
     /// A single-instance container whose **scan** entry function is
     /// [`FunctionId::SCAN`], matching the passthrough breakpoint resolver
@@ -915,7 +916,7 @@ mod tests {
 
     #[test]
     fn serve_when_step_while_paused_then_request_not_applicable() {
-        // Stepping is deferred to Phase 4b: refused even though the legality
+        // Stepping is not yet implemented: refused even though the legality
         // table models `next` as valid while paused.
         let (_file, path) = scan_container_file(&[0x8C], 0);
         let out = run_server(&[

--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -1,33 +1,52 @@
 //! The single-threaded DAP event loop.
 //!
-//! This commit implements the `initialize` → `launch` → `disconnect`
-//! handshake against the Phase 3 VM engine. Every request is gated through the
-//! [`state::legal`] table; an illegal or not-yet-supported request is answered
-//! with a DAP error whose message is `requestNotApplicable`.
+//! This module implements the minimal Phase 4 debugger: the `initialize` →
+//! `launch` → `setBreakpoints` → `configurationDone` → (run) → `stopped` →
+//! inspect → `continue` → `terminated` → `disconnect` lifecycle against the
+//! Phase 3 VM engine. Every request is gated through the [`state::legal`]
+//! table; an illegal or not-yet-supported request is answered with a DAP error
+//! whose message is `requestNotApplicable`.
 //!
 //! The loop is split at the launch boundary so lifetimes stay simple: the
 //! *pre-launch* loop ([`serve`]) handles `initialize` / `disconnect` and the
 //! `launch` preconditions with nothing borrowed; once preconditions pass it
 //! hands the owned [`Container`] to [`launched_session`], which sizes the VM
-//! buffers, starts the VM, and runs the *post-launch* loop borrowing them.
+//! buffers, starts the VM, and runs the *post-launch* run/stop loop borrowing
+//! them.
 //!
-//! The full run/stop loop — `configurationDone` starting execution,
-//! `continue`/`next`/`stepIn`/`stepOut`, `stackTrace`/`scopes`/`variables`, and
-//! the `stopped`/`terminated` events — is commit 4. It slots into
-//! [`launched_session`]'s post-launch loop, where the live [`VmRunning`] is
-//! already in scope.
+//! **Deferred to Phase 4b** (see the plan,
+//! `specs/plans/2026-06-25-dap-server-scaffold.md`): single-stepping
+//! (`next`/`stepIn`/`stepOut`) and trap→`stopped{reason:"exception"}`. Both are
+//! refused with `requestNotApplicable` / reported as `terminated` for now.
 
 use std::io::{self, BufRead, Write};
 use std::path::Path;
 
-use ironplc_container::Container;
-use ironplc_vm::VmBuffers;
+use ironplc_container::debug_section::DebugSection;
+use ironplc_container::{Container, VarIndex};
+use ironplc_vm::{BreakpointTable, DebuggerHook, PauseReason, RoundOutcome, VmBuffers, VmRunning};
 use serde::Serialize;
+use serde_json::Value;
 
+use super::debug_info;
 use super::framing;
 use super::launch;
 use super::state::{self, Command, Phase};
-use super::types::{Capabilities, Event, LaunchRequestArguments, Request, Response};
+use super::types::{
+    Breakpoint, Capabilities, ContinueResponseBody, Event, LaunchRequestArguments, Request,
+    Response, Scope, ScopesResponseBody, SetBreakpointsArguments, SetBreakpointsResponseBody,
+    StackFrame, StackTraceResponseBody, StoppedEventBody, Thread, ThreadsResponseBody,
+    VariablesResponseBody,
+};
+
+/// The id of the single synthetic thread the v1 server exposes.
+const THREAD_ID: i64 = 1;
+
+/// The `variablesReference` handle for the one variable scope. Non-zero so DAP
+/// treats it as expandable; the (flat) list of program variables is returned
+/// for it. Structured expansion (nested FB fields) is a later phase, so every
+/// returned [`Variable`](super::types::Variable) has `variablesReference: 0`.
+const VARIABLES_REF: i64 = 1;
 
 /// The DAP `message` returned for any request that is illegal in the current
 /// phase or not supported by this server slice.
@@ -137,12 +156,24 @@ fn load_and_check(request: &Request) -> Result<Container, String> {
 }
 
 /// Owns the loaded `container`, starts the VM, answers the `launch` request,
-/// and runs the post-launch service loop.
+/// and runs the post-launch run/stop loop (minimal Phase 4).
 ///
 /// The `container` and the buffers sized from it live here so the [`VmRunning`]
-/// can borrow them for the remainder of the session. Commit 4 replaces the
-/// handshake-only loop below with the run/stop loop; the live VM it needs is
-/// already constructed here.
+/// can borrow them for the remainder of the session.
+///
+/// The loop alternates between two modes (see the plan,
+/// `specs/plans/2026-06-25-dap-server-scaffold.md` §"Single-threaded event
+/// loop"): when `Running`, it drives one `run_round_debug` and reacts to the
+/// outcome; otherwise it reads and services one client request. Because the
+/// [`BreakpointTable`] is mutated between rounds (a `setBreakpoints` at a
+/// pause) while the [`DebuggerHook`] borrows it during a round, the hook is
+/// built fresh per round; after a breakpoint pause the next hook is told to
+/// suppress that location once so `continue` makes forward progress.
+///
+/// **Minimal cut:** `continue` is the only execution control (stepping and
+/// trap→`exception` are Phase 4b); one completed scan is reported as
+/// `terminated`; `stopOnEntry`/`scanLimit` launch options are accepted but not
+/// yet acted on.
 fn launched_session<R: BufRead, W: Write>(
     reader: &mut R,
     writer: &mut W,
@@ -155,9 +186,7 @@ fn launched_session<R: BufRead, W: Write>(
     // Construct + start the VM. Buffer sizing (operand stack, variable table,
     // data region, and the frame stack from `header.max_call_depth`) is done by
     // `VmBuffers::from_container`, reused from the `ironplcvm` embedding path.
-    // Commit 4 keeps `_running` live to drive the run/stop loop; the handshake
-    // only needs to prove the VM builds and starts.
-    let _running = match launch::start_vm(&container, &mut bufs) {
+    let mut running = match launch::start_vm(&container, &mut bufs) {
         Ok(running) => running,
         Err(err) => {
             send(
@@ -174,11 +203,67 @@ fn launched_session<R: BufRead, W: Write>(
         &Response::success(take_seq(seq), launch_request, None),
     )?;
 
-    // Post-launch loop. The DAP phase stays `Configuring` until
-    // `configurationDone` starts the run (commit 4). For the handshake slice we
-    // service `disconnect` and refuse everything else with
-    // `requestNotApplicable`.
+    let debug = container.debug_section.as_ref();
+    let mut breakpoints = BreakpointTable::new();
+    // The session opens in `Configuring`: the client sets breakpoints and then
+    // sends `configurationDone` to begin the run.
+    let mut phase = Phase::Configuring;
+    // A monotonic clock for the debug driver. `run_round_debug` bypasses the
+    // scheduler and watchdog, so the exact value only feeds the uptime system
+    // variable; a per-round bump keeps it non-decreasing.
+    let mut current_time_us: u64 = 0;
+    // Set after a breakpoint pause so the next resume skips that one location
+    // instead of re-triggering in place.
+    let mut suppress_bp = false;
+
     loop {
+        if phase == Phase::Running {
+            let outcome = {
+                let mut hook = DebuggerHook::new(&breakpoints);
+                if suppress_bp {
+                    hook.suppress_next_breakpoint();
+                    suppress_bp = false;
+                }
+                running.run_round_debug(current_time_us, &mut hook)
+            };
+            current_time_us = current_time_us.saturating_add(1000);
+
+            match outcome {
+                // One completed scan ends the minimal session; a multi-scan run
+                // loop is a later phase.
+                Ok(RoundOutcome::Completed) | Ok(RoundOutcome::PausedAfterScan) => {
+                    send(writer, &Event::new(take_seq(seq), "terminated", None))?;
+                    phase = Phase::Terminated;
+                }
+                Ok(RoundOutcome::Paused(reason)) => {
+                    let dap_reason = match reason {
+                        PauseReason::Breakpoint(_) => {
+                            // Skip this location on the following resume.
+                            suppress_bp = true;
+                            "breakpoint"
+                        }
+                        // Neither is produced in minimal Phase 4 (no stepping,
+                        // no stop-on-entry), but map them so the loop is total.
+                        PauseReason::Step => {
+                            suppress_bp = true;
+                            "step"
+                        }
+                        PauseReason::Entry => "entry",
+                    };
+                    send(writer, &stopped_event(take_seq(seq), dap_reason))?;
+                    phase = Phase::Paused;
+                }
+                // Trap-stop is Phase 4b; for now a trap ends the session like a
+                // normal termination rather than surfacing an `exception` stop.
+                Err(_fault) => {
+                    send(writer, &Event::new(take_seq(seq), "terminated", None))?;
+                    phase = Phase::Terminated;
+                }
+            }
+            continue;
+        }
+
+        // Stopped mode: read and service one request.
         let Some(body) = framing::read_message(reader)? else {
             return Ok(());
         };
@@ -186,12 +271,62 @@ fn launched_session<R: BufRead, W: Write>(
             continue;
         };
 
-        match Command::from_request(&request.command) {
+        let command = Command::from_request(&request.command);
+        let legal_here = command.is_some_and(|c| state::legal(phase, c));
+
+        match command {
             Some(Command::Disconnect) => {
                 send(writer, &Response::success(take_seq(seq), &request, None))?;
                 return Ok(());
             }
+            Some(Command::ConfigurationDone) if legal_here => {
+                send(writer, &Response::success(take_seq(seq), &request, None))?;
+                phase = Phase::Running;
+            }
+            Some(Command::SetBreakpoints) if legal_here => {
+                let body = set_breakpoints(&request, debug, &mut breakpoints);
+                send(writer, &Response::success(take_seq(seq), &request, body))?;
+            }
+            Some(Command::Threads) if legal_here => {
+                let body = serde_json::to_value(ThreadsResponseBody {
+                    threads: vec![Thread {
+                        id: THREAD_ID,
+                        name: "plc".to_string(),
+                    }],
+                })
+                .ok();
+                send(writer, &Response::success(take_seq(seq), &request, body))?;
+            }
+            Some(Command::StackTrace) if legal_here => {
+                let body = stack_trace_body(&running);
+                send(writer, &Response::success(take_seq(seq), &request, body))?;
+            }
+            Some(Command::Scopes) if legal_here => {
+                let body = serde_json::to_value(ScopesResponseBody {
+                    scopes: vec![Scope {
+                        name: "Variables".to_string(),
+                        variables_reference: VARIABLES_REF,
+                        expensive: false,
+                    }],
+                })
+                .ok();
+                send(writer, &Response::success(take_seq(seq), &request, body))?;
+            }
+            Some(Command::Variables) if legal_here => {
+                let body = variables_body(&running, debug);
+                send(writer, &Response::success(take_seq(seq), &request, body))?;
+            }
+            Some(Command::Continue) if legal_here => {
+                let body = serde_json::to_value(ContinueResponseBody {
+                    all_threads_continued: true,
+                })
+                .ok();
+                send(writer, &Response::success(take_seq(seq), &request, body))?;
+                phase = Phase::Running;
+            }
             _ => {
+                // Illegal in this phase, unknown, or deferred to Phase 4b
+                // (`next`/`stepIn`/`stepOut`).
                 send(
                     writer,
                     &Response::error(take_seq(seq), &request, REQUEST_NOT_APPLICABLE),
@@ -199,6 +334,108 @@ fn launched_session<R: BufRead, W: Write>(
             }
         }
     }
+}
+
+/// Builds the `stopped` event for `reason`, scoped to the single thread.
+fn stopped_event(seq: i64, reason: &'static str) -> Event {
+    let body = serde_json::to_value(StoppedEventBody {
+        reason,
+        thread_id: Some(THREAD_ID),
+        description: None,
+        all_threads_stopped: true,
+    })
+    .ok();
+    Event::new(seq, "stopped", body)
+}
+
+/// Applies a `setBreakpoints` request: replaces the breakpoint set and returns
+/// the response body echoing each requested breakpoint's resolved state.
+///
+/// DAP `setBreakpoints` carries the full set for one source, so the table is
+/// cleared and rebuilt. v1 debugs a single source, so a table-wide clear is
+/// correct. Line→location resolution is delegated to [`debug_info`] (a
+/// passthrough until the Layer-1 swap in commit 5).
+fn set_breakpoints(
+    request: &Request,
+    debug: Option<&DebugSection>,
+    breakpoints: &mut BreakpointTable,
+) -> Option<Value> {
+    let args: SetBreakpointsArguments = request
+        .arguments
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok())?;
+
+    breakpoints.clear();
+    let source_path = args.source.path.clone().unwrap_or_default();
+    let source = Some(args.source.clone());
+
+    let resolved: Vec<Breakpoint> = args
+        .breakpoints
+        .iter()
+        .map(|bp| {
+            let locations = debug_info::resolve_breakpoint(debug, &source_path, bp.line);
+            if locations.is_empty() {
+                Breakpoint {
+                    verified: false,
+                    line: Some(bp.line),
+                    source: source.clone(),
+                    message: Some("no executable location for this line".to_string()),
+                }
+            } else {
+                for (function_id, offset) in locations {
+                    breakpoints.add(function_id, offset);
+                }
+                Breakpoint {
+                    verified: true,
+                    line: Some(bp.line),
+                    source: source.clone(),
+                    message: None,
+                }
+            }
+        })
+        .collect();
+
+    serde_json::to_value(SetBreakpointsResponseBody {
+        breakpoints: resolved,
+    })
+    .ok()
+}
+
+/// Builds the `stackTrace` response body from the paused instance's live
+/// frames. DAP orders frames innermost-first; [`VmRunning::debug_frames`] is
+/// outermost-first, so the walk is reversed. Frame names and lines are
+/// passthrough (function id, bytecode offset) until the Layer-1 swap.
+fn stack_trace_body(running: &VmRunning) -> Option<Value> {
+    let frames = running.debug_frames();
+    let stack_frames: Vec<StackFrame> = frames
+        .iter()
+        .enumerate()
+        .rev()
+        .map(|(index, frame)| StackFrame {
+            id: index as i64,
+            name: format!("function {}", frame.function_id.raw()),
+            line: frame.pc as i64,
+            column: 0,
+            source: None,
+        })
+        .collect();
+    let total = stack_frames.len() as i64;
+    serde_json::to_value(StackTraceResponseBody {
+        stack_frames,
+        total_frames: Some(total),
+    })
+    .ok()
+}
+
+/// Builds the `variables` response body: every program variable slot, rendered
+/// by [`debug_info`] (passthrough `var[i]` names until the Layer-1 swap).
+fn variables_body(running: &VmRunning, debug: Option<&DebugSection>) -> Option<Value> {
+    let count = running.num_variables();
+    let values: Vec<u64> = (0..count)
+        .map(|i| running.read_variable_raw(VarIndex::new(i)).unwrap_or(0))
+        .collect();
+    let variables = debug_info::render_variables(debug, &values);
+    serde_json::to_value(VariablesResponseBody { variables }).ok()
 }
 
 #[cfg(test)]
@@ -517,5 +754,186 @@ mod tests {
         let out = run_server(&[json!({"seq": 1, "type": "request", "command": "initialize"})]);
         // Handshake still produced its two messages; the loop returned on EOF.
         assert_eq!(out.len(), 2);
+    }
+
+    // -- run/stop loop (minimal Phase 4) ------------------------------------
+
+    /// A single-instance container whose **scan** entry function is
+    /// [`FunctionId::SCAN`], matching the passthrough breakpoint resolver
+    /// (which keys line→offset breakpoints to `SCAN`). `init` is a bare
+    /// `RET_VOID`; `scan` runs `scan_bytecode`.
+    fn scan_container_file(
+        scan_bytecode: &[u8],
+        max_stack: u16,
+    ) -> (tempfile::NamedTempFile, String) {
+        let container = ContainerBuilder::new()
+            .num_variables(1)
+            .add_function(FunctionId::INIT, &[0x8C], 0, 1, 0)
+            .add_function(FunctionId::SCAN, scan_bytecode, max_stack, 1, 0)
+            .max_call_depth(1)
+            .add_var_name(a_var_name())
+            .add_task(a_task(TaskId::new(0)))
+            .add_program_instance(ProgramInstanceEntry {
+                instance_id: InstanceId::new(0),
+                task_id: TaskId::new(0),
+                entry_function_id: FunctionId::SCAN,
+                var_table_offset: 0,
+                var_table_count: 1,
+                fb_instance_offset: 0,
+                fb_instance_count: 0,
+                init_function_id: FunctionId::INIT,
+            })
+            .build();
+        write_container_to_temp(&container)
+    }
+
+    /// All response messages for `command`, in order.
+    fn responses<'a>(out: &'a [Value], command: &str) -> Vec<&'a Value> {
+        out.iter()
+            .filter(|m| m["type"] == "response" && m["command"] == command)
+            .collect()
+    }
+
+    /// All event messages named `event`, in order.
+    fn events<'a>(out: &'a [Value], event: &str) -> Vec<&'a Value> {
+        out.iter()
+            .filter(|m| m["type"] == "event" && m["event"] == event)
+            .collect()
+    }
+
+    /// Index of the first message matching `pred`, for ordering assertions.
+    fn index_of(out: &[Value], pred: impl Fn(&Value) -> bool) -> usize {
+        out.iter().position(pred).expect("message not found")
+    }
+
+    #[test]
+    fn serve_when_no_breakpoints_then_runs_to_completion_and_terminates() {
+        let (_file, path) = scan_container_file(&[0x8C], 0);
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+            json!({"seq": 3, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 4, "type": "request", "command": "disconnect"}),
+        ]);
+        assert_eq!(responses(&out, "configurationDone")[0]["success"], true);
+        // One scan completes → a single terminated event, then disconnect.
+        assert_eq!(events(&out, "terminated").len(), 1);
+        assert_eq!(responses(&out, "disconnect")[0]["success"], true);
+        // terminated precedes the disconnect response.
+        let terminated_at = index_of(&out, |m| m["event"] == "terminated");
+        let disconnect_at = index_of(&out, |m| m["command"] == "disconnect");
+        assert!(terminated_at < disconnect_at);
+    }
+
+    #[test]
+    fn serve_when_breakpoint_then_stops_inspects_continues_and_terminates() {
+        let (_file, path) = scan_container_file(&[0x8C], 0);
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+            json!({"seq": 3, "type": "request", "command": "setBreakpoints",
+                   "arguments": {"source": {"path": "demo.st"},
+                                 "breakpoints": [{"line": 0}]}}),
+            json!({"seq": 4, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 5, "type": "request", "command": "threads"}),
+            json!({"seq": 6, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 7, "type": "request", "command": "scopes",
+                   "arguments": {"frameId": 0}}),
+            json!({"seq": 8, "type": "request", "command": "variables",
+                   "arguments": {"variablesReference": 1}}),
+            json!({"seq": 9, "type": "request", "command": "continue",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 10, "type": "request", "command": "disconnect"}),
+        ]);
+
+        // The breakpoint is verified back to the client.
+        let sbp = responses(&out, "setBreakpoints");
+        assert_eq!(sbp[0]["body"]["breakpoints"][0]["verified"], true);
+        assert_eq!(sbp[0]["body"]["breakpoints"][0]["line"], 0);
+
+        // The VM stops at the breakpoint before running to completion.
+        let stopped = events(&out, "stopped");
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(stopped[0]["body"]["reason"], "breakpoint");
+        assert_eq!(stopped[0]["body"]["threadId"], 1);
+
+        // One synthetic thread.
+        assert_eq!(responses(&out, "threads")[0]["body"]["threads"][0]["id"], 1);
+
+        // The stack has the single scan frame (function id 1 = SCAN).
+        let st = responses(&out, "stackTrace");
+        assert_eq!(st[0]["body"]["stackFrames"].as_array().unwrap().len(), 1);
+        assert_eq!(st[0]["body"]["stackFrames"][0]["name"], "function 1");
+
+        // One scope, whose handle enumerates the variables.
+        let sc = responses(&out, "scopes");
+        assert_eq!(
+            sc[0]["body"]["scopes"][0]["variablesReference"],
+            VARIABLES_REF
+        );
+
+        // The single program variable is rendered (passthrough name).
+        let vars = responses(&out, "variables");
+        assert_eq!(vars[0]["body"]["variables"][0]["name"], "var[0]");
+
+        // Continue resumes, past the breakpoint, to completion.
+        assert_eq!(
+            responses(&out, "continue")[0]["body"]["allThreadsContinued"],
+            true
+        );
+        assert_eq!(events(&out, "terminated").len(), 1);
+
+        // Ordering: stop before inspection, terminate after continue.
+        let stopped_at = index_of(&out, |m| m["event"] == "stopped");
+        let stacktrace_at = index_of(&out, |m| m["command"] == "stackTrace");
+        let continue_at = index_of(&out, |m| m["command"] == "continue");
+        let terminated_at = index_of(&out, |m| m["event"] == "terminated");
+        assert!(stopped_at < stacktrace_at);
+        assert!(continue_at < terminated_at);
+    }
+
+    #[test]
+    fn serve_when_setbreakpoints_line_unresolvable_then_reports_unverified() {
+        // The passthrough resolver rejects a negative line (no location).
+        let (_file, path) = scan_container_file(&[0x8C], 0);
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+            json!({"seq": 3, "type": "request", "command": "setBreakpoints",
+                   "arguments": {"source": {"path": "demo.st"},
+                                 "breakpoints": [{"line": -1}]}}),
+            json!({"seq": 4, "type": "request", "command": "disconnect"}),
+        ]);
+        let sbp = responses(&out, "setBreakpoints");
+        assert_eq!(sbp[0]["body"]["breakpoints"][0]["verified"], false);
+        assert!(sbp[0]["body"]["breakpoints"][0]["message"].is_string());
+    }
+
+    #[test]
+    fn serve_when_step_while_paused_then_request_not_applicable() {
+        // Stepping is deferred to Phase 4b: refused even though the legality
+        // table models `next` as valid while paused.
+        let (_file, path) = scan_container_file(&[0x8C], 0);
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path}}),
+            json!({"seq": 3, "type": "request", "command": "setBreakpoints",
+                   "arguments": {"source": {"path": "demo.st"},
+                                 "breakpoints": [{"line": 0}]}}),
+            json!({"seq": 4, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 5, "type": "request", "command": "next",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 6, "type": "request", "command": "disconnect"}),
+        ]);
+        // It did stop at the breakpoint first.
+        assert_eq!(events(&out, "stopped").len(), 1);
+        let next = responses(&out, "next");
+        assert_eq!(next[0]["success"], false);
+        assert_eq!(next[0]["message"], "requestNotApplicable");
     }
 }

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -6,7 +6,7 @@
 //! bytecode_offset)` space, with no dependency on source-line debug info.
 //!
 //! It is deliberately single-threaded: the [`BreakpointTable`] is a plain
-//! sorted `Vec` owned and mutated directly by the caller (the Phase 4 DAP
+//! sorted `Vec` owned and mutated directly by the caller (the DAP server
 //! loop). There are no atomics, no `ArcSwap`, and no cross-thread pause.
 //!
 //! [`DebugHook`]: crate::debug_hook::DebugHook

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -256,6 +256,18 @@ impl<'a> DebuggerHook<'a> {
             origin_offset: self.last_offset,
         };
     }
+
+    /// Suppress the breakpoint check for the very next instruction.
+    ///
+    /// A single-threaded driver that constructs a fresh hook per resume (so it
+    /// can mutate the [`BreakpointTable`] between rounds) uses this to avoid
+    /// re-triggering, in place, the breakpoint it just paused on: after a
+    /// [`PauseReason::Breakpoint`] pause it builds the next round's hook and
+    /// calls this before resuming, matching the in-hook `skip_breakpoint_once`
+    /// a long-lived hook would have carried across the pause.
+    pub fn suppress_next_breakpoint(&mut self) {
+        self.skip_breakpoint_once = true;
+    }
 }
 
 impl DebugHook for DebuggerHook<'_> {
@@ -346,6 +358,25 @@ mod tests {
         let ghost = BreakpointId(999);
         assert!(!table.set_enabled(ghost, false));
         assert!(!table.remove(ghost));
+    }
+
+    #[test]
+    fn debugger_hook_when_suppress_next_breakpoint_then_skips_one_hit_then_pauses() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let mut table = BreakpointTable::new();
+        table.add(FunctionId::SCAN, 4);
+        let mut hook = DebuggerHook::new(&table);
+        hook.suppress_next_breakpoint();
+        // The suppressed location is skipped exactly once (the resume step).
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 4, 0),
+            HookAction::Continue
+        ));
+        // A later arrival at the same location pauses as normal.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 4, 0),
+            HookAction::Pause(PauseReason::Breakpoint(_))
+        ));
     }
 
     #[test]

--- a/specs/plans/2026-06-25-dap-server-scaffold.md
+++ b/specs/plans/2026-06-25-dap-server-scaffold.md
@@ -1,15 +1,28 @@
 # Phase 4: DAP Server Scaffold (minimal v1)
 
+## Status (2026-08-02)
+
+Commits 1–3 have landed (PR #1205 merged commit 3: the `initialize → launch →
+disconnect` handshake, launch preconditions, and VM buffer sizing/startup).
+This plan has since been **narrowed to a minimal Phase 4** whose only purpose
+is to give Phase 5 (VS Code integration) something to launch: stop on a
+source-line breakpoint, inspect the stack and variables, and resume.
+**Single-stepping (`next`/`stepIn`/`stepOut`) and trap→`exception` handling
+are deferred to a new Phase 4b** (see §"Phase 4b — deferred follow-up"),
+because Phase 5 does not depend on them and the Phase 3 engine already
+implements the stepping primitives, so wiring them later is cheap.
+
 ## Goal
 
 Stand up `ironplcdap <file.iplc>` — a single-threaded Debug Adapter Protocol
 server that VS Code (or any DAP client) can connect to, drive through the
-`initialize → launch → setBreakpoints → configurationDone →
-continue/step → disconnect` lifecycle, pause on a **line breakpoint**, walk
-the stack, and inspect variables. This is Phase 4 of the debugger design
+`initialize → launch → setBreakpoints → configurationDone → continue →
+disconnect` lifecycle, pause on a **line breakpoint**, walk the stack, and
+inspect variables. This is Phase 4 of the debugger design
 (`specs/design/debugger-support.md` §"Phase 4: DAP Server"), **deliberately
 cut down** from the surface in that spec to the smallest thing that is a real
-debugger.
+debugger — and cut down again (no stepping) to the smallest thing Phase 5 can
+launch.
 
 ## Scope cut from the design spec
 
@@ -17,12 +30,21 @@ The design spec's Phase 4 lists logpoints, `evaluate`, custom scan-cycle
 requests, and a packaging split. This plan cuts the first DAP phase to the
 minimum and defers the rest:
 
-- **In:** the handshake; **line breakpoints** (pause-only); one synthetic
-  thread; `stackTrace` / `scopes` / `variables`; and the four execution-
-  control commands **`continue`, `next`, `stepIn`, `stepOut`**.
-- **Deferred to a later phase:** logpoints, `evaluate` (any expression
-  evaluation), the custom `ironplc/stepScan` + `ironplc/scanCount` requests,
-  conditional breakpoints, `pause`, `setVariable`/forcing, multi-instance.
+- **In (minimal Phase 4):** the handshake; **line breakpoints** (pause-only);
+  one synthetic thread; `stackTrace` / `scopes` / `variables`; and the single
+  execution-control command **`continue`** — everything needed to launch from
+  VS Code, stop on a source-line breakpoint, inspect the stack and variables,
+  and resume.
+- **Deferred to Phase 4b (this plan, below):** single-stepping (`next`,
+  `stepIn`, `stepOut`) and trap→`stopped{reason:"exception"}` handling. The
+  Phase 3 engine already implements stepping
+  (`DebuggerHook::step_over`/`step_in`/`step_out`) and the trap surfaces
+  through the fault path, so both are small follow-ups that Phase 5 does not
+  depend on.
+- **Deferred to a later phase (unchanged):** logpoints, `evaluate` (any
+  expression evaluation), the custom `ironplc/stepScan` + `ironplc/scanCount`
+  requests, conditional breakpoints, `pause`, `setVariable`/forcing,
+  multi-instance.
 
 Logpoints are deferred out of this first DAP phase. The engine hooks for them
 are cheap once breakpoints work, so they are a natural early follow-up, but
@@ -110,14 +132,17 @@ The hand-rolled `types.rs` uses `serde` derive + the already-present
 
 ## DAP surface for the first phase
 
-Requests handled: `initialize`, `launch`, `setBreakpoints` (line breakpoints
-only — no `logMessage`), `configurationDone`, `threads` (one synthetic
-thread), `stackTrace`, `scopes`, `variables`, `continue`, `next`
-(step-over), `stepIn`, `stepOut`, `disconnect`.
+Requests handled (minimal Phase 4): `initialize`, `launch`, `setBreakpoints`
+(line breakpoints only — no `logMessage`), `configurationDone`, `threads`
+(one synthetic thread), `stackTrace`, `scopes`, `variables`, `continue`,
+`disconnect`.
 
-Everything else returns DAP error `requestNotApplicable`, explicitly
-including `pause`, `setVariable`, `evaluate`, `restart`, and the (not-yet-
-registered) custom `ironplc/*` requests.
+Everything else returns DAP error `requestNotApplicable`. This explicitly
+includes the stepping requests **`next`, `stepIn`, `stepOut`** (deferred to
+Phase 4b — the `state::legal` table already models them, so promoting them is
+a legality-plus-handler change), as well as `pause`, `setVariable`,
+`evaluate`, `restart`, and the (not-yet-registered) custom `ironplc/*`
+requests.
 
 Capabilities advertised in `initialize`:
 `supportsConfigurationDoneRequest: true`. Everything optional is **false /
@@ -151,10 +176,16 @@ loop {
 
 `setBreakpoints` received while `Running` is **queued** and applied at the
 next natural stop (documented single-threaded behaviour, not a bug).
-`continue` / `next` / `stepIn` / `stepOut` set the `StepController` mode on
-the `DebuggerHook` and flip state to `Running`. The launch `scanLimit`
-bounds runaway scans. The `DebuggerHook`, its `BreakpointTable`, and the VM
-buffers are owned directly by the loop — no `Arc`, no atomics.
+`continue` clears any step mode and flips state to `Running`; the stepping
+commands (`next` / `stepIn` / `stepOut`), which set the `StepController` mode
+on the `DebuggerHook`, are Phase 4b. The launch `scanLimit` bounds runaway
+scans. The `BreakpointTable` and the VM buffers are owned directly by the
+loop — no `Arc`, no atomics. Because the loop mutates the `BreakpointTable`
+between rounds (a `setBreakpoints` at a pause) while the `DebuggerHook`
+borrows it during a round, the hook is constructed per round; a fresh hook
+after a breakpoint pause is told to suppress that one location once
+(`DebuggerHook::suppress_next_breakpoint`) so `continue` makes forward
+progress instead of re-triggering in place.
 
 ### State legality (`dap/state.rs`)
 
@@ -199,12 +230,17 @@ before Layer 1 finishes; swap in real lookups behind the same signatures.
   breakpoint. (Offset-based breakpoint until Layer 1 line maps land.)
 - **Integration — inspection**: from `stopped`, request `stackTrace`,
   `scopes`, `variables`; verify frames and entries.
-- **Integration — stepping**: `next` over a CALL lands on the next line in
-  the caller; `stepIn` enters the callee; `stepOut` returns to the caller.
 - **Integration — queued setBreakpoints**: sent while `Running`, applied at
   the next stop, not mid-instruction.
 - **Integration — pause refused**: `pause` while `Running` →
   `requestNotApplicable`.
+- **Integration — stepping refused (minimal Phase 4)**: `next` / `stepIn` /
+  `stepOut` while `Paused` → `requestNotApplicable` (promoted in Phase 4b).
+
+Deferred to Phase 4b (see below):
+
+- **Integration — stepping**: `next` over a CALL lands on the next line in
+  the caller; `stepIn` enters the callee; `stepOut` returns to the caller.
 - **Integration — trap**: trigger a trap; expect `stopped{reason:"exception"}`
   then a clean `disconnect`.
 
@@ -220,12 +256,40 @@ Each commit compiles and passes `cd compiler && just` (DAP code behind the
 3. `dap/launch.rs` preconditions + buffer sizing; `initialize`/`launch`/
    `disconnect` handshake against the Phase 3 engine with an
    offset-passthrough `dap/debug_info.rs`; handshake integration test.
-4. `dap/server.rs` run/stop loop: `continue`, `next`/`stepIn`/`stepOut`,
-   `stackTrace`/`scopes`/`variables`, `stopped`/`terminated` events;
-   inspection + stepping integration tests.
+4. `dap/server.rs` **minimal** run/stop loop: `configurationDone` starts the
+   run; `setBreakpoints`; `continue`; `threads`; `stackTrace`/`scopes`/
+   `variables`; `stopped`(breakpoint)/`terminated` events. Inspection + queued
+   `setBreakpoints` + refusal integration tests. **No stepping, no trap-stop.**
+   Adds `DebuggerHook::suppress_next_breakpoint` to the `vm` crate so a
+   per-round hook resumes past a hit breakpoint.
 5. Swap `debug_info.rs` passthrough for real line-map / `debug_format`
    lookups once Layer 1 is complete (or in parallel, behind the same
-   signatures).
+   signatures). This is the last piece of minimal Phase 4: it turns
+   offset-keyed breakpoints and `var[i]` slots into source-line breakpoints
+   and named/typed variables, which is what makes the Phase 5 VS Code session
+   read as a real debugger.
+
+## Phase 4b — deferred follow-up
+
+Not required for Phase 5. Landed as its own change(s) after the minimal loop
+is working in VS Code. The Phase 3 engine already provides the primitives, so
+each is a thin server-side addition:
+
+6. **Stepping.** Promote `next`/`stepIn`/`stepOut` from `requestNotApplicable`
+   to handlers that call `DebuggerHook::step_over`/`step_in`/`step_out` and
+   flip to `Running`; emit `stopped{reason:"step"}` on the `Step` pause.
+   Because stepping consumes the hook's call-depth (`before_call`/
+   `after_return`), the per-round-hook construction from commit 4 must
+   preserve depth across a resume (not just the breakpoint-skip flag) — extend
+   the `suppress_next_breakpoint` seam to carry the full resume state, or keep
+   one hook alive for the duration of a `Running` span. Tests: `next` over a
+   CALL, `stepIn` into a callee, `stepOut` back to the caller.
+7. **Trap-stop.** Map an `Err(FaultContext)` from `run_round_debug` to
+   `stopped{reason:"exception"}` with the trap's V-code in `description`;
+   accept only inspection requests in the resulting `Faulted` phase (the
+   `state::legal` table already encodes this); `disconnect` tears down
+   cleanly. Test: trigger a divide-by-zero in the scan body and assert the
+   exception stop + clean disconnect.
 
 ## Dependencies & packaging
 


### PR DESCRIPTION
Turn the handshake-only DAP session into a driveable debugger: the
single-threaded loop starts the run on configurationDone, stops on a
line breakpoint, exposes threads/stackTrace/scopes/variables for
inspection, and resumes on continue, emitting stopped/terminated events.

Scope is the minimal Phase 4 needed by Phase 5 (VS Code integration):
- Handled: configurationDone, setBreakpoints, threads, stackTrace,
  scopes, variables, continue.
- Deferred to Phase 4b: single-stepping (next/stepIn/stepOut) and
  trap -> stopped{reason:"exception"}, both refused / reported as
  terminated for now.

Because the breakpoint table is mutated between rounds while the
DebuggerHook borrows it during a round, the hook is built per round;
add DebuggerHook::suppress_next_breakpoint so a fresh hook resumes past
the location it just paused on instead of re-triggering in place.

The scaffold plan is updated to reflect the narrowed minimal Phase 4 and
the new Phase 4b follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CQ9zwk7HVXsJgvTip5pZkR