### PR TITLE
fix(twincat): enable --allow-fb-inheritance for the TwinCAT dialect

### DIFF
--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -343,7 +343,7 @@ define_compiler_options! {
 
     "Allow function-block inheritance syntax: EXTENDS/IMPLEMENTS on FUNCTION_BLOCK and INTERFACE declarations",
     "--allow-fb-inheritance",
-    [Rusty, Codesys],
+    [Rusty, Codesys, TwinCat],
     allow_fb_inheritance,
 }
 
@@ -529,6 +529,7 @@ mod tests {
                 "allow_bit_string_case_labels",
                 "allow_paren_string_length",
                 "allow_struct_initializer_expressions",
+                "allow_fb_inheritance",
             ],
         );
     }

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -98,8 +98,9 @@ Supported Dialects
    ``--allow-partial-access-syntax``, ``--allow-pragmas``,
    ``--allow-short-circuit-operators``,
    ``--allow-mixed-located-var-declarations``,
-   ``--allow-bit-string-case-labels``, ``--allow-paren-string-length``, and
-   ``--allow-struct-initializer-expressions``.
+   ``--allow-bit-string-case-labels``, ``--allow-paren-string-length``,
+   ``--allow-struct-initializer-expressions``, and
+   ``--allow-fb-inheritance``.
 
 Editions are additive — enabling a later edition includes all features from
 earlier editions.

--- a/docs/reference/compiler/source-formats/twincat.rst
+++ b/docs/reference/compiler/source-formats/twincat.rst
@@ -15,7 +15,8 @@ IronPLC recognizes the following TwinCAT file extensions (case-insensitive):
 - :file:`.TcGVL` - Global Variable Lists
 - :file:`.TcDUT` - Data Unit Types (type declarations)
 - :file:`.TcIO` - Interface declarations (requires
-  ``--allow-fb-inheritance``; see :doc:`/explanation/enabling-dialects-and-features`)
+  ``--allow-fb-inheritance``, which the ``twincat`` dialect enables
+  automatically; see :doc:`/explanation/enabling-dialects-and-features`)
 
 -------------------
 Supported Languages


### PR DESCRIPTION
The --allow-fb-inheritance flag (EXTENDS/IMPLEMENTS on FUNCTION_BLOCK and
INTERFACE declarations) was scoped to [Rusty, Codesys], omitting TwinCat
even though function-block inheritance is a CODESYS/TwinCAT extension.
TwinCAT 3 runs on the CODESYS V3 runtime and fully supports these OOP
constructs, so the twincat dialect should enable the flag by default.

- Add TwinCat to the dialect list for allow_fb_inheritance in options.rs.
- Update the twincat_dialect_enables_exactly_these_vendor_flags guard test.
- Add --allow-fb-inheritance to the twincat "Enables:" list in the docs
  (the ironplc_flags.py Sphinx validator requires each dialect's documented
  list to match options.rs exactly) and note in the TwinCAT source-format
  reference that the twincat dialect turns the flag on automatically.

Closes #1299