### PR TITLE
docs: explain hiding of inherited names in OOP concepts

### DIFF
--- a/docs/explanation/object-orientation.rst
+++ b/docs/explanation/object-orientation.rst
@@ -59,6 +59,40 @@ provides single inheritance for function block types. An instance of a derived
 type *is a* kind of its base type, so it can be used wherever the base type is
 expected.
 
+Hiding inherited names
+----------------------
+
+A derived type can declare a variable whose name is already used by an
+inherited variable. The declaration in the derived type **hides** (or
+*shadows*) the inherited one: within the derived type's own body the name
+refers to the member declared there, not to the one it inherited. The
+inherited member is not removed — it still exists on every instance and is
+reached through the base type.
+
+.. code-block::
+
+   FUNCTION_BLOCK FB_Base
+       VAR
+           state : INT;
+       END_VAR
+   END_FUNCTION_BLOCK
+
+   FUNCTION_BLOCK FB_Derived EXTENDS FB_Base
+       VAR
+           state : BOOL;
+       END_VAR
+   END_FUNCTION_BLOCK
+
+Inside ``FB_Derived``, ``state`` names the ``BOOL`` declared there; the
+inherited ``INT`` is hidden but still present on the instance.
+
+Hiding is different from declaring the same name twice in one place. Two
+declarations of the same name in a single scope — for example two variables in
+one ``VAR`` block — are a duplicate and are rejected
+(:doc:`P4014 </reference/compiler/problems/P4014>`). Hiding involves two
+*different* scopes, the base type and the derived type, so the name is
+resolved by choosing the nearer declaration rather than reported as an error.
+
 Interfaces
 ==========
 
@@ -140,6 +174,9 @@ Terminology
      - A type that extends a base type and inherits its members.
    * - Inheritance
      - Deriving one type from another so it reuses the base type's members.
+   * - Hiding (shadowing)
+     - A member declared in a derived type takes precedence, within that type,
+       over an inherited member of the same name.
    * - Interface
      - A named set of method signatures with no implementation.
    * - Implement
@@ -164,6 +201,8 @@ See Also
 - :doc:`/reference/language/object-orientation/index` — the object-oriented
   keywords
 - :doc:`/reference/language/pous/function-block` — the ``FUNCTION_BLOCK`` unit
+- :doc:`/reference/language/variables/scope` — variable scope and resolution
+- :doc:`/reference/compiler/problems/P4014` — duplicate name in a single scope
 - :doc:`enabling-dialects-and-features` — enabling the object-oriented syntax
 - :doc:`/reference/compiler/problems/P9999` — the diagnostic reported for
   not-yet-supported object-oriented constructs


### PR DESCRIPTION
The object-oriented programming explanation covered inheritance,
interfaces, and abstract types but never described what happens when a
derived type reuses the name of an inherited variable.

Add a "Hiding inherited names" concept subsection under Inheritance
explaining that the derived declaration shadows the inherited one within
the derived type while the inherited member still exists on the instance,
and distinguishing this from a same-scope duplicate (P4014). Add a
terminology row for hiding/shadowing and See Also links to variable scope
and P4014.

This documents the language concept only, consistent with the page's
existing framing that IronPLC parses but does not yet analyze or execute
the object-oriented syntax. The concrete diagnostic behavior is tracked
separately in issue #1294.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017wdNEuVstiPjLT3vx7z5GC