### PR TITLE
refactor: disambiguate "vendor" vs "dialect" terminology (#1295)

### DIFF
--- a/compiler/analyzer/src/intermediates/enumeration.rs
+++ b/compiler/analyzer/src/intermediates/enumeration.rs
@@ -5,8 +5,8 @@ use ironplc_dsl::diagnostic::*;
 use ironplc_problems::Problem;
 
 /// Resolves each enum member's effective integer value using ordinary
-/// C-style enum semantics: an explicit value (`member := 5`, a
-/// CODESYS/TwinCAT extension) is used as-is; an unlabeled member
+/// C-style enum semantics: an explicit value (`member := 5`,
+/// an extension) is used as-is; an unlabeled member
 /// continues from the previous resolved value + 1 (starting at 0 if the
 /// very first member has no explicit value). Matches Beckhoff's own
 /// documented example (`Red := 2, Green, Blue := 10` -> Green resolves to

--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -1028,7 +1028,7 @@ pub fn get_all_stdlib_functions() -> Vec<FunctionSignature> {
 }
 
 // =============================================================================
-// SIZEOF (Vendor Extension)
+// SIZEOF (Dialect Extension)
 // =============================================================================
 
 /// Returns the SIZEOF function definition.

--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -1028,7 +1028,7 @@ pub fn get_all_stdlib_functions() -> Vec<FunctionSignature> {
 }
 
 // =============================================================================
-// SIZEOF (Dialect Extension)
+// SIZEOF (Language Extension)
 // =============================================================================
 
 /// Returns the SIZEOF function definition.

--- a/compiler/analyzer/src/rule_abstract_not_instantiated.rs
+++ b/compiler/analyzer/src/rule_abstract_not_instantiated.rs
@@ -1,5 +1,5 @@
 //! Semantic rule that rejects a variable declared with the type of an
-//! `ABSTRACT` function block (the CODESYS/TwinCAT vendor extension).
+//! `ABSTRACT` function block (the CODESYS/TwinCAT dialect extension).
 //!
 //! An `ABSTRACT` function block exists only to be extended via
 //! `EXTENDS` -- it cannot be instantiated directly.

--- a/compiler/analyzer/src/rule_abstract_not_instantiated.rs
+++ b/compiler/analyzer/src/rule_abstract_not_instantiated.rs
@@ -1,5 +1,5 @@
 //! Semantic rule that rejects a variable declared with the type of an
-//! `ABSTRACT` function block (the CODESYS/TwinCAT dialect extension).
+//! `ABSTRACT` function block.
 //!
 //! An `ABSTRACT` function block exists only to be extended via
 //! `EXTENDS` -- it cannot be instantiated directly.

--- a/compiler/analyzer/src/rule_case_bit_string_label.rs
+++ b/compiler/analyzer/src/rule_case_bit_string_label.rs
@@ -7,7 +7,7 @@
 //! where `signed_integer` is a *decimal* digit sequence. Radix-prefixed
 //! bit-string literals (`hex_integer` / `binary_integer` / `octal_integer`)
 //! are deliberately not in `case_list_element`, so accepting them as a
-//! label is a vendor extension (TwinCAT/CODESYS). The parser always accepts
+//! label is a dialect extension (TwinCAT/CODESYS). The parser always accepts
 //! the form; this rule is what enforces the flag.
 //!
 //! ## Fails (without the flag)

--- a/compiler/analyzer/src/rule_case_bit_string_label.rs
+++ b/compiler/analyzer/src/rule_case_bit_string_label.rs
@@ -7,7 +7,7 @@
 //! where `signed_integer` is a *decimal* digit sequence. Radix-prefixed
 //! bit-string literals (`hex_integer` / `binary_integer` / `octal_integer`)
 //! are deliberately not in `case_list_element`, so accepting them as a
-//! label is a dialect extension (TwinCAT/CODESYS). The parser always accepts
+//! label is an extension. The parser always accepts
 //! the form; this rule is what enforces the flag.
 //!
 //! ## Fails (without the flag)

--- a/compiler/analyzer/src/rule_extends_field_duplicated.rs
+++ b/compiler/analyzer/src/rule_extends_field_duplicated.rs
@@ -1,5 +1,5 @@
 //! Semantic rule that rejects a derived function block (via the
-//! CODESYS/TwinCAT `EXTENDS` dialect extension) redeclaring a field
+//! `EXTENDS` extension) redeclaring a field
 //! already declared on its base function block or any ancestor further
 //! up the `EXTENDS` chain.
 //!

--- a/compiler/analyzer/src/rule_extends_field_duplicated.rs
+++ b/compiler/analyzer/src/rule_extends_field_duplicated.rs
@@ -1,5 +1,5 @@
 //! Semantic rule that rejects a derived function block (via the
-//! CODESYS/TwinCAT `EXTENDS` vendor extension) redeclaring a field
+//! CODESYS/TwinCAT `EXTENDS` dialect extension) redeclaring a field
 //! already declared on its base function block or any ancestor further
 //! up the `EXTENDS` chain.
 //!

--- a/compiler/analyzer/src/rule_mixed_located_var_declarations.rs
+++ b/compiler/analyzer/src/rule_mixed_located_var_declarations.rs
@@ -6,7 +6,7 @@
 //! like `AT %IX0.0`, or incomplete/wildcard address like `AT %I*`) to live
 //! in their own dedicated `VAR ... END_VAR` block, separate from ordinary
 //! symbolic variables. Real CODESYS/TwinCAT code commonly mixes them in one
-//! block; this is a dialect extension.
+//! block; this is an extension.
 //!
 //! The parser always accepts the mixed form; this rule is what actually
 //! enforces the flag, by deriving "is this declaration mixed with a plain

--- a/compiler/analyzer/src/rule_mixed_located_var_declarations.rs
+++ b/compiler/analyzer/src/rule_mixed_located_var_declarations.rs
@@ -6,7 +6,7 @@
 //! like `AT %IX0.0`, or incomplete/wildcard address like `AT %I*`) to live
 //! in their own dedicated `VAR ... END_VAR` block, separate from ordinary
 //! symbolic variables. Real CODESYS/TwinCAT code commonly mixes them in one
-//! block; this is a vendor extension.
+//! block; this is a dialect extension.
 //!
 //! The parser always accepts the mixed form; this rule is what actually
 //! enforces the flag, by deriving "is this declaration mixed with a plain

--- a/compiler/analyzer/src/rule_no_top_level_var_global.rs
+++ b/compiler/analyzer/src/rule_no_top_level_var_global.rs
@@ -1,6 +1,6 @@
 //! Semantic rule that rejects `VAR_GLOBAL` declarations at the top level of a
 //! library (outside any `CONFIGURATION`/`RESOURCE` block) unless the
-//! `--allow-top-level-var-global` vendor extension is enabled.
+//! `--allow-top-level-var-global` dialect extension is enabled.
 //!
 //! In strict IEC 61131-3, `VAR_GLOBAL` is only permitted inside
 //! `CONFIGURATION` and `RESOURCE`. The parser represents a top-level block as a

--- a/compiler/analyzer/src/rule_no_top_level_var_global.rs
+++ b/compiler/analyzer/src/rule_no_top_level_var_global.rs
@@ -1,6 +1,6 @@
 //! Semantic rule that rejects `VAR_GLOBAL` declarations at the top level of a
 //! library (outside any `CONFIGURATION`/`RESOURCE` block) unless the
-//! `--allow-top-level-var-global` dialect extension is enabled.
+//! `--allow-top-level-var-global` extension is enabled.
 //!
 //! In strict IEC 61131-3, `VAR_GLOBAL` is only permitted inside
 //! `CONFIGURATION` and `RESOURCE`. The parser represents a top-level block as a

--- a/compiler/analyzer/src/rule_struct_initializer_expression_allowed.rs
+++ b/compiler/analyzer/src/rule_struct_initializer_expression_allowed.rs
@@ -9,7 +9,7 @@
 //! | enumerated_value | array_initialization | structure_initialization)`.
 //! A general expression -- and in particular a pointer dereference plus
 //! member access like `pDevice^.Delta` -- is deliberately not one of those
-//! productions, so accepting it is a vendor extension (TwinCAT/CODESYS). The
+//! productions, so accepting it is a dialect extension (TwinCAT/CODESYS). The
 //! parser always accepts the broader form; this rule is what enforces the
 //! flag.
 //!

--- a/compiler/analyzer/src/rule_struct_initializer_expression_allowed.rs
+++ b/compiler/analyzer/src/rule_struct_initializer_expression_allowed.rs
@@ -9,7 +9,7 @@
 //! | enumerated_value | array_initialization | structure_initialization)`.
 //! A general expression -- and in particular a pointer dereference plus
 //! member access like `pDevice^.Delta` -- is deliberately not one of those
-//! productions, so accepting it is a dialect extension (TwinCAT/CODESYS). The
+//! productions, so accepting it is an extension. The
 //! parser always accepts the broader form; this rule is what enforces the
 //! flag.
 //!

--- a/compiler/analyzer/src/rule_unsupported_extension.rs
+++ b/compiler/analyzer/src/rule_unsupported_extension.rs
@@ -1,7 +1,7 @@
-//! Semantic rule that flags vendor-specific language extensions that are
-//! parsed and represented in the AST but not yet semantically analyzed.
+//! Semantic rule that flags non-standard (dialect) language extensions that
+//! are parsed and represented in the AST but not yet semantically analyzed.
 //!
-//! See `ironplc_dsl::extension::VendorExtension`,
+//! See `ironplc_dsl::extension::DialectExtension`,
 //! `specs/plans/2026-07-18-twincat-extends-implements-interface.md`, and
 //! `specs/plans/2026-07-20-twincat-extends-field-inheritance.md` (plain
 //! `EXTENDS` with no `IMPLEMENTS`/`ABSTRACT` no longer flags, since field
@@ -21,7 +21,7 @@
 use ironplc_dsl::{
     common::*,
     diagnostic::{Diagnostic, Label},
-    extension::VendorExtension,
+    extension::DialectExtension,
     visitor::Visitor,
 };
 
@@ -49,7 +49,7 @@ struct RuleUnsupportedExtension {
 }
 
 impl RuleUnsupportedExtension {
-    fn flag(&mut self, ext: &dyn VendorExtension) {
+    fn flag(&mut self, ext: &dyn DialectExtension) {
         let origins: Vec<&str> = ext.extension_origins().iter().map(|o| o.as_str()).collect();
         self.diagnostics
             .push(Diagnostic::not_implemented(Label::span(
@@ -91,7 +91,7 @@ impl Visitor<Diagnostic> for RuleUnsupportedExtension {
         node: &InterfaceDeclaration,
     ) -> Result<Self::Value, Diagnostic> {
         // An InterfaceDeclaration only exists when INTERFACE syntax was
-        // used, so it is always a vendor extension.
+        // used, so it is always a dialect extension.
         self.flag(node);
         node.recurse_visit(self)
     }

--- a/compiler/analyzer/src/rule_unsupported_extension.rs
+++ b/compiler/analyzer/src/rule_unsupported_extension.rs
@@ -1,7 +1,7 @@
-//! Semantic rule that flags non-standard (dialect) language extensions that
+//! Semantic rule that flags non-standard language extensions that
 //! are parsed and represented in the AST but not yet semantically analyzed.
 //!
-//! See `ironplc_dsl::extension::DialectExtension`,
+//! See `ironplc_dsl::extension::LanguageExtension`,
 //! `specs/plans/2026-07-18-twincat-extends-implements-interface.md`, and
 //! `specs/plans/2026-07-20-twincat-extends-field-inheritance.md` (plain
 //! `EXTENDS` with no `IMPLEMENTS`/`ABSTRACT` no longer flags, since field
@@ -21,7 +21,7 @@
 use ironplc_dsl::{
     common::*,
     diagnostic::{Diagnostic, Label},
-    extension::DialectExtension,
+    extension::LanguageExtension,
     visitor::Visitor,
 };
 
@@ -49,7 +49,7 @@ struct RuleUnsupportedExtension {
 }
 
 impl RuleUnsupportedExtension {
-    fn flag(&mut self, ext: &dyn DialectExtension) {
+    fn flag(&mut self, ext: &dyn LanguageExtension) {
         let origins: Vec<&str> = ext.extension_origins().iter().map(|o| o.as_str()).collect();
         self.diagnostics
             .push(Diagnostic::not_implemented(Label::span(
@@ -91,7 +91,7 @@ impl Visitor<Diagnostic> for RuleUnsupportedExtension {
         node: &InterfaceDeclaration,
     ) -> Result<Self::Value, Diagnostic> {
         // An InterfaceDeclaration only exists when INTERFACE syntax was
-        // used, so it is always a dialect extension.
+        // used, so it is always an extension.
         self.flag(node);
         node.recurse_visit(self)
     }

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -101,7 +101,7 @@ pub fn resolve_types(
         .with_stdlib_functions()
         .build();
 
-    // Conditionally register vendor-extension functions gated by allow flags.
+    // Conditionally register dialect-extension functions gated by allow flags.
     if options.allow_sizeof {
         use crate::intermediates::stdlib_function::get_sizeof_function;
         function_environment

--- a/compiler/analyzer/src/xform_int_to_bool_initializer.rs
+++ b/compiler/analyzer/src/xform_int_to_bool_initializer.rs
@@ -1,7 +1,7 @@
 //! Transform that rewrites integer literal 0/1 initializers on BOOL variables
 //! into proper boolean literals (FALSE/TRUE).
 //!
-//! This is a vendor extension enabled by `--allow-int-to-bool-initializer`
+//! This is a dialect extension enabled by `--allow-int-to-bool-initializer`
 //! (or `--dialect rusty`). It allows patterns like `debug : BOOL := 0;`
 //! which are universally supported by CoDeSys, TwinCAT, RuSTy, and
 //! virtually every PLC runtime.

--- a/compiler/analyzer/src/xform_int_to_bool_initializer.rs
+++ b/compiler/analyzer/src/xform_int_to_bool_initializer.rs
@@ -1,7 +1,7 @@
 //! Transform that rewrites integer literal 0/1 initializers on BOOL variables
 //! into proper boolean literals (FALSE/TRUE).
 //!
-//! This is a dialect extension enabled by `--allow-int-to-bool-initializer`
+//! This is an extension enabled by `--allow-int-to-bool-initializer`
 //! (or `--dialect rusty`). It allows patterns like `debug : BOOL := 0;`
 //! which are universally supported by CoDeSys, TwinCAT, RuSTy, and
 //! virtually every PLC runtime.

--- a/compiler/analyzer/src/xform_resolve_constant_expressions.rs
+++ b/compiler/analyzer/src/xform_resolve_constant_expressions.rs
@@ -5,7 +5,7 @@
 //! this pass substitutes the constant's value so downstream analysis sees
 //! only concrete integer literals.
 //!
-//! This is a dialect extension — the IEC 61131-3 standard requires integer
+//! This is an extension — the IEC 61131-3 standard requires integer
 //! literals in these positions. The `--allow-constant-type-params` flag
 //! controls whether unresolved references are accepted or rejected.
 
@@ -32,7 +32,7 @@ struct ConstantInfo {
 /// constants (VAR CONSTANT inside FUNCTION, FUNCTION_BLOCK, or PROGRAM) are
 /// scoped — they are only visible within their declaring POU.
 ///
-/// Using a constant reference in a type parameter is a dialect extension. When
+/// Using a constant reference in a type parameter is an extension. When
 /// `options.allow_constant_type_params` is false (strict IEC 61131-3), any such
 /// reference is rejected with [`Problem::ConstantTypeParamNotAllowed`] instead
 /// of being resolved.
@@ -128,7 +128,7 @@ fn extract_integer_value(init: &InitialValueAssignmentKind) -> Option<u128> {
 
 struct ConstantResolver {
     constants: HashMap<String, ConstantInfo>,
-    /// Whether the `--allow-constant-type-params` dialect extension is enabled.
+    /// Whether the `--allow-constant-type-params` extension is enabled.
     /// When false, a constant reference in a type parameter is rejected outright
     /// (P4029) rather than resolved.
     allow_constant_type_params: bool,
@@ -137,7 +137,7 @@ struct ConstantResolver {
 
 impl ConstantResolver {
     /// Records a P4029 diagnostic for a constant reference that appears in a type
-    /// parameter while the dialect extension is disabled. Returns `true` when the
+    /// parameter while the extension is disabled. Returns `true` when the
     /// reference was rejected (flag off), so callers skip resolution.
     fn reject_if_not_allowed(&mut self, id: &Id) -> bool {
         if self.allow_constant_type_params {
@@ -150,7 +150,7 @@ impl ConstantResolver {
             )
             .with_help(
                 "Use an integer literal in the type parameter, or enable the \
-                 --allow-constant-type-params dialect extension.",
+                 --allow-constant-type-params extension.",
             ),
         );
         true
@@ -266,7 +266,7 @@ mod tests {
         .unwrap()
     }
 
-    /// Options with the constant-type-params dialect extension enabled, so the
+    /// Options with the constant-type-params extension enabled, so the
     /// transform resolves references instead of rejecting them (P4029).
     fn enabled() -> CompilerOptions {
         CompilerOptions {
@@ -556,7 +556,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // Enforcement of the `--allow-constant-type-params` dialect extension.
+    // Enforcement of the `--allow-constant-type-params` extension.
     // See ironplc/ironplc#1234.
     // ---------------------------------------------------------------------
 

--- a/compiler/analyzer/src/xform_resolve_constant_expressions.rs
+++ b/compiler/analyzer/src/xform_resolve_constant_expressions.rs
@@ -5,7 +5,7 @@
 //! this pass substitutes the constant's value so downstream analysis sees
 //! only concrete integer literals.
 //!
-//! This is a vendor extension — the IEC 61131-3 standard requires integer
+//! This is a dialect extension — the IEC 61131-3 standard requires integer
 //! literals in these positions. The `--allow-constant-type-params` flag
 //! controls whether unresolved references are accepted or rejected.
 
@@ -32,7 +32,7 @@ struct ConstantInfo {
 /// constants (VAR CONSTANT inside FUNCTION, FUNCTION_BLOCK, or PROGRAM) are
 /// scoped — they are only visible within their declaring POU.
 ///
-/// Using a constant reference in a type parameter is a vendor extension. When
+/// Using a constant reference in a type parameter is a dialect extension. When
 /// `options.allow_constant_type_params` is false (strict IEC 61131-3), any such
 /// reference is rejected with [`Problem::ConstantTypeParamNotAllowed`] instead
 /// of being resolved.
@@ -128,7 +128,7 @@ fn extract_integer_value(init: &InitialValueAssignmentKind) -> Option<u128> {
 
 struct ConstantResolver {
     constants: HashMap<String, ConstantInfo>,
-    /// Whether the `--allow-constant-type-params` vendor extension is enabled.
+    /// Whether the `--allow-constant-type-params` dialect extension is enabled.
     /// When false, a constant reference in a type parameter is rejected outright
     /// (P4029) rather than resolved.
     allow_constant_type_params: bool,
@@ -137,7 +137,7 @@ struct ConstantResolver {
 
 impl ConstantResolver {
     /// Records a P4029 diagnostic for a constant reference that appears in a type
-    /// parameter while the vendor extension is disabled. Returns `true` when the
+    /// parameter while the dialect extension is disabled. Returns `true` when the
     /// reference was rejected (flag off), so callers skip resolution.
     fn reject_if_not_allowed(&mut self, id: &Id) -> bool {
         if self.allow_constant_type_params {
@@ -150,7 +150,7 @@ impl ConstantResolver {
             )
             .with_help(
                 "Use an integer literal in the type parameter, or enable the \
-                 --allow-constant-type-params vendor extension.",
+                 --allow-constant-type-params dialect extension.",
             ),
         );
         true
@@ -266,7 +266,7 @@ mod tests {
         .unwrap()
     }
 
-    /// Options with the constant-type-params vendor extension enabled, so the
+    /// Options with the constant-type-params dialect extension enabled, so the
     /// transform resolves references instead of rejecting them (P4029).
     fn enabled() -> CompilerOptions {
         CompilerOptions {
@@ -556,7 +556,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // Enforcement of the `--allow-constant-type-params` vendor extension.
+    // Enforcement of the `--allow-constant-type-params` dialect extension.
     // See ironplc/ironplc#1234.
     // ---------------------------------------------------------------------
 

--- a/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
@@ -122,7 +122,7 @@ impl DeclarationResolver<'_> {
             InitialValueAssignmentKind::LateResolvedType(type_name) => {
                 VariableType::LateResolvedType(type_name.clone())
             }
-            // Not yet folded to a literal (vendor extension, folded by a
+            // Not yet folded to a literal (dialect extension, folded by a
             // later pass); treat like `Simple` for type-inference purposes.
             InitialValueAssignmentKind::SimpleExpr(_) => VariableType::Simple,
         };

--- a/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
@@ -122,7 +122,7 @@ impl DeclarationResolver<'_> {
             InitialValueAssignmentKind::LateResolvedType(type_name) => {
                 VariableType::LateResolvedType(type_name.clone())
             }
-            // Not yet folded to a literal (dialect extension, folded by a
+            // Not yet folded to a literal (extension, folded by a
             // later pass); treat like `Simple` for type-inference purposes.
             InitialValueAssignmentKind::SimpleExpr(_) => VariableType::Simple,
         };

--- a/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
+++ b/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
@@ -245,7 +245,7 @@ impl Fold<Diagnostic> for TypeEnvironment {
             }
             InitialValueAssignmentKind::SimpleExpr(_) => {
                 // Constant-expression initializers are a VAR-declaration
-                // dialect extension; they never appear in a TYPE alias's
+                // extension; they never appear in a TYPE alias's
                 // spec_and_init (that grammar path is unchanged).
                 return Err(Diagnostic::internal_error(file!(), line!()));
             }

--- a/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
+++ b/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
@@ -245,7 +245,7 @@ impl Fold<Diagnostic> for TypeEnvironment {
             }
             InitialValueAssignmentKind::SimpleExpr(_) => {
                 // Constant-expression initializers are a VAR-declaration
-                // vendor extension; they never appear in a TYPE alias's
+                // dialect extension; they never appear in a TYPE alias's
                 // spec_and_init (that grammar path is unchanged).
                 return Err(Diagnostic::internal_error(file!(), line!()));
             }

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -173,7 +173,7 @@ pub(crate) fn compile_function_call(
         "move" => compile_move(emitter, ctx, func, op_type),
         // Truncation function
         "trunc" => compile_trunc(emitter, ctx, func, op_type),
-        // SIZEOF operator (vendor extension)
+        // SIZEOF operator (dialect extension)
         "sizeof" => compile_sizeof(emitter, ctx, func),
         // BCD conversion functions
         "bcd_to_int" => compile_bcd_to_int(emitter, ctx, func, op_type),

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -173,7 +173,7 @@ pub(crate) fn compile_function_call(
         "move" => compile_move(emitter, ctx, func, op_type),
         // Truncation function
         "trunc" => compile_trunc(emitter, ctx, func, op_type),
-        // SIZEOF operator (dialect extension)
+        // SIZEOF operator (extension)
         "sizeof" => compile_sizeof(emitter, ctx, func),
         // BCD conversion functions
         "bcd_to_int" => compile_bcd_to_int(emitter, ctx, func, op_type),

--- a/compiler/codegen/src/compile_enum.rs
+++ b/compiler/codegen/src/compile_enum.rs
@@ -59,8 +59,8 @@ pub(crate) fn build_enum_ordinal_map(library: &Library) -> EnumOrdinalMap {
                 let mut value_names = Vec::new();
 
                 // Uses the resolved ordinal (not just declaration
-                // position) so explicit values (`member := 5`, a
-                // CODESYS/TwinCAT extension) are reflected at runtime,
+                // position) so explicit values (`member := 5`,
+                // an extension) are reflected at runtime,
                 // not just at the type-sizing stage.
                 let resolved = ironplc_analyzer::resolve_ordinal_values(&spec_values.values);
                 for (ev, ordinal) in spec_values.values.iter().zip(resolved) {

--- a/compiler/codegen/tests/it/end_to_end_case.rs
+++ b/compiler/codegen/tests/it/end_to_end_case.rs
@@ -132,7 +132,7 @@ END_PROGRAM
     assert_eq!(bufs.vars[1].as_i32(), 50);
 }
 
-/// Options enabling only the bit-string CASE label dialect extension, on the
+/// Options enabling only the bit-string CASE label extension, on the
 /// default Edition 2 base. The selector is a standard integer type (`DINT`);
 /// only the radix-prefixed *label* form is the extension under test.
 fn opts_with_bit_string_case_labels() -> CompilerOptions {

--- a/compiler/codegen/tests/it/end_to_end_case.rs
+++ b/compiler/codegen/tests/it/end_to_end_case.rs
@@ -132,7 +132,7 @@ END_PROGRAM
     assert_eq!(bufs.vars[1].as_i32(), 50);
 }
 
-/// Options enabling only the bit-string CASE label vendor extension, on the
+/// Options enabling only the bit-string CASE label dialect extension, on the
 /// default Edition 2 base. The selector is a standard integer type (`DINT`);
 /// only the radix-prefixed *label* form is the extension under test.
 fn opts_with_bit_string_case_labels() -> CompilerOptions {

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -11,7 +11,7 @@ use dsl_macro_derive::Recurse;
 
 use crate::configuration::{ConfigurationDeclaration, Direction};
 use crate::core::{Id, Located, SourceSpan};
-use crate::extension::{ExtensionOrigin, VendorExtension};
+use crate::extension::{DialectExtension, ExtensionOrigin};
 use crate::fold::Fold;
 use crate::sfc::{Network, Sfc};
 use crate::textual::*;
@@ -318,7 +318,7 @@ impl SignedInteger {
 
 /// An integer value that may be either a literal or a reference to a named constant.
 ///
-/// This enables vendor extensions where constant identifiers can be used in
+/// This enables dialect extensions where constant identifiers can be used in
 /// positions that normally require integer literals, such as STRING lengths
 /// and array bounds.
 #[derive(Clone, Debug, PartialEq, Recurse)]
@@ -338,7 +338,7 @@ impl IntegerRef {
 
 /// A signed integer value that may be either a literal or a reference to a named constant.
 ///
-/// See `IntegerRef` for details on the vendor extension support.
+/// See `IntegerRef` for details on the dialect extension support.
 #[derive(Clone, Debug, PartialEq, Recurse)]
 pub enum SignedIntegerRef {
     Literal(SignedInteger),
@@ -2128,7 +2128,7 @@ impl VarDecl {
 
 /// Declarations that are `AT`-located but share a `BlockId` with at least
 /// one plain (symbolic) declaration -- derived from block identity, not
-/// stored. This is the CODESYS/TwinCAT vendor extension gated by
+/// stored. This is the CODESYS/TwinCAT dialect extension gated by
 /// `--allow-mixed-located-var-declarations`: standard IEC 61131-3 requires
 /// located variables to live in their own dedicated block, separate from
 /// ordinary symbolic ones.
@@ -2448,7 +2448,7 @@ pub enum InitialValueAssignmentKind {
     /// definitions. Value is the name of the type.
     LateResolvedType(TypeName),
     /// A constant-expression initializer not yet folded to a literal
-    /// (vendor extension — see `allow_constant_initializer_expressions`).
+    /// (dialect extension — see `allow_constant_initializer_expressions`).
     /// Always normalized to `Simple` by
     /// `xform_fold_initializer_expressions` before any other pass runs;
     /// no other code should ever match on this variant.
@@ -2543,7 +2543,7 @@ pub struct SimpleInitializer {
 /// A variable initializer expressed as a constant expression (e.g.
 /// `PI/180.0`) rather than a bare literal.
 ///
-/// This is a vendor extension — the IEC 61131-3 standard's `constant()`
+/// This is a dialect extension — the IEC 61131-3 standard's `constant()`
 /// grammar production only permits literals in this position. Parsed
 /// unconditionally; `xform_fold_initializer_expressions` folds it back to
 /// `SimpleInitializer` or emits a diagnostic, depending on
@@ -2695,13 +2695,13 @@ pub enum LibraryElementKind {
     FunctionBlockDeclaration(FunctionBlockDeclaration),
     ProgramDeclaration(ProgramDeclaration),
     ConfigurationDeclaration(ConfigurationDeclaration),
-    /// Top-level global variable declarations (vendor extension).
+    /// Top-level global variable declarations (dialect extension).
     ///
     /// In the IEC 61131-3 standard, VAR_GLOBAL only appears inside
     /// CONFIGURATION/RESOURCE blocks. This variant enables the common
-    /// vendor extension of declaring globals at the top level.
+    /// dialect extension of declaring globals at the top level.
     GlobalVarDeclarations(Vec<VarDecl>),
-    /// `INTERFACE ... END_INTERFACE` (vendor extension). See
+    /// `INTERFACE ... END_INTERFACE` (dialect extension). See
     /// `InterfaceDeclaration`.
     InterfaceDeclaration(InterfaceDeclaration),
 }
@@ -2781,7 +2781,7 @@ pub struct FunctionBlockDeclaration {
     /// `None` for an ordinary function block — the common case — so OOP is
     /// unrepresentable on a plain FB rather than "present but empty."
     /// `Some` only when the source actually uses `EXTENDS`, `IMPLEMENTS`,
-    /// or `ABSTRACT`. See `VendorExtension` impl on `FunctionBlockOop` and
+    /// or `ABSTRACT`. See `DialectExtension` impl on `FunctionBlockOop` and
     /// `specs/plans/2026-07-18-twincat-extends-implements-interface.md`.
     pub oop: Option<FunctionBlockOop>,
 }
@@ -2828,11 +2828,11 @@ pub struct FunctionBlockOop {
     pub span: SourceSpan,
 }
 
-/// Only the OOP facet is a vendor/edition extension — the rest of a
-/// function block is standard IEC 61131-3. Implementing `VendorExtension`
+/// Only the OOP facet is a dialect/edition extension — the rest of a
+/// function block is standard IEC 61131-3. Implementing `DialectExtension`
 /// here (rather than on `FunctionBlockDeclaration`) means an ordinary
-/// function block is not, and cannot claim to be, a vendor extension.
-impl VendorExtension for FunctionBlockOop {
+/// function block is not, and cannot claim to be, a dialect extension.
+impl DialectExtension for FunctionBlockOop {
     fn extension_name(&self) -> &'static str {
         "EXTENDS/IMPLEMENTS/ABSTRACT clause"
     }
@@ -2871,10 +2871,10 @@ impl Located for InterfaceDeclaration {
     }
 }
 
-/// An `InterfaceDeclaration` is always a vendor extension — unlike
+/// An `InterfaceDeclaration` is always a dialect extension — unlike
 /// `FunctionBlockDeclaration`, there is no standard-IEC-61131-3 meaning for
 /// it.
-impl VendorExtension for InterfaceDeclaration {
+impl DialectExtension for InterfaceDeclaration {
     fn extension_name(&self) -> &'static str {
         "INTERFACE declaration"
     }

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -11,7 +11,7 @@ use dsl_macro_derive::Recurse;
 
 use crate::configuration::{ConfigurationDeclaration, Direction};
 use crate::core::{Id, Located, SourceSpan};
-use crate::extension::{DialectExtension, ExtensionOrigin};
+use crate::extension::{ExtensionOrigin, LanguageExtension};
 use crate::fold::Fold;
 use crate::sfc::{Network, Sfc};
 use crate::textual::*;
@@ -318,7 +318,7 @@ impl SignedInteger {
 
 /// An integer value that may be either a literal or a reference to a named constant.
 ///
-/// This enables dialect extensions where constant identifiers can be used in
+/// This enables extensions where constant identifiers can be used in
 /// positions that normally require integer literals, such as STRING lengths
 /// and array bounds.
 #[derive(Clone, Debug, PartialEq, Recurse)]
@@ -338,7 +338,7 @@ impl IntegerRef {
 
 /// A signed integer value that may be either a literal or a reference to a named constant.
 ///
-/// See `IntegerRef` for details on the dialect extension support.
+/// See `IntegerRef` for details on the extension support.
 #[derive(Clone, Debug, PartialEq, Recurse)]
 pub enum SignedIntegerRef {
     Literal(SignedInteger),
@@ -1501,7 +1501,7 @@ pub struct EnumeratedValue {
     pub value: Id,
     /// Present when this member's value was assigned explicitly
     /// (`member := 5`) in an enum *declaration's* value list -- a
-    /// CODESYS/TwinCAT extension (also standard as of IEC 61131-3:2013).
+    /// an extension (also standard as of IEC 61131-3:2013).
     /// `None` in every other context `EnumeratedValue` is used in
     /// (references, default values, case labels) -- only the
     /// declaration-list grammar path sets this.
@@ -2128,7 +2128,7 @@ impl VarDecl {
 
 /// Declarations that are `AT`-located but share a `BlockId` with at least
 /// one plain (symbolic) declaration -- derived from block identity, not
-/// stored. This is the CODESYS/TwinCAT dialect extension gated by
+/// stored. This is the extension gated by
 /// `--allow-mixed-located-var-declarations`: standard IEC 61131-3 requires
 /// located variables to live in their own dedicated block, separate from
 /// ordinary symbolic ones.
@@ -2448,7 +2448,7 @@ pub enum InitialValueAssignmentKind {
     /// definitions. Value is the name of the type.
     LateResolvedType(TypeName),
     /// A constant-expression initializer not yet folded to a literal
-    /// (dialect extension — see `allow_constant_initializer_expressions`).
+    /// (extension — see `allow_constant_initializer_expressions`).
     /// Always normalized to `Simple` by
     /// `xform_fold_initializer_expressions` before any other pass runs;
     /// no other code should ever match on this variant.
@@ -2543,7 +2543,7 @@ pub struct SimpleInitializer {
 /// A variable initializer expressed as a constant expression (e.g.
 /// `PI/180.0`) rather than a bare literal.
 ///
-/// This is a dialect extension — the IEC 61131-3 standard's `constant()`
+/// This is an extension — the IEC 61131-3 standard's `constant()`
 /// grammar production only permits literals in this position. Parsed
 /// unconditionally; `xform_fold_initializer_expressions` folds it back to
 /// `SimpleInitializer` or emits a diagnostic, depending on
@@ -2695,13 +2695,13 @@ pub enum LibraryElementKind {
     FunctionBlockDeclaration(FunctionBlockDeclaration),
     ProgramDeclaration(ProgramDeclaration),
     ConfigurationDeclaration(ConfigurationDeclaration),
-    /// Top-level global variable declarations (dialect extension).
+    /// Top-level global variable declarations (extension).
     ///
     /// In the IEC 61131-3 standard, VAR_GLOBAL only appears inside
     /// CONFIGURATION/RESOURCE blocks. This variant enables the common
-    /// dialect extension of declaring globals at the top level.
+    /// extension of declaring globals at the top level.
     GlobalVarDeclarations(Vec<VarDecl>),
-    /// `INTERFACE ... END_INTERFACE` (dialect extension). See
+    /// `INTERFACE ... END_INTERFACE` (extension). See
     /// `InterfaceDeclaration`.
     InterfaceDeclaration(InterfaceDeclaration),
 }
@@ -2781,7 +2781,7 @@ pub struct FunctionBlockDeclaration {
     /// `None` for an ordinary function block — the common case — so OOP is
     /// unrepresentable on a plain FB rather than "present but empty."
     /// `Some` only when the source actually uses `EXTENDS`, `IMPLEMENTS`,
-    /// or `ABSTRACT`. See `DialectExtension` impl on `FunctionBlockOop` and
+    /// or `ABSTRACT`. See `LanguageExtension` impl on `FunctionBlockOop` and
     /// `specs/plans/2026-07-18-twincat-extends-implements-interface.md`.
     pub oop: Option<FunctionBlockOop>,
 }
@@ -2829,10 +2829,10 @@ pub struct FunctionBlockOop {
 }
 
 /// Only the OOP facet is a dialect/edition extension — the rest of a
-/// function block is standard IEC 61131-3. Implementing `DialectExtension`
+/// function block is standard IEC 61131-3. Implementing `LanguageExtension`
 /// here (rather than on `FunctionBlockDeclaration`) means an ordinary
-/// function block is not, and cannot claim to be, a dialect extension.
-impl DialectExtension for FunctionBlockOop {
+/// function block is not, and cannot claim to be, an extension.
+impl LanguageExtension for FunctionBlockOop {
     fn extension_name(&self) -> &'static str {
         "EXTENDS/IMPLEMENTS/ABSTRACT clause"
     }
@@ -2877,10 +2877,10 @@ impl Located for InterfaceDeclaration {
     }
 }
 
-/// An `InterfaceDeclaration` is always a dialect extension — unlike
+/// An `InterfaceDeclaration` is always an extension — unlike
 /// `FunctionBlockDeclaration`, there is no standard-IEC-61131-3 meaning for
 /// it.
-impl DialectExtension for InterfaceDeclaration {
+impl LanguageExtension for InterfaceDeclaration {
     fn extension_name(&self) -> &'static str {
         "INTERFACE declaration"
     }

--- a/compiler/dsl/src/extension.rs
+++ b/compiler/dsl/src/extension.rs
@@ -1,4 +1,4 @@
-//! Marks AST nodes representing non-standard (dialect) language extensions
+//! Marks AST nodes representing non-standard language extensions
 //! that IronPLC parses but does not yet semantically analyze.
 //!
 //! See `specs/design/beckhoff-twincat-dialect.md` and
@@ -25,7 +25,7 @@ impl ExtensionOrigin {
     }
 }
 
-/// Marker trait for AST nodes representing non-standard (dialect) language
+/// Marker trait for AST nodes representing non-standard language
 /// extensions.
 ///
 /// Nodes implementing this trait are parsed and represented in the AST but
@@ -33,9 +33,9 @@ impl ExtensionOrigin {
 /// semantic rule `rule_unsupported_extension` walks the AST and emits P9999
 /// for every node that implements this trait.
 ///
-/// As each extension graduates to full support, remove its `DialectExtension`
+/// As each extension graduates to full support, remove its `LanguageExtension`
 /// impl. The semantic rule automatically stops flagging it.
-pub trait DialectExtension {
+pub trait LanguageExtension {
     /// Human-readable name of this extension (e.g., "EXTENDS clause").
     fn extension_name(&self) -> &'static str;
 

--- a/compiler/dsl/src/extension.rs
+++ b/compiler/dsl/src/extension.rs
@@ -1,5 +1,5 @@
-//! Marks AST nodes representing vendor-specific language extensions that
-//! IronPLC parses but does not yet semantically analyze.
+//! Marks AST nodes representing non-standard (dialect) language extensions
+//! that IronPLC parses but does not yet semantically analyze.
 //!
 //! See `specs/design/beckhoff-twincat-dialect.md` and
 //! `specs/plans/2026-07-18-twincat-extends-implements-interface.md`.
@@ -25,7 +25,7 @@ impl ExtensionOrigin {
     }
 }
 
-/// Marker trait for AST nodes representing vendor-specific language
+/// Marker trait for AST nodes representing non-standard (dialect) language
 /// extensions.
 ///
 /// Nodes implementing this trait are parsed and represented in the AST but
@@ -33,14 +33,14 @@ impl ExtensionOrigin {
 /// semantic rule `rule_unsupported_extension` walks the AST and emits P9999
 /// for every node that implements this trait.
 ///
-/// As each extension graduates to full support, remove its `VendorExtension`
+/// As each extension graduates to full support, remove its `DialectExtension`
 /// impl. The semantic rule automatically stops flagging it.
-pub trait VendorExtension {
+pub trait DialectExtension {
     /// Human-readable name of this extension (e.g., "EXTENDS clause").
     fn extension_name(&self) -> &'static str;
 
-    /// Which vendor dialects introduced this extension. A single extension
-    /// may originate from multiple vendors.
+    /// Which dialects introduced this extension. A single extension may
+    /// originate from multiple vendors.
     fn extension_origins(&self) -> &'static [ExtensionOrigin];
 
     /// The source span for diagnostic reporting.

--- a/compiler/dsl/src/fold.rs
+++ b/compiler/dsl/src/fold.rs
@@ -179,7 +179,7 @@ pub trait Fold<E> {
     // 2.4.3.2
     dispatch!(SimpleInitializer);
 
-    // CODESYS/TwinCAT dialect extension
+    // Expression-valued initializer (extension)
     dispatch!(SimpleExprInitializer);
 
     // 2.4.3.1 and 2.4.3.2

--- a/compiler/dsl/src/fold.rs
+++ b/compiler/dsl/src/fold.rs
@@ -179,7 +179,7 @@ pub trait Fold<E> {
     // 2.4.3.2
     dispatch!(SimpleInitializer);
 
-    // CODESYS/TwinCAT vendor extension
+    // CODESYS/TwinCAT dialect extension
     dispatch!(SimpleExprInitializer);
 
     // 2.4.3.1 and 2.4.3.2

--- a/compiler/dsl/src/visitor.rs
+++ b/compiler/dsl/src/visitor.rs
@@ -230,7 +230,7 @@ pub trait Visitor<E> {
     // 2.4.3.2
     dispatch!(SimpleInitializer);
 
-    // CODESYS/TwinCAT dialect extension
+    // Expression-valued initializer (extension)
     dispatch!(SimpleExprInitializer);
 
     // 2.4.3.1 and 2.4.3.2

--- a/compiler/dsl/src/visitor.rs
+++ b/compiler/dsl/src/visitor.rs
@@ -230,7 +230,7 @@ pub trait Visitor<E> {
     // 2.4.3.2
     dispatch!(SimpleInitializer);
 
-    // CODESYS/TwinCAT vendor extension
+    // CODESYS/TwinCAT dialect extension
     dispatch!(SimpleExprInitializer);
 
     // 2.4.3.1 and 2.4.3.2

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -74,17 +74,17 @@ struct FileArgs {
     allow_missing_semicolon: bool,
 
     /// Allow VAR_GLOBAL declarations at the top level (outside CONFIGURATION).
-    /// This is a vendor extension not part of the IEC 61131-3 standard.
+    /// This is a dialect extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_top_level_var_global: bool,
 
     /// Allow constant references in type parameters (e.g., STRING[MY_CONST]).
-    /// This is a vendor extension not part of the IEC 61131-3 standard.
+    /// This is a dialect extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_constant_type_params: bool,
 
     /// Allow empty variable blocks (VAR END_VAR, VAR_INPUT END_VAR, etc.).
-    /// This is a vendor extension not part of the IEC 61131-3 standard.
+    /// This is a dialect extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_empty_var_blocks: bool,
 
@@ -105,13 +105,13 @@ struct FileArgs {
     allow_ref_to: bool,
 
     /// Allow the Beckhoff TwinCAT/CODESYS `REFERENCE TO` reference type and the
-    /// `REF=` binding operator. This is a vendor extension, an alternative to
+    /// `REF=` binding operator. This is a dialect extension, an alternative to
     /// `--allow-ref-to`; the `twincat` and `codesys` dialects enable it.
     #[arg(long)]
     allow_reference_to: bool,
 
     /// Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types.
-    /// This is a vendor extension not part of the IEC 61131-3 standard.
+    /// This is a dialect extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_ref_arithmetic: bool,
 
@@ -127,12 +127,12 @@ struct FileArgs {
     allow_ref_type_punning: bool,
 
     /// Allow integer literals (0 or 1) as BOOL variable initializers.
-    /// This is a vendor extension supported by CoDeSys, TwinCAT, and RuSTy.
+    /// This is a dialect extension supported by CoDeSys, TwinCAT, and RuSTy.
     #[arg(long)]
     allow_int_to_bool_initializer: bool,
 
     /// Allow SIZEOF() operator that returns the size in bytes of a variable or type.
-    /// This is a vendor extension supported by CODESYS, TwinCAT, and RuSTy.
+    /// This is a dialect extension supported by CODESYS, TwinCAT, and RuSTy.
     #[arg(long)]
     allow_sizeof: bool,
 
@@ -142,7 +142,7 @@ struct FileArgs {
     allow_system_uptime_global: bool,
 
     /// Allow implicit widening between bit-string and integer type families
-    /// (e.g. BYTE→INT, literal 0→BYTE). This is a vendor extension.
+    /// (e.g. BYTE→INT, literal 0→BYTE). This is a dialect extension.
     #[arg(long)]
     allow_cross_family_widening: bool,
 
@@ -153,48 +153,48 @@ struct FileArgs {
     allow_partial_access_syntax: bool,
 
     /// Allow curly-brace pragmas ({attribute 'name'}) as opaque, skipped trivia.
-    /// This is a vendor extension not part of the IEC 61131-3 standard.
+    /// This is a dialect extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_pragmas: bool,
 
     /// Allow the AND_THEN short-circuit boolean operator (Beckhoff/CODESYS extension).
-    /// This is a vendor extension not part of the IEC 61131-3 standard.
+    /// This is a dialect extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_short_circuit_operators: bool,
 
     /// Allow an AT-located variable inside an otherwise plain
     /// VAR/VAR_INPUT/VAR_OUTPUT block, instead of requiring its own dedicated
-    /// block. This is a vendor extension not part of the IEC 61131-3 standard.
+    /// block. This is a dialect extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_mixed_located_var_declarations: bool,
 
     /// Allow a VAR initializer to be a constant expression (e.g. SCALE*4.0)
-    /// rather than only a bare literal. This is a vendor extension not part
+    /// rather than only a bare literal. This is a dialect extension not part
     /// of the IEC 61131-3 standard.
     #[arg(long)]
     allow_constant_initializer_expressions: bool,
 
     /// Allow hex/binary/octal bit-string literals (e.g. 16#D012, 2#1010) as
-    /// CASE labels. This is a vendor extension not part of the IEC 61131-3
+    /// CASE labels. This is a dialect extension not part of the IEC 61131-3
     /// standard.
     #[arg(long)]
     allow_bit_string_case_labels: bool,
 
     /// Allow the STRING(n)/WSTRING(n) parenthesis length delimiter in addition
-    /// to the standard STRING[n]/WSTRING[n] brackets. This is a vendor
+    /// to the standard STRING[n]/WSTRING[n] brackets. This is a dialect
     /// extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_paren_string_length: bool,
 
     /// Allow a general (non-constant) expression as the value in a
     /// structured/call-style initializer's `name := value` pairs (e.g.
-    /// `tonDelta : TON := (PT := pDevice^.Delta);`). This is a vendor
+    /// `tonDelta : TON := (PT := pDevice^.Delta);`). This is a dialect
     /// extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_struct_initializer_expressions: bool,
 
     /// Allow function-block inheritance syntax: EXTENDS/IMPLEMENTS on
-    /// FUNCTION_BLOCK and INTERFACE declarations. This is a vendor
+    /// FUNCTION_BLOCK and INTERFACE declarations. This is a dialect
     /// extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_fb_inheritance: bool,
@@ -331,12 +331,12 @@ mod tests {
     }
 
     /// Guards the hand-maintained `FileArgs` flag list against drifting out of
-    /// sync with the compiler's `FEATURE_DESCRIPTORS`: every vendor flag must be
+    /// sync with the compiler's `FEATURE_DESCRIPTORS`: every dialect flag must be
     /// reachable via its `--allow-*` CLI form and wired through to
     /// `CompilerOptions`. clap needs a static field per arg, so the list cannot
     /// be derived — but this test makes an omission fail CI instead of shipping.
     #[test]
-    fn file_args_when_each_vendor_flag_cli_form_passed_then_option_enabled() {
+    fn file_args_when_each_dialect_flag_cli_form_passed_then_option_enabled() {
         #[derive(Parser)]
         struct TestCli {
             #[command(flatten)]

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -74,17 +74,17 @@ struct FileArgs {
     allow_missing_semicolon: bool,
 
     /// Allow VAR_GLOBAL declarations at the top level (outside CONFIGURATION).
-    /// This is a dialect extension not part of the IEC 61131-3 standard.
+    /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_top_level_var_global: bool,
 
     /// Allow constant references in type parameters (e.g., STRING[MY_CONST]).
-    /// This is a dialect extension not part of the IEC 61131-3 standard.
+    /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_constant_type_params: bool,
 
     /// Allow empty variable blocks (VAR END_VAR, VAR_INPUT END_VAR, etc.).
-    /// This is a dialect extension not part of the IEC 61131-3 standard.
+    /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_empty_var_blocks: bool,
 
@@ -105,13 +105,13 @@ struct FileArgs {
     allow_ref_to: bool,
 
     /// Allow the Beckhoff TwinCAT/CODESYS `REFERENCE TO` reference type and the
-    /// `REF=` binding operator. This is a dialect extension, an alternative to
+    /// `REF=` binding operator. This is an extension, an alternative to
     /// `--allow-ref-to`; the `twincat` and `codesys` dialects enable it.
     #[arg(long)]
     allow_reference_to: bool,
 
     /// Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types.
-    /// This is a dialect extension not part of the IEC 61131-3 standard.
+    /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_ref_arithmetic: bool,
 
@@ -127,12 +127,12 @@ struct FileArgs {
     allow_ref_type_punning: bool,
 
     /// Allow integer literals (0 or 1) as BOOL variable initializers.
-    /// This is a dialect extension supported by CoDeSys, TwinCAT, and RuSTy.
+    /// This is an extension supported by CoDeSys, TwinCAT, and RuSTy.
     #[arg(long)]
     allow_int_to_bool_initializer: bool,
 
     /// Allow SIZEOF() operator that returns the size in bytes of a variable or type.
-    /// This is a dialect extension supported by CODESYS, TwinCAT, and RuSTy.
+    /// This is an extension supported by CODESYS, TwinCAT, and RuSTy.
     #[arg(long)]
     allow_sizeof: bool,
 
@@ -142,7 +142,7 @@ struct FileArgs {
     allow_system_uptime_global: bool,
 
     /// Allow implicit widening between bit-string and integer type families
-    /// (e.g. BYTE→INT, literal 0→BYTE). This is a dialect extension.
+    /// (e.g. BYTE→INT, literal 0→BYTE). This is an extension.
     #[arg(long)]
     allow_cross_family_widening: bool,
 
@@ -153,29 +153,29 @@ struct FileArgs {
     allow_partial_access_syntax: bool,
 
     /// Allow curly-brace pragmas ({attribute 'name'}) as opaque, skipped trivia.
-    /// This is a dialect extension not part of the IEC 61131-3 standard.
+    /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_pragmas: bool,
 
     /// Allow the AND_THEN short-circuit boolean operator (Beckhoff/CODESYS extension).
-    /// This is a dialect extension not part of the IEC 61131-3 standard.
+    /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_short_circuit_operators: bool,
 
     /// Allow an AT-located variable inside an otherwise plain
     /// VAR/VAR_INPUT/VAR_OUTPUT block, instead of requiring its own dedicated
-    /// block. This is a dialect extension not part of the IEC 61131-3 standard.
+    /// block. This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
     allow_mixed_located_var_declarations: bool,
 
     /// Allow a VAR initializer to be a constant expression (e.g. SCALE*4.0)
-    /// rather than only a bare literal. This is a dialect extension not part
+    /// rather than only a bare literal. This is an extension not part
     /// of the IEC 61131-3 standard.
     #[arg(long)]
     allow_constant_initializer_expressions: bool,
 
     /// Allow hex/binary/octal bit-string literals (e.g. 16#D012, 2#1010) as
-    /// CASE labels. This is a dialect extension not part of the IEC 61131-3
+    /// CASE labels. This is an extension not part of the IEC 61131-3
     /// standard.
     #[arg(long)]
     allow_bit_string_case_labels: bool,

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -76,7 +76,7 @@ fn extract_compiler_options(initialize_params: &InitializeParams) -> CompilerOpt
 
         let mut options = CompilerOptions::from_dialect(dialect);
 
-        // Overlay individual vendor flags (can only enable, never disable). The
+        // Overlay individual dialect flags (can only enable, never disable). The
         // LSP option key is the lowerCamelCase form of each descriptor's
         // `option_key` (e.g. `allow_ref_to` -> `allowRefTo`). Deriving from
         // `FEATURE_DESCRIPTORS` keeps this in lockstep with the compiler: a new
@@ -788,12 +788,12 @@ mod test {
     }
 
     /// Guards the LSP option surface against drifting out of sync with the
-    /// compiler: every vendor flag must be enablable via its lowerCamelCase
+    /// compiler: every dialect flag must be enablable via its lowerCamelCase
     /// `initializationOptions` key. `extract_compiler_options` derives these
     /// from `FEATURE_DESCRIPTORS`, so this also pins the snake -> camelCase
     /// contract the VS Code extension relies on.
     #[test]
-    fn extract_compiler_options_when_each_vendor_flag_key_set_then_flag_enabled() {
+    fn extract_compiler_options_when_each_dialect_flag_key_set_then_flag_enabled() {
         for fd in ironplc_parser::options::CompilerOptions::FEATURE_DESCRIPTORS {
             let key = super::to_lower_camel_case(fd.option_key);
             let params = params_with_init_options(serde_json::json!({ key.clone(): true }));
@@ -862,7 +862,7 @@ mod test {
     }
 
     #[test]
-    fn extract_compiler_options_when_rusty_dialect_then_enables_ref_to_and_vendor_flags() {
+    fn extract_compiler_options_when_rusty_dialect_then_enables_ref_to_and_dialect_flags() {
         #[allow(deprecated)]
         let params = InitializeParams {
             process_id: None,

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Why this exists
 //!
-//! The `list_options` tool exposes one entry per vendor-extension flag in
+//! The `list_options` tool exposes one entry per dialect-extension flag in
 //! [`CompilerOptions::FEATURE_DESCRIPTORS`]. It is tempting to test that surface
 //! by *counting* flags (`assert_eq!(flags.len(), 16)`) or by asserting a flag's
 //! boolean is set. Both couple the test suite to every feature commit — the
@@ -52,7 +52,7 @@ struct FlagFixture {
     source: &'static str,
 }
 
-/// One fixture per vendor-extension flag. Order mirrors
+/// One fixture per dialect-extension flag. Order mirrors
 /// `FEATURE_DESCRIPTORS` for readability; the suite does not depend on ordering.
 /// Snippets are adapted from the compiler's own positive/negative tests (parser
 /// and analyzer) so they exercise the real enforcement path.

--- a/compiler/mcp/src/tools/common.rs
+++ b/compiler/mcp/src/tools/common.rs
@@ -398,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_options_when_rusty_dialect_then_vendor_flags_enabled() {
+    fn parse_options_when_rusty_dialect_then_dialect_flags_enabled() {
         let val = serde_json::json!({"dialect": "rusty"});
         let opts = parse_options(&val).unwrap();
         assert!(opts.allow_c_style_comments);

--- a/compiler/mcp/src/tools/list_options.rs
+++ b/compiler/mcp/src/tools/list_options.rs
@@ -48,7 +48,7 @@ pub fn build_response() -> ListOptionsResponse {
 
     let mut flags = Vec::with_capacity(CompilerOptions::FEATURE_DESCRIPTORS.len());
 
-    // All vendor-extension flags from the macro-generated descriptors.
+    // All dialect-extension flags from the macro-generated descriptors.
     for fd in CompilerOptions::FEATURE_DESCRIPTORS {
         flags.push(FlagInfo {
             id: fd.option_key.to_string(),

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -2,33 +2,33 @@
 //!
 //! Use [`Dialect`] to select a preset configuration, then optionally
 //! override individual flags.  Use the [`define_compiler_options`] macro
-//! to declare vendor-extension fields so that [`CompilerOptions::from_dialect`]
+//! to declare dialect-extension fields so that [`CompilerOptions::from_dialect`]
 //! is the single place that maps dialects to flags.
 
 use std::fmt;
 use std::str::FromStr;
 
 /// A named configuration preset that sets the IEC edition and
-/// vendor-extension flags in one shot.
+/// dialect-extension flags in one shot.
 ///
 /// Individual `--allow-*` CLI flags can still override on top of a dialect.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Dialect {
-    /// Strict IEC 61131-3:2003 (Edition 2).  No vendor extensions.
+    /// Strict IEC 61131-3:2003 (Edition 2).  No dialect extensions.
     #[default]
     Iec61131_3Ed2,
-    /// Strict IEC 61131-3:2013 (Edition 3).  No vendor extensions.
+    /// Strict IEC 61131-3:2013 (Edition 3).  No dialect extensions.
     Iec61131_3Ed3,
     /// RuSTy-compatible dialect: Edition 2 base (so long-time keywords
     /// like `LDT` stay as identifiers) plus `REF_TO` support and all
-    /// vendor extensions enabled.
+    /// dialect extensions enabled.
     Rusty,
     /// CODESYS-compatible dialect: Edition 2 base plus `REF_TO` support
-    /// and the vendor extensions that CODESYS accepts.  Does not bind the
+    /// and the dialect extensions that CODESYS accepts.  Does not bind the
     /// implicit `__SYSTEM_UP_TIME` globals, which are an IronPLC runtime
     /// convention rather than a CODESYS feature.
     Codesys,
-    /// Beckhoff TwinCAT-compatible dialect: Edition 2 base plus the vendor
+    /// Beckhoff TwinCAT-compatible dialect: Edition 2 base plus the dialect
     /// extensions that TwinCAT accepts.  TwinCAT 3 is built on the CODESYS V3
     /// runtime, so this is close to [`Dialect::Codesys`], but does not enable
     /// the `REF_TO` / `REF()` / `NULL` reference extensions: TwinCAT spells
@@ -65,17 +65,17 @@ impl Dialect {
     pub fn description(&self) -> &'static str {
         match self {
             Dialect::Iec61131_3Ed2 => {
-                "Strict IEC 61131-3:2003 (Edition 2). No vendor extensions. [default]"
+                "Strict IEC 61131-3:2003 (Edition 2). No dialect extensions. [default]"
             }
-            Dialect::Iec61131_3Ed3 => "Strict IEC 61131-3:2013 (Edition 3). No vendor extensions.",
+            Dialect::Iec61131_3Ed3 => "Strict IEC 61131-3:2013 (Edition 3). No dialect extensions.",
             Dialect::Rusty => {
-                "RuSTy-compatible: Edition 2 base with REF_TO and all vendor extensions."
+                "RuSTy-compatible: Edition 2 base with REF_TO and all dialect extensions."
             }
             Dialect::Codesys => {
-                "CODESYS-compatible: Edition 2 base with REF_TO and CODESYS vendor extensions."
+                "CODESYS-compatible: Edition 2 base with REF_TO and CODESYS dialect extensions."
             }
             Dialect::TwinCat => {
-                "TwinCAT-compatible: Edition 2 base with the vendor extensions TwinCAT accepts."
+                "TwinCAT-compatible: Edition 2 base with the dialect extensions TwinCAT accepts."
             }
         }
     }
@@ -128,7 +128,7 @@ impl fmt::Display for ParseDialectError {
 
 impl std::error::Error for ParseDialectError {}
 
-/// Metadata for a single vendor-extension feature flag.
+/// Metadata for a single dialect-extension feature flag.
 pub struct FeatureDescriptor {
     /// The CLI flag name (e.g. `"--allow-c-style-comments"`).
     pub cli_flag: &'static str,
@@ -141,7 +141,7 @@ pub struct FeatureDescriptor {
     pub dialects: &'static [Dialect],
 }
 
-/// Declares [`CompilerOptions`] with a set of vendor-extension boolean flags.
+/// Declares [`CompilerOptions`] with a set of dialect-extension boolean flags.
 ///
 /// Each field carries a description string and a list of [`Dialect`] variants
 /// that enable it.  The macro auto-generates the struct, its `Default` impl,
@@ -152,7 +152,7 @@ macro_rules! define_compiler_options {
             $desc:literal,
             $cli_flag:literal,
             [$($dialect:ident),* $(,)?],
-            $vendor_field:ident
+            $flag_field:ident
         ),* $(,)?
     ) => {
         #[derive(Debug, Default, Clone, Copy)]
@@ -160,7 +160,7 @@ macro_rules! define_compiler_options {
             /// When `true`, IEC 61131-3:2013 keywords (`LTIME`, `LDATE`,
             /// `LTOD`, `LDT`, `REF_TO`, `REF`, `NULL`) are recognised.
             pub allow_iec_61131_3_2013: bool,
-            $(pub $vendor_field: bool,)*
+            $(pub $flag_field: bool,)*
         }
 
         impl CompilerOptions {
@@ -175,33 +175,33 @@ macro_rules! define_compiler_options {
                 }
                 $(
                     if [$(Dialect::$dialect),*].contains(&dialect) {
-                        opts.$vendor_field = true;
+                        opts.$flag_field = true;
                     }
                 )*
                 opts
             }
 
-            /// Metadata for every vendor-extension feature flag.
+            /// Metadata for every dialect-extension feature flag.
             pub const FEATURE_DESCRIPTORS: &[FeatureDescriptor] = &[
                 $(
                     FeatureDescriptor {
                         cli_flag: $cli_flag,
-                        option_key: stringify!($vendor_field),
+                        option_key: stringify!($flag_field),
                         description: $desc,
                         dialects: &[$(Dialect::$dialect),*],
                     },
                 )*
             ];
 
-            /// Set a vendor-extension feature flag by its `option_key` (the
+            /// Set a dialect-extension feature flag by its `option_key` (the
             /// field name from [`FeatureDescriptor`]).
             ///
             /// Returns `true` if the key matched a known flag.
             pub fn set_flag_by_key(&mut self, key: &str, value: bool) -> bool {
                 match key {
                     $(
-                        stringify!($vendor_field) => {
-                            self.$vendor_field = value;
+                        stringify!($flag_field) => {
+                            self.$flag_field = value;
                             true
                         }
                     )*
@@ -209,14 +209,14 @@ macro_rules! define_compiler_options {
                 }
             }
 
-            /// Get a vendor-extension feature flag by its `option_key` (the
+            /// Get a dialect-extension feature flag by its `option_key` (the
             /// field name from [`FeatureDescriptor`]).
             ///
             /// Returns `None` if the key does not match a known flag.
             pub fn get_flag_by_key(&self, key: &str) -> Option<bool> {
                 match key {
                     $(
-                        stringify!($vendor_field) => Some(self.$vendor_field),
+                        stringify!($flag_field) => Some(self.$flag_field),
                     )*
                     _ => None,
                 }
@@ -381,9 +381,9 @@ pub fn describe_dialects() -> String {
 mod tests {
     use super::*;
 
-    /// Collect the vendor-flag `option_key`s that `from_dialect(dialect)`
+    /// Collect the dialect-flag `option_key`s that `from_dialect(dialect)`
     /// turns on, sorted for order-independent comparison.
-    fn enabled_vendor_flags(dialect: Dialect) -> Vec<&'static str> {
+    fn enabled_flags(dialect: Dialect) -> Vec<&'static str> {
         let options = CompilerOptions::from_dialect(dialect);
         let mut enabled: Vec<&'static str> = CompilerOptions::FEATURE_DESCRIPTORS
             .iter()
@@ -394,43 +394,43 @@ mod tests {
         enabled
     }
 
-    /// Assert that a dialect enables *exactly* the given set of vendor flags --
+    /// Assert that a dialect enables *exactly* the given set of dialect flags --
     /// no more, no less. This is the guard against a newly added option
     /// silently leaking into a dialect it should not belong to: adding an
     /// option to a dialect's macro tags forces a matching update here, and an
     /// accidental extra tag makes that dialect's expected set mismatch.
-    fn assert_enabled_vendor_flags(dialect: Dialect, expected: &[&str]) {
+    fn assert_enabled_flags(dialect: Dialect, expected: &[&str]) {
         let mut expected_sorted = expected.to_vec();
         expected_sorted.sort_unstable();
         assert_eq!(
-            enabled_vendor_flags(dialect),
+            enabled_flags(dialect),
             expected_sorted,
-            "dialect {dialect} does not enable exactly the expected vendor flags"
+            "dialect {dialect} does not enable exactly the expected dialect flags"
         );
     }
 
-    /// IEC 61131-3 Ed. 2 (the default) enables no vendor extensions at all.
+    /// IEC 61131-3 Ed. 2 (the default) enables no dialect extensions at all.
     #[test]
-    fn ed2_dialect_enables_no_vendor_flags() {
+    fn ed2_dialect_enables_no_flags() {
         assert!(!CompilerOptions::from_dialect(Dialect::Iec61131_3Ed2).allow_iec_61131_3_2013);
-        assert_enabled_vendor_flags(Dialect::Iec61131_3Ed2, &[]);
+        assert_enabled_flags(Dialect::Iec61131_3Ed2, &[]);
     }
 
-    /// IEC 61131-3 Ed. 3 turns on the Edition-3 keyword set and, among vendor
+    /// IEC 61131-3 Ed. 3 turns on the Edition-3 keyword set and, among dialect
     /// extensions, only partial-access syntax (standardized in Edition 3).
     #[test]
     fn ed3_dialect_enables_only_partial_access_syntax() {
         assert!(CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3).allow_iec_61131_3_2013);
-        assert_enabled_vendor_flags(Dialect::Iec61131_3Ed3, &["allow_partial_access_syntax"]);
+        assert_enabled_flags(Dialect::Iec61131_3Ed3, &["allow_partial_access_syntax"]);
     }
 
     /// The RuSTy dialect stays on the Edition-2 keyword base and enables every
-    /// vendor extension. Listed explicitly (not derived) so a new option that
+    /// dialect extension. Listed explicitly (not derived) so a new option that
     /// is meant to be Rusty-only, or accidentally left off Rusty, is caught.
     #[test]
-    fn rusty_dialect_enables_exactly_these_vendor_flags() {
+    fn rusty_dialect_enables_exactly_these_flags() {
         assert!(!CompilerOptions::from_dialect(Dialect::Rusty).allow_iec_61131_3_2013);
-        assert_enabled_vendor_flags(
+        assert_enabled_flags(
             Dialect::Rusty,
             &[
                 "allow_c_style_comments",
@@ -465,9 +465,9 @@ mod tests {
     /// IronPLC/RuSTy runtime convention rather than a CODESYS feature. Listed
     /// explicitly so that omission is asserted rather than assumed.
     #[test]
-    fn codesys_dialect_enables_exactly_these_vendor_flags() {
+    fn codesys_dialect_enables_exactly_these_flags() {
         assert!(!CompilerOptions::from_dialect(Dialect::Codesys).allow_iec_61131_3_2013);
-        assert_enabled_vendor_flags(
+        assert_enabled_flags(
             Dialect::Codesys,
             &[
                 "allow_c_style_comments",
@@ -507,9 +507,9 @@ mod tests {
     /// with `ADR()` are not parsed yet.) Listed explicitly so an accidental
     /// divergence from the intended set is caught.
     #[test]
-    fn twincat_dialect_enables_exactly_these_vendor_flags() {
+    fn twincat_dialect_enables_exactly_these_flags() {
         assert!(!CompilerOptions::from_dialect(Dialect::TwinCat).allow_iec_61131_3_2013);
-        assert_enabled_vendor_flags(
+        assert_enabled_flags(
             Dialect::TwinCat,
             &[
                 "allow_c_style_comments",

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -14,17 +14,17 @@ use std::str::FromStr;
 /// Individual `--allow-*` CLI flags can still override on top of a dialect.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Dialect {
-    /// Strict IEC 61131-3:2003 (Edition 2).  No dialect extensions.
+    /// Strict IEC 61131-3:2003 (Edition 2).  No extensions.
     #[default]
     Iec61131_3Ed2,
-    /// Strict IEC 61131-3:2013 (Edition 3).  No dialect extensions.
+    /// Strict IEC 61131-3:2013 (Edition 3).  No extensions.
     Iec61131_3Ed3,
     /// RuSTy-compatible dialect: Edition 2 base (so long-time keywords
     /// like `LDT` stay as identifiers) plus `REF_TO` support and all
-    /// dialect extensions enabled.
+    /// extensions enabled.
     Rusty,
     /// CODESYS-compatible dialect: Edition 2 base plus `REF_TO` support
-    /// and the dialect extensions that CODESYS accepts.  Does not bind the
+    /// and the extensions that CODESYS accepts.  Does not bind the
     /// implicit `__SYSTEM_UP_TIME` globals, which are an IronPLC runtime
     /// convention rather than a CODESYS feature.
     Codesys,
@@ -65,17 +65,17 @@ impl Dialect {
     pub fn description(&self) -> &'static str {
         match self {
             Dialect::Iec61131_3Ed2 => {
-                "Strict IEC 61131-3:2003 (Edition 2). No dialect extensions. [default]"
+                "Strict IEC 61131-3:2003 (Edition 2). No extensions. [default]"
             }
-            Dialect::Iec61131_3Ed3 => "Strict IEC 61131-3:2013 (Edition 3). No dialect extensions.",
+            Dialect::Iec61131_3Ed3 => "Strict IEC 61131-3:2013 (Edition 3). No extensions.",
             Dialect::Rusty => {
-                "RuSTy-compatible: Edition 2 base with REF_TO and all dialect extensions."
+                "RuSTy-compatible: Edition 2 base with REF_TO and the extensions RuSTy accepts."
             }
             Dialect::Codesys => {
-                "CODESYS-compatible: Edition 2 base with REF_TO and CODESYS dialect extensions."
+                "CODESYS-compatible: Edition 2 base with REF_TO and CODESYS extensions."
             }
             Dialect::TwinCat => {
-                "TwinCAT-compatible: Edition 2 base with the dialect extensions TwinCAT accepts."
+                "TwinCAT-compatible: Edition 2 base with the extensions TwinCAT accepts."
             }
         }
     }
@@ -409,7 +409,7 @@ mod tests {
         );
     }
 
-    /// IEC 61131-3 Ed. 2 (the default) enables no dialect extensions at all.
+    /// IEC 61131-3 Ed. 2 (the default) enables no extensions at all.
     #[test]
     fn ed2_dialect_enables_no_flags() {
         assert!(!CompilerOptions::from_dialect(Dialect::Iec61131_3Ed2).allow_iec_61131_3_2013);
@@ -425,7 +425,7 @@ mod tests {
     }
 
     /// The RuSTy dialect stays on the Edition-2 keyword base and enables every
-    /// dialect extension. Listed explicitly (not derived) so a new option that
+    /// extension. Listed explicitly (not derived) so a new option that
     /// is meant to be Rusty-only, or accidentally left off Rusty, is caught.
     #[test]
     fn rusty_dialect_enables_exactly_these_flags() {

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -68,7 +68,7 @@ fn negate_literal_constant(c: ConstantKind) -> Result<ConstantKind, ConstantKind
 
 /// Collapses an initializer expression to `Simple` when it is exactly a
 /// literal (optionally with one leading unary minus, e.g. `-123`), and
-/// otherwise wraps it as `SimpleExpr` (the constant-expression vendor
+/// otherwise wraps it as `SimpleExpr` (the constant-expression dialect
 /// extension, folded by `xform_fold_initializer_expressions`).
 fn resolve_initializer_expr(type_name: TypeName, e: ExprKind) -> InitialValueAssignmentKind {
     match e {
@@ -554,7 +554,7 @@ parser! {
     rule simple_spec_init() -> InitialValueAssignmentKind = type_name:simple_specification() _ tok(TokenType::Assignment) _ e:expression() {
       // A bare literal parses as ExprKind::Const via expression() too (it's
       // one of its own alternatives), so this single rule handles both the
-      // standard literal-only case and the constant-expression vendor
+      // standard literal-only case and the constant-expression dialect
       // extension (e.g. PI/180.0) without ambiguity — trying constant()
       // first and falling back to expression() doesn't work here because
       // constant() greedily matches a leading literal and stops, without
@@ -770,7 +770,7 @@ parser! {
     rule simple_or_enumerated_or_subrange_ambiguous_struct_spec_init() -> InitialValueAssignmentKind = s:simple_specification() _ tok(TokenType::Assignment) _ e:expression() {?
       // A bare literal parses as ExprKind::Const via expression() too (it's
       // one of its own alternatives), so this handles both the standard
-      // literal-only case and the constant-expression vendor extension
+      // literal-only case and the constant-expression dialect extension
       // (e.g. PI/180.0) — see allow_constant_initializer_expressions and
       // xform_fold_initializer_expressions, which folds SimpleExpr back to
       // Simple or diagnoses it.
@@ -941,7 +941,7 @@ parser! {
     // because these share the same syntax. We only know the type after trying to resolve the
     // type name.
     rule var_init_decl() -> Vec<UntypedVarDecl> = located_var1_init_decl() / structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() / fb_call_style_var_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
-    // CODESYS/TwinCAT vendor extension: a located variable (complete or
+    // CODESYS/TwinCAT dialect extension: a located variable (complete or
     // incomplete/wildcard address) declared inside an otherwise plain
     // VAR/VAR_INPUT/VAR_OUTPUT block, instead of requiring its own
     // dedicated located_var_declarations()/incompl_located_var_declarations()
@@ -1225,7 +1225,7 @@ parser! {
     }
     // CODESYS/TwinCAT accept STRING(n)/WSTRING(n) with parentheses as an
     // alternate delimiter to the standard STRING[n]/WSTRING[n] brackets.
-    // The parenthesis form is a vendor extension (not standard IEC
+    // The parenthesis form is a dialect extension (not standard IEC
     // 61131-3), so the grammar accepts it permissively here and
     // rule_token_no_paren_string_length rejects it (P4042) unless
     // allow_paren_string_length is set.

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -770,7 +770,7 @@ parser! {
     rule simple_or_enumerated_or_subrange_ambiguous_struct_spec_init() -> InitialValueAssignmentKind = s:simple_specification() _ tok(TokenType::Assignment) _ e:expression() {?
       // A bare literal parses as ExprKind::Const via expression() too (it's
       // one of its own alternatives), so this handles both the standard
-      // literal-only case and the constant-expression dialect extension
+      // literal-only case and the constant-expression extension
       // (e.g. PI/180.0) — see allow_constant_initializer_expressions and
       // xform_fold_initializer_expressions, which folds SimpleExpr back to
       // Simple or diagnoses it.
@@ -941,7 +941,7 @@ parser! {
     // because these share the same syntax. We only know the type after trying to resolve the
     // type name.
     rule var_init_decl() -> Vec<UntypedVarDecl> = located_var1_init_decl() / structured_var_init_decl__without_ambiguous() / string_var_declaration() / array_var_init_decl() / ref_to_var_init_decl() / fb_call_style_var_decl() / string_var_declaration() / var1_init_decl__with_ambiguous_struct()
-    // CODESYS/TwinCAT dialect extension: a located variable (complete or
+    // Extension: a located variable (complete or
     // incomplete/wildcard address) declared inside an otherwise plain
     // VAR/VAR_INPUT/VAR_OUTPUT block, instead of requiring its own
     // dedicated located_var_declarations()/incompl_located_var_declarations()
@@ -1225,7 +1225,7 @@ parser! {
     }
     // CODESYS/TwinCAT accept STRING(n)/WSTRING(n) with parentheses as an
     // alternate delimiter to the standard STRING[n]/WSTRING[n] brackets.
-    // The parenthesis form is a dialect extension (not standard IEC
+    // The parenthesis form is an extension (not standard IEC
     // 61131-3), so the grammar accepts it permissively here and
     // rule_token_no_paren_string_length rejects it (P4042) unless
     // allow_paren_string_length is set.

--- a/compiler/parser/src/rule_token_no_paren_string_length.rs
+++ b/compiler/parser/src/rule_token_no_paren_string_length.rs
@@ -2,7 +2,7 @@
 //! delimiter unless the `allow_paren_string_length` flag is set.
 //!
 //! IEC 61131-3 (Annex B) declares a string length only with square brackets
-//! (`STRING [ n ]`). The parenthesis form is a dialect extension, accepted
+//! (`STRING [ n ]`). The parenthesis form is an extension, accepted
 //! under `--allow-paren-string-length`; which dialects enable it is defined
 //! by the dialect mapping in `options.rs`, not restated here.
 //!

--- a/compiler/parser/src/rule_token_no_paren_string_length.rs
+++ b/compiler/parser/src/rule_token_no_paren_string_length.rs
@@ -2,7 +2,7 @@
 //! delimiter unless the `allow_paren_string_length` flag is set.
 //!
 //! IEC 61131-3 (Annex B) declares a string length only with square brackets
-//! (`STRING [ n ]`). The parenthesis form is a vendor extension, accepted
+//! (`STRING [ n ]`). The parenthesis form is a dialect extension, accepted
 //! under `--allow-paren-string-length`; which dialects enable it is defined
 //! by the dialect mapping in `options.rs`, not restated here.
 //!

--- a/compiler/parser/src/tests/case.rs
+++ b/compiler/parser/src/tests/case.rs
@@ -6,7 +6,7 @@ use super::common::*;
 fn parse_when_case_branch_empty_and_followed_by_another_label_then_ok() {
     // An empty CASE branch isn't strict IEC 61131-3 (the standard only
     // allows an explicit empty statement, `5: ;`) -- this is the
-    // `--allow-missing-semicolon` vendor extension filling in the
+    // `--allow-missing-semicolon` dialect extension filling in the
     // dropped `;`, so it must be gated behind that flag.
     let source = "
 FUNCTION_BLOCK FB_Example

--- a/compiler/parser/src/tests/case.rs
+++ b/compiler/parser/src/tests/case.rs
@@ -6,7 +6,7 @@ use super::common::*;
 fn parse_when_case_branch_empty_and_followed_by_another_label_then_ok() {
     // An empty CASE branch isn't strict IEC 61131-3 (the standard only
     // allows an explicit empty statement, `5: ;`) -- this is the
-    // `--allow-missing-semicolon` dialect extension filling in the
+    // `--allow-missing-semicolon` extension filling in the
     // dropped `;`, so it must be gated behind that flag.
     let source = "
 FUNCTION_BLOCK FB_Example

--- a/compiler/parser/src/tests/common.rs
+++ b/compiler/parser/src/tests/common.rs
@@ -79,7 +79,7 @@ pub(crate) fn parse_text_reference_to(source: &str) -> Library {
 }
 
 /// Parse with `allow_paren_string_length` enabled (the STRING(n)/WSTRING(n)
-/// vendor delimiter). The default (strict IEC 61131-3) dialect rejects it.
+/// dialect delimiter). The default (strict IEC 61131-3) dialect rejects it.
 pub(crate) fn parse_text_paren_string_length(source: &str) -> Library {
     let options = CompilerOptions {
         allow_paren_string_length: true,

--- a/compiler/parser/src/tests/constant_initializers.rs
+++ b/compiler/parser/src/tests/constant_initializers.rs
@@ -6,7 +6,7 @@ use super::common::*;
 fn parse_when_negative_integer_initializer_then_parses_as_simple_not_simple_expr() {
     // Regression test: switching the initializer grammar from
     // constant() to expression() must not turn ordinary negative
-    // literals into the vendor-extension SimpleExpr shape, since
+    // literals into the dialect-extension SimpleExpr shape, since
     // expression() routes a leading '-' through its own unary-operator
     // handling rather than constant()'s built-in signed-literal
     // parsing. This must parse identically with or without the flag.

--- a/compiler/parser/src/tests/short_circuit.rs
+++ b/compiler/parser/src/tests/short_circuit.rs
@@ -48,7 +48,7 @@ END_FUNCTION_BLOCK";
 #[test]
 fn parse_when_and_then_and_disabled_then_parses_as_identifiers() {
     // AND_THEN demotes to an ordinary identifier when the flag is
-    // off, matching the pattern used for every other vendor-extension
+    // off, matching the pattern used for every other dialect-extension
     // keyword.
     let source = "
 FUNCTION_BLOCK FB_ALL_AND_THEN_AS_VAR

--- a/compiler/parser/src/tests/types_and_returns.rs
+++ b/compiler/parser/src/tests/types_and_returns.rs
@@ -241,7 +241,7 @@ END_PROGRAM",
 
 #[test]
 fn parse_when_var_with_string_paren_length_and_strict_dialect_then_rejected() {
-    // The STRING(n) parenthesis delimiter is a dialect extension, not
+    // The STRING(n) parenthesis delimiter is an extension, not
     // standard IEC 61131-3. Under the strict default dialect (no
     // allow_paren_string_length flag) it must be rejected (P4042).
     let result = parse_program(

--- a/compiler/parser/src/tests/types_and_returns.rs
+++ b/compiler/parser/src/tests/types_and_returns.rs
@@ -145,7 +145,7 @@ fn parse_when_function_with_wstring_length_return_type_then_parses() {
 #[test]
 fn parse_when_function_with_string_paren_length_return_type_then_parses() {
     // CODESYS/TwinCAT accept STRING(n) with parentheses as an alternate
-    // delimiter to the standard STRING[n] brackets. This is a vendor
+    // delimiter to the standard STRING[n] brackets. This is a dialect
     // extension, not standard IEC 61131-3, so it requires the
     // `allow_paren_string_length` flag; the strict default dialect rejects
     // it (see parse_when_var_with_string_paren_length_and_strict_dialect_
@@ -241,7 +241,7 @@ END_PROGRAM",
 
 #[test]
 fn parse_when_var_with_string_paren_length_and_strict_dialect_then_rejected() {
-    // The STRING(n) parenthesis delimiter is a vendor extension, not
+    // The STRING(n) parenthesis delimiter is a dialect extension, not
     // standard IEC 61131-3. Under the strict default dialect (no
     // allow_paren_string_length flag) it must be rejected (P4042).
     let result = parse_program(
@@ -260,7 +260,7 @@ END_PROGRAM",
 fn parse_when_var_with_string_mixed_bracket_paren_delimiters_then_rejected() {
     // A mismatched delimiter pair (`[` ... `)`) is not a valid length spec
     // under either form. Uses the flag ON so the failure is attributable to
-    // the delimiter mismatch, not the vendor-extension gate.
+    // the delimiter mismatch, not the dialect-extension gate.
     let options = CompilerOptions {
         allow_paren_string_length: true,
         ..CompilerOptions::default()

--- a/compiler/parser/src/token.rs
+++ b/compiler/parser/src/token.rs
@@ -421,7 +421,7 @@ pub enum TokenType {
     DirectAddress,
     /// Partial-access bit selector: `%X<digits>` (case-insensitive), used as
     /// `var.%Xn` to access bit `n` of an integer variable. IEC 61131-3:2013
-    /// equivalent of the vendor short form `var.n`. Gated behind
+    /// equivalent of the dialect short form `var.n`. Gated behind
     /// `--allow-partial-access-syntax`.
     #[regex(r"%[Xx]\d+")]
     PartialAccessBit,

--- a/compiler/parser/src/vars.rs
+++ b/compiler/parser/src/vars.rs
@@ -17,7 +17,7 @@ pub struct UntypedVarDecl {
     pub name: Id,
     /// Present when this declaration has an `AT` location clause inside an
     /// otherwise plain `VAR`/`VAR_INPUT`/`VAR_OUTPUT` block (CODESYS/TwinCAT
-    /// vendor extension — see `allow_mixed_located_var_declarations`).
+    /// dialect extension — see `allow_mixed_located_var_declarations`).
     pub location: Option<AddressAssignment>,
     pub initializer: InitialValueAssignmentKind,
 }

--- a/compiler/parser/src/vars.rs
+++ b/compiler/parser/src/vars.rs
@@ -17,7 +17,7 @@ pub struct UntypedVarDecl {
     pub name: Id,
     /// Present when this declaration has an `AT` location clause inside an
     /// otherwise plain `VAR`/`VAR_INPUT`/`VAR_OUTPUT` block (CODESYS/TwinCAT
-    /// dialect extension — see `allow_mixed_located_var_declarations`).
+    /// extension — see `allow_mixed_located_var_declarations`).
     pub location: Option<AddressAssignment>,
     pub initializer: InitialValueAssignmentKind,
 }

--- a/compiler/parser/src/xform_demote_reference_keyword.rs
+++ b/compiler/parser/src/xform_demote_reference_keyword.rs
@@ -1,7 +1,7 @@
 //! Demote the `REFERENCE` keyword to an identifier unless the Beckhoff /
 //! CODESYS `REFERENCE TO` extension is enabled.
 //!
-//! `REFERENCE` is a vendor-flag-gated keyword (`--allow-reference-to`), not an
+//! `REFERENCE` is a dialect-flag-gated keyword (`--allow-reference-to`), not an
 //! edition-gated one, so it lives in its own transform rather than in
 //! `xform_demote_edition3_keywords`. When the flag is off, `REFERENCE` behaves
 //! like any ordinary identifier so existing programs that use it as a name keep

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -51,7 +51,7 @@ thread_local! {
 /// `"iec61131-3-ed3"`, `"rusty"`, `"codesys"`).
 ///
 /// The empty string (and any unrecognized value) resolves to the RuSTy
-/// dialect, which enables all vendor extensions. This keeps the many existing
+/// dialect, which enables all dialect extensions. This keeps the many existing
 /// documentation embeds that omit a dialect working, since they rely on the
 /// lenient default to explore non-standard features without toggling flags.
 fn dialect_from(dialect: &str) -> Dialect {

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -51,7 +51,7 @@ thread_local! {
 /// `"iec61131-3-ed3"`, `"rusty"`, `"codesys"`).
 ///
 /// The empty string (and any unrecognized value) resolves to the RuSTy
-/// dialect, which enables all dialect extensions. This keeps the many existing
+/// dialect, which enables the broadest set of extensions. This keeps the many existing
 /// documentation embeds that omit a dialect working, since they rely on the
 /// lenient default to explore non-standard features without toggling flags.
 fn dialect_from(dialect: &str) -> Dialect {

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -740,7 +740,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         Ok(())
     }
 
-    // CODESYS/TwinCAT dialect extension: constant-expression VAR initializer
+    // Extension: constant-expression VAR initializer
     // (e.g. `PI/180.0`), not yet folded to a literal.
     fn visit_simple_expr_initializer(
         &mut self,

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -740,7 +740,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         Ok(())
     }
 
-    // CODESYS/TwinCAT vendor extension: constant-expression VAR initializer
+    // CODESYS/TwinCAT dialect extension: constant-expression VAR initializer
     // (e.g. `PI/180.0`), not yet folded to a literal.
     fn visit_simple_expr_initializer(
         &mut self,

--- a/compiler/plc2plc/src/tests/declarations.rs
+++ b/compiler/plc2plc/src/tests/declarations.rs
@@ -58,7 +58,7 @@ VAR
 END_VAR
 END_FUNCTION_BLOCK
 ";
-    // The parenthesis length form is a dialect extension, so it only parses
+    // The parenthesis length form is an extension, so it only parses
     // with allow_paren_string_length enabled.
     let paren_options = CompilerOptions {
         allow_paren_string_length: true,

--- a/compiler/plc2plc/src/tests/declarations.rs
+++ b/compiler/plc2plc/src/tests/declarations.rs
@@ -58,7 +58,7 @@ VAR
 END_VAR
 END_FUNCTION_BLOCK
 ";
-    // The parenthesis length form is a vendor extension, so it only parses
+    // The parenthesis length form is a dialect extension, so it only parses
     // with allow_paren_string_length enabled.
     let paren_options = CompilerOptions {
         allow_paren_string_length: true,

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -4,7 +4,7 @@ Enabling Dialects and Features
 
 IronPLC aims to let you take code from another PLC environment and use it
 without changes. To support this, IronPLC uses **dialects** — named presets
-that select the IEC 61131-3 edition and a default set of vendor extensions.
+that select the IEC 61131-3 edition and a default set of dialect extensions.
 Individual ``--allow-*`` flags provide fine-grained control on top of the
 selected dialect.
 
@@ -13,10 +13,10 @@ Supported Dialects
 ---------------------------------
 
 **iec61131-3-ed2** *(default)*
-   Strict IEC 61131-3:2003 (Edition 2). No vendor extensions are enabled.
+   Strict IEC 61131-3:2003 (Edition 2). No dialect extensions are enabled.
    This is the default when no dialect is specified.
 
-   **Enables:** nothing beyond strict IEC 61131-3 (no vendor extensions).
+   **Enables:** nothing beyond strict IEC 61131-3 (no dialect extensions).
 
 **iec61131-3-ed3**
    Strict IEC 61131-3:2013 (Edition 3). Enables Edition 3 keywords
@@ -26,14 +26,14 @@ Supported Dialects
    :doc:`LDATE_AND_TIME </reference/language/data-types/elementary/ldate-and-time>`,
    :doc:`REF_TO </reference/language/data-types/derived/reference-types>`,
    :doc:`REF </reference/language/data-types/derived/reference-types>`, and
-   :doc:`NULL </reference/language/data-types/derived/reference-types>`. No vendor extensions.
+   :doc:`NULL </reference/language/data-types/derived/reference-types>`. No dialect extensions.
 
    **Enables:** Edition 3 keywords, plus ``--allow-partial-access-syntax``.
 
 **rusty**
    RuSTy-compatible dialect. Uses Edition 2 as a base (so Edition 3 type
    names like :doc:`LDT </reference/language/data-types/elementary/ldate-and-time>` remain available as identifiers) and enables
-   :doc:`REF_TO </reference/language/data-types/derived/reference-types>` support plus all vendor extensions.
+   :doc:`REF_TO </reference/language/data-types/derived/reference-types>` support plus all dialect extensions.
 
    **Enables:** ``--allow-c-style-comments``, ``--allow-missing-semicolon``,
    ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
@@ -55,7 +55,7 @@ Supported Dialects
    :doc:`LDT </reference/language/data-types/elementary/ldate-and-time>` are
    preserved) and enables
    :doc:`REF_TO </reference/language/data-types/derived/reference-types>`
-   together with the vendor extensions that the CODESYS IDE accepts. The
+   together with the dialect extensions that the CODESYS IDE accepts. The
    implicit :doc:`__SYSTEM_UP_TIME </reference/extension-library/variables/system-uptime>`
    globals are not pre-bound under this dialect, since they are an IronPLC
    runtime convention rather than a CODESYS feature.
@@ -78,7 +78,7 @@ Supported Dialects
    Beckhoff TwinCAT-compatible dialect. TwinCAT 3 is built on the CODESYS V3
    runtime, so it uses an Edition 2 base (identifiers like
    :doc:`LDT </reference/language/data-types/elementary/ldate-and-time>` are
-   preserved) and enables the vendor extensions TwinCAT shares with CODESYS,
+   preserved) and enables the dialect extensions TwinCAT shares with CODESYS,
    such as curly-brace pragmas, C-style comments, and the ``AND_THEN``
    short-circuit operator. Unlike ``codesys``, it does **not** enable the
    ``REF_TO`` / ``REF()`` / ``NULL`` reference extensions: TwinCAT spells
@@ -224,12 +224,12 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
 ``--allow-int-to-bool-initializer``
    Allow integer literals ``0`` and ``1`` as ``BOOL`` variable initializers
    (e.g., ``debug : BOOL := 0;``). The compiler rewrites ``0`` to ``FALSE``
-   and ``1`` to ``TRUE``. This is a universal vendor extension supported by
+   and ``1`` to ``TRUE``. This is a universal dialect extension supported by
    CoDeSys, TwinCAT, RuSTy, and virtually every PLC runtime.
 
 ``--allow-sizeof``
    Allow the ``SIZEOF()`` operator that returns the size in bytes of a
-   variable or type. This is a vendor extension supported by CODESYS,
+   variable or type. This is a dialect extension supported by CODESYS,
    TwinCAT, and RuSTy. See
    :doc:`/reference/extension-library/functions/sizeof`.
 
@@ -242,7 +242,7 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    Allow implicit widening between bit-string and integer type families.
    For example, passing a ``BYTE`` variable where an ``INT`` parameter is
    expected, or passing a bare integer literal ``0`` where a ``BYTE``
-   parameter is expected. This is a vendor extension supported by CODESYS,
+   parameter is expected. This is a dialect extension supported by CODESYS,
    TwinCAT, and RuSTy.
 
 ``--allow-partial-access-syntax``
@@ -292,7 +292,7 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    between literals and/or references to declared ``CONSTANT`` variables
    (e.g. ``scaled : LREAL := SCALE*4.0;``) — rather than only a bare
    literal. The IEC 61131-3 standard's initializer grammar permits only
-   literals in this position; this vendor extension folds the expression
+   literals in this position; this dialect extension folds the expression
    to a literal at compile time. Using this form without the flag produces
    :doc:`P4037 </reference/compiler/problems/P4037>`; if the expression
    does not fully reduce to a constant (e.g. it references a
@@ -313,7 +313,7 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    Allow a string type's maximum length to be delimited with parentheses
    (``STRING(255)``, ``WSTRING(100)``) in addition to the standard square
    brackets (``STRING[255]``). The IEC 61131-3 standard grammar declares a
-   string length only with brackets; the parenthesis form is a vendor
+   string length only with brackets; the parenthesis form is a dialect
    extension. Without this flag, the parenthesis form produces
    :doc:`P4042 </reference/compiler/problems/P4042>`. The bracket form is
    standard syntax and is always allowed, and the delimiters must match
@@ -327,7 +327,7 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    ``tonDelta : TON := (PT := pDevice^.Delta);``). The IEC 61131-3 standard
    grammar for a structured initializer value permits only a constant,
    enumerated value, array initializer, or nested structure initializer;
-   a value computed at instantiation time is a vendor extension used by
+   a value computed at instantiation time is a dialect extension used by
    TwinCAT/CODESYS. Without this flag, such a value produces
    :doc:`P4043 </reference/compiler/problems/P4043>`. A constant value is
    standard syntax and is always allowed.

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -4,7 +4,7 @@ Enabling Dialects and Features
 
 IronPLC aims to let you take code from another PLC environment and use it
 without changes. To support this, IronPLC uses **dialects** — named presets
-that select the IEC 61131-3 edition and a default set of dialect extensions.
+that select the IEC 61131-3 edition and a default set of extensions.
 Individual ``--allow-*`` flags provide fine-grained control on top of the
 selected dialect.
 
@@ -13,10 +13,10 @@ Supported Dialects
 ---------------------------------
 
 **iec61131-3-ed2** *(default)*
-   Strict IEC 61131-3:2003 (Edition 2). No dialect extensions are enabled.
+   Strict IEC 61131-3:2003 (Edition 2). No extensions are enabled.
    This is the default when no dialect is specified.
 
-   **Enables:** nothing beyond strict IEC 61131-3 (no dialect extensions).
+   **Enables:** nothing beyond strict IEC 61131-3 (no extensions).
 
 **iec61131-3-ed3**
    Strict IEC 61131-3:2013 (Edition 3). Enables Edition 3 keywords
@@ -26,14 +26,14 @@ Supported Dialects
    :doc:`LDATE_AND_TIME </reference/language/data-types/elementary/ldate-and-time>`,
    :doc:`REF_TO </reference/language/data-types/derived/reference-types>`,
    :doc:`REF </reference/language/data-types/derived/reference-types>`, and
-   :doc:`NULL </reference/language/data-types/derived/reference-types>`. No dialect extensions.
+   :doc:`NULL </reference/language/data-types/derived/reference-types>`. No extensions.
 
    **Enables:** Edition 3 keywords, plus ``--allow-partial-access-syntax``.
 
 **rusty**
    RuSTy-compatible dialect. Uses Edition 2 as a base (so Edition 3 type
    names like :doc:`LDT </reference/language/data-types/elementary/ldate-and-time>` remain available as identifiers) and enables
-   :doc:`REF_TO </reference/language/data-types/derived/reference-types>` support plus all dialect extensions.
+   :doc:`REF_TO </reference/language/data-types/derived/reference-types>` support together with the extensions that RuSTy accepts (listed below).
 
    **Enables:** ``--allow-c-style-comments``, ``--allow-missing-semicolon``,
    ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
@@ -55,7 +55,7 @@ Supported Dialects
    :doc:`LDT </reference/language/data-types/elementary/ldate-and-time>` are
    preserved) and enables
    :doc:`REF_TO </reference/language/data-types/derived/reference-types>`
-   together with the dialect extensions that the CODESYS IDE accepts. The
+   together with the extensions that the CODESYS IDE accepts. The
    implicit :doc:`__SYSTEM_UP_TIME </reference/extension-library/variables/system-uptime>`
    globals are not pre-bound under this dialect, since they are an IronPLC
    runtime convention rather than a CODESYS feature.
@@ -78,7 +78,7 @@ Supported Dialects
    Beckhoff TwinCAT-compatible dialect. TwinCAT 3 is built on the CODESYS V3
    runtime, so it uses an Edition 2 base (identifiers like
    :doc:`LDT </reference/language/data-types/elementary/ldate-and-time>` are
-   preserved) and enables the dialect extensions TwinCAT shares with CODESYS,
+   preserved) and enables the extensions TwinCAT shares with CODESYS,
    such as curly-brace pragmas, C-style comments, and the ``AND_THEN``
    short-circuit operator. Unlike ``codesys``, it does **not** enable the
    ``REF_TO`` / ``REF()`` / ``NULL`` reference extensions: TwinCAT spells
@@ -224,12 +224,12 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
 ``--allow-int-to-bool-initializer``
    Allow integer literals ``0`` and ``1`` as ``BOOL`` variable initializers
    (e.g., ``debug : BOOL := 0;``). The compiler rewrites ``0`` to ``FALSE``
-   and ``1`` to ``TRUE``. This is a universal dialect extension supported by
+   and ``1`` to ``TRUE``. This is a universal extension supported by
    CoDeSys, TwinCAT, RuSTy, and virtually every PLC runtime.
 
 ``--allow-sizeof``
    Allow the ``SIZEOF()`` operator that returns the size in bytes of a
-   variable or type. This is a dialect extension supported by CODESYS,
+   variable or type. This is an extension supported by CODESYS,
    TwinCAT, and RuSTy. See
    :doc:`/reference/extension-library/functions/sizeof`.
 
@@ -242,7 +242,7 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    Allow implicit widening between bit-string and integer type families.
    For example, passing a ``BYTE`` variable where an ``INT`` parameter is
    expected, or passing a bare integer literal ``0`` where a ``BYTE``
-   parameter is expected. This is a dialect extension supported by CODESYS,
+   parameter is expected. This is an extension supported by CODESYS,
    TwinCAT, and RuSTy.
 
 ``--allow-partial-access-syntax``
@@ -292,7 +292,7 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    between literals and/or references to declared ``CONSTANT`` variables
    (e.g. ``scaled : LREAL := SCALE*4.0;``) — rather than only a bare
    literal. The IEC 61131-3 standard's initializer grammar permits only
-   literals in this position; this dialect extension folds the expression
+   literals in this position; this extension folds the expression
    to a literal at compile time. Using this form without the flag produces
    :doc:`P4037 </reference/compiler/problems/P4037>`; if the expression
    does not fully reduce to a constant (e.g. it references a
@@ -327,7 +327,7 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    ``tonDelta : TON := (PT := pDevice^.Delta);``). The IEC 61131-3 standard
    grammar for a structured initializer value permits only a constant,
    enumerated value, array initializer, or nested structure initializer;
-   a value computed at instantiation time is a dialect extension used by
+   a value computed at instantiation time is an extension used by
    TwinCAT/CODESYS. Without this flag, such a value produces
    :doc:`P4043 </reference/compiler/problems/P4043>`. A constant value is
    standard syntax and is always allowed.

--- a/docs/explanation/system-clock-and-uptime.rst
+++ b/docs/explanation/system-clock-and-uptime.rst
@@ -25,7 +25,7 @@ When enabled, IronPLC updates the system update into two variables each scan cyc
 any task runs. The default name of these variables  are ``__SYSTEM_UP_TIME`` and
 ``__SYSTEM_UP_LTIME``.
 
-These variables are specific to IronPLC so you must enable this feature as a vendor extension
+These variables are specific to IronPLC so you must enable this feature
 using ``--allow-system-uptime-global`` or a dialect that enables this feature. See
 :doc:`/explanation/enabling-dialects-and-features` for more information about dialects and feature flags.
 

--- a/docs/explanation/type-conversions.rst
+++ b/docs/explanation/type-conversions.rst
@@ -282,7 +282,7 @@ Cross-family widening
 
 Widening from a bit-string type to an integer type crosses the ``ANY_BIT`` /
 ``ANY_INT`` boundary and is not part of the IEC 61131-3 standard. IronPLC
-supports this as a dialect extension behind the ``--allow-cross-family-widening``
+supports this as an extension behind the ``--allow-cross-family-widening``
 flag (enabled by default in the ``Rusty`` dialect). See
 :doc:`/explanation/enabling-dialects-and-features` for how to enable this flag.
 

--- a/docs/explanation/type-conversions.rst
+++ b/docs/explanation/type-conversions.rst
@@ -282,7 +282,7 @@ Cross-family widening
 
 Widening from a bit-string type to an integer type crosses the ``ANY_BIT`` /
 ``ANY_INT`` boundary and is not part of the IEC 61131-3 standard. IronPLC
-supports this as a vendor extension behind the ``--allow-cross-family-widening``
+supports this as a dialect extension behind the ``--allow-cross-family-widening``
 flag (enabled by default in the ``Rusty`` dialect). See
 :doc:`/explanation/enabling-dialects-and-features` for how to enable this flag.
 

--- a/docs/includes/requires-dialect-extension.rst
+++ b/docs/includes/requires-dialect-extension.rst
@@ -1,4 +1,4 @@
 .. note::
 
-   This is a vendor extension not part of the IEC 61131-3 standard.
+   This is a dialect extension not part of the IEC 61131-3 standard.
    See :doc:`/explanation/enabling-dialects-and-features` for how to enable it.

--- a/docs/includes/requires-dialect-extension.rst
+++ b/docs/includes/requires-dialect-extension.rst
@@ -1,4 +1,4 @@
 .. note::
 
-   This is a dialect extension not part of the IEC 61131-3 standard.
+   This is an extension not part of the IEC 61131-3 standard.
    See :doc:`/explanation/enabling-dialects-and-features` for how to enable it.

--- a/docs/reference/compiler/ironplcc.rst
+++ b/docs/reference/compiler/ironplcc.rst
@@ -94,43 +94,43 @@ Options
 
 ``--dialect`` *DIALECT*
    Select the language dialect. A dialect sets the IEC 61131-3 edition and a
-   default set of dialect extensions. Individual ``--allow-*`` flags can
+   default set of extensions. Individual ``--allow-*`` flags can
    override the dialect's defaults. Available values: ``iec61131-3-ed2``
    (default), ``iec61131-3-ed3``, ``rusty``, ``codesys``, ``twincat``. See
    :doc:`/explanation/enabling-dialects-and-features` for details.
 
 ``--allow-c-style-comments``
    Allow C-style comments (``//`` line comments and ``/* */`` block
-   comments). This is a dialect extension not part of the IEC 61131-3
+   comments). This is an extension not part of the IEC 61131-3
    standard.
 
 ``--allow-missing-semicolon``
    Allow missing semicolons after keyword statements like ``END_IF`` and
-   ``END_STRUCT``. This is a dialect extension not part of the IEC 61131-3
+   ``END_STRUCT``. This is an extension not part of the IEC 61131-3
    standard.
 
 ``--allow-top-level-var-global``
    Allow ``VAR_GLOBAL`` declarations at the top level of a file, outside of
-   a ``CONFIGURATION`` block. This is a dialect extension not part of the
+   a ``CONFIGURATION`` block. This is an extension not part of the
    IEC 61131-3 standard.
 
 ``--allow-constant-type-params``
    Allow constant references in type parameters (e.g., ``STRING[MY_CONST]``
-   or ``ARRAY[1..MY_CONST] OF INT``). This is a dialect extension not part
+   or ``ARRAY[1..MY_CONST] OF INT``). This is an extension not part
    of the IEC 61131-3 standard.
 
 ``--allow-empty-var-blocks``
    Allow empty variable blocks (``VAR END_VAR``, ``VAR_INPUT END_VAR``,
-   etc.). This is a dialect extension not part of the IEC 61131-3 standard.
+   etc.). This is an extension not part of the IEC 61131-3 standard.
 
 ``--allow-time-as-function-name``
    Allow ``TIME`` to be used as a function name (e.g., ``TIME()``).
-   Required for OSCAT compatibility. This is a dialect extension not part
+   Required for OSCAT compatibility. This is an extension not part
    of the IEC 61131-3 standard.
 
 ``--allow-ref-to``
    Allow ``REF_TO``, ``REF()``, and ``NULL`` syntax without enabling full
-   Edition 3. This is a dialect extension useful when you need references
+   Edition 3. This is an extension useful when you need references
    but want to keep Edition 2 keyword handling for the rest of your code.
 
 ``--allow-reference-to``
@@ -145,12 +145,12 @@ Options
 
 ``--allow-ref-stack-variables``
    Allow ``REF()`` on stack-allocated variables (``VAR_TEMP`` and function
-   ``VAR_INPUT``/``VAR_OUTPUT``). This is a dialect extension not part of the
+   ``VAR_INPUT``/``VAR_OUTPUT``). This is an extension not part of the
    IEC 61131-3 standard.
 
 ``--allow-ref-type-punning``
    Allow assigning between ``REF_TO`` types of different base types (type
-   punning). This is a dialect extension not part of the IEC 61131-3 standard.
+   punning). This is an extension not part of the IEC 61131-3 standard.
 
 ``--allow-int-to-bool-initializer``
    Allow integer literals ``0`` and ``1`` as ``BOOL`` variable initializers,
@@ -160,7 +160,7 @@ Options
 
 ``--allow-sizeof``
    Allow the ``SIZEOF()`` operator that returns the size in bytes of a
-   variable or type. This is a dialect extension supported by CODESYS,
+   variable or type. This is an extension supported by CODESYS,
    TwinCAT, and RuSTy.
 
 ``--allow-system-uptime-global``
@@ -217,7 +217,7 @@ Options
    Allow a string type's maximum length to be delimited with parentheses
    (``STRING(255)``, ``WSTRING(100)``) in addition to the standard square
    brackets. The IEC 61131-3 standard declares a string length only with
-   brackets; the parenthesis form is a dialect extension. Produces
+   brackets; the parenthesis form is an extension. Produces
    :doc:`P4042 </reference/compiler/problems/P4042>` when used without this
    flag.
 
@@ -227,7 +227,7 @@ Options
    structured or call-style initializer's ``name := value`` pairs (e.g.
    ``tonDelta : TON := (PT := pDevice^.Delta);``). The IEC 61131-3 standard
    permits only a constant, enumerated value, array initializer, or nested
-   structure initializer here; this dialect extension accepts a value
+   structure initializer here; this extension accepts a value
    computed at instantiation time. Produces
    :doc:`P4043 </reference/compiler/problems/P4043>` when used without this
    flag.

--- a/docs/reference/compiler/ironplcc.rst
+++ b/docs/reference/compiler/ironplcc.rst
@@ -94,43 +94,43 @@ Options
 
 ``--dialect`` *DIALECT*
    Select the language dialect. A dialect sets the IEC 61131-3 edition and a
-   default set of vendor extensions. Individual ``--allow-*`` flags can
+   default set of dialect extensions. Individual ``--allow-*`` flags can
    override the dialect's defaults. Available values: ``iec61131-3-ed2``
    (default), ``iec61131-3-ed3``, ``rusty``, ``codesys``, ``twincat``. See
    :doc:`/explanation/enabling-dialects-and-features` for details.
 
 ``--allow-c-style-comments``
    Allow C-style comments (``//`` line comments and ``/* */`` block
-   comments). This is a vendor extension not part of the IEC 61131-3
+   comments). This is a dialect extension not part of the IEC 61131-3
    standard.
 
 ``--allow-missing-semicolon``
    Allow missing semicolons after keyword statements like ``END_IF`` and
-   ``END_STRUCT``. This is a vendor extension not part of the IEC 61131-3
+   ``END_STRUCT``. This is a dialect extension not part of the IEC 61131-3
    standard.
 
 ``--allow-top-level-var-global``
    Allow ``VAR_GLOBAL`` declarations at the top level of a file, outside of
-   a ``CONFIGURATION`` block. This is a vendor extension not part of the
+   a ``CONFIGURATION`` block. This is a dialect extension not part of the
    IEC 61131-3 standard.
 
 ``--allow-constant-type-params``
    Allow constant references in type parameters (e.g., ``STRING[MY_CONST]``
-   or ``ARRAY[1..MY_CONST] OF INT``). This is a vendor extension not part
+   or ``ARRAY[1..MY_CONST] OF INT``). This is a dialect extension not part
    of the IEC 61131-3 standard.
 
 ``--allow-empty-var-blocks``
    Allow empty variable blocks (``VAR END_VAR``, ``VAR_INPUT END_VAR``,
-   etc.). This is a vendor extension not part of the IEC 61131-3 standard.
+   etc.). This is a dialect extension not part of the IEC 61131-3 standard.
 
 ``--allow-time-as-function-name``
    Allow ``TIME`` to be used as a function name (e.g., ``TIME()``).
-   Required for OSCAT compatibility. This is a vendor extension not part
+   Required for OSCAT compatibility. This is a dialect extension not part
    of the IEC 61131-3 standard.
 
 ``--allow-ref-to``
    Allow ``REF_TO``, ``REF()``, and ``NULL`` syntax without enabling full
-   Edition 3. This is a vendor extension useful when you need references
+   Edition 3. This is a dialect extension useful when you need references
    but want to keep Edition 2 keyword handling for the rest of your code.
 
 ``--allow-reference-to``
@@ -145,22 +145,22 @@ Options
 
 ``--allow-ref-stack-variables``
    Allow ``REF()`` on stack-allocated variables (``VAR_TEMP`` and function
-   ``VAR_INPUT``/``VAR_OUTPUT``). This is a vendor extension not part of the
+   ``VAR_INPUT``/``VAR_OUTPUT``). This is a dialect extension not part of the
    IEC 61131-3 standard.
 
 ``--allow-ref-type-punning``
    Allow assigning between ``REF_TO`` types of different base types (type
-   punning). This is a vendor extension not part of the IEC 61131-3 standard.
+   punning). This is a dialect extension not part of the IEC 61131-3 standard.
 
 ``--allow-int-to-bool-initializer``
    Allow integer literals ``0`` and ``1`` as ``BOOL`` variable initializers,
-   treating ``0`` as ``FALSE`` and ``1`` as ``TRUE``. This is a vendor
+   treating ``0`` as ``FALSE`` and ``1`` as ``TRUE``. This is a dialect
    extension supported by CoDeSys, TwinCAT, RuSTy, and virtually every
    PLC runtime.
 
 ``--allow-sizeof``
    Allow the ``SIZEOF()`` operator that returns the size in bytes of a
-   variable or type. This is a vendor extension supported by CODESYS,
+   variable or type. This is a dialect extension supported by CODESYS,
    TwinCAT, and RuSTy.
 
 ``--allow-system-uptime-global``
@@ -170,7 +170,7 @@ Options
 
 ``--allow-cross-family-widening``
    Allow implicit widening between bit-string and integer type families
-   (e.g. ``BYTE`` to ``INT``, literal ``0`` to ``BYTE``). This is a vendor
+   (e.g. ``BYTE`` to ``INT``, literal ``0`` to ``BYTE``). This is a dialect
    extension supported by CODESYS, TwinCAT, and RuSTy.
 
 ``--allow-partial-access-syntax``
@@ -217,7 +217,7 @@ Options
    Allow a string type's maximum length to be delimited with parentheses
    (``STRING(255)``, ``WSTRING(100)``) in addition to the standard square
    brackets. The IEC 61131-3 standard declares a string length only with
-   brackets; the parenthesis form is a vendor extension. Produces
+   brackets; the parenthesis form is a dialect extension. Produces
    :doc:`P4042 </reference/compiler/problems/P4042>` when used without this
    flag.
 
@@ -227,7 +227,7 @@ Options
    structured or call-style initializer's ``name := value`` pairs (e.g.
    ``tonDelta : TON := (PT := pDevice^.Delta);``). The IEC 61131-3 standard
    permits only a constant, enumerated value, array initializer, or nested
-   structure initializer here; this vendor extension accepts a value
+   structure initializer here; this dialect extension accepts a value
    computed at instantiation time. Produces
    :doc:`P4043 </reference/compiler/problems/P4043>` when used without this
    flag.

--- a/docs/reference/compiler/problems/P4028.rst
+++ b/docs/reference/compiler/problems/P4028.rst
@@ -4,7 +4,7 @@ P4028
 
 .. problem-summary:: P4028
 
-This error occurs when ``VAR_GLOBAL`` declarations appear at the top level (outside a ``CONFIGURATION`` block) without the ``--allow-top-level-var-global`` compiler flag. In the IEC 61131-3 standard, ``VAR_GLOBAL`` declarations are only permitted inside ``CONFIGURATION`` and ``RESOURCE`` blocks. Top-level ``VAR_GLOBAL`` is a dialect extension.
+This error occurs when ``VAR_GLOBAL`` declarations appear at the top level (outside a ``CONFIGURATION`` block) without the ``--allow-top-level-var-global`` compiler flag. In the IEC 61131-3 standard, ``VAR_GLOBAL`` declarations are only permitted inside ``CONFIGURATION`` and ``RESOURCE`` blocks. Top-level ``VAR_GLOBAL`` is an extension.
 
 Example
 -------
@@ -38,4 +38,4 @@ To fix this error, either wrap the declaration in a ``CONFIGURATION`` block:
        END_RESOURCE
    END_CONFIGURATION
 
-Or enable the dialect extension with the ``--allow-top-level-var-global`` flag.
+Or enable the extension with the ``--allow-top-level-var-global`` flag.

--- a/docs/reference/compiler/problems/P4028.rst
+++ b/docs/reference/compiler/problems/P4028.rst
@@ -4,7 +4,7 @@ P4028
 
 .. problem-summary:: P4028
 
-This error occurs when ``VAR_GLOBAL`` declarations appear at the top level (outside a ``CONFIGURATION`` block) without the ``--allow-top-level-var-global`` compiler flag. In the IEC 61131-3 standard, ``VAR_GLOBAL`` declarations are only permitted inside ``CONFIGURATION`` and ``RESOURCE`` blocks. Top-level ``VAR_GLOBAL`` is a vendor extension.
+This error occurs when ``VAR_GLOBAL`` declarations appear at the top level (outside a ``CONFIGURATION`` block) without the ``--allow-top-level-var-global`` compiler flag. In the IEC 61131-3 standard, ``VAR_GLOBAL`` declarations are only permitted inside ``CONFIGURATION`` and ``RESOURCE`` blocks. Top-level ``VAR_GLOBAL`` is a dialect extension.
 
 Example
 -------
@@ -38,4 +38,4 @@ To fix this error, either wrap the declaration in a ``CONFIGURATION`` block:
        END_RESOURCE
    END_CONFIGURATION
 
-Or enable the vendor extension with the ``--allow-top-level-var-global`` flag.
+Or enable the dialect extension with the ``--allow-top-level-var-global`` flag.

--- a/docs/reference/compiler/problems/P4029.rst
+++ b/docs/reference/compiler/problems/P4029.rst
@@ -4,7 +4,7 @@ P4029
 
 .. problem-summary:: P4029
 
-This error occurs when a constant name is used in place of an integer literal in a type parameter (such as a ``STRING`` length or array bound) without the ``--allow-constant-type-params`` compiler flag. In the IEC 61131-3 standard, type parameters require integer literals. Using constant references is a dialect extension.
+This error occurs when a constant name is used in place of an integer literal in a type parameter (such as a ``STRING`` length or array bound) without the ``--allow-constant-type-params`` compiler flag. In the IEC 61131-3 standard, type parameters require integer literals. Using constant references is an extension.
 
 Example
 -------
@@ -33,4 +33,4 @@ To fix this error, either use an integer literal directly:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the dialect extension with the ``--allow-constant-type-params`` flag.
+Or enable the extension with the ``--allow-constant-type-params`` flag.

--- a/docs/reference/compiler/problems/P4029.rst
+++ b/docs/reference/compiler/problems/P4029.rst
@@ -4,7 +4,7 @@ P4029
 
 .. problem-summary:: P4029
 
-This error occurs when a constant name is used in place of an integer literal in a type parameter (such as a ``STRING`` length or array bound) without the ``--allow-constant-type-params`` compiler flag. In the IEC 61131-3 standard, type parameters require integer literals. Using constant references is a vendor extension.
+This error occurs when a constant name is used in place of an integer literal in a type parameter (such as a ``STRING`` length or array bound) without the ``--allow-constant-type-params`` compiler flag. In the IEC 61131-3 standard, type parameters require integer literals. Using constant references is a dialect extension.
 
 Example
 -------
@@ -33,4 +33,4 @@ To fix this error, either use an integer literal directly:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the vendor extension with the ``--allow-constant-type-params`` flag.
+Or enable the dialect extension with the ``--allow-constant-type-params`` flag.

--- a/docs/reference/compiler/problems/P4036.rst
+++ b/docs/reference/compiler/problems/P4036.rst
@@ -10,7 +10,7 @@ inside an otherwise plain ``VAR``/``VAR_INPUT``/``VAR_OUTPUT`` block,
 without the ``--allow-mixed-located-var-declarations`` compiler flag. The
 IEC 61131-3 standard requires located variables to be declared in their
 own dedicated block, separate from ordinary symbolic variables. Mixing
-them in one block is a dialect extension.
+them in one block is an extension.
 
 A block containing *only* located variables is unaffected by this error —
 that is standard syntax and always allowed.
@@ -42,7 +42,7 @@ To fix this error, either move the located variable into its own block:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the dialect extension:
+Or enable the extension:
 
 .. |flag| replace:: ``--allow-mixed-located-var-declarations``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4036.rst
+++ b/docs/reference/compiler/problems/P4036.rst
@@ -10,7 +10,7 @@ inside an otherwise plain ``VAR``/``VAR_INPUT``/``VAR_OUTPUT`` block,
 without the ``--allow-mixed-located-var-declarations`` compiler flag. The
 IEC 61131-3 standard requires located variables to be declared in their
 own dedicated block, separate from ordinary symbolic variables. Mixing
-them in one block is a vendor extension.
+them in one block is a dialect extension.
 
 A block containing *only* located variables is unaffected by this error —
 that is standard syntax and always allowed.
@@ -42,7 +42,7 @@ To fix this error, either move the located variable into its own block:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the vendor extension:
+Or enable the dialect extension:
 
 .. |flag| replace:: ``--allow-mixed-located-var-declarations``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4037.rst
+++ b/docs/reference/compiler/problems/P4037.rst
@@ -9,7 +9,7 @@ This error occurs when a ``VAR`` initializer uses a constant expression
 variables) instead of a bare literal, without the
 ``--allow-constant-initializer-expressions`` compiler flag. The IEC 61131-3
 standard's initializer grammar only permits a single literal in this
-position. Constant expressions are a dialect extension.
+position. Constant expressions are an extension.
 
 Example
 -------
@@ -38,7 +38,7 @@ To fix this error, either use a literal value directly:
    END_VAR
    END_PROGRAM
 
-Or enable the dialect extension:
+Or enable the extension:
 
 .. |flag| replace:: ``--allow-constant-initializer-expressions``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4037.rst
+++ b/docs/reference/compiler/problems/P4037.rst
@@ -9,7 +9,7 @@ This error occurs when a ``VAR`` initializer uses a constant expression
 variables) instead of a bare literal, without the
 ``--allow-constant-initializer-expressions`` compiler flag. The IEC 61131-3
 standard's initializer grammar only permits a single literal in this
-position. Constant expressions are a vendor extension.
+position. Constant expressions are a dialect extension.
 
 Example
 -------
@@ -38,7 +38,7 @@ To fix this error, either use a literal value directly:
    END_VAR
    END_PROGRAM
 
-Or enable the vendor extension:
+Or enable the dialect extension:
 
 .. |flag| replace:: ``--allow-constant-initializer-expressions``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4041.rst
+++ b/docs/reference/compiler/problems/P4041.rst
@@ -12,7 +12,7 @@ The IEC 61131-3 standard grammar for a case label (Annex B) is
 ``case_list_element ::= subrange | signed_integer | enumerated_value``,
 where ``signed_integer`` is a *decimal* digit sequence. Radix-prefixed
 bit-string literals are separate productions that the standard does not
-include as case labels, so accepting them is a dialect extension used by
+include as case labels, so accepting them is an extension used by
 TwinCAT and CODESYS.
 
 A plain decimal label (``5:``) is standard syntax and is always allowed.
@@ -48,7 +48,7 @@ To fix this error, either use a decimal label:
    END_CASE;
    END_FUNCTION_BLOCK
 
-Or enable the dialect extension:
+Or enable the extension:
 
 .. |flag| replace:: ``--allow-bit-string-case-labels``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4041.rst
+++ b/docs/reference/compiler/problems/P4041.rst
@@ -12,7 +12,7 @@ The IEC 61131-3 standard grammar for a case label (Annex B) is
 ``case_list_element ::= subrange | signed_integer | enumerated_value``,
 where ``signed_integer`` is a *decimal* digit sequence. Radix-prefixed
 bit-string literals are separate productions that the standard does not
-include as case labels, so accepting them is a vendor extension used by
+include as case labels, so accepting them is a dialect extension used by
 TwinCAT and CODESYS.
 
 A plain decimal label (``5:``) is standard syntax and is always allowed.
@@ -48,7 +48,7 @@ To fix this error, either use a decimal label:
    END_CASE;
    END_FUNCTION_BLOCK
 
-Or enable the vendor extension:
+Or enable the dialect extension:
 
 .. |flag| replace:: ``--allow-bit-string-case-labels``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4042.rst
+++ b/docs/reference/compiler/problems/P4042.rst
@@ -12,7 +12,7 @@ The IEC 61131-3 standard grammar (Annex B) declares a string length only
 with square brackets --
 ``single_byte_string_spec ::= 'STRING' ['[' unsigned_int ']'] ...`` (and the
 corresponding ``'WSTRING' ['[' unsigned_int ']']``). The parenthesis form is
-a dialect extension.
+an extension.
 
 A bracketed length (``STRING[255]``) is standard syntax and is always
 allowed.
@@ -40,6 +40,6 @@ To fix this error, either use the standard bracket form:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the dialect extension with the ``--allow-paren-string-length``
+Or enable the extension with the ``--allow-paren-string-length``
 flag. See :doc:`/explanation/enabling-dialects-and-features` for how to
-enable dialect extensions and which dialects include them.
+enable extensions and which dialects include them.

--- a/docs/reference/compiler/problems/P4042.rst
+++ b/docs/reference/compiler/problems/P4042.rst
@@ -12,7 +12,7 @@ The IEC 61131-3 standard grammar (Annex B) declares a string length only
 with square brackets --
 ``single_byte_string_spec ::= 'STRING' ['[' unsigned_int ']'] ...`` (and the
 corresponding ``'WSTRING' ['[' unsigned_int ']']``). The parenthesis form is
-a vendor extension.
+a dialect extension.
 
 A bracketed length (``STRING[255]``) is standard syntax and is always
 allowed.
@@ -40,6 +40,6 @@ To fix this error, either use the standard bracket form:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the vendor extension with the ``--allow-paren-string-length``
+Or enable the dialect extension with the ``--allow-paren-string-length``
 flag. See :doc:`/explanation/enabling-dialects-and-features` for how to
-enable vendor extensions and which dialects include them.
+enable dialect extensions and which dialects include them.

--- a/docs/reference/compiler/problems/P4043.rst
+++ b/docs/reference/compiler/problems/P4043.rst
@@ -15,7 +15,7 @@ The IEC 61131-3 standard grammar for a structured initializer value
 enumerated_value | array_initialization | structure_initialization)``. A
 general expression -- and in particular a pointer dereference plus member
 access like ``pDevice^.Delta`` -- is not one of those productions, so
-accepting it is a vendor extension used by TwinCAT and CODESYS, where such a
+accepting it is a dialect extension used by TwinCAT and CODESYS, where such a
 value is computed at instantiation time rather than being a compile-time
 constant.
 
@@ -46,7 +46,7 @@ To fix this error, either use a constant value:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the vendor extension:
+Or enable the dialect extension:
 
 .. |flag| replace:: ``--allow-struct-initializer-expressions``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4043.rst
+++ b/docs/reference/compiler/problems/P4043.rst
@@ -15,7 +15,7 @@ The IEC 61131-3 standard grammar for a structured initializer value
 enumerated_value | array_initialization | structure_initialization)``. A
 general expression -- and in particular a pointer dereference plus member
 access like ``pDevice^.Delta`` -- is not one of those productions, so
-accepting it is a dialect extension used by TwinCAT and CODESYS, where such a
+accepting it is an extension used by TwinCAT and CODESYS, where such a
 value is computed at instantiation time rather than being a compile-time
 constant.
 
@@ -46,7 +46,7 @@ To fix this error, either use a constant value:
    END_VAR
    END_FUNCTION_BLOCK
 
-Or enable the dialect extension:
+Or enable the extension:
 
 .. |flag| replace:: ``--allow-struct-initializer-expressions``
 .. include:: /includes/enabled-by-flag.rst

--- a/docs/reference/compiler/problems/P4044.rst
+++ b/docs/reference/compiler/problems/P4044.rst
@@ -5,7 +5,7 @@ P4044
 .. problem-summary:: P4044
 
 This error occurs when a derived function block (using the
-CODESYS/TwinCAT ``EXTENDS`` dialect extension) redeclares a field that is
+CODESYS/TwinCAT ``EXTENDS`` extension) redeclares a field that is
 already declared on its base function block, or any ancestor further up
 the ``EXTENDS`` chain. Real TwinCAT rejects this as a duplicate
 definition even when the redeclared field has a different type.

--- a/docs/reference/compiler/problems/P4044.rst
+++ b/docs/reference/compiler/problems/P4044.rst
@@ -5,7 +5,7 @@ P4044
 .. problem-summary:: P4044
 
 This error occurs when a derived function block (using the
-CODESYS/TwinCAT ``EXTENDS`` vendor extension) redeclares a field that is
+CODESYS/TwinCAT ``EXTENDS`` dialect extension) redeclares a field that is
 already declared on its base function block, or any ancestor further up
 the ``EXTENDS`` chain. Real TwinCAT rejects this as a duplicate
 definition even when the redeclared field has a different type.

--- a/docs/reference/compiler/problems/P4045.rst
+++ b/docs/reference/compiler/problems/P4045.rst
@@ -5,7 +5,7 @@ P4045
 .. problem-summary:: P4045
 
 This error occurs when a variable is declared with the type of a
-function block marked ``ABSTRACT`` (the CODESYS/TwinCAT vendor
+function block marked ``ABSTRACT`` (the CODESYS/TwinCAT dialect
 extension). An ``ABSTRACT`` function block exists only to be extended
 via ``EXTENDS`` -- it cannot be instantiated directly.
 

--- a/docs/reference/editor/settings.rst
+++ b/docs/reference/editor/settings.rst
@@ -88,15 +88,15 @@ ironplc.dialect
 :Values: ``iec61131-3-ed2``, ``iec61131-3-ed3``, ``rusty``, ``codesys``, ``twincat``
 
 Selects the language dialect preset. A dialect controls the IEC 61131-3 edition
-and a default set of dialect extensions.
+and a default set of extensions.
 
-* ``iec61131-3-ed2``: Strict IEC 61131-3:2003 (Edition 2). No dialect extensions.
+* ``iec61131-3-ed2``: Strict IEC 61131-3:2003 (Edition 2). No extensions.
 * ``iec61131-3-ed3``: IEC 61131-3:2013 (Edition 3) with ``LTIME``, ``REF_TO``, etc.
 * ``rusty``: RuSTy-compatible — designed for compatibility with code from
   RuSTy-based PLC environments.
 * ``codesys``: CODESYS-compatible — Edition 2 base with ``REF_TO`` and the
-  dialect extensions that the CODESYS IDE accepts.
-* ``twincat``: TwinCAT-compatible — Edition 2 base with the dialect extensions
+  extensions that the CODESYS IDE accepts.
+* ``twincat``: TwinCAT-compatible — Edition 2 base with the extensions
   Beckhoff TwinCAT shares with CODESYS. Unlike ``codesys`` it does not enable
   the ``REF_TO`` reference extensions, since TwinCAT uses ``REFERENCE TO`` /
   ``POINTER TO`` (not yet parsed by IronPLC).

--- a/docs/reference/editor/settings.rst
+++ b/docs/reference/editor/settings.rst
@@ -88,15 +88,15 @@ ironplc.dialect
 :Values: ``iec61131-3-ed2``, ``iec61131-3-ed3``, ``rusty``, ``codesys``, ``twincat``
 
 Selects the language dialect preset. A dialect controls the IEC 61131-3 edition
-and a default set of vendor extensions.
+and a default set of dialect extensions.
 
-* ``iec61131-3-ed2``: Strict IEC 61131-3:2003 (Edition 2). No vendor extensions.
+* ``iec61131-3-ed2``: Strict IEC 61131-3:2003 (Edition 2). No dialect extensions.
 * ``iec61131-3-ed3``: IEC 61131-3:2013 (Edition 3) with ``LTIME``, ``REF_TO``, etc.
 * ``rusty``: RuSTy-compatible — designed for compatibility with code from
   RuSTy-based PLC environments.
 * ``codesys``: CODESYS-compatible — Edition 2 base with ``REF_TO`` and the
-  vendor extensions that the CODESYS IDE accepts.
-* ``twincat``: TwinCAT-compatible — Edition 2 base with the vendor extensions
+  dialect extensions that the CODESYS IDE accepts.
+* ``twincat``: TwinCAT-compatible — Edition 2 base with the dialect extensions
   Beckhoff TwinCAT shares with CODESYS. Unlike ``codesys`` it does not enable
   the ``REF_TO`` reference extensions, since TwinCAT uses ``REFERENCE TO`` /
   ``POINTER TO`` (not yet parsed by IronPLC).

--- a/docs/reference/extension-library/function-blocks/index.rst
+++ b/docs/reference/extension-library/function-blocks/index.rst
@@ -2,4 +2,4 @@
 Function Blocks
 ===============
 
-No vendor extension function blocks are currently defined.
+No extension function blocks are currently defined.

--- a/docs/reference/extension-library/functions/index.rst
+++ b/docs/reference/extension-library/functions/index.rst
@@ -2,7 +2,7 @@
 Functions
 =========
 
-Vendor extension functions provided by IronPLC. These are not part of the
+Extension functions provided by IronPLC. These are not part of the
 IEC 61131-3 standard but are widely supported across PLC environments.
 
 .. list-table::

--- a/docs/reference/extension-library/functions/isvalidref.rst
+++ b/docs/reference/extension-library/functions/isvalidref.rst
@@ -52,7 +52,7 @@ function name.
 Enabling
 --------
 
-``__ISVALIDREF`` is a vendor extension and must be explicitly enabled:
+``__ISVALIDREF`` is a dialect extension and must be explicitly enabled:
 
 .. code-block:: shell
 
@@ -76,4 +76,4 @@ See Also
 --------
 
 - :doc:`/reference/language/data-types/derived/reference-types` — ``REFERENCE TO`` reference types
-- :doc:`/explanation/enabling-dialects-and-features` — enabling vendor extensions
+- :doc:`/explanation/enabling-dialects-and-features` — enabling dialect extensions

--- a/docs/reference/extension-library/functions/isvalidref.rst
+++ b/docs/reference/extension-library/functions/isvalidref.rst
@@ -52,7 +52,7 @@ function name.
 Enabling
 --------
 
-``__ISVALIDREF`` is a dialect extension and must be explicitly enabled:
+``__ISVALIDREF`` is a language extension and must be explicitly enabled:
 
 .. code-block:: shell
 
@@ -76,4 +76,4 @@ See Also
 --------
 
 - :doc:`/reference/language/data-types/derived/reference-types` — ``REFERENCE TO`` reference types
-- :doc:`/explanation/enabling-dialects-and-features` — enabling dialect extensions
+- :doc:`/explanation/enabling-dialects-and-features` — enabling language extensions

--- a/docs/reference/extension-library/functions/sizeof.rst
+++ b/docs/reference/extension-library/functions/sizeof.rst
@@ -8,7 +8,7 @@ Returns the size in bytes of a variable or type.
    :widths: 30 70
 
    * - **IEC 61131-3**
-     - Not part of the standard (vendor extension)
+     - Not part of the standard (dialect extension)
    * - **Support**
      - Supported (requires ``--allow-sizeof``)
 
@@ -33,7 +33,7 @@ Description
 
 ``SIZEOF`` returns the size in bytes of the argument's type as a
 compile-time constant. It is not part of the IEC 61131-3 standard but is
-a widely supported vendor extension available in CODESYS, TwinCAT/Beckhoff,
+a widely supported dialect extension available in CODESYS, TwinCAT/Beckhoff,
 and RuSTy. It is commonly used in buffer management functions that work with
 ``REF_TO`` pointers, such as those in the OSCAT library.
 
@@ -51,7 +51,7 @@ elements (element count × element size).
 Enabling
 --------
 
-``SIZEOF`` is a vendor extension and must be explicitly enabled:
+``SIZEOF`` is a dialect extension and must be explicitly enabled:
 
 .. code-block:: shell
 
@@ -73,4 +73,4 @@ Example
 See Also
 --------
 
-- :doc:`/explanation/enabling-dialects-and-features` — enabling vendor extensions
+- :doc:`/explanation/enabling-dialects-and-features` — enabling dialect extensions

--- a/docs/reference/extension-library/functions/sizeof.rst
+++ b/docs/reference/extension-library/functions/sizeof.rst
@@ -8,7 +8,7 @@ Returns the size in bytes of a variable or type.
    :widths: 30 70
 
    * - **IEC 61131-3**
-     - Not part of the standard (dialect extension)
+     - Not part of the standard (language extension)
    * - **Support**
      - Supported (requires ``--allow-sizeof``)
 
@@ -33,7 +33,7 @@ Description
 
 ``SIZEOF`` returns the size in bytes of the argument's type as a
 compile-time constant. It is not part of the IEC 61131-3 standard but is
-a widely supported dialect extension available in CODESYS, TwinCAT/Beckhoff,
+a widely supported language extension available in CODESYS, TwinCAT/Beckhoff,
 and RuSTy. It is commonly used in buffer management functions that work with
 ``REF_TO`` pointers, such as those in the OSCAT library.
 
@@ -51,7 +51,7 @@ elements (element count × element size).
 Enabling
 --------
 
-``SIZEOF`` is a dialect extension and must be explicitly enabled:
+``SIZEOF`` is a language extension and must be explicitly enabled:
 
 .. code-block:: shell
 
@@ -73,4 +73,4 @@ Example
 See Also
 --------
 
-- :doc:`/explanation/enabling-dialects-and-features` — enabling dialect extensions
+- :doc:`/explanation/enabling-dialects-and-features` — enabling language extensions

--- a/docs/reference/extension-library/index.rst
+++ b/docs/reference/extension-library/index.rst
@@ -2,9 +2,10 @@
 Extension Library
 =================
 
-IronPLC provides vendor extension functions, function blocks, and variables
-that go beyond the IEC 61131-3 standard. These extensions are commonly
-supported by other PLC environments such as CODESYS, TwinCAT, and RuSTy.
+IronPLC provides extension functions, function blocks, and variables
+that go beyond the IEC 61131-3 standard. Some of these extensions are commonly
+supported by other PLC environments such as CODESYS, TwinCAT, and RuSTy, while
+others (such as the ``__SYSTEM_UP_TIME`` globals) are IronPLC's own conventions.
 
 .. tip::
 
@@ -27,7 +28,7 @@ Functions
 Function Blocks
 ---------------
 
-No vendor extension function blocks are currently defined.
+No extension function blocks are currently defined.
 
 Variables
 ---------

--- a/docs/reference/extension-library/variables/index.rst
+++ b/docs/reference/extension-library/variables/index.rst
@@ -2,7 +2,7 @@
 Variables
 =========
 
-Vendor extension variables provided by IronPLC. These are implicit global
+Extension variables provided by IronPLC. These are implicit global
 variables injected by the compiler and updated by the VM at runtime.
 
 .. list-table::

--- a/docs/reference/extension-library/variables/system-uptime.rst
+++ b/docs/reference/extension-library/variables/system-uptime.rst
@@ -8,7 +8,7 @@ Implicit global variables that expose the VM's monotonic uptime counter.
    :widths: 30 70
 
    * - **IEC 61131-3**
-     - Not part of the standard (dialect extension)
+     - Not part of the standard (language extension)
    * - **Support**
      - Supported (requires ``--allow-system-uptime-global``)
 
@@ -97,4 +97,4 @@ with CODESYS-style code:
 See Also
 --------
 
-- :doc:`/explanation/enabling-dialects-and-features` -- enabling dialect extensions
+- :doc:`/explanation/enabling-dialects-and-features` -- enabling language extensions

--- a/docs/reference/extension-library/variables/system-uptime.rst
+++ b/docs/reference/extension-library/variables/system-uptime.rst
@@ -8,7 +8,7 @@ Implicit global variables that expose the VM's monotonic uptime counter.
    :widths: 30 70
 
    * - **IEC 61131-3**
-     - Not part of the standard (vendor extension)
+     - Not part of the standard (dialect extension)
    * - **Support**
      - Supported (requires ``--allow-system-uptime-global``)
 
@@ -56,7 +56,7 @@ and effectively never wraps (~292 million years).
 Enabling
 --------
 
-System uptime variables are a vendor extension and must be explicitly enabled:
+System uptime variables are an IronPLC extension and must be explicitly enabled:
 
 .. code-block:: shell
 
@@ -97,4 +97,4 @@ with CODESYS-style code:
 See Also
 --------
 
-- :doc:`/explanation/enabling-dialects-and-features` -- enabling vendor extensions
+- :doc:`/explanation/enabling-dialects-and-features` -- enabling dialect extensions

--- a/docs/reference/language/data-types/derived/array-types.rst
+++ b/docs/reference/language/data-types/derived/array-types.rst
@@ -43,8 +43,8 @@ Example
 Multi-dimensional arrays use comma-separated ranges in the index
 specification.
 
-Constant Bounds (Dialect Extension)
------------------------------------
+Constant Bounds (Language Extension)
+------------------------------------
 
 .. include:: ../../../../includes/requires-dialect-extension.rst
 

--- a/docs/reference/language/data-types/derived/array-types.rst
+++ b/docs/reference/language/data-types/derived/array-types.rst
@@ -43,10 +43,10 @@ Example
 Multi-dimensional arrays use comma-separated ranges in the index
 specification.
 
-Constant Bounds (Vendor Extension)
-----------------------------------
+Constant Bounds (Dialect Extension)
+-----------------------------------
 
-.. include:: ../../../../includes/requires-vendor-extension.rst
+.. include:: ../../../../includes/requires-dialect-extension.rst
 
 Many PLC vendors allow global constants in place of literal values for
 array bounds. IronPLC supports this with the ``--allow-constant-type-params``

--- a/docs/reference/language/data-types/derived/subrange-types.rst
+++ b/docs/reference/language/data-types/derived/subrange-types.rst
@@ -42,10 +42,10 @@ Example
        level := level + 10;
    END_PROGRAM
 
-Constant Bounds (Vendor Extension)
-----------------------------------
+Constant Bounds (Dialect Extension)
+-----------------------------------
 
-.. include:: ../../../../includes/requires-vendor-extension.rst
+.. include:: ../../../../includes/requires-dialect-extension.rst
 
 With the ``--allow-constant-type-params`` flag, you can
 use global constants for the subrange bounds:

--- a/docs/reference/language/data-types/derived/subrange-types.rst
+++ b/docs/reference/language/data-types/derived/subrange-types.rst
@@ -42,8 +42,8 @@ Example
        level := level + 10;
    END_PROGRAM
 
-Constant Bounds (Dialect Extension)
------------------------------------
+Constant Bounds (Language Extension)
+------------------------------------
 
 .. include:: ../../../../includes/requires-dialect-extension.rst
 

--- a/docs/reference/language/data-types/elementary/string.rst
+++ b/docs/reference/language/data-types/elementary/string.rst
@@ -43,8 +43,8 @@ Example
    name := 'my name';
    msg := 'a message';
 
-Constant Length (Dialect Extension)
------------------------------------
+Constant Length (Language Extension)
+------------------------------------
 
 .. include:: ../../../../includes/requires-dialect-extension.rst
 

--- a/docs/reference/language/data-types/elementary/string.rst
+++ b/docs/reference/language/data-types/elementary/string.rst
@@ -43,10 +43,10 @@ Example
    name := 'my name';
    msg := 'a message';
 
-Constant Length (Vendor Extension)
-----------------------------------
+Constant Length (Dialect Extension)
+-----------------------------------
 
-.. include:: ../../../../includes/requires-vendor-extension.rst
+.. include:: ../../../../includes/requires-dialect-extension.rst
 
 With the ``--allow-constant-type-params`` flag, you can
 use a global constant for the maximum length instead of a literal:

--- a/docs/reference/language/variables/scope.rst
+++ b/docs/reference/language/variables/scope.rst
@@ -100,7 +100,7 @@ global variable it references.
      firstReading := Readings[1];
    END_PROGRAM
 
-Top-Level Global Variables (Dialect Extension)
+Top-Level Global Variables (Language Extension)
 -----------------------------------------------
 
 .. include:: ../../../includes/requires-dialect-extension.rst

--- a/docs/reference/language/variables/scope.rst
+++ b/docs/reference/language/variables/scope.rst
@@ -100,10 +100,10 @@ global variable it references.
      firstReading := Readings[1];
    END_PROGRAM
 
-Top-Level Global Variables (Vendor Extension)
-----------------------------------------------
+Top-Level Global Variables (Dialect Extension)
+-----------------------------------------------
 
-.. include:: ../../../includes/requires-vendor-extension.rst
+.. include:: ../../../includes/requires-dialect-extension.rst
 
 Many PLC vendors allow :code:`VAR_GLOBAL` blocks at the top level of a file,
 outside of a :code:`CONFIGURATION` block. IronPLC supports this common

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -140,7 +140,7 @@
           "editPresentation": "singlelineText"
         },
         "ironplc.dialect": {
-          "markdownDescription": "Language dialect preset. Controls IEC edition and vendor extensions.\n\n- `iec61131-3-ed2`: Strict IEC 61131-3:2003 (Edition 2)\n- `iec61131-3-ed3`: IEC 61131-3:2013 (Edition 3) with `LTIME`, `REF_TO`, etc.\n- `rusty`: RuSTy-compatible — Edition 2 base with `REF_TO` and all vendor extensions\n- `codesys`: CODESYS-compatible — Edition 2 base with `REF_TO` and CODESYS vendor extensions\n- `twincat`: TwinCAT-compatible — Edition 2 base with the vendor extensions TwinCAT shares with CODESYS (no `REF_TO`; TwinCAT uses `REFERENCE TO`/`POINTER TO`)",
+          "markdownDescription": "Language dialect preset. Controls IEC edition and dialect extensions.\n\n- `iec61131-3-ed2`: Strict IEC 61131-3:2003 (Edition 2)\n- `iec61131-3-ed3`: IEC 61131-3:2013 (Edition 3) with `LTIME`, `REF_TO`, etc.\n- `rusty`: RuSTy-compatible — Edition 2 base with `REF_TO` and all dialect extensions\n- `codesys`: CODESYS-compatible — Edition 2 base with `REF_TO` and the CODESYS dialect extensions\n- `twincat`: TwinCAT-compatible — Edition 2 base with the dialect extensions TwinCAT shares with CODESYS (no `REF_TO`; TwinCAT uses `REFERENCE TO`/`POINTER TO`)",
           "type": "string",
           "default": "iec61131-3-ed2",
           "enum": [

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -140,7 +140,7 @@
           "editPresentation": "singlelineText"
         },
         "ironplc.dialect": {
-          "markdownDescription": "Language dialect preset. Controls IEC edition and dialect extensions.\n\n- `iec61131-3-ed2`: Strict IEC 61131-3:2003 (Edition 2)\n- `iec61131-3-ed3`: IEC 61131-3:2013 (Edition 3) with `LTIME`, `REF_TO`, etc.\n- `rusty`: RuSTy-compatible — Edition 2 base with `REF_TO` and all dialect extensions\n- `codesys`: CODESYS-compatible — Edition 2 base with `REF_TO` and the CODESYS dialect extensions\n- `twincat`: TwinCAT-compatible — Edition 2 base with the dialect extensions TwinCAT shares with CODESYS (no `REF_TO`; TwinCAT uses `REFERENCE TO`/`POINTER TO`)",
+          "markdownDescription": "Language dialect preset. Controls IEC edition and extensions.\n\n- `iec61131-3-ed2`: Strict IEC 61131-3:2003 (Edition 2)\n- `iec61131-3-ed3`: IEC 61131-3:2013 (Edition 3) with `LTIME`, `REF_TO`, etc.\n- `rusty`: RuSTy-compatible — Edition 2 base with `REF_TO` and the extensions RuSTy accepts\n- `codesys`: CODESYS-compatible — Edition 2 base with `REF_TO` and the CODESYS extensions\n- `twincat`: TwinCAT-compatible — Edition 2 base with the extensions TwinCAT shares with CODESYS (no `REF_TO`; TwinCAT uses `REFERENCE TO`/`POINTER TO`)",
           "type": "string",
           "default": "iec61131-3-ed2",
           "enum": [

--- a/specs/adrs/0012-accept-vendor-dialect-files-as-is.md
+++ b/specs/adrs/0012-accept-vendor-dialect-files-as-is.md
@@ -3,6 +3,12 @@
 status: proposed
 date: 2026-02-27
 
+> **Terminology note (added later):** This ADR predates
+> [`specs/steering/glossary.md`](../steering/glossary.md), which now draws a
+> firm line between a *dialect* (the syntax the parser accepts) and a *vendor*
+> (a product/runtime). This ADR's text uses "vendor" loosely in both senses and
+> is preserved as written; for current terminology, defer to the glossary.
+
 ## Context and Problem Statement
 
 IEC 61131-3 defines the standard syntax for Structured Text, but no major PLC vendor ships a strict implementation. Every vendor extends the language with proprietary syntax: Siemens SCL adds `#` variable prefixes, `REGION`/`END_REGION` blocks, and curly-brace pragmas; Beckhoff TwinCAT adds object-oriented features (`INTERFACE`, `METHOD`, `PROPERTY`, `EXTENDS`), `POINTER TO`/`REFERENCE TO` types, and `VAR_INST` sections; other vendors make similar additions. These extensions are not cosmetic — they appear on virtually every line of real-world vendor-authored code.

--- a/specs/design/beckhoff-twincat-dialect.md
+++ b/specs/design/beckhoff-twincat-dialect.md
@@ -749,9 +749,9 @@ pub enum Operator {
 }
 ```
 
-## Dialect Extension Trait and Semantic Rule
+## Language Extension Trait and Semantic Rule
 
-### The `DialectExtension` Trait
+### The `LanguageExtension` Trait
 
 Every AST node representing a non-standard construct implements this trait. It provides the metadata needed for the `P9004` diagnostic without any per-instance runtime data — origins are static per type.
 
@@ -763,9 +763,9 @@ Every AST node representing a non-standard construct implements this trait. It p
 /// rule `rule_unsupported_extension` walks the AST and emits P9004 for every
 /// node that implements this trait.
 ///
-/// As each extension graduates to full support, remove its DialectExtension
+/// As each extension graduates to full support, remove its LanguageExtension
 /// impl. The semantic rule automatically stops flagging it.
-pub trait DialectExtension {
+pub trait LanguageExtension {
     /// Human-readable name of this extension (e.g., "METHOD declaration").
     fn extension_name(&self) -> &'static str;
 
@@ -784,7 +784,7 @@ pub trait DialectExtension {
 ```rust
 // Beckhoff/CODESYS extension — METHOD declaration
 // Extension: Beckhoff/CODESYS OOP
-impl DialectExtension for MethodDeclaration {
+impl LanguageExtension for MethodDeclaration {
     fn extension_name(&self) -> &'static str { "METHOD declaration" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::BeckhoffCodesys] }
     fn extension_span(&self) -> SourceSpan { self.span }
@@ -792,7 +792,7 @@ impl DialectExtension for MethodDeclaration {
 
 // Shared extension — VAR_STAT
 // Extension: Beckhoff/CODESYS, Siemens SCL
-impl DialectExtension for VarStatSection {
+impl LanguageExtension for VarStatSection {
     fn extension_name(&self) -> &'static str { "VAR_STAT section" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] {
         &[ExtensionOrigin::BeckhoffCodesys, ExtensionOrigin::SiemensSCL]
@@ -802,7 +802,7 @@ impl DialectExtension for VarStatSection {
 
 // IEC 61131-3 3rd edition + Beckhoff — CONTINUE statement
 // Extension: IEC 61131-3 3rd edition, Beckhoff/CODESYS
-impl DialectExtension for ContinueStatement {
+impl LanguageExtension for ContinueStatement {
     fn extension_name(&self) -> &'static str { "CONTINUE statement" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] {
         &[ExtensionOrigin::Iec61131Ed3, ExtensionOrigin::BeckhoffCodesys]
@@ -837,7 +837,7 @@ P9004 - Recognized extension not supported
 
 ### Semantic Rule: `rule_unsupported_extension.rs`
 
-A single visitor walks the AST and emits `P9004` for every `DialectExtension` node. The visitor checks each AST node type that could be a dialect extension:
+A single visitor walks the AST and emits `P9004` for every `LanguageExtension` node. The visitor checks each AST node type that could be an extension:
 
 ```rust
 pub fn apply(lib: &Library, _context: &SemanticContext) -> SemanticResult {
@@ -850,7 +850,7 @@ pub fn apply(lib: &Library, _context: &SemanticContext) -> SemanticResult {
 }
 
 impl RuleUnsupportedExtension {
-    fn check_extension(&mut self, ext: &dyn DialectExtension) {
+    fn check_extension(&mut self, ext: &dyn LanguageExtension) {
         let origins: Vec<&str> = ext.extension_origins().iter().map(|o| o.as_str()).collect();
         let origin_text = origins.join(", ");
         self.diagnostics.push(Diagnostic::problem(
@@ -868,13 +868,13 @@ impl RuleUnsupportedExtension {
 }
 ```
 
-The visitor overrides `visit_*` for each extension node type (MethodDeclaration, PropertyDeclaration, InterfaceDeclaration, etc.) and calls `check_extension`. As extensions graduate to full support, their `visit_*` override is removed (or their `DialectExtension` impl is removed) and the rule stops flagging them.
+The visitor overrides `visit_*` for each extension node type (MethodDeclaration, PropertyDeclaration, InterfaceDeclaration, etc.) and calls `check_extension`. As extensions graduate to full support, their `visit_*` override is removed (or their `LanguageExtension` impl is removed) and the rule stops flagging them.
 
 ### Graduation Path
 
 When an extension moves from "parsed but unsupported" to "fully supported":
 
-1. Remove the `DialectExtension` impl from the AST node
+1. Remove the `LanguageExtension` impl from the AST node
 2. Remove the `visit_*` override in `rule_unsupported_extension.rs`
 3. Add real semantic rules for the construct
 4. The `P9004` diagnostic automatically stops appearing for that construct
@@ -992,7 +992,7 @@ This test lives in `compiler/parser/src/tests/` alongside the other parser tests
 0. **Phase 0 — Prerequisites** (before any dialect code):
    - Keyword safety regression test: function block with all planned keywords as variable names, parsed in standard mode
    - `ExtensionOrigin` enum in the DSL crate
-   - `DialectExtension` trait in the DSL crate
+   - `LanguageExtension` trait in the DSL crate
    - `P9004 UnsupportedExtension` problem code in CSV and documentation
    - `rule_unsupported_extension.rs` semantic rule (empty initially — no extension nodes exist yet)
 
@@ -1006,14 +1006,14 @@ This test lives in `compiler/parser/src/tests/` alongside the other parser tests
    - Method, Property, and Interface XML element handling in `twincat_parser.rs`
    - `INTERFACE` / `END_INTERFACE`
    - DSL: `MethodDeclaration`, `PropertyDeclaration`, `InterfaceDeclaration`, `extends`/`implements` fields
-   - `DialectExtension` impls on all new AST nodes; `rule_unsupported_extension` visitor overrides
+   - `LanguageExtension` impls on all new AST nodes; `rule_unsupported_extension` visitor overrides
 
 2. **Phase 2 — Access modifiers and expressions**:
    - Access modifiers on methods/properties (`PUBLIC`, `PRIVATE`, `PROTECTED`, `INTERNAL`)
    - `ABSTRACT` / `FINAL` / `OVERRIDE` method modifiers
    - `THIS^` / `SUPER^` expressions
    - DSL: `AccessModifier`, `ThisRef`, `SuperRef`
-   - `DialectExtension` impls on new nodes
+   - `LanguageExtension` impls on new nodes
 
 3. **Phase 3 — Type system extensions**:
    - `POINTER TO` / `REFERENCE TO`
@@ -1025,11 +1025,11 @@ This test lives in `compiler/parser/src/tests/` alongside the other parser tests
    - `AND_THEN` / `OR_ELSE` short-circuit operators
    - `CONTINUE` statement
    - DSL: `PointerTo`, `ReferenceTo`, `UnionDeclaration`, `RefAssign`, `Continue`, `AndThen`/`OrElse`
-   - `DialectExtension` impls on new nodes
+   - `LanguageExtension` impls on new nodes
 
 4. **Phase 4 — Advanced features**:
    - `S=` / `R=` extended assignment operators (parser-level, assignment context)
    - `__TRY` / `__CATCH` / `__FINALLY` / `__ENDTRY`
    - Conditional compilation pragmas (`{IF defined(...)}` / `{END_IF}`)
    - DSL: `SetAssign`, `ResetAssign`
-   - `DialectExtension` impls on new nodes
+   - `LanguageExtension` impls on new nodes

--- a/specs/design/beckhoff-twincat-dialect.md
+++ b/specs/design/beckhoff-twincat-dialect.md
@@ -415,7 +415,7 @@ END_TYPE
 
 ## Extension Origin Model
 
-Every vendor-specific construct in IronPLC is tagged with its origin — which vendor dialects introduced it. This enum is the **single source of truth** that drives both the token transform pipeline (which keywords to promote) and the semantic diagnostic (which extensions to flag as unsupported).
+Every non-standard construct in IronPLC is tagged with its origin — which dialects introduced it. This enum is the **single source of truth** that drives both the token transform pipeline (which keywords to promote) and the semantic diagnostic (which extensions to flag as unsupported).
 
 ### `ExtensionOrigin` Enum
 
@@ -749,27 +749,27 @@ pub enum Operator {
 }
 ```
 
-## Vendor Extension Trait and Semantic Rule
+## Dialect Extension Trait and Semantic Rule
 
-### The `VendorExtension` Trait
+### The `DialectExtension` Trait
 
-Every AST node representing a vendor-specific construct implements this trait. It provides the metadata needed for the `P9004` diagnostic without any per-instance runtime data — origins are static per type.
+Every AST node representing a non-standard construct implements this trait. It provides the metadata needed for the `P9004` diagnostic without any per-instance runtime data — origins are static per type.
 
 ```rust
-/// Marker trait for AST nodes representing vendor-specific language extensions.
+/// Marker trait for AST nodes representing non-standard language extensions.
 ///
 /// Nodes implementing this trait are parsed and represented in the AST but
 /// not yet semantically analyzed or supported in code generation. The semantic
 /// rule `rule_unsupported_extension` walks the AST and emits P9004 for every
 /// node that implements this trait.
 ///
-/// As each extension graduates to full support, remove its VendorExtension
+/// As each extension graduates to full support, remove its DialectExtension
 /// impl. The semantic rule automatically stops flagging it.
-pub trait VendorExtension {
+pub trait DialectExtension {
     /// Human-readable name of this extension (e.g., "METHOD declaration").
     fn extension_name(&self) -> &'static str;
 
-    /// Which vendor dialects introduced this extension. A single extension
+    /// Which dialects introduced this extension. A single extension
     /// may originate from multiple vendors (e.g., VAR_STAT is both
     /// BeckhoffCodesys and SiemensSCL).
     fn extension_origins(&self) -> &'static [ExtensionOrigin];
@@ -784,7 +784,7 @@ pub trait VendorExtension {
 ```rust
 // Beckhoff/CODESYS extension — METHOD declaration
 // Extension: Beckhoff/CODESYS OOP
-impl VendorExtension for MethodDeclaration {
+impl DialectExtension for MethodDeclaration {
     fn extension_name(&self) -> &'static str { "METHOD declaration" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::BeckhoffCodesys] }
     fn extension_span(&self) -> SourceSpan { self.span }
@@ -792,7 +792,7 @@ impl VendorExtension for MethodDeclaration {
 
 // Shared extension — VAR_STAT
 // Extension: Beckhoff/CODESYS, Siemens SCL
-impl VendorExtension for VarStatSection {
+impl DialectExtension for VarStatSection {
     fn extension_name(&self) -> &'static str { "VAR_STAT section" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] {
         &[ExtensionOrigin::BeckhoffCodesys, ExtensionOrigin::SiemensSCL]
@@ -802,7 +802,7 @@ impl VendorExtension for VarStatSection {
 
 // IEC 61131-3 3rd edition + Beckhoff — CONTINUE statement
 // Extension: IEC 61131-3 3rd edition, Beckhoff/CODESYS
-impl VendorExtension for ContinueStatement {
+impl DialectExtension for ContinueStatement {
     fn extension_name(&self) -> &'static str { "CONTINUE statement" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] {
         &[ExtensionOrigin::Iec61131Ed3, ExtensionOrigin::BeckhoffCodesys]
@@ -837,7 +837,7 @@ P9004 - Recognized extension not supported
 
 ### Semantic Rule: `rule_unsupported_extension.rs`
 
-A single visitor walks the AST and emits `P9004` for every `VendorExtension` node. The visitor checks each AST node type that could be a vendor extension:
+A single visitor walks the AST and emits `P9004` for every `DialectExtension` node. The visitor checks each AST node type that could be a dialect extension:
 
 ```rust
 pub fn apply(lib: &Library, _context: &SemanticContext) -> SemanticResult {
@@ -850,7 +850,7 @@ pub fn apply(lib: &Library, _context: &SemanticContext) -> SemanticResult {
 }
 
 impl RuleUnsupportedExtension {
-    fn check_extension(&mut self, ext: &dyn VendorExtension) {
+    fn check_extension(&mut self, ext: &dyn DialectExtension) {
         let origins: Vec<&str> = ext.extension_origins().iter().map(|o| o.as_str()).collect();
         let origin_text = origins.join(", ");
         self.diagnostics.push(Diagnostic::problem(
@@ -868,13 +868,13 @@ impl RuleUnsupportedExtension {
 }
 ```
 
-The visitor overrides `visit_*` for each extension node type (MethodDeclaration, PropertyDeclaration, InterfaceDeclaration, etc.) and calls `check_extension`. As extensions graduate to full support, their `visit_*` override is removed (or their `VendorExtension` impl is removed) and the rule stops flagging them.
+The visitor overrides `visit_*` for each extension node type (MethodDeclaration, PropertyDeclaration, InterfaceDeclaration, etc.) and calls `check_extension`. As extensions graduate to full support, their `visit_*` override is removed (or their `DialectExtension` impl is removed) and the rule stops flagging them.
 
 ### Graduation Path
 
 When an extension moves from "parsed but unsupported" to "fully supported":
 
-1. Remove the `VendorExtension` impl from the AST node
+1. Remove the `DialectExtension` impl from the AST node
 2. Remove the `visit_*` override in `rule_unsupported_extension.rs`
 3. Add real semantic rules for the construct
 4. The `P9004` diagnostic automatically stops appearing for that construct
@@ -992,7 +992,7 @@ This test lives in `compiler/parser/src/tests/` alongside the other parser tests
 0. **Phase 0 — Prerequisites** (before any dialect code):
    - Keyword safety regression test: function block with all planned keywords as variable names, parsed in standard mode
    - `ExtensionOrigin` enum in the DSL crate
-   - `VendorExtension` trait in the DSL crate
+   - `DialectExtension` trait in the DSL crate
    - `P9004 UnsupportedExtension` problem code in CSV and documentation
    - `rule_unsupported_extension.rs` semantic rule (empty initially — no extension nodes exist yet)
 
@@ -1006,14 +1006,14 @@ This test lives in `compiler/parser/src/tests/` alongside the other parser tests
    - Method, Property, and Interface XML element handling in `twincat_parser.rs`
    - `INTERFACE` / `END_INTERFACE`
    - DSL: `MethodDeclaration`, `PropertyDeclaration`, `InterfaceDeclaration`, `extends`/`implements` fields
-   - `VendorExtension` impls on all new AST nodes; `rule_unsupported_extension` visitor overrides
+   - `DialectExtension` impls on all new AST nodes; `rule_unsupported_extension` visitor overrides
 
 2. **Phase 2 — Access modifiers and expressions**:
    - Access modifiers on methods/properties (`PUBLIC`, `PRIVATE`, `PROTECTED`, `INTERNAL`)
    - `ABSTRACT` / `FINAL` / `OVERRIDE` method modifiers
    - `THIS^` / `SUPER^` expressions
    - DSL: `AccessModifier`, `ThisRef`, `SuperRef`
-   - `VendorExtension` impls on new nodes
+   - `DialectExtension` impls on new nodes
 
 3. **Phase 3 — Type system extensions**:
    - `POINTER TO` / `REFERENCE TO`
@@ -1025,11 +1025,11 @@ This test lives in `compiler/parser/src/tests/` alongside the other parser tests
    - `AND_THEN` / `OR_ELSE` short-circuit operators
    - `CONTINUE` statement
    - DSL: `PointerTo`, `ReferenceTo`, `UnionDeclaration`, `RefAssign`, `Continue`, `AndThen`/`OrElse`
-   - `VendorExtension` impls on new nodes
+   - `DialectExtension` impls on new nodes
 
 4. **Phase 4 — Advanced features**:
    - `S=` / `R=` extended assignment operators (parser-level, assignment context)
    - `__TRY` / `__CATCH` / `__FINALLY` / `__ENDTRY`
    - Conditional compilation pragmas (`{IF defined(...)}` / `{END_IF}`)
    - DSL: `SetAssign`, `ResetAssign`
-   - `VendorExtension` impls on new nodes
+   - `DialectExtension` impls on new nodes

--- a/specs/design/dialect-token-transforms.md
+++ b/specs/design/dialect-token-transforms.md
@@ -2,21 +2,21 @@
 
 ## Overview
 
-This document describes the architecture for dialect-specific token transforms — the mechanism that enables vendor-dialect parsing without modifying the core logos lexer. It is the shared infrastructure underlying both the [Siemens SCL](siemens-scl-dialect.md) and [Beckhoff TwinCAT](beckhoff-twincat-dialect.md) dialect designs.
+This document describes the architecture for dialect-specific token transforms — the mechanism that enables dialect parsing without modifying the core logos lexer. It is the shared infrastructure underlying both the [Siemens SCL](siemens-scl-dialect.md) and [Beckhoff TwinCAT](beckhoff-twincat-dialect.md) dialect designs.
 
-The core principle: **the logos lexer stays dialect-neutral**. It only recognizes IEC 61131-3 standard tokens. Vendor-specific syntax is handled by a pipeline of token transforms that run between lexing and parsing.
+The core principle: **the logos lexer stays dialect-neutral**. It only recognizes IEC 61131-3 standard tokens. Non-standard syntax is handled by a pipeline of token transforms that run between lexing and parsing.
 
 ## Problem
 
 The logos lexer in `token.rs` declares standard keywords with `#[token("KEYWORD", ignore(case))]` at higher priority than the `Identifier` regex. This means `FUNCTION_BLOCK` always lexes as `TokenType::FunctionBlock`, never as `Identifier`. This is correct for IEC 61131-3.
 
-Vendor dialects introduce new keywords (`METHOD`, `REGION`, `BEGIN`, `EXTENDS`, etc.) and new syntax conventions (`#variable`, `"quoted_name"`, `{pragma}`). These cannot be added to the logos lexer because:
+Dialects introduce new keywords (`METHOD`, `REGION`, `BEGIN`, `EXTENDS`, etc.) and new syntax conventions (`#variable`, `"quoted_name"`, `{pragma}`). These cannot be added to the logos lexer because:
 
-1. **Vendor keywords shadow valid identifiers.** In standard IEC 61131-3, `METHOD`, `INTERFACE`, `BEGIN`, `REGION` are all legal variable or type names. Making them always-on keywords breaks valid standard programs.
+1. **Dialect keywords shadow valid identifiers.** In standard IEC 61131-3, `METHOD`, `INTERFACE`, `BEGIN`, `REGION` are all legal variable or type names. Making them always-on keywords breaks valid standard programs.
 
-2. **Vendor syntax changes token semantics.** In Siemens SCL, `"FB_Motor"` is an identifier, not a wide string literal. In standard mode, it's a `DoubleByteString`. The same token text has different meaning depending on dialect.
+2. **Dialect syntax changes token semantics.** In Siemens SCL, `"FB_Motor"` is an identifier, not a wide string literal. In standard mode, it's a `DoubleByteString`. The same token text has different meaning depending on dialect.
 
-3. **Vendor syntax merges or removes tokens.** Siemens SCL's `#counter` should become a single variable reference, not `Hash` + `Identifier`. Pragma blocks `{ ... }` should become a single opaque token.
+3. **Dialect syntax merges or removes tokens.** Siemens SCL's `#counter` should become a single variable reference, not `Hash` + `Identifier`. Pragma blocks `{ ... }` should become a single opaque token.
 
 ## Transform Categories
 
@@ -24,7 +24,7 @@ Token transforms fall into four distinct categories, each with different invaria
 
 ### Category 1: Keyword Promotion
 
-**What:** Change an `Identifier` token's `token_type` to a vendor keyword type.
+**What:** Change an `Identifier` token's `token_type` to a dialect keyword type.
 
 **Invariants:**
 - `token_type` changes
@@ -147,7 +147,7 @@ Source text
 ┌─────────────────────────────────────────────────┐
 │ 1. Logos lexer                                  │
 │    Standard IEC 61131-3 tokens only.            │
-│    Vendor keywords arrive as Identifier.        │
+│    Dialect keywords arrive as Identifier.       │
 │    "quoted" text arrives as DoubleByteString.   │
 │    # arrives as Hash.                           │
 │    { } arrive as LeftBrace / RightBrace.        │
@@ -167,7 +167,7 @@ Source text
 │    Standard). Order within this stage:          │
 │                                                 │
 │    a. Keyword promotion                         │
-│       Identifier → vendor keyword TokenType.    │
+│       Identifier → dialect keyword TokenType.   │
 │       Must run first so subsequent transforms   │
 │       can match on promoted types (e.g.,        │
 │       Region, EndRegion).                       │

--- a/specs/design/language-reference.md
+++ b/specs/design/language-reference.md
@@ -186,5 +186,5 @@ Metadata table with: IEC 61131-3 section, Support status. Followed by Inputs tab
 ## Future Extensibility
 
 - New IEC 61131-3 languages (FBD, SFC) add a subdirectory under `language/`
-- Vendor dialect features can add an "Availability" row to the metadata table (e.g., "Siemens S7 dialect, requires `--dialect s7`")
+- Dialect features can add an "Availability" row to the metadata table (e.g., "Siemens S7 dialect, requires `--dialect s7`")
 - New standard functions/FBs add individual pages under the appropriate directory

--- a/specs/design/partial-access-bit-syntax.md
+++ b/specs/design/partial-access-bit-syntax.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-IronPLC supports bit-level access on integer-typed variables using the vendor
+IronPLC supports bit-level access on integer-typed variables using the non-standard
 short form `x.n` (for example, `byte_var.3`). This design adds support for the
 IEC 61131-3:2013 standard form `x.%Xn` (for example, `byte_var.%X3`), which is
 semantically equivalent. The new form is accepted on any symbolic variable,

--- a/specs/design/reference-to-twincat.md
+++ b/specs/design/reference-to-twincat.md
@@ -49,7 +49,7 @@ The feature is delivered in two phases, one PR each:
 
 ## Gating & coexistence
 
-`REFERENCE TO` is gated behind a new `--allow-reference-to` vendor flag,
+`REFERENCE TO` is gated behind a new `--allow-reference-to` flag,
 following the established token-demotion pattern. A new `REFERENCE` keyword
 token is demoted to `Identifier` unless `--allow-reference-to` is set — exactly
 how `REF_TO`/`REF`/`NULL` are demoted today. The always-present grammar

--- a/specs/design/siemens-scl-dialect.md
+++ b/specs/design/siemens-scl-dialect.md
@@ -380,14 +380,14 @@ Keywords shared with Beckhoff (already in the table from the [Beckhoff design](b
 | `VAR_STAT` | `VarStat` | `BeckhoffCodesys, SiemensSCL` |
 | `CONTINUE` | `Continue` | `Iec61131Ed3, BeckhoffCodesys, SiemensSCL` |
 
-### `DialectExtension` Implementations for SCL Nodes
+### `LanguageExtension` Implementations for SCL Nodes
 
-Every new AST node representing an SCL-specific construct implements the `DialectExtension` trait defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-dialectextension-trait). This enables the `rule_unsupported_extension.rs` semantic rule to emit `P9004` diagnostics:
+Every new AST node representing an SCL-specific construct implements the `LanguageExtension` trait defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-languageextension-trait). This enables the `rule_unsupported_extension.rs` semantic rule to emit `P9004` diagnostics:
 
 ```rust
 // Siemens SCL extension — DATA_BLOCK declaration
 // Extension: Siemens SCL
-impl DialectExtension for DataBlockDeclaration {
+impl LanguageExtension for DataBlockDeclaration {
     fn extension_name(&self) -> &'static str { "DATA_BLOCK declaration" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::SiemensSCL] }
     fn extension_span(&self) -> SourceSpan { self.span }
@@ -395,7 +395,7 @@ impl DialectExtension for DataBlockDeclaration {
 
 // Siemens SCL extension — ORGANIZATION_BLOCK declaration
 // Extension: Siemens SCL
-impl DialectExtension for OrganizationBlockDeclaration {
+impl LanguageExtension for OrganizationBlockDeclaration {
     fn extension_name(&self) -> &'static str { "ORGANIZATION_BLOCK declaration" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::SiemensSCL] }
     fn extension_span(&self) -> SourceSpan { self.span }
@@ -403,14 +403,14 @@ impl DialectExtension for OrganizationBlockDeclaration {
 
 // Siemens SCL extension — GOTO statement
 // Extension: Siemens SCL
-impl DialectExtension for GotoStatement {
+impl LanguageExtension for GotoStatement {
     fn extension_name(&self) -> &'static str { "GOTO statement" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::SiemensSCL] }
     fn extension_span(&self) -> SourceSpan { self.span }
 }
 ```
 
-`VAR_STAT` and `CONTINUE` are shared with Beckhoff — their `DialectExtension` implementations are defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-dialectextension-trait) with multiple origins.
+`VAR_STAT` and `CONTINUE` are shared with Beckhoff — their `LanguageExtension` implementations are defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-languageextension-trait) with multiple origins.
 
 ## AST Extensions (DSL Crate)
 
@@ -657,7 +657,7 @@ Phase 0 is shared infrastructure with the [Beckhoff design](beckhoff-twincat-dia
 0. **Phase 0 — Prerequisites** (before any dialect code, shared with Beckhoff):
    - Keyword safety regression test: function block with all planned keywords (both Beckhoff AND Siemens) as variable names, parsed in standard mode
    - `ExtensionOrigin` enum in the DSL crate
-   - `DialectExtension` trait in the DSL crate
+   - `LanguageExtension` trait in the DSL crate
    - `P9004 UnsupportedExtension` problem code in CSV and documentation
    - `rule_unsupported_extension.rs` semantic rule (empty initially — no extension nodes exist yet)
    - `Dialect` enum and `CompilerOptions` extension (shared infrastructure)
@@ -672,21 +672,21 @@ Phase 0 is shared infrastructure with the [Beckhoff design](beckhoff-twincat-dia
    - `BEGIN` keyword (optional body separator)
    - `CONTINUE` statement (shared with Beckhoff)
    - DSL: `VariableType::Static` (shared), `StmtKind::Continue` (shared)
-   - `DialectExtension` impls on new AST nodes; `rule_unsupported_extension` visitor overrides
+   - `LanguageExtension` impls on new AST nodes; `rule_unsupported_extension` visitor overrides
 
 2. **Phase 2 — Declarations**:
    - `VERSION : 0.1` parsing and `version` field on POU declarations
    - `VAR_STAT` support (shared with Beckhoff)
    - Classic block attributes (`TITLE`, `AUTHOR`, `FAMILY`, `NAME`, `KNOW_HOW_PROTECT`)
    - DSL: `version` field on `FunctionBlockDeclaration`, `FunctionDeclaration`, `ProgramDeclaration`
-   - `DialectExtension` impls on new nodes
+   - `LanguageExtension` impls on new nodes
 
 3. **Phase 3 — Siemens-specific POU types**:
    - `DATA_BLOCK` / `END_DATA_BLOCK` with `STRUCT` body, `NON_RETAIN`, and `BEGIN` initialization section
    - Instance data blocks with FB type reference
    - `ORGANIZATION_BLOCK` / `END_ORGANIZATION_BLOCK`
    - DSL: `DataBlockDeclaration`, `OrganizationBlockDeclaration`
-   - `DialectExtension` impls on new nodes
+   - `LanguageExtension` impls on new nodes
 
 4. **Phase 4 — Advanced syntax**:
    - `GOTO` and labels
@@ -694,4 +694,4 @@ Phase 0 is shared infrastructure with the [Beckhoff design](beckhoff-twincat-dia
    - `REF_TO` type constructor (maps to shared `TypeSpec::ReferenceTo` from Beckhoff design)
    - Assign-attempt operator `?=` (also a Beckhoff/CODESYS construct — shared AST representation)
    - DSL: `GotoStatement`, `LabelStatement`, `RefTo` → `ReferenceTo`
-   - `DialectExtension` impls on new nodes
+   - `LanguageExtension` impls on new nodes

--- a/specs/design/siemens-scl-dialect.md
+++ b/specs/design/siemens-scl-dialect.md
@@ -348,7 +348,7 @@ The REGION filter removes `Region` token + all tokens until the next `Newline` (
 
 ## Extension Origin Model
 
-Every vendor-specific construct is tagged with its origin using the shared `ExtensionOrigin` enum defined in the [Beckhoff design](beckhoff-twincat-dialect.md#extension-origin-model). This enum is the **single source of truth** that drives both the token transform pipeline and the semantic diagnostic (`P9004 UnsupportedExtension`).
+Every non-standard construct is tagged with its origin using the shared `ExtensionOrigin` enum defined in the [Beckhoff design](beckhoff-twincat-dialect.md#extension-origin-model). This enum is the **single source of truth** that drives both the token transform pipeline and the semantic diagnostic (`P9004 UnsupportedExtension`).
 
 SCL-specific keywords are added to the shared `DIALECT_KEYWORDS` table. Keywords shared between SCL and Beckhoff/CODESYS have multiple origins:
 
@@ -380,14 +380,14 @@ Keywords shared with Beckhoff (already in the table from the [Beckhoff design](b
 | `VAR_STAT` | `VarStat` | `BeckhoffCodesys, SiemensSCL` |
 | `CONTINUE` | `Continue` | `Iec61131Ed3, BeckhoffCodesys, SiemensSCL` |
 
-### `VendorExtension` Implementations for SCL Nodes
+### `DialectExtension` Implementations for SCL Nodes
 
-Every new AST node representing an SCL-specific construct implements the `VendorExtension` trait defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-vendorextension-trait). This enables the `rule_unsupported_extension.rs` semantic rule to emit `P9004` diagnostics:
+Every new AST node representing an SCL-specific construct implements the `DialectExtension` trait defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-dialectextension-trait). This enables the `rule_unsupported_extension.rs` semantic rule to emit `P9004` diagnostics:
 
 ```rust
 // Siemens SCL extension — DATA_BLOCK declaration
 // Extension: Siemens SCL
-impl VendorExtension for DataBlockDeclaration {
+impl DialectExtension for DataBlockDeclaration {
     fn extension_name(&self) -> &'static str { "DATA_BLOCK declaration" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::SiemensSCL] }
     fn extension_span(&self) -> SourceSpan { self.span }
@@ -395,7 +395,7 @@ impl VendorExtension for DataBlockDeclaration {
 
 // Siemens SCL extension — ORGANIZATION_BLOCK declaration
 // Extension: Siemens SCL
-impl VendorExtension for OrganizationBlockDeclaration {
+impl DialectExtension for OrganizationBlockDeclaration {
     fn extension_name(&self) -> &'static str { "ORGANIZATION_BLOCK declaration" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::SiemensSCL] }
     fn extension_span(&self) -> SourceSpan { self.span }
@@ -403,14 +403,14 @@ impl VendorExtension for OrganizationBlockDeclaration {
 
 // Siemens SCL extension — GOTO statement
 // Extension: Siemens SCL
-impl VendorExtension for GotoStatement {
+impl DialectExtension for GotoStatement {
     fn extension_name(&self) -> &'static str { "GOTO statement" }
     fn extension_origins(&self) -> &'static [ExtensionOrigin] { &[ExtensionOrigin::SiemensSCL] }
     fn extension_span(&self) -> SourceSpan { self.span }
 }
 ```
 
-`VAR_STAT` and `CONTINUE` are shared with Beckhoff — their `VendorExtension` implementations are defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-vendorextension-trait) with multiple origins.
+`VAR_STAT` and `CONTINUE` are shared with Beckhoff — their `DialectExtension` implementations are defined in the [Beckhoff design](beckhoff-twincat-dialect.md#the-dialectextension-trait) with multiple origins.
 
 ## AST Extensions (DSL Crate)
 
@@ -657,7 +657,7 @@ Phase 0 is shared infrastructure with the [Beckhoff design](beckhoff-twincat-dia
 0. **Phase 0 — Prerequisites** (before any dialect code, shared with Beckhoff):
    - Keyword safety regression test: function block with all planned keywords (both Beckhoff AND Siemens) as variable names, parsed in standard mode
    - `ExtensionOrigin` enum in the DSL crate
-   - `VendorExtension` trait in the DSL crate
+   - `DialectExtension` trait in the DSL crate
    - `P9004 UnsupportedExtension` problem code in CSV and documentation
    - `rule_unsupported_extension.rs` semantic rule (empty initially — no extension nodes exist yet)
    - `Dialect` enum and `CompilerOptions` extension (shared infrastructure)
@@ -672,21 +672,21 @@ Phase 0 is shared infrastructure with the [Beckhoff design](beckhoff-twincat-dia
    - `BEGIN` keyword (optional body separator)
    - `CONTINUE` statement (shared with Beckhoff)
    - DSL: `VariableType::Static` (shared), `StmtKind::Continue` (shared)
-   - `VendorExtension` impls on new AST nodes; `rule_unsupported_extension` visitor overrides
+   - `DialectExtension` impls on new AST nodes; `rule_unsupported_extension` visitor overrides
 
 2. **Phase 2 — Declarations**:
    - `VERSION : 0.1` parsing and `version` field on POU declarations
    - `VAR_STAT` support (shared with Beckhoff)
    - Classic block attributes (`TITLE`, `AUTHOR`, `FAMILY`, `NAME`, `KNOW_HOW_PROTECT`)
    - DSL: `version` field on `FunctionBlockDeclaration`, `FunctionDeclaration`, `ProgramDeclaration`
-   - `VendorExtension` impls on new nodes
+   - `DialectExtension` impls on new nodes
 
 3. **Phase 3 — Siemens-specific POU types**:
    - `DATA_BLOCK` / `END_DATA_BLOCK` with `STRUCT` body, `NON_RETAIN`, and `BEGIN` initialization section
    - Instance data blocks with FB type reference
    - `ORGANIZATION_BLOCK` / `END_ORGANIZATION_BLOCK`
    - DSL: `DataBlockDeclaration`, `OrganizationBlockDeclaration`
-   - `VendorExtension` impls on new nodes
+   - `DialectExtension` impls on new nodes
 
 4. **Phase 4 — Advanced syntax**:
    - `GOTO` and labels
@@ -694,4 +694,4 @@ Phase 0 is shared infrastructure with the [Beckhoff design](beckhoff-twincat-dia
    - `REF_TO` type constructor (maps to shared `TypeSpec::ReferenceTo` from Beckhoff design)
    - Assign-attempt operator `?=` (also a Beckhoff/CODESYS construct — shared AST representation)
    - DSL: `GotoStatement`, `LabelStatement`, `RefTo` → `ReferenceTo`
-   - `VendorExtension` impls on new nodes
+   - `DialectExtension` impls on new nodes

--- a/specs/steering/glossary.md
+++ b/specs/steering/glossary.md
@@ -49,8 +49,8 @@ syntax a real toolchain accepts (see [ADR-0036](../adrs/0036-no-ironplc-dialect.
 IronPLC never invents a dialect of its own). A file belongs to exactly one
 dialect (see [ADR-0012](../adrs/0012-accept-vendor-dialect-files-as-is.md)).
 
-*Canonical uses:* "the CODESYS dialect", "select a dialect", "dialect
-extension", "per-file dialect detection", "the `--dialect` flag".
+*Canonical uses:* "the CODESYS dialect", "select a dialect", "per-file dialect
+detection", "the `--dialect` flag".
 
 *Do not say:* "vendor dialect" (redundant — a dialect is already the syntax a
 target accepts; just say "dialect", or name the dialect).
@@ -68,17 +68,24 @@ A single **non-standard syntax feature** — something beyond strict IEC 61131-3
 that a dialect may enable, gated by an `--allow-*` [flag](#flag). "Extension"
 always refers to *syntax the parser recognizes*, never to a runtime library.
 
-*Canonical uses:* "dialect extension", "the `--allow-sizeof` extension", "this
-extension is not part of the standard".
+The default word is just **"extension"**. When the bare word would be ambiguous
+(see the overload note below), qualify it as a **"language extension"** — *not*
+a "dialect extension". Do not attach the "dialect" qualifier to an extension:
+an extension is a syntax feature; a dialect is a bundle of them.
 
-*Do not say:* "vendor extension" — an extension is defined by the *syntax* it
-adds, not by a company. Name it a "dialect extension" or just an "extension",
-and put the "which vendors accept it" mapping in the dialect table.
+*Canonical uses:* "extension", "language extension" (when disambiguation is
+needed), "the `--allow-sizeof` extension", "this extension is not part of the
+standard".
+
+*Do not say:* "vendor extension" or "dialect extension" — an extension is
+defined by the *syntax* it adds, not by a company or a dialect. Say
+"extension" (or "language extension" when generic), and put the "which vendors
+accept it" mapping in the dialect table.
 
 > **Beware the overload.** "Extension" is used in three unrelated senses in this
 > project: (1) a syntax feature, as defined here; (2) the **Extension Library**
 > (runtime functions/function blocks/variables such as `SIZEOF`); and (3) the
-> **VS Code extension**. When ambiguous, qualify it: *dialect extension*,
+> **VS Code extension**. When ambiguous, qualify it: *language extension*,
 > *extension library*, *editor extension*.
 
 ### Flag
@@ -154,7 +161,7 @@ extensions. Anything an `--allow-*` flag enables is, by definition,
 | Say this | Not this | Because |
 |---|---|---|
 | dialect | vendor dialect | "dialect" already means the accepted syntax |
-| dialect extension / extension | vendor extension | an extension is defined by syntax, not a company |
+| extension / language extension | vendor extension, dialect extension | an extension is a syntax feature, not a company or a dialect |
 | dialect flag / `--allow-*` flag | vendor flag, vendor-extension flag | the flag gates syntax |
 | non-standard syntax | vendor syntax | it's about the standard, not a vendor |
 | vendor toolchain / vendor files / vendor library | *(keep — correct)* | these really are about the product/runtime |
@@ -173,6 +180,7 @@ These are externally-defined identifiers, not IronPLC vocabulary.
   concept, define it here before it spreads.
 - **Challenge conflicts on sight.** When wording in code or docs contradicts a
   definition here, that is a bug to fix, not a variation to tolerate.
-- **New syntax feature?** It is a *dialect extension*; describe it by the syntax
-  it adds and record which dialects enable it in the dialect table. See
+- **New syntax feature?** It is an *extension* (a *language extension* when the
+  bare word is ambiguous); describe it by the syntax it adds and record which
+  dialects enable it in the dialect table. See
   [Syntax Support Guide](syntax-support-guide.md).

--- a/specs/steering/iec-61131-3-compliance.md
+++ b/specs/steering/iec-61131-3-compliance.md
@@ -19,7 +19,7 @@ IronPLC follows a **permissive parsing, configurable validation** approach:
 
 ## Standard Compliance Levels
 
-IEC 61131-3 compliance levels relate to dialect extensions and vendor restrictions, not progressive feature implementation:
+IEC 61131-3 compliance levels relate to extensions and vendor restrictions, not progressive feature implementation:
 
 ### Base Standard Compliance
 - Full IEC 61131-3 standard implementation
@@ -27,7 +27,7 @@ IEC 61131-3 compliance levels relate to dialect extensions and vendor restrictio
 - Standard-compliant semantic validation
 - Complete type system as defined by the standard
 
-### Dialect Extensions (Additive)
+### Language Extensions (Additive)
 - Additional data types beyond the standard
 - Extended function libraries
 - Enhanced language constructs
@@ -125,7 +125,7 @@ Design validation to be configurable rather than fixed:
 - Maintain compatibility with older versions
 - Document compliance level clearly
 
-### Dialect Extensions
+### Language Extensions
 - Provide clear extension points
 - Avoid conflicts with standard features
 - Document extension behavior

--- a/specs/steering/iec-61131-3-compliance.md
+++ b/specs/steering/iec-61131-3-compliance.md
@@ -19,7 +19,7 @@ IronPLC follows a **permissive parsing, configurable validation** approach:
 
 ## Standard Compliance Levels
 
-IEC 61131-3 compliance levels relate to vendor extensions and restrictions, not progressive feature implementation:
+IEC 61131-3 compliance levels relate to dialect extensions and vendor restrictions, not progressive feature implementation:
 
 ### Base Standard Compliance
 - Full IEC 61131-3 standard implementation
@@ -27,7 +27,7 @@ IEC 61131-3 compliance levels relate to vendor extensions and restrictions, not 
 - Standard-compliant semantic validation
 - Complete type system as defined by the standard
 
-### Vendor Extensions (Additive)
+### Dialect Extensions (Additive)
 - Additional data types beyond the standard
 - Extended function libraries
 - Enhanced language constructs
@@ -125,7 +125,7 @@ Design validation to be configurable rather than fixed:
 - Maintain compatibility with older versions
 - Document compliance level clearly
 
-### Vendor Extensions
+### Dialect Extensions
 - Provide clear extension points
 - Avoid conflicts with standard features
 - Document extension behavior

--- a/specs/steering/syntax-support-guide.md
+++ b/specs/steering/syntax-support-guide.md
@@ -1,6 +1,6 @@
 # Syntax Support Guide
 
-This guide describes everything needed to add support for new syntax in the IronPLC compiler. Follow this guide when adding new language features, vendor extensions, or fixing syntax-related issues.
+This guide describes everything needed to add support for new syntax in the IronPLC compiler. Follow this guide when adding new language features, dialect extensions, or fixing syntax-related issues.
 
 > **Note**: This covers the full pipeline from lexer through execution. For general compiler architecture, see [compiler-architecture.md](compiler-architecture.md). For IEC 61131-3 compliance rules, see [iec-61131-3-compliance.md](iec-61131-3-compliance.md).
 
@@ -67,7 +67,7 @@ Keywords are case-insensitive (`ignore(case)`). Identifiers have lower priority 
 
 ### Token Demotion Pattern
 
-**When to use**: When a keyword is only valid under certain conditions (e.g., Edition 3 mode, or a vendor extension flag) and programs may use that keyword as an identifier otherwise.
+**When to use**: When a keyword is only valid under certain conditions (e.g., Edition 3 mode, or a dialect extension flag) and programs may use that keyword as an identifier otherwise.
 
 **How it works**: Define the token as a specific type in the lexer, then "demote" it to `TokenType::Identifier` in a transform pass when the feature is disabled.
 
@@ -142,7 +142,7 @@ pub fn apply(tokens: &[Token], options: &CompilerOptions) -> Result<(), Vec<Diag
 | New keyword that could conflict with existing identifiers | Token demotion |
 | Syntax that is always distinct from standard syntax | Validation rule |
 | Feature controlled by `--dialect` (edition selection) | Token demotion |
-| Feature controlled by `--allow-x` vendor flag | Either, depending on conflict risk |
+| Feature controlled by `--allow-x` flag | Either, depending on conflict risk |
 
 ### Token Insertion Pattern
 
@@ -165,7 +165,7 @@ pub fn insert_keyword_statement_terminators(
 
 ## Non-Standard Syntax Gating (`--allow-x` Flags)
 
-**Rule**: Anything not in the IEC 61131-3 standard **must** be gated behind an `--allow-x` flag. Using `--dialect=rusty` enables all vendor extensions.
+**Rule**: Anything not in the IEC 61131-3 standard **must** be gated behind an `--allow-x` flag. Using `--dialect=rusty` enables all dialect extensions.
 
 ### Before Creating a New Flag
 
@@ -190,7 +190,7 @@ your syntax.
 
 Dialects (`--dialect`) set the base configuration. Individual `--allow-*` flags can override on top.
 
-| Dialect | `--dialect` value | Edition 3 types | REF_TO | Vendor extensions |
+| Dialect | `--dialect` value | Edition 3 types | REF_TO | Dialect extensions |
 |---------|-------------------|----------------|--------|-------------------|
 | IEC 61131-3 Ed 2 (default) | `iec61131-3-ed2` | OFF | OFF | all OFF |
 | IEC 61131-3 Ed 3 | `iec61131-3-ed3` | ON | ON | all OFF |
@@ -254,7 +254,7 @@ Add the clap argument:
 
 ```rust
 /// Allow [description of what this enables].
-/// This is a vendor extension not part of the IEC 61131-3 standard.
+/// This is a dialect extension not part of the IEC 61131-3 standard.
 #[arg(long)]
 allow_my_extension: bool,
 ```
@@ -293,7 +293,7 @@ Use either the token demotion pattern, validation rule pattern, or analyzer-leve
 #### 6. Documentation
 
 Update these files to document the new flag:
-- `docs/explanation/enabling-dialects-and-features.rst` — add to the Vendor Extensions section
+- `docs/explanation/enabling-dialects-and-features.rst` — add to the Dialect Extensions section
 - `docs/reference/compiler/ironplcc.rst` — add to the Options section
 - Update the flag table in this file (syntax-support-guide.md)
 
@@ -350,7 +350,7 @@ fn parse_and_render_with_options(name: &'static str, options: CompilerOptions) -
 }
 
 #[test]
-fn write_to_string_my_vendor_extension() {
+fn write_to_string_my_dialect_extension() {
     let options = CompilerOptions {
         allow_my_extension: true,
         ..CompilerOptions::default()
@@ -502,7 +502,7 @@ New demotion transforms must be called in `tokenize_program()` **before** `check
 - **Missing LSP wiring**: The flag works on the CLI but not in VS Code because `extract_compiler_options()` in `plc2x/src/lsp.rs` was not updated. Always add LSP extraction for new flags.
 - **No round-trip test**: The feature parses but the renderer in `plc2plc` cannot write it back. Always add the round-trip test.
 - **No execution test**: The feature parses and analyzes but was never proven to execute correctly. Always add at least one end-to-end test.
-- **Creating a flag for standard syntax**: Only vendor extensions get `--allow-x` flags. Standard IEC 61131-3 syntax is always on (or gated by `--dialect`).
+- **Creating a flag for standard syntax**: Only dialect extensions get `--allow-x` flags. Standard IEC 61131-3 syntax is always on (or gated by `--dialect`).
 - **Stateful lexer changes**: The lexer (`logos`) is stateless. Use token transforms for context-dependent behavior, not lexer rules.
 - **Not registering transforms**: Adding a new `xform_*.rs` module but forgetting to call it from `tokenize_program()` in `parser/src/lib.rs`, or adding a new rule module but forgetting to register it in `check_tokens()`.
 
@@ -510,7 +510,7 @@ New demotion transforms must be called in `tokenize_program()` **before** `check
 
 This walkthrough shows the typical sequence for adding a new syntax feature.
 
-### Example: Adding Support for a Hypothetical Vendor Extension
+### Example: Adding Support for a Hypothetical Dialect Extension
 
 Suppose a vendor allows `REPEAT ... UNTIL ... END_REPEAT` with an optional `LIMIT` clause (non-standard).
 
@@ -520,7 +520,7 @@ Review `parser/src/options.rs` — does an existing flag cover this? If not, pro
 
 #### Step 2: Add the Flag
 
-1. Add `allow_repeat_limit` to `CompilerOptions` vendor fields in the `define_compiler_options!` macro
+1. Add `allow_repeat_limit` to `CompilerOptions` dialect fields in the `define_compiler_options!` macro
 2. Add `--allow-repeat-limit` to CLI `FileArgs`
 3. Add `|= self.allow_repeat_limit` in `compiler_options()`
 4. Add to relevant dialect presets in `CompilerOptions::from_dialect()`

--- a/specs/steering/syntax-support-guide.md
+++ b/specs/steering/syntax-support-guide.md
@@ -1,6 +1,6 @@
 # Syntax Support Guide
 
-This guide describes everything needed to add support for new syntax in the IronPLC compiler. Follow this guide when adding new language features, dialect extensions, or fixing syntax-related issues.
+This guide describes everything needed to add support for new syntax in the IronPLC compiler. Follow this guide when adding new language features, extensions, or fixing syntax-related issues.
 
 > **Note**: This covers the full pipeline from lexer through execution. For general compiler architecture, see [compiler-architecture.md](compiler-architecture.md). For IEC 61131-3 compliance rules, see [iec-61131-3-compliance.md](iec-61131-3-compliance.md).
 
@@ -67,7 +67,7 @@ Keywords are case-insensitive (`ignore(case)`). Identifiers have lower priority 
 
 ### Token Demotion Pattern
 
-**When to use**: When a keyword is only valid under certain conditions (e.g., Edition 3 mode, or a dialect extension flag) and programs may use that keyword as an identifier otherwise.
+**When to use**: When a keyword is only valid under certain conditions (e.g., Edition 3 mode, or an extension flag) and programs may use that keyword as an identifier otherwise.
 
 **How it works**: Define the token as a specific type in the lexer, then "demote" it to `TokenType::Identifier` in a transform pass when the feature is disabled.
 
@@ -165,7 +165,7 @@ pub fn insert_keyword_statement_terminators(
 
 ## Non-Standard Syntax Gating (`--allow-x` Flags)
 
-**Rule**: Anything not in the IEC 61131-3 standard **must** be gated behind an `--allow-x` flag. Using `--dialect=rusty` enables all dialect extensions.
+**Rule**: Anything not in the IEC 61131-3 standard **must** be gated behind an `--allow-x` flag. Using `--dialect=rusty` enables the broadest set of extensions.
 
 ### Before Creating a New Flag
 
@@ -190,7 +190,7 @@ your syntax.
 
 Dialects (`--dialect`) set the base configuration. Individual `--allow-*` flags can override on top.
 
-| Dialect | `--dialect` value | Edition 3 types | REF_TO | Dialect extensions |
+| Dialect | `--dialect` value | Edition 3 types | REF_TO | Extensions |
 |---------|-------------------|----------------|--------|-------------------|
 | IEC 61131-3 Ed 2 (default) | `iec61131-3-ed2` | OFF | OFF | all OFF |
 | IEC 61131-3 Ed 3 | `iec61131-3-ed3` | ON | ON | all OFF |
@@ -254,7 +254,7 @@ Add the clap argument:
 
 ```rust
 /// Allow [description of what this enables].
-/// This is a dialect extension not part of the IEC 61131-3 standard.
+/// This is an extension not part of the IEC 61131-3 standard.
 #[arg(long)]
 allow_my_extension: bool,
 ```
@@ -293,7 +293,7 @@ Use either the token demotion pattern, validation rule pattern, or analyzer-leve
 #### 6. Documentation
 
 Update these files to document the new flag:
-- `docs/explanation/enabling-dialects-and-features.rst` — add to the Dialect Extensions section
+- `docs/explanation/enabling-dialects-and-features.rst` — add to the Language Extensions section
 - `docs/reference/compiler/ironplcc.rst` — add to the Options section
 - Update the flag table in this file (syntax-support-guide.md)
 
@@ -502,7 +502,7 @@ New demotion transforms must be called in `tokenize_program()` **before** `check
 - **Missing LSP wiring**: The flag works on the CLI but not in VS Code because `extract_compiler_options()` in `plc2x/src/lsp.rs` was not updated. Always add LSP extraction for new flags.
 - **No round-trip test**: The feature parses but the renderer in `plc2plc` cannot write it back. Always add the round-trip test.
 - **No execution test**: The feature parses and analyzes but was never proven to execute correctly. Always add at least one end-to-end test.
-- **Creating a flag for standard syntax**: Only dialect extensions get `--allow-x` flags. Standard IEC 61131-3 syntax is always on (or gated by `--dialect`).
+- **Creating a flag for standard syntax**: Only extensions get `--allow-x` flags. Standard IEC 61131-3 syntax is always on (or gated by `--dialect`).
 - **Stateful lexer changes**: The lexer (`logos`) is stateless. Use token transforms for context-dependent behavior, not lexer rules.
 - **Not registering transforms**: Adding a new `xform_*.rs` module but forgetting to call it from `tokenize_program()` in `parser/src/lib.rs`, or adding a new rule module but forgetting to register it in `check_tokens()`.
 
@@ -510,7 +510,7 @@ New demotion transforms must be called in `tokenize_program()` **before** `check
 
 This walkthrough shows the typical sequence for adding a new syntax feature.
 
-### Example: Adding Support for a Hypothetical Dialect Extension
+### Example: Adding Support for a Hypothetical Language Extension
 
 Suppose a vendor allows `REPEAT ... UNTIL ... END_REPEAT` with an optional `LIMIT` clause (non-standard).
 


### PR DESCRIPTION
Rename the syntax-sense uses of "vendor" to "dialect"/"extension" per the
new glossary (specs/steering/glossary.md), while keeping "vendor" where it
correctly names a product / runtime / library.

A dialect is what you parse against; a vendor is what you emulate the runtime
of. The two had drifted together throughout the codebase.

Renamed (syntax sense):
- Trait `VendorExtension` -> `DialectExtension` (dsl/extension.rs and its
  impls on FunctionBlockOop / InterfaceDeclaration; rule_unsupported_extension)
- "vendor extension" -> "dialect extension" / "extension" in code comments,
  CLI help, LSP/MCP text, docs, and design specs
- "vendor dialect" -> "dialect"; "vendor-specific syntax" -> "non-standard"
- `$vendor_field` macro metavar and `*_vendor_flags` test helpers/names ->
  dialect/flag naming
- docs/includes/requires-vendor-extension.rst -> requires-dialect-extension.rst
  (+ all include references and section headings)
- Fixed Extension Library mislabeling: __SYSTEM_UP_TIME globals are IronPLC's
  own conventions, not a vendor feature

Kept (product / runtime sense):
- `ExtensionOrigin` / `extension_origins` (they enumerate real vendors)
- Vendor Compatibility Shims, "vendor files/toolchain/platform",
  "vendor-compatible dialect", subtractive "Vendor Restrictions"

Preserved verbatim (external schema): `vendor`/`vendorElement` in the
PLCopen / IEC TC6 XML schema and the mirroring TextMate grammar.

Annotated ADR-0012 with a glossary pointer instead of rewriting its history.

CI (cd compiler && just) and the Sphinx docs build (-W) both pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CxV5Z2QdvBcp8XNGxbWccj