### PR TITLE
feat(vm-cli): wire DAP single-stepping (next/stepIn/stepOut)

### DIFF
--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -15,16 +15,17 @@
 //! buffers, starts the VM, and runs the *post-launch* run/stop loop borrowing
 //! them.
 //!
-//! Not yet implemented: single-stepping (`next`/`stepIn`/`stepOut`) is refused
-//! with `requestNotApplicable`, and a trap ends the session as `terminated`
-//! rather than surfacing a `stopped{reason:"exception"}`.
+//! Not yet implemented: a trap ends the session as `terminated` rather than
+//! surfacing a `stopped{reason:"exception"}`.
 
 use std::io::{self, BufRead, Write};
 use std::path::Path;
 
 use ironplc_container::debug_section::DebugSection;
 use ironplc_container::{Container, VarIndex};
-use ironplc_vm::{BreakpointTable, DebuggerHook, PauseReason, RoundOutcome, VmBuffers, VmRunning};
+use ironplc_vm::{
+    BreakpointTable, DebuggerHook, PauseReason, RoundOutcome, StepMode, VmBuffers, VmRunning,
+};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -178,10 +179,14 @@ fn load_and_check(request: &Request) -> Result<(Container, LaunchRequestArgument
 /// — the session terminates once `scan_count` reaches it — and `stopOnEntry`
 /// pauses before the first instruction of the first scan.
 ///
-/// Current limitations: `continue` is the only execution control (stepping and
-/// trap→`exception` are not yet implemented). A free-running program with no
-/// breakpoint and no `scanLimit` scans until the client disconnects — the
-/// single-threaded loop cannot service an interactive `pause` (a Phase 6 cut).
+/// Execution control is `continue` plus single-stepping (`next`/`stepIn`/
+/// `stepOut`); a step is armed on the next round's hook, seeded from the paused
+/// frames so it measures from the real pause point.
+///
+/// Current limitations: trap→`exception` is not yet implemented. A free-running
+/// program with no breakpoint and no `scanLimit` scans until the client
+/// disconnects — the single-threaded loop cannot service an interactive `pause`
+/// (a Phase 6 cut).
 fn launched_session<R: BufRead, W: Write>(
     reader: &mut R,
     writer: &mut W,
@@ -229,6 +234,8 @@ fn launched_session<R: BufRead, W: Write>(
     let scan_limit = args.scan_limit;
     // Armed once, before the first scan, when the launch requested `stopOnEntry`.
     let mut pending_stop_on_entry = args.stop_on_entry;
+    // Set by a `next`/`stepIn`/`stepOut` request; armed on the next round's hook.
+    let mut pending_step: Option<StepMode> = None;
 
     loop {
         if phase == Phase::Running {
@@ -241,6 +248,21 @@ fn launched_session<R: BufRead, W: Write>(
                 if pending_stop_on_entry {
                     hook.stop_on_entry();
                     pending_stop_on_entry = false;
+                }
+                if let Some(mode) = pending_step.take() {
+                    // Seed the hook to the paused position so the step's origin
+                    // is where the VM actually stopped, not scan entry. Frames
+                    // are outermost-first; the entry frame is depth 0.
+                    let frames = running.debug_frames();
+                    let depth = frames.len().saturating_sub(1);
+                    let offset = frames.last().map_or(0, |f| f.pc as usize);
+                    hook.seed_resume_position(depth, offset);
+                    match mode {
+                        StepMode::Over => hook.step_over(),
+                        StepMode::In => hook.step_in(),
+                        StepMode::Out => hook.step_out(),
+                        StepMode::None => {}
+                    }
                 }
                 running.run_round_debug(current_time_us, &mut hook)
             };
@@ -346,9 +368,23 @@ fn launched_session<R: BufRead, W: Write>(
                 send(writer, &Response::success(take_seq(seq), &request, body))?;
                 phase = Phase::Running;
             }
+            Some(Command::Next) if legal_here => {
+                send(writer, &Response::success(take_seq(seq), &request, None))?;
+                pending_step = Some(StepMode::Over);
+                phase = Phase::Running;
+            }
+            Some(Command::StepIn) if legal_here => {
+                send(writer, &Response::success(take_seq(seq), &request, None))?;
+                pending_step = Some(StepMode::In);
+                phase = Phase::Running;
+            }
+            Some(Command::StepOut) if legal_here => {
+                send(writer, &Response::success(take_seq(seq), &request, None))?;
+                pending_step = Some(StepMode::Out);
+                phase = Phase::Running;
+            }
             _ => {
-                // Illegal in this phase, unknown, or not yet implemented
-                // (`next`/`stepIn`/`stepOut`).
+                // Illegal in this phase or an unknown command.
                 send(
                     writer,
                     &Response::error(take_seq(seq), &request, REQUEST_NOT_APPLICABLE),
@@ -1041,11 +1077,25 @@ mod tests {
         assert!(sbp[0]["body"]["breakpoints"][0]["message"].is_string());
     }
 
+    /// A scan of four single-byte-operand statements at the same call depth,
+    /// then `RET_VOID`, needing no constant pool: `LOAD_VAR var[0]; STORE_VAR
+    /// var[0]; LOAD_VAR var[0]; STORE_VAR var[0]; RET_VOID`. Statement starts
+    /// land at offsets 0, 3, 6, 9, 12 — so a step advances the paused pc by one
+    /// statement each time.
+    const MULTI_STATEMENT_SCAN: [u8; 13] = [
+        0x0C, 0x00, 0x00, // LOAD_VAR_I32  var[0]  (offset 0)
+        0x10, 0x00, 0x00, // STORE_VAR_I32 var[0]  (offset 3)
+        0x0C, 0x00, 0x00, // LOAD_VAR_I32  var[0]  (offset 6)
+        0x10, 0x00, 0x00, // STORE_VAR_I32 var[0]  (offset 9)
+        0x8C, // RET_VOID                          (offset 12)
+    ];
+
     #[test]
-    fn serve_when_step_while_paused_then_request_not_applicable() {
-        // Stepping is not yet implemented: refused even though the legality
-        // table models `next` as valid while paused.
-        let (_file, path) = scan_container_file(&[0x8C], 0);
+    fn serve_when_step_over_then_advances_paused_pc_statement_by_statement() {
+        // From a breakpoint at offset 0, each `next` lands on the next statement
+        // (no CALL to step over, so step-over lands on the immediately-following
+        // instruction). The paused pc is read back via `stackTrace`.
+        let (_file, path) = scan_container_file(&MULTI_STATEMENT_SCAN, 1);
         let out = run_server(&[
             json!({"seq": 1, "type": "request", "command": "initialize"}),
             json!({"seq": 2, "type": "request", "command": "launch",
@@ -1054,14 +1104,74 @@ mod tests {
                    "arguments": {"source": {"path": "demo.st"},
                                  "breakpoints": [{"line": 0}]}}),
             json!({"seq": 4, "type": "request", "command": "configurationDone"}),
-            json!({"seq": 5, "type": "request", "command": "next",
+            json!({"seq": 5, "type": "request", "command": "stackTrace",
                    "arguments": {"threadId": 1}}),
-            json!({"seq": 6, "type": "request", "command": "disconnect"}),
+            json!({"seq": 6, "type": "request", "command": "next",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 7, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 8, "type": "request", "command": "next",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 9, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 10, "type": "request", "command": "disconnect"}),
         ]);
-        // It did stop at the breakpoint first.
-        assert_eq!(events(&out, "stopped").len(), 1);
-        let next = responses(&out, "next");
-        assert_eq!(next[0]["success"], false);
-        assert_eq!(next[0]["message"], "requestNotApplicable");
+
+        // Breakpoint stop, then a step stop for each `next`.
+        let stopped = events(&out, "stopped");
+        assert_eq!(stopped.len(), 3);
+        assert_eq!(stopped[0]["body"]["reason"], "breakpoint");
+        assert_eq!(stopped[1]["body"]["reason"], "step");
+        assert_eq!(stopped[2]["body"]["reason"], "step");
+
+        // The paused pc advances one statement per step: 0 → 3 → 6.
+        let st = responses(&out, "stackTrace");
+        assert_eq!(st[0]["body"]["stackFrames"][0]["line"], 0);
+        assert_eq!(st[1]["body"]["stackFrames"][0]["line"], 3);
+        assert_eq!(st[2]["body"]["stackFrames"][0]["line"], 6);
+
+        for n in responses(&out, "next") {
+            assert_eq!(n["success"], true);
+        }
+    }
+
+    #[test]
+    fn serve_when_step_in_and_step_out_then_wired_and_resume() {
+        // Cover the `stepIn` and `stepOut` handlers. With no callee: `stepIn`
+        // lands on the next instruction; `stepOut` from the sole (entry) frame
+        // has no shallower frame to reach, so it runs the scan to completion.
+        // `scanLimit: 1` bounds the run so completing that scan terminates the
+        // session (rather than continuing into the next scan).
+        let (_file, path) = scan_container_file(&MULTI_STATEMENT_SCAN, 1);
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path, "scanLimit": 1}}),
+            json!({"seq": 3, "type": "request", "command": "setBreakpoints",
+                   "arguments": {"source": {"path": "demo.st"},
+                                 "breakpoints": [{"line": 0}]}}),
+            json!({"seq": 4, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 5, "type": "request", "command": "stepIn",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 6, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 7, "type": "request", "command": "stepOut",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 8, "type": "request", "command": "disconnect"}),
+        ]);
+
+        // Breakpoint stop, then a step stop from `stepIn` landing at offset 3.
+        let stopped = events(&out, "stopped");
+        assert_eq!(stopped.len(), 2);
+        assert_eq!(stopped[1]["body"]["reason"], "step");
+        assert_eq!(
+            responses(&out, "stackTrace")[0]["body"]["stackFrames"][0]["line"],
+            3
+        );
+
+        // stepOut from the top frame runs the scan to completion.
+        assert_eq!(events(&out, "terminated").len(), 1);
+        assert_eq!(responses(&out, "stepIn")[0]["success"], true);
+        assert_eq!(responses(&out, "stepOut")[0]["success"], true);
     }
 }

--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -255,7 +255,7 @@ fn launched_session<R: BufRead, W: Write>(
                     // are outermost-first; the entry frame is depth 0.
                     let frames = running.debug_frames();
                     let depth = frames.len().saturating_sub(1);
-                    let offset = frames.last().map_or(0, |f| f.pc as usize);
+                    let offset = frames.last().map_or(0, |f| f.pc);
                     hook.seed_resume_position(depth, offset);
                     match mode {
                         StepMode::Over => hook.step_over(),

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -273,6 +273,20 @@ impl<'a> DebuggerHook<'a> {
         };
     }
 
+    /// Seed the depth / last-offset mirror to a resumed pause position.
+    ///
+    /// A fresh hook starts at depth 0 / offset 0, but the single-threaded driver
+    /// rebuilds the hook each round; when it resumes a mid-scan paused frame
+    /// stack it seeds the live call depth (`frames.len() - 1`, so the entry
+    /// frame is depth 0, matching the `before_call`/`after_return` mirror) and
+    /// the current offset here, so a step armed immediately after
+    /// ([`step_over`](Self::step_over) etc.) measures from where the VM actually
+    /// paused rather than from scan entry.
+    pub fn seed_resume_position(&mut self, depth: usize, offset: usize) {
+        self.depth = depth;
+        self.last_offset = offset;
+    }
+
     /// Suppress the breakpoint check for the very next instruction.
     ///
     /// A single-threaded driver that constructs a fresh hook per resume (so it
@@ -415,6 +429,98 @@ mod tests {
         assert!(matches!(
             hook.before_instruction(FunctionId::SCAN, 1, 0),
             HookAction::Continue
+        ));
+    }
+
+    #[test]
+    fn debugger_hook_when_step_over_then_lands_on_next_instruction_same_depth() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let table = BreakpointTable::new();
+        let mut hook = DebuggerHook::new(&table);
+        // Paused at (depth 0, offset 4); arm step-over from there.
+        hook.seed_resume_position(0, 4);
+        hook.step_over();
+        // The resume re-executes the origin instruction: not a landing.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 4, 0),
+            HookAction::Continue
+        ));
+        // The next instruction at the same depth is the landing.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 7, 0),
+            HookAction::Pause(PauseReason::Step)
+        ));
+    }
+
+    #[test]
+    fn debugger_hook_when_step_over_call_then_skips_callee_body() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let table = BreakpointTable::new();
+        let mut hook = DebuggerHook::new(&table);
+        hook.seed_resume_position(0, 4);
+        hook.step_over();
+        // Origin instruction resumes.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 4, 0),
+            HookAction::Continue
+        ));
+        // A CALL descends into a callee; instructions there are deeper than the
+        // origin, so step-over does not land inside the callee body.
+        hook.before_call(FunctionId::new(2));
+        assert!(matches!(
+            hook.before_instruction(FunctionId::new(2), 0, 0),
+            HookAction::Continue
+        ));
+        // The callee returns; the next instruction back at origin depth lands.
+        hook.after_return(Some(FunctionId::SCAN));
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 8, 0),
+            HookAction::Pause(PauseReason::Step)
+        ));
+    }
+
+    #[test]
+    fn debugger_hook_when_step_in_then_lands_on_first_instruction_of_callee() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let table = BreakpointTable::new();
+        let mut hook = DebuggerHook::new(&table);
+        hook.seed_resume_position(0, 4);
+        hook.step_in();
+        // Origin instruction (the CALL site) resumes.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 4, 0),
+            HookAction::Continue
+        ));
+        // Step-in descends: the first instruction of the callee is the landing.
+        hook.before_call(FunctionId::new(2));
+        assert!(matches!(
+            hook.before_instruction(FunctionId::new(2), 0, 0),
+            HookAction::Pause(PauseReason::Step)
+        ));
+    }
+
+    #[test]
+    fn debugger_hook_when_step_out_then_lands_only_after_origin_frame_returns() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let table = BreakpointTable::new();
+        let mut hook = DebuggerHook::new(&table);
+        // Paused inside a callee at depth 1; step out of it.
+        hook.seed_resume_position(1, 2);
+        hook.step_out();
+        // Still inside the callee (origin depth): no landing yet.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::new(2), 2, 0),
+            HookAction::Continue
+        ));
+        assert!(matches!(
+            hook.before_instruction(FunctionId::new(2), 5, 0),
+            HookAction::Continue
+        ));
+        // The callee returns to the caller (shallower than origin): landing.
+        hook.after_return(Some(FunctionId::SCAN));
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 8, 0),
+            HookAction::Pause(PauseReason::Step)
         ));
     }
 

--- a/specs/plans/2026-08-03-dap-server-stepping.md
+++ b/specs/plans/2026-08-03-dap-server-stepping.md
@@ -1,0 +1,75 @@
+# Plan: DAP Server-Side Single-Stepping
+
+## Context
+
+Phases 1–5 of the debugger (`specs/design/debugger-support.md`) delivered the VM
+debug engine, whose `DebuggerHook` (`compiler/vm/src/debug.rs`) already
+implements `next`/`stepIn`/`stepOut` via a `StepController` (`step_over`,
+`step_in`, `step_out`; `StepMode::{Over, In, Out}`). The DAP server, however,
+still refuses those requests with `requestNotApplicable` — the design's Phase 5
+note lists "single-stepping (`next`/`stepIn`/`stepOut`) server support" as a
+later phase.
+
+This change wires the three execution-control requests through to the engine
+that already supports them. It touches only the DAP server plus one small
+addition to the hook; it does not add new stepping semantics.
+
+## The one wrinkle: seeding the resumed position
+
+The single-threaded server rebuilds the `DebuggerHook` fresh each round (so the
+`BreakpointTable` can be mutated between rounds). A fresh hook starts at call
+depth `0` and offset `0`. That is correct when a scan starts from entry, but a
+step is armed while **paused mid-scan**, and the `StepController` measures
+"landed" relative to the *origin* depth/offset captured when the step is armed.
+
+So before arming a step on the per-round hook, the server must seed the hook's
+depth/offset mirror to where the VM actually paused. The VM already exposes the
+live frames via `VmRunning::debug_frames()` (outermost-first, each `Frame`
+carrying `function_id` and `pc`): the origin depth is `frames.len() - 1` (entry
+frame = depth 0, matching the hook's `before_call`/`after_return` mirror) and the
+origin offset is the innermost frame's `pc`.
+
+## Design
+
+### VM crate (`compiler/vm/src/debug.rs`)
+
+Add `DebuggerHook::seed_resume_position(depth, offset)` — sets the depth and
+last-offset mirror so a step armed immediately after uses the real paused
+location as its origin.
+
+### Server crate (`compiler/vm-cli/src/dap/server.rs`)
+
+- A `pending_step: Option<StepMode>` local in `launched_session`.
+- `next`/`stepIn`/`stepOut` handlers (already legal while `Paused` per
+  `state::legal`): answer success, set `pending_step`, transition to `Running`.
+- When building the per-round hook, if a step is pending: read
+  `running.debug_frames()`, seed the hook's position, and arm the matching
+  `step_over`/`step_in`/`step_out`. The existing `suppress_bp` (set on every
+  pause) already skips a co-located breakpoint on the resume instruction, so a
+  step off a breakpoint makes forward progress.
+
+The `PauseReason::Step → "step"` stopped-event mapping already exists in the loop.
+
+## Non-goals
+
+- Continuous multi-scan run loop / `scanLimit` / `stopOnEntry` (separate change).
+- Trap → `stopped{reason:"exception"}` events.
+- Server-side `ironplc/stepScan` / `ironplc/scanCount` custom requests.
+
+## Testing
+
+Unit (`vm/src/debug.rs`): `step_over` lands on the next instruction at the same
+depth and skips a callee body; `step_in` lands on the first instruction of a
+callee; `step_out` lands only after the origin frame returns — each armed from a
+seeded resume position.
+
+Integration (`vm-cli/src/dap/server.rs`): from a breakpoint pause, `next`
+advances the paused pc statement-by-statement (observed via `stackTrace`);
+`stepIn`/`stepOut` are wired and resume the VM. The prior
+"step ⇒ requestNotApplicable" test is replaced by these.
+
+## Note on merge order
+
+This branch and the continuous-run-loop change both edit the `launched_session`
+run loop, so whichever merges second needs a small rebase. They are functionally
+independent.


### PR DESCRIPTION
## Summary

The VM debug engine already implements step-over/in/out via `StepController` (`vm/src/debug.rs`), but the DAP server refused `next`/`stepIn`/`stepOut` with `requestNotApplicable`. This wires the three execution-control requests through to the engine that already supports them. The legality table already permits them while `Paused`, so no state-machine change is needed.

## The one wrinkle

The single-threaded server rebuilds the `DebuggerHook` fresh each round (so the `BreakpointTable` can be mutated between rounds), and a fresh hook starts at call depth `0` / offset `0`. But a step is armed while **paused mid-scan**, and the `StepController` measures "landed" relative to the origin depth/offset captured when the step is armed. So the server must seed the hook to the real pause position first.

- Adds `DebuggerHook::seed_resume_position(depth, offset)`.
- Before arming a pending step, the server reads `VmRunning::debug_frames()` (outermost-first) and seeds origin depth = `frames.len() - 1` (entry frame = depth 0, matching the `before_call`/`after_return` mirror) and origin offset = innermost frame `pc`.
- The existing per-pause `suppress_bp` already skips a co-located breakpoint on the resume instruction, so a step off a breakpoint makes forward progress.

## Out of scope (follow-ups)

- Continuous multi-scan run loop / `scanLimit` / `stopOnEntry` — separate PR (#1304).
- Trap → `stopped{reason:"exception"}` events.
- Server-side `ironplc/stepScan` / `ironplc/scanCount` custom requests.

## Testing

`cd compiler && just` passes (compile, coverage ≥85%, clippy, fmt, dupes).

- **VM unit tests:** step-over lands on the next instruction at the same depth and skips a callee body; step-in lands on the first instruction of a callee; step-out lands only after the origin frame returns — each armed from a seeded resume position.
- **Server integration:** from a breakpoint pause, `next` advances the paused pc statement-by-statement (0 → 3 → 6, observed via `stackTrace`); `stepIn`/`stepOut` are wired and resume the VM. The prior "step ⇒ requestNotApplicable" test is replaced.

Plan: `specs/plans/2026-08-03-dap-server-stepping.md`.

## Note on merge order

This PR and #1304 (continuous run loop) both edit the `launched_session` run loop, so whichever merges second needs a small rebase. They are functionally independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsrpEhMzVGdnYtJRsUtGty

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsrpEhMzVGdnYtJRsUtGty)_