### PR TITLE
refactor(dsl): derive InterfaceDeclaration span from contained elements

### DIFF
--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -2862,12 +2862,18 @@ pub struct InterfaceDeclaration {
     /// Interfaces this interface extends (an interface may extend more than
     /// one other interface, unlike a function block).
     pub extends: Vec<TypeName>,
-    pub span: SourceSpan,
 }
 
 impl Located for InterfaceDeclaration {
+    /// Derived from the declaration's own located parts rather than stored:
+    /// the name (always present) through the last extended interface, if any.
+    /// This spans the declaration's identifiers rather than the surrounding
+    /// `INTERFACE`/`END_INTERFACE` keywords.
     fn span(&self) -> SourceSpan {
-        self.span.clone()
+        match self.extends.last() {
+            Some(last) => SourceSpan::join(&self.name.span(), &last.span()),
+            None => self.name.span(),
+        }
     }
 }
 
@@ -2884,7 +2890,7 @@ impl VendorExtension for InterfaceDeclaration {
     }
 
     fn extension_span(&self) -> SourceSpan {
-        self.span.clone()
+        self.span()
     }
 }
 

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1357,11 +1357,10 @@ parser! {
     // header (name + optional EXTENDS list) is parsed — method/property
     // signatures are not yet supported (see
     // specs/plans/2026-07-18-twincat-extends-implements-interface.md).
-    rule interface_declaration() -> InterfaceDeclaration = start:tok(TokenType::Interface) _ name:identifier() _ extends:(tok(TokenType::Extends) _ names:type_name_list() {names})? _ end:tok(TokenType::EndInterface) {
+    rule interface_declaration() -> InterfaceDeclaration = tok(TokenType::Interface) _ name:identifier() _ extends:(tok(TokenType::Extends) _ names:type_name_list() {names})? _ tok(TokenType::EndInterface) {
       InterfaceDeclaration {
         name,
         extends: extends.unwrap_or_default(),
-        span: SourceSpan::join(&start.span, &end.span),
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up cleanup to the OOP foundation (#1287). Removes the stored `span: SourceSpan` field from `InterfaceDeclaration` and computes the span on demand from the node's own already-`Located` parts — the `name` (always present) through the last extended interface, if any. The parser no longer constructs this span manually.

This removes redundant state that duplicated information the children already carry, matching the pattern used elsewhere in the AST (e.g. `LateBoundDeclaration`, `StructuredVariable`).

Resolves #1296.

## Behavior note

The derived span covers the declaration's identifiers rather than the surrounding `INTERFACE`/`END_INTERFACE` keywords, so it is slightly **narrower** than before. This tightens the `P9004` "recognized but not yet supported" diagnostic to point at the interface name (and extends list, if present). This is a deliberate, acceptable narrowing — no test asserted the old keyword-inclusive range.

## Scope

`InterfaceDeclaration` only. The analogous change for `FunctionBlockOop` was considered and intentionally left out: an `ABSTRACT`-only function block (no `EXTENDS`/`IMPLEMENTS`) has no contained `Located` elements to derive from, so eliminating its stored span would relocate the span state rather than remove it. See #1296 for the rationale.

## Test plan
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)