### PR TITLE
docs(steering): add vendor/dialect glossary and terminology plan

### DIFF
--- a/.cursor/rules/ironplc-steering.mdc
+++ b/.cursor/rules/ironplc-steering.mdc
@@ -11,6 +11,7 @@ alwaysApply: true
 
 ## Read when relevant
 
+- `specs/steering/glossary.md` — authoritative vocabulary (dialect, vendor, extension, edition); check before coining a term
 - `specs/steering/development-standards.md` — conventions, tests, planning requirement
 - `specs/steering/compiler-architecture.md` — compiler layout and semantic patterns
 - `specs/steering/iec-61131-3-compliance.md` — analyzer / standard compliance

--- a/.kiro/steering/glossary.md
+++ b/.kiro/steering/glossary.md
@@ -1,0 +1,9 @@
+---
+inclusion: always
+---
+
+# Glossary
+
+See [specs/steering/glossary.md](../../specs/steering/glossary.md) for the full glossary.
+
+Authoritative definitions of IronPLC's core vocabulary — dialect (syntax IronPLC parses), vendor (a real product/runtime/library), extension, edition, and flag. Resolve terminology questions here before coining a new term for an existing concept.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides entry points for Claude Code when working on the IronPLC proj
 
 Before making changes, read the relevant steering files in `specs/steering/`:
 
+- **[Glossary](specs/steering/glossary.md)** - Authoritative definitions of core vocabulary (dialect, vendor, extension, edition); resolve terminology questions here before coining a new term
 - **[Development Standards](specs/steering/development-standards.md)** - Core project conventions, testing patterns, error handling, and documentation standards
 - **[Compiler Architecture](specs/steering/compiler-architecture.md)** - Patterns for implementing language features, module organization, and semantic analysis
 - **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules (especially relevant for `**/analyzer/**` files)

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -6,6 +6,7 @@ This file is the IronPLC entry point for Cursor. Detailed guidance lives in **`s
 
 Before making changes, read the relevant steering files in `specs/steering/`:
 
+- **[Glossary](specs/steering/glossary.md)** - Authoritative definitions of core vocabulary (dialect, vendor, extension, edition); resolve terminology questions here before coining a new term
 - **[Development Standards](specs/steering/development-standards.md)** - Core project conventions, testing patterns, error handling, and documentation standards
 - **[Compiler Architecture](specs/steering/compiler-architecture.md)** - Patterns for implementing language features, module organization, and semantic analysis
 - **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules (especially relevant for `**/analyzer/**` files)

--- a/specs/plans/2026-08-03-vendor-dialect-terminology.md
+++ b/specs/plans/2026-08-03-vendor-dialect-terminology.md
@@ -1,0 +1,156 @@
+# Split "vendor" vs. "dialect" terminology (issue #1295)
+
+## Motivation
+
+Issue [#1295](https://github.com/ironplc/ironplc/issues/1295) proposes removing
+the word "vendor" globally in favor of "dialect"/"extension". `vendor` appears
+~427 times across ~100 files.
+
+The issue is **half right**. Most occurrences use "vendor" as a loose synonym
+for *dialect/syntax* ("vendor extension", "vendor dialect", "vendor-specific"),
+and those genuinely should go. But its acceptance criterion — `git grep -i
+vendor` returns essentially nothing — would also erase a concept the project
+actually needs and already uses correctly: **vendor** as the *product / runtime
+/ library* (CODESYS, Beckhoff, Siemens), including the existing "Vendor
+Compatibility Shims" documentation. A dialect is syntax you parse against; a
+vendor is a runtime you emulate. We will have **vendor compatibility
+libraries**, never "dialect compatibility libraries".
+
+The deeper reason "vendor" drifted into meaning "dialect" is that **the project
+never defined either word**. There is no glossary; definitions live implicitly
+and inconsistently across ADR-0012, ADR-0036, `options.rs` doc-comments, and the
+dialect docs. A rename alone will not stay fixed, because nothing stops the next
+PR from re-coining the term (as PR #1287 did with `VendorExtension`).
+
+## Decision
+
+Reframe #1295 from **"remove vendor"** to **"disambiguate vendor vs. dialect"**:
+
+1. **Glossary first.** `specs/steering/glossary.md` is the authoritative
+   definition of dialect, vendor, extension, edition, flag, and vendor
+   compatibility library. This lands before the rename so the rename has a
+   standard to conform to, and wires into the steering pointer pattern
+   (CLAUDE.md, CURSOR.md, `.kiro/steering/`) so it is load-bearing.
+2. **Rename the *syntax-sense* uses** of "vendor" to dialect/extension.
+3. **Keep the *product/runtime-sense* uses** of "vendor".
+4. **Preserve** external schema names and annotate (do not rewrite) ADR history.
+
+Canonical replacements (from the glossary):
+
+- "vendor extension" → **"dialect extension"** / **"extension"**
+- "vendor-extension flag" / "vendor flag" → **"dialect flag"** / **"`--allow-*`
+  flag"**
+- "vendor dialect" → **"dialect"**
+- "vendor-specific (syntax)" → **"non-standard (syntax)"** / **"dialect-specific"**
+- `VendorExtension` (trait) → **`DialectExtension`**; `extension_origins` /
+  `ExtensionOrigin` keep their names (origins legitimately name vendors).
+
+## Inventory (buckets)
+
+Counts are approximate (`git grep -in vendor`, 427 lines total). The bucket, not
+the exact count, drives the treatment.
+
+### A. EXCLUDE — external, preserve verbatim (~6 lines)
+
+Defined by the PLCopen / IEC TC6 XML standard, not IronPLC vocabulary.
+
+- `compiler/resources/schemas/tc6_xml_v201.xsd` — `vendor`, `vendorElement`,
+  "Vendor specific".
+- `integrations/vscode/syntaxes/plcopen-xml.tmLanguage.json` — grammar mirroring
+  the XSD element name.
+
+### B. KEEP — "vendor" = product / runtime / library (~30 lines)
+
+Correct usage under the glossary; leave as-is (light copyedits only).
+
+- `docs/explanation/system-clock-and-uptime.rst` — **"Vendor Compatibility
+  Shims"** section (the canonical vendor-library concept).
+- ADR-0012 / ADR-0036 body prose about "vendor toolchain", "vendor files",
+  "vendor platforms", "vendor ships…", "the vendor's own toolchain".
+- Scattered "vendor files", "vendor-compatible", "vendor tool", "vendor
+  ecosystem/environments/project" in docs and design specs.
+
+*Judgement call:* "vendor-compatible dialect" (rusty/codesys) is **keep** — it
+correctly names a dialect *compatible with a vendor*.
+
+### C. RENAME — "vendor" = syntax (the bulk, ~350+ lines)
+
+Rename to dialect/extension per the canonical table above.
+
+- **Rust code — symbols (do first; they ripple into docs):**
+  - `compiler/dsl/src/extension.rs` — trait `VendorExtension` → `DialectExtension`;
+    module/trait doc-comments ("vendor-specific language extensions",
+    "vendor dialects").
+  - `compiler/dsl/src/common.rs` — `impl VendorExtension for
+    FunctionBlockOop` / `InterfaceDeclaration` and doc-comments.
+  - `compiler/analyzer/src/rule_unsupported_extension.rs` — `use` + `dyn
+    VendorExtension` + doc-comments.
+  - `compiler/parser/src/options.rs` — macro metavariable `$vendor_field`,
+    "vendor-extension" doc-comments, test helpers `enabled_vendor_flags` /
+    `assert_enabled_vendor_flags` / `*_vendor_flags` test names.
+  - Test names carrying "vendor": `main.rs` `…each_vendor_flag_cli_form…`,
+    `lsp.rs` `…enables_ref_to_and_vendor_flags`, `mcp/tools/common.rs`
+    `…rusty_dialect_then_vendor_flags_enabled`.
+  - Comments in `compiler/parser/src/{parser.rs,token.rs}`,
+    `compiler/analyzer/**` (`// vendor extension`), `compiler/plc2plc/**`,
+    `compiler/dsl/src/{fold,visitor}.rs`.
+- **Docs:**
+  - `docs/includes/requires-vendor-extension.rst` → **file rename** to
+    `requires-dialect-extension.rst` (or `requires-extension.rst`) + update all
+    `.. include::` references; reword its body ("This is a vendor extension…").
+  - `docs/explanation/enabling-dialects-and-features.rst` — "vendor extensions"
+    throughout.
+  - `docs/reference/extension-library/index.rst` — "vendor extension functions"
+    → "extension functions"; fix the mislabeling where `__SYSTEM_UP_TIME` is
+    implied to be a vendor feature (it is an IronPLC convention).
+  - `docs/reference/compiler/ironplcc.rst`, problem-code pages
+    (P4028/P4036/P4037/P4041–P4045), `docs/reference/editor/settings.rst`,
+    extension-library sub-pages.
+- **Specs:** `specs/design/**` (`beckhoff-twincat-dialect.md`,
+  `siemens-scl-dialect.md`, `dialect-token-transforms.md`, …),
+  `specs/steering/{syntax-support-guide.md,iec-61131-3-compliance.md}`.
+- **VS Code:** `integrations/vscode/package.json` setting descriptions.
+
+### D. ADRs — annotate, do not rewrite (history)
+
+`specs/adrs/0012-accept-vendor-dialect-files-as-is.md` (title + 44 refs),
+`0036`, `0038`, `0040`, and dated `specs/plans/*.md` are decision history.
+Leave their text; the title `0012-accept-vendor-dialect-files-as-is` stays.
+Optionally add a one-line note at the top of ADR-0012 pointing to the glossary
+for current terminology. Much of ADR-0012's "vendor" usage is already the
+*product* sense (bucket B) and is correct regardless.
+
+## Sequencing
+
+1. Land the glossary + steering pointers (this branch).
+2. Rename Rust symbols (bucket C code), starting with `VendorExtension` →
+   `DialectExtension`. `cd compiler && just` must stay green.
+3. Sweep docs/specs (bucket C docs), including the `requires-vendor-extension`
+   file rename; rebuild docs.
+4. Copyedit bucket B for consistency; annotate ADR-0012.
+5. Verify against the revised acceptance criteria.
+
+## Acceptance criteria (revised from #1295)
+
+- `specs/steering/glossary.md` exists and is referenced from CLAUDE.md,
+  CURSOR.md, and `.kiro/steering/`.
+- No `vendor` remains where it means *syntax/dialect*: no "vendor extension",
+  "vendor dialect", "vendor-extension flag", or `VendorExtension` symbol in
+  code, docs, diagnostics, or CLI help.
+- Every surviving `vendor` refers to a **product / runtime / library** (bucket
+  B) or an **external schema name** (bucket A), and is intentional.
+- No user-facing docs, diagnostics, CLI help, or public Rust API describe
+  *syntax* as "vendor".
+- CI passes (`cd compiler && just`) and docs rebuild.
+
+## Notes / risks
+
+- **"Extension" is overloaded** (syntax feature vs. Extension Library vs. VS
+  Code extension). Prefer "dialect extension" for the syntax sense to keep them
+  separable; the glossary flags this.
+- **Overlap with #1298** (`specs/plans/2026-08-03-rename-allow-fb-inheritance-flag.md`):
+  that plan deliberately deferred the `VendorExtension` trait rename ("a
+  separate, still-accurate concept"). This plan owns that rename; coordinate so
+  the two don't collide on `options.rs` / `rule_unsupported_extension.rs`.
+- The `ExtensionOrigin` enum and `extension_origins()` legitimately enumerate
+  **vendors** (`BeckhoffCodesys`) — that is the product sense and stays.

--- a/specs/steering/glossary.md
+++ b/specs/steering/glossary.md
@@ -1,0 +1,178 @@
+# Glossary
+
+This file is the **single authoritative definition** of IronPLC's core
+vocabulary — the words the project uses to talk about *what code it accepts*
+and *what platforms it is compatible with*. It exists so that these terms mean
+exactly one thing across code, docs, ADRs, diagnostics, and CLI help.
+
+Treat it as load-bearing:
+
+- If a term below contradicts how a piece of code, doc, or PR uses the word,
+  the glossary wins — fix the usage, or change the glossary deliberately (not
+  casually) if the definition is wrong.
+- Before introducing a new noun for an existing concept, check whether one of
+  these terms already covers it. Do not coin a synonym.
+- When a genuinely new concept appears, add it here **first**, then use it.
+
+Keep this file about *meaning*, not implementation. It names concepts and their
+relationships; it does not track types, line numbers, or specifics that belong
+in code or design docs.
+
+---
+
+## The core distinction: dialect vs. vendor
+
+These two words are the reason this file exists. They are **not synonyms**, and
+history shows they drift together unless pinned down.
+
+> A **dialect** is something you *parse against*.
+> A **vendor** is something you *emulate the runtime of*.
+>
+> A vendor has both a dialect **and** a library.
+> A dialect has neither source files nor a runtime of its own.
+
+Everything else follows from that split.
+
+---
+
+## Terms
+
+### Dialect
+
+A named set of **syntax** that IronPLC will parse without error — an
+[edition](#edition) baseline plus a bundle of [extensions](#extension). A
+dialect describes *the shape of the text the parser accepts*; it says nothing
+about runtime behavior or libraries.
+
+Each dialect corresponds to something real — a published IEC edition, or the
+syntax a real toolchain accepts (see [ADR-0036](../adrs/0036-no-ironplc-dialect.md):
+IronPLC never invents a dialect of its own). A file belongs to exactly one
+dialect (see [ADR-0012](../adrs/0012-accept-vendor-dialect-files-as-is.md)).
+
+*Canonical uses:* "the CODESYS dialect", "select a dialect", "dialect
+extension", "per-file dialect detection", "the `--dialect` flag".
+
+*Do not say:* "vendor dialect" (redundant — a dialect is already the syntax a
+target accepts; just say "dialect", or name the dialect).
+
+### Edition
+
+A published version of the IEC 61131-3 standard — **Edition 2** (2003) or
+**Edition 3** (2013). Editions are additive: a later edition includes the
+earlier one's features. An edition is the strict-standard baseline a dialect
+builds on; it is not vendor-specific.
+
+### Extension
+
+A single **non-standard syntax feature** — something beyond strict IEC 61131-3
+that a dialect may enable, gated by an `--allow-*` [flag](#flag). "Extension"
+always refers to *syntax the parser recognizes*, never to a runtime library.
+
+*Canonical uses:* "dialect extension", "the `--allow-sizeof` extension", "this
+extension is not part of the standard".
+
+*Do not say:* "vendor extension" — an extension is defined by the *syntax* it
+adds, not by a company. Name it a "dialect extension" or just an "extension",
+and put the "which vendors accept it" mapping in the dialect table.
+
+> **Beware the overload.** "Extension" is used in three unrelated senses in this
+> project: (1) a syntax feature, as defined here; (2) the **Extension Library**
+> (runtime functions/function blocks/variables such as `SIZEOF`); and (3) the
+> **VS Code extension**. When ambiguous, qualify it: *dialect extension*,
+> *extension library*, *editor extension*.
+
+### Flag
+
+An `--allow-*` command-line (and LSP/MCP) option that enables one
+[extension](#extension) on top of the selected dialect. A dialect preset is
+exactly a named bundle of flags. Flags only ever *enable* features; they never
+disable what a dialect includes.
+
+*Do not say:* "vendor flag" / "vendor-extension flag" — say "dialect flag",
+"extension flag", or just "`--allow-*` flag".
+
+### Vendor
+
+A real PLC **product or company** whose platform a program targets — e.g.
+CODESYS, Beckhoff TwinCAT, Siemens, RuSTy. A vendor is a concrete thing in the
+world with its own toolchain, its own accepted syntax (its dialect), and its own
+runtime library.
+
+"Vendor" is the correct word whenever the subject is the *product/company or its
+runtime*: `vendor toolchain`, `vendor files` (files authored for a vendor's
+tool), `vendor platform`, `vendor-compatible` (a dialect compatible with a
+vendor), `the vendor's library`.
+
+*Do not* stretch "vendor" to mean syntax. If the sentence is about what the
+parser accepts, the word is [dialect](#dialect) or [extension](#extension).
+
+### Vendor compatibility library (vendor shim)
+
+A library of IEC 61131-3 POUs (functions, function blocks) that **emulates a
+vendor's runtime library** so that code written for that vendor compiles and
+behaves correctly under IronPLC — for example, a `TIME()` function that returns
+system uptime the way CODESYS's does.
+
+This is a **vendor** concept, not a dialect one: it is about *runtime behavior
+and libraries*, not syntax. There is deliberately no such thing as a "dialect
+compatibility library" — a dialect has no runtime to emulate.
+
+### Extension Library
+
+IronPLC's own set of runtime functions, function blocks, and variables that go
+beyond the standard (e.g. `SIZEOF`, `__SYSTEM_UP_TIME`). Distinct from a
+[vendor compatibility library](#vendor-compatibility-library-vendor-shim): the
+Extension Library is IronPLC's, and some of its members (e.g. the
+`__SYSTEM_UP_TIME` globals) are IronPLC runtime conventions rather than any
+vendor's feature — so they are *not* "vendor extensions" and must not be
+described as such.
+
+### Standard (IEC 61131-3)
+
+The published IEC 61131-3 language, in a given [edition](#edition). "Standard"
+syntax is what strict `iec61131-3-ed2` / `iec61131-3-ed3` accept with no
+extensions. Anything an `--allow-*` flag enables is, by definition,
+*non-standard*.
+
+---
+
+## How the terms compose
+
+- A **vendor** (Beckhoff TwinCAT) is compatible with IronPLC through two
+  separate things: a **dialect** (the syntax IronPLC parses for it) and,
+  optionally, a **vendor compatibility library** (POUs emulating its runtime).
+- A **dialect** = an **edition** baseline + a set of **extensions**, each turned
+  on by a **flag**.
+- A **standard** program uses no extensions; it loads in any conformant tool.
+  A program that uses extensions loads in the vendor(s) whose dialect includes
+  them — never in a hypothetical "IronPLC dialect" ([ADR-0036](../adrs/0036-no-ironplc-dialect.md)).
+
+---
+
+## Naming rules (quick reference)
+
+| Say this | Not this | Because |
+|---|---|---|
+| dialect | vendor dialect | "dialect" already means the accepted syntax |
+| dialect extension / extension | vendor extension | an extension is defined by syntax, not a company |
+| dialect flag / `--allow-*` flag | vendor flag, vendor-extension flag | the flag gates syntax |
+| non-standard syntax | vendor syntax | it's about the standard, not a vendor |
+| vendor toolchain / vendor files / vendor library | *(keep — correct)* | these really are about the product/runtime |
+| vendor compatibility library / vendor shim | dialect compatibility library | a dialect has no runtime to emulate |
+
+**Preserved verbatim (external, do not rename):** names defined by the PLCopen /
+IEC TC6 XML schema — `vendor`, `vendorElement`, "Vendor specific" — in
+`compiler/resources/schemas/tc6_xml_v201.xsd` and the grammar that mirrors it.
+These are externally-defined identifiers, not IronPLC vocabulary.
+
+---
+
+## Maintaining this file
+
+- **Add a term the moment it crystallizes.** If a session or PR coins a new
+  concept, define it here before it spreads.
+- **Challenge conflicts on sight.** When wording in code or docs contradicts a
+  definition here, that is a bug to fix, not a variation to tolerate.
+- **New syntax feature?** It is a *dialect extension*; describe it by the syntax
+  it adds and record which dialects enable it in the dialect table. See
+  [Syntax Support Guide](syntax-support-guide.md).


### PR DESCRIPTION
Introduce specs/steering/glossary.md as the single authoritative
definition of IronPLC's core vocabulary, drawing the load-bearing
distinction between:

- dialect  — the syntax IronPLC parses against (edition + extensions)
- vendor   — a real product/runtime/library IronPLC emulates

A dialect has no runtime of its own; a vendor has both a dialect and a
compatibility library. This resolves issue #1295, which conflated the
two by proposing to remove "vendor" entirely.

Wire the glossary into the steering pointer pattern (CLAUDE.md,
CURSOR.md, .cursor/rules, .kiro/steering) so it is loaded like every
other steering doc.

Add specs/plans/2026-08-03-vendor-dialect-terminology.md: reframes #1295
from "remove vendor" to "disambiguate vendor vs dialect", with the ~427
occurrences bucketed into exclude (external TC6 schema), keep (vendor =
product/runtime), rename (vendor = syntax), and annotate (ADR history),
plus revised acceptance criteria. No renames performed yet.

Refs #1295

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dyzs95tWb6Na4TUsg45jwe