### PR TITLE
feat(libraries): compatibility libraries phase 3 — round-trip fidelity + playground

### DIFF
--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -19,6 +19,7 @@ use ironplc_codegen::compile as codegen_compile;
 use ironplc_container::debug_format::{build_var_debug_map, VarDebugInfo};
 use ironplc_container::debug_section::iec_type_tag;
 use ironplc_container::{Container, STRING_HEADER_BYTES};
+use ironplc_dsl::common::Library;
 use ironplc_dsl::core::FileId;
 use ironplc_dsl::diagnostic::{Diagnostic, LineColumn};
 use ironplc_parser::options::{CompilerOptions, Dialect, FeatureDescriptor};
@@ -186,6 +187,23 @@ fn diagnostic_info(diag: &Diagnostic, source: &str) -> DiagnosticInfo {
         end_column: end.column + 1,
         compiler_file: diag.source_file.clone().unwrap_or_default(),
         compiler_line: diag.source_line.unwrap_or(0),
+    }
+}
+
+/// Build an `INTERNAL` [`DiagnosticInfo`] for a playground-side failure that has
+/// no user-source location (e.g. a malformed library payload from the host).
+fn internal_diagnostic(message: String) -> DiagnosticInfo {
+    DiagnosticInfo {
+        code: "INTERNAL".to_string(),
+        message,
+        label: String::new(),
+        help: Vec::new(),
+        start_line: 1,
+        start_column: 1,
+        end_line: 1,
+        end_column: 1,
+        compiler_file: String::new(),
+        compiler_line: 0,
     }
 }
 
@@ -506,16 +524,67 @@ struct StepResult {
 /// ```
 /// Line and column are 1-based.
 #[wasm_bindgen]
-pub fn compile(source: &str, dialect: &str, allows: &str) -> String {
-    let result = compile_inner(source, dialect, allows);
+pub fn compile(source: &str, dialect: &str, allows: &str, libraries: &str) -> String {
+    let result = compile_inner(source, dialect, allows, libraries);
     serde_json::to_string(&result).unwrap_or_else(|e| {
         format!(r#"{{"ok":false,"diagnostics":[{{"code":"INTERNAL","message":"Serialization error: {e}","label":"","start_line":1,"start_column":1,"end_line":1,"end_column":1}}]}}"#)
     })
 }
 
-fn compile_inner(source: &str, dialect: &str, allows: &str) -> CompileResult {
+/// Parse the activated compatibility libraries from their served plain-text
+/// sources (`REQ-CL-playground-001`).
+///
+/// `libraries` is a JSON array of ST source strings — the plain-text library
+/// files the browser fetched from the app's served assets. Each is parsed into
+/// a [`Library`] to be injected ahead of user source in analysis, so its
+/// symbols (e.g. `Tc2_System`'s `PI`) resolve under their exact vendor names.
+/// An empty or blank string activates no library.
+fn parse_activated_libraries(
+    libraries: &str,
+    options: &CompilerOptions,
+) -> Result<Vec<Library>, CompileResult> {
+    if libraries.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let sources: Vec<String> = serde_json::from_str(libraries).map_err(|e| CompileResult {
+        ok: false,
+        bytecode: None,
+        diagnostics: vec![internal_diagnostic(format!(
+            "Failed to parse library sources: {e}"
+        ))],
+    })?;
+
+    let mut parsed = Vec::with_capacity(sources.len());
+    for source in &sources {
+        let file_type = FileType::from_content(source);
+        match parse_source(file_type, source, &FileId::default(), options) {
+            Ok(lib) => parsed.push(lib),
+            Err(diag) => {
+                return Err(CompileResult {
+                    ok: false,
+                    bytecode: None,
+                    diagnostics: vec![diagnostic_info(&diag, source)],
+                });
+            }
+        }
+    }
+    Ok(parsed)
+}
+
+fn compile_inner(source: &str, dialect: &str, allows: &str, libraries: &str) -> CompileResult {
     let file_type = FileType::from_content(source);
     let options = compiler_options_from(dialect, allows);
+
+    // Activated compatibility libraries, loaded from their served plain-text
+    // files. They are injected ahead of user source (base stdlib -> library ->
+    // user), so a user declaration shadows a library declaration of the same
+    // name (`REQ-CL-playground-001`).
+    let compat_libraries = match parse_activated_libraries(libraries, &options) {
+        Ok(libs) => libs,
+        Err(result) => return result,
+    };
+
     let library = match parse_source(file_type, source, &FileId::default(), &options) {
         Ok(lib) => lib,
         Err(diag) => {
@@ -531,7 +600,11 @@ fn compile_inner(source: &str, dialect: &str, allows: &str) -> CompileResult {
     // Type resolution populates expr.resolved_type so codegen can select
     // correct opcodes. Semantic checks catch errors like undeclared variables,
     // wrong argument counts, type mismatches, etc.
-    let (library, context) = match analyze(&[&library], &options) {
+    let analyze_input: Vec<&Library> = compat_libraries
+        .iter()
+        .chain(std::iter::once(&library))
+        .collect();
+    let (library, context) = match analyze(&analyze_input, &options) {
         Ok((resolved_lib, ctx)) => (resolved_lib, ctx),
         Err(diagnostics) => {
             return CompileResult {
@@ -726,15 +799,27 @@ fn run_bytes(bytes: &[u8], scans: u32) -> RunResult {
 ///
 /// Returns a JSON string with both compilation diagnostics and execution results.
 #[wasm_bindgen]
-pub fn run_source(source: &str, scans: u32, dialect: &str, allows: &str) -> String {
-    let result = run_source_inner(source, scans, dialect, allows);
+pub fn run_source(
+    source: &str,
+    scans: u32,
+    dialect: &str,
+    allows: &str,
+    libraries: &str,
+) -> String {
+    let result = run_source_inner(source, scans, dialect, allows, libraries);
     serde_json::to_string(&result).unwrap_or_else(|e| {
         format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"scans_completed":0,"error":{{"message":"Serialization error: {e}"}}}}"#)
     })
 }
 
-fn run_source_inner(source: &str, scans: u32, dialect: &str, allows: &str) -> RunSourceResult {
-    let compile_result = compile_inner(source, dialect, allows);
+fn run_source_inner(
+    source: &str,
+    scans: u32,
+    dialect: &str,
+    allows: &str,
+    libraries: &str,
+) -> RunSourceResult {
+    let compile_result = compile_inner(source, dialect, allows, libraries);
     if !compile_result.ok {
         return RunSourceResult {
             ok: false,
@@ -837,15 +922,27 @@ fn format_value(
 /// The session stores compiled bytecode and a variable buffer that persists
 /// across calls to [`step`]. Returns a JSON `StepResult` with `total_scans: 0`.
 #[wasm_bindgen]
-pub fn load_program(source: &str, cycle_time_us: u32, dialect: &str, allows: &str) -> String {
-    let result = load_program_inner(source, cycle_time_us, dialect, allows);
+pub fn load_program(
+    source: &str,
+    cycle_time_us: u32,
+    dialect: &str,
+    allows: &str,
+    libraries: &str,
+) -> String {
+    let result = load_program_inner(source, cycle_time_us, dialect, allows, libraries);
     serde_json::to_string(&result).unwrap_or_else(|e| {
         format!(r#"{{"ok":false,"diagnostics":[],"variables":[],"total_scans":0,"error":{{"message":"Serialization error: {e}"}}}}"#)
     })
 }
 
-fn load_program_inner(source: &str, cycle_time_us: u32, dialect: &str, allows: &str) -> StepResult {
-    let compile_result = compile_inner(source, dialect, allows);
+fn load_program_inner(
+    source: &str,
+    cycle_time_us: u32,
+    dialect: &str,
+    allows: &str,
+    libraries: &str,
+) -> StepResult {
+    let compile_result = compile_inner(source, dialect, allows, libraries);
     if !compile_result.ok {
         return StepResult {
             ok: false,
@@ -1118,7 +1215,7 @@ PROGRAM main
   x := 42;
 END_PROGRAM
 ";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(result.ok);
         assert!(result.bytecode.is_some());
         assert!(result.diagnostics.is_empty());
@@ -1127,7 +1224,7 @@ END_PROGRAM
     #[test]
     fn compile_when_syntax_error_then_returns_diagnostics() {
         let source = "PROGRAM main INVALID END_PROGRAM";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(result.bytecode.is_none());
         assert!(!result.diagnostics.is_empty());
@@ -1138,7 +1235,7 @@ END_PROGRAM
     fn compile_when_error_on_later_line_then_diagnostic_has_line_and_column() {
         // Line numbers are 1-based; the error is after the first line.
         let source = "PROGRAM main\nVAR\nEND_VAR\nINVALID\nEND_PROGRAM";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
         let diag = &result.diagnostics[0];
@@ -1161,7 +1258,8 @@ PROGRAM main
   x := 42;
 END_PROGRAM
 ";
-        let compile_result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let compile_result: CompileResult =
+            serde_json::from_str(&compile(source, "", "", "")).unwrap();
         let bytecode = compile_result.bytecode.unwrap();
 
         let result: RunResult = serde_json::from_str(&run(&bytecode, 1)).unwrap();
@@ -1186,7 +1284,8 @@ PROGRAM main
   x := 1 / y;
 END_PROGRAM
 ";
-        let compile_result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let compile_result: CompileResult =
+            serde_json::from_str(&compile(source, "", "", "")).unwrap();
         let bytecode = compile_result.bytecode.unwrap();
 
         let json = run(&bytecode, 1);
@@ -1225,7 +1324,8 @@ PROGRAM main
   y := x + 32;
 END_PROGRAM
 ";
-        let result: RunSourceResult = serde_json::from_str(&run_source(source, 1, "", "")).unwrap();
+        let result: RunSourceResult =
+            serde_json::from_str(&run_source(source, 1, "", "", "")).unwrap();
         assert!(result.ok);
         assert!(result.diagnostics.is_empty());
         assert!(result.error.is_none());
@@ -1238,7 +1338,8 @@ END_PROGRAM
     #[test]
     fn run_source_when_syntax_error_then_returns_diagnostics() {
         let source = "PROGRAM main INVALID END_PROGRAM";
-        let result: RunSourceResult = serde_json::from_str(&run_source(source, 1, "", "")).unwrap();
+        let result: RunSourceResult =
+            serde_json::from_str(&run_source(source, 1, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
         assert_eq!(result.scans_completed, 0);
@@ -1254,7 +1355,8 @@ PROGRAM main
   x := 99;
 END_PROGRAM
 ";
-        let result: RunSourceResult = serde_json::from_str(&run_source(source, 5, "", "")).unwrap();
+        let result: RunSourceResult =
+            serde_json::from_str(&run_source(source, 5, "", "", "")).unwrap();
         assert!(result.ok);
         assert_eq!(result.scans_completed, 5);
         assert_eq!(result.variables[2].value, "99"); // indices 0-1 are system globals
@@ -1270,7 +1372,7 @@ PROGRAM main
   x := 1;
 END_PROGRAM
 ";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         let bytecode = result.bytecode.unwrap();
         let decoded = BASE64.decode(&bytecode);
         assert!(decoded.is_ok());
@@ -1287,7 +1389,8 @@ PROGRAM main
   x := 42;
 END_PROGRAM
 ";
-        let compile_result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let compile_result: CompileResult =
+            serde_json::from_str(&compile(source, "", "", "")).unwrap();
         let bytecode = compile_result.bytecode.unwrap();
 
         let result: RunResult = serde_json::from_str(&run(&bytecode, 0)).unwrap();
@@ -1309,7 +1412,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let result: StepResult =
-            serde_json::from_str(&load_program(source, 100_000, "", "")).unwrap();
+            serde_json::from_str(&load_program(source, 100_000, "", "", "")).unwrap();
         assert!(result.ok);
         assert_eq!(result.total_scans, 0);
         assert!(result.diagnostics.is_empty());
@@ -1321,7 +1424,7 @@ END_PROGRAM
         reset_session();
         let source = "PROGRAM main INVALID END_PROGRAM";
         let result: StepResult =
-            serde_json::from_str(&load_program(source, 100_000, "", "")).unwrap();
+            serde_json::from_str(&load_program(source, 100_000, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
     }
@@ -1345,7 +1448,7 @@ PROGRAM main
   x := 42;
 END_PROGRAM
 ";
-        load_program(source, 100_000, "", "");
+        load_program(source, 100_000, "", "", "");
         let result: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert!(result.ok);
         assert_eq!(result.total_scans, 1);
@@ -1364,7 +1467,7 @@ PROGRAM main
   count := count + 1;
 END_PROGRAM
 ";
-        load_program(source, 100_000, "", "");
+        load_program(source, 100_000, "", "", "");
 
         let r1: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert!(r1.ok);
@@ -1386,7 +1489,7 @@ PROGRAM main
   x := 1;
 END_PROGRAM
 ";
-        load_program(source, 100_000, "", "");
+        load_program(source, 100_000, "", "", "");
 
         let r1: StepResult = serde_json::from_str(&step(3)).unwrap();
         assert_eq!(r1.total_scans, 3);
@@ -1408,7 +1511,7 @@ PROGRAM main
   x := 1 / y;
 END_PROGRAM
 ";
-        load_program(source, 100_000, "", "");
+        load_program(source, 100_000, "", "", "");
 
         // First step should fault (divide by zero)
         let r1: StepResult = serde_json::from_str(&step(1)).unwrap();
@@ -1431,7 +1534,7 @@ PROGRAM main
   x := 1;
 END_PROGRAM
 ";
-        load_program(source, 100_000, "", "");
+        load_program(source, 100_000, "", "", "");
         step(1);
 
         reset_session();
@@ -1476,7 +1579,7 @@ bSwitch := TRUE;
     </pous>
   </types>
 </project>"#;
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(
             result.ok,
             "Expected ok but got diagnostics: {:?}",
@@ -1499,7 +1602,7 @@ END_VAR]]></Declaration>
     </Implementation>
   </POU>
 </TcPlcObject>"#;
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(
             result.ok,
             "Expected ok but got diagnostics: {:?}",
@@ -1511,7 +1614,7 @@ END_VAR]]></Declaration>
     #[test]
     fn compile_when_malformed_xml_then_returns_diagnostics() {
         let source = "<?xml version=\"1.0\"?><project><invalid";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
     }
@@ -1527,7 +1630,7 @@ PROGRAM main
   x := 10;
 END_PROGRAM
 ";
-        load_program(source_a, 100_000, "", "");
+        load_program(source_a, 100_000, "", "", "");
         let r1: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert_eq!(r1.variables[2].value, "10"); // indices 0-1 are system globals
 
@@ -1539,7 +1642,7 @@ PROGRAM main
   x := 20;
 END_PROGRAM
 ";
-        load_program(source_b, 100_000, "", "");
+        load_program(source_b, 100_000, "", "", "");
         let r2: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert_eq!(r2.variables[2].value, "20"); // indices 0-1 are system globals
         assert_eq!(r2.total_scans, 1);
@@ -1556,7 +1659,7 @@ PROGRAM main
   exponentially := exponentially * 2;
 END_PROGRAM
 ";
-        load_program(source, 100_000, "", "");
+        load_program(source, 100_000, "", "", "");
 
         let r1: StepResult = serde_json::from_str(&step(1)).unwrap();
         assert!(r1.ok);
@@ -1584,7 +1687,8 @@ PROGRAM main
   int_val := BCD_TO_INT(BYTE#16#42);
 END_PROGRAM
 ";
-        let result: RunSourceResult = serde_json::from_str(&run_source(source, 1, "", "")).unwrap();
+        let result: RunSourceResult =
+            serde_json::from_str(&run_source(source, 1, "", "", "")).unwrap();
         assert!(result.ok, "Expected ok but got error: {:?}", result.error);
         assert_eq!(result.variables[2].value, "42"); // indices 0-1 are system globals
     }
@@ -1599,7 +1703,8 @@ PROGRAM main
   bcd_val := INT_TO_BCD(USINT#42);
 END_PROGRAM
 ";
-        let result: RunSourceResult = serde_json::from_str(&run_source(source, 1, "", "")).unwrap();
+        let result: RunSourceResult =
+            serde_json::from_str(&run_source(source, 1, "", "", "")).unwrap();
         assert!(result.ok, "Expected ok but got error: {:?}", result.error);
         assert_eq!(result.variables[2].value, "16#42"); // indices 0-1 are system globals
     }
@@ -1617,7 +1722,7 @@ PROGRAM main
   %QX0.0 := TRUE;
 END_PROGRAM
 ";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(!result.ok);
         let diag = result
             .diagnostics
@@ -1642,7 +1747,7 @@ PROGRAM main
   x := undeclared_var;
 END_PROGRAM
 ";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
     }
@@ -1664,7 +1769,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let load: StepResult =
-            serde_json::from_str(&load_program(source, 100_000, "", "")).unwrap();
+            serde_json::from_str(&load_program(source, 100_000, "", "", "")).unwrap();
         assert!(
             load.ok,
             "load failed: error={:?}, diagnostics={:?}",
@@ -1708,7 +1813,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let load: StepResult =
-            serde_json::from_str(&load_program(source, 100_000, "", "")).unwrap();
+            serde_json::from_str(&load_program(source, 100_000, "", "", "")).unwrap();
         assert!(
             load.ok,
             "load failed: error={:?}, diagnostics={:?}",
@@ -1789,7 +1894,8 @@ PROGRAM main
   END_VAR
 END_PROGRAM
 ";
-        let result: RunSourceResult = serde_json::from_str(&run_source(source, 1, "", "")).unwrap();
+        let result: RunSourceResult =
+            serde_json::from_str(&run_source(source, 1, "", "", "")).unwrap();
         assert!(
             result.ok,
             "Expected ok but got diagnostics: {:?}, error: {:?}",
@@ -1845,7 +1951,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let result: CompileResult =
-            serde_json::from_str(&compile(source, "iec61131-3-ed3", "")).unwrap();
+            serde_json::from_str(&compile(source, "iec61131-3-ed3", "", "")).unwrap();
         assert!(
             result.ok,
             "Expected ok but got diagnostics: {:?}",
@@ -1864,7 +1970,7 @@ PROGRAM main
   duration := LTIME#100ms;
 END_PROGRAM
 ";
-        let result: CompileResult = serde_json::from_str(&compile(source, "", "")).unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
     }
@@ -1881,7 +1987,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let result: StepResult =
-            serde_json::from_str(&load_program(source, 100_000, "iec61131-3-ed3", "")).unwrap();
+            serde_json::from_str(&load_program(source, 100_000, "iec61131-3-ed3", "", "")).unwrap();
         assert!(
             result.ok,
             "Expected ok but got error: {:?}, diagnostics: {:?}",
@@ -1905,7 +2011,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let result: CompileResult =
-            serde_json::from_str(&compile(source, "iec61131-3-ed3", "")).unwrap();
+            serde_json::from_str(&compile(source, "iec61131-3-ed3", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
     }
@@ -1922,7 +2028,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let result: CompileResult =
-            serde_json::from_str(&compile(source, "iec61131-3-ed3", "sizeof")).unwrap();
+            serde_json::from_str(&compile(source, "iec61131-3-ed3", "sizeof", "")).unwrap();
         assert!(
             result.ok,
             "Expected ok but got diagnostics: {:?}",
@@ -1941,9 +2047,13 @@ PROGRAM main
   x := 1;
 END_PROGRAM
 ";
-        let result: CompileResult =
-            serde_json::from_str(&compile(source, "iec61131-3-ed3", "not-a-real-flag,sizeof"))
-                .unwrap();
+        let result: CompileResult = serde_json::from_str(&compile(
+            source,
+            "iec61131-3-ed3",
+            "not-a-real-flag,sizeof",
+            "",
+        ))
+        .unwrap();
         assert!(result.ok);
     }
 
@@ -1964,6 +2074,7 @@ END_PROGRAM
             source,
             "iec61131-3-ed3",
             " sizeof , c-style-comments ",
+            "",
         ))
         .unwrap();
         assert!(result.ok, "Expected ok but got: {:?}", result.diagnostics);
@@ -2012,7 +2123,7 @@ PROGRAM main
 END_PROGRAM
 ";
         let result: CompileResult =
-            serde_json::from_str(&compile(source, "iec61131-3-ed2", "")).unwrap();
+            serde_json::from_str(&compile(source, "iec61131-3-ed2", "", "")).unwrap();
         assert!(!result.ok);
         let cstyle = result
             .diagnostics
@@ -2033,7 +2144,8 @@ PROGRAM main
   x := 1;
 END_PROGRAM
 ";
-        let result: CompileResult = serde_json::from_str(&compile(source, "codesys", "")).unwrap();
+        let result: CompileResult =
+            serde_json::from_str(&compile(source, "codesys", "", "")).unwrap();
         assert!(result.ok, "Expected ok but got: {:?}", result.diagnostics);
     }
 }

--- a/compiler/playground/src/spec_conformance.rs
+++ b/compiler/playground/src/spec_conformance.rs
@@ -2,12 +2,11 @@
 //! requirement).
 //!
 //! The `all_spec_requirements_have_tests` meta-test asserts every
-//! playground-owned requirement has a test here. The browser-activation
-//! behavior lands with the playground phase; wired here as an ignored test so
-//! the meta-test passes.
+//! playground-owned requirement has a test here.
 //!
 //! See `specs/design/compatibility-libraries.md`.
 
+use serde_json::Value;
 use spec_test_macro::spec_test;
 
 #[test]
@@ -19,8 +18,41 @@ fn all_spec_requirements_have_tests() {
     );
 }
 
+/// A user POU that uses `PI`, the constant `Tc2_System` provides. Standing
+/// alone the name is undefined; it resolves only when the library is activated.
+const PI_PROGRAM: &str = "PROGRAM main
+VAR
+    d2r : LREAL := PI / 180.0;
+END_VAR
+END_PROGRAM";
+
+/// The plain-text `Tc2_System` library file, as served alongside the app and
+/// fetched by the browser. Injecting it activates the library.
+const TC2_SYSTEM_ST: &str =
+    "VAR_GLOBAL CONSTANT PI : LREAL := 3.1415926535897932384626433832795; END_VAR";
+
+fn compile_ok(source: &str, libraries: &str) -> bool {
+    let json = crate::compile(source, "", "", libraries);
+    let value: Value = serde_json::from_str(&json).expect("compile returns JSON");
+    value["ok"] == Value::Bool(true)
+}
+
 /// REQ-CL-playground-001: The playground activates a library by loading it from
 /// the plain-text library files served alongside the app.
 #[spec_test(REQ_CL_playground_001)]
-#[ignore = "phase 3: serve and load library files in the browser playground"]
-fn playground_spec_req_cl_001_activates_library_from_served_files() {}
+fn playground_spec_req_cl_001_activates_library_from_served_files() {
+    // With no library activated, `PI` is undefined and the compile fails.
+    assert!(
+        !compile_ok(PI_PROGRAM, ""),
+        "PI must be undefined when no library is loaded"
+    );
+
+    // Loading the served library file (as the browser would, passing its text
+    // as a JSON array of sources) activates the library: `PI` resolves, folds
+    // at compile time, and the same source compiles.
+    let libraries = serde_json::to_string(&[TC2_SYSTEM_ST]).expect("serialize library sources");
+    assert!(
+        compile_ok(PI_PROGRAM, &libraries),
+        "loading the served library file must make PI resolve"
+    );
+}

--- a/compiler/plc2plc/src/spec_conformance.rs
+++ b/compiler/plc2plc/src/spec_conformance.rs
@@ -94,13 +94,58 @@ fn plc2plc_spec_req_rto_602_ref_to_still_renders() {
 // ---------------------------------------------------------------------------
 // Compatibility libraries (plc2plc-owned requirement).
 //
-// See `specs/design/compatibility-libraries.md`. The round-trip guarantee for
-// injected library declarations lands with the playground/round-trip phase;
-// wired here as an ignored test so the meta-test passes.
+// See `specs/design/compatibility-libraries.md`. An activated library injects
+// its declarations into semantic analysis only — as a *separate* `Library`
+// that is merged for type resolution but never handed to `plc2plc`. `plc2plc`
+// renders exactly the library it is given, so rendering the user's source
+// reproduces it unchanged and never emits the injected declarations.
 // ---------------------------------------------------------------------------
 
 /// REQ-CL-plc2plc-001: `plc2plc` emits the user's source unchanged; declarations
 /// injected by an activated library are never rendered as user source.
 #[spec_test(REQ_CL_plc2plc_001)]
-#[ignore = "phase 3: round-trip fidelity with injected library declarations"]
-fn plc2plc_spec_req_cl_001_injected_declarations_not_rendered() {}
+fn plc2plc_spec_req_cl_001_injected_declarations_not_rendered() {
+    // A user POU that *uses* `PI`, exactly as a TwinCAT source would. `PI` is a
+    // constant the activated `Tc2_System` library provides; the user never
+    // writes its declaration.
+    let user_source = "PROGRAM main
+VAR
+    d2r : LREAL := PI / 180.0;
+END_VAR
+END_PROGRAM";
+
+    // The declarations an activated library injects: `Tc2_System`'s global
+    // constant `PI`. In a real compile these are parsed into a *separate*
+    // `Library` (see `ironplc_sources::libraries`) that is merged for analysis
+    // only; `plc2plc` is only ever handed the user's library.
+    let library_source =
+        "VAR_GLOBAL CONSTANT PI : LREAL := 3.1415926535897932384626433832795; END_VAR";
+
+    let options = CompilerOptions::default();
+
+    // Rendering the user's library round-trips its source: the *use* of `PI` is
+    // preserved...
+    let rendered_user = render(user_source, &options);
+    assert!(
+        rendered_user.contains("PI"),
+        "the user's use of PI must be preserved:\n{rendered_user}"
+    );
+    // ...but the injected library *declaration* is never emitted as user source.
+    assert!(
+        !rendered_user.contains("VAR_GLOBAL"),
+        "an injected VAR_GLOBAL declaration must not be rendered:\n{rendered_user}"
+    );
+    assert!(
+        !rendered_user.contains("3.1415926535897932384626433832795"),
+        "the injected PI constant value must not be rendered:\n{rendered_user}"
+    );
+
+    // The exclusion is a property of *what `plc2plc` is handed*, not an
+    // inability to render the declaration: handed the library, it renders the
+    // constant faithfully.
+    let rendered_library = render(library_source, &options);
+    assert!(
+        rendered_library.contains("PI") && rendered_library.contains("VAR_GLOBAL"),
+        "the library declaration must render when it is the input:\n{rendered_library}"
+    );
+}

--- a/playground/justfile
+++ b/playground/justfile
@@ -15,6 +15,10 @@ compile:
   npx tsc -p tsconfig.worker.json
   cp posthog-init.js _build/
   cp *.html *.css *.txt *.xml _build/
+  # Serve the compatibility libraries as plain-text files and generate the
+  # fetch index the browser uses to activate a library (REQ-CL-playground-001).
+  cp -r ../compiler/sources/resources/libs _build/libs
+  node scripts/gen-libs-index.mjs _build
 
 # Run end-to-end tests (requires a compiled _build/)
 test: compile

--- a/playground/scripts/gen-libs-index.mjs
+++ b/playground/scripts/gen-libs-index.mjs
@@ -1,0 +1,51 @@
+// Generate `libs/index.json` for the served compatibility libraries.
+//
+// The playground activates a compatibility library by fetching its plain-text
+// `.st` files, served alongside the app (REQ-CL-playground-001). Static hosts
+// do not offer directory listing, so the browser cannot discover a library's
+// files on its own. This build step scans the copied `libs/` tree and writes an
+// index mapping each library name to the paths of its `.st` files (relative to
+// the app root), which `app.ts` fetches to load a library.
+//
+// Usage: `node scripts/gen-libs-index.mjs <served-root>` (e.g. `_build`).
+
+import { readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const root = process.argv[2];
+if (!root) {
+  console.error("usage: gen-libs-index.mjs <served-root>");
+  process.exit(1);
+}
+
+const libsDir = join(root, "libs");
+
+// Recursively collect the `.st` files under `dir` (a library's version
+// subdirectories hold the declarations).
+function stFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...stFiles(full));
+    } else if (entry.endsWith(".st")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// name -> [ "libs/<Name>/<version>/<file>.st", ... ], paths relative to the
+// served app root so the browser can fetch them directly.
+const index = {};
+for (const name of readdirSync(libsDir)) {
+  const full = join(libsDir, name);
+  if (!statSync(full).isDirectory()) {
+    continue;
+  }
+  index[name] = stFiles(full)
+    .map((path) => relative(root, path))
+    .sort();
+}
+
+writeFileSync(join(libsDir, "index.json"), `${JSON.stringify(index, null, 2)}\n`);

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -388,6 +388,74 @@ const allowsParam = (params.get("allows") || "")
   .map((s) => s.trim())
   .filter((s) => s.length > 0);
 
+// `libraries` is a comma-separated list of compatibility-library names to
+// activate (e.g. "Tc2_System"), mirroring the CLI `--library` option and a
+// `.plcproj`'s referenced-library list. Each named library's declarations are
+// served alongside the app as plain-text `.st` files; we fetch and load them so
+// their symbols (e.g. `PI`) resolve, without editing the user's source
+// (REQ-CL-playground-001).
+const librariesParam = (params.get("libraries") || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0);
+
+// The served library sources, once fetched: a JSON array of `.st` file
+// contents ready to hand to the WASM compile path. Empty until fetched (and
+// when no library is activated), which the compiler treats as "no library".
+let activatedLibrarySources: string[] = [];
+
+// Index of the served compatibility libraries, generated at build time and
+// served at `libs/index.json`: library name -> the paths of its `.st` files
+// (relative to the app root). A static index avoids relying on directory
+// listing, which static hosts do not provide.
+type LibraryIndex = Record<string, string[]>;
+
+// Fetch and load the activated libraries' plain-text files. Best-effort: a
+// missing index or file leaves the affected library inactive (its symbols stay
+// undefined and surface as ordinary diagnostics) rather than blocking the app.
+async function loadActivatedLibraries(): Promise<void> {
+  if (librariesParam.length === 0) {
+    return;
+  }
+  let index: LibraryIndex;
+  try {
+    const response = await fetch("libs/index.json");
+    if (!response.ok) {
+      return;
+    }
+    index = (await response.json()) as LibraryIndex;
+  } catch {
+    return;
+  }
+
+  const sources: string[] = [];
+  for (const name of librariesParam) {
+    const files = index[name];
+    if (!files) {
+      continue;
+    }
+    for (const path of files) {
+      try {
+        const response = await fetch(path);
+        if (response.ok) {
+          sources.push(await response.text());
+        }
+      } catch {
+        // Skip a file that fails to load; its symbols stay undefined.
+      }
+    }
+  }
+  activatedLibrarySources = sources;
+}
+
+// The activated library sources as the WASM compile path expects them: a JSON
+// array of `.st` file contents, or "" when none are active.
+function getLibraries(): string {
+  return activatedLibrarySources.length > 0
+    ? JSON.stringify(activatedLibrarySources)
+    : "";
+}
+
 // Populate the dialect picker from the compiler-provided list (via the WASM
 // `dialects()` export), then apply the URL dialect parameter and dialect badge.
 // Called once the worker reports the WASM module is ready.
@@ -541,8 +609,13 @@ worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
     compilerVersion = msg.version || "";
     initDialects(msg.dialects);
     initAnalytics();
-    startBtn.disabled = false;
-    statusEl.textContent = "Ready";
+    // Fetch any activated compatibility libraries' served files before enabling
+    // Start, so the first compile already has them. The load is best-effort and
+    // resolves even if a file is missing.
+    void loadActivatedLibraries().finally(() => {
+      startBtn.disabled = false;
+      statusEl.textContent = "Ready";
+    });
     return;
   }
 
@@ -728,7 +801,15 @@ startBtn.addEventListener("click", async () => {
   const allows = getAllows();
   const compileStart = performance.now();
   capture("compile_attempted", { trigger: "manual" });
-  const loadMsg = await postCommand({ command: "load_program", source, cycleTimeUs, dialect, allows });
+  const libraries = getLibraries();
+  const loadMsg = await postCommand({
+    command: "load_program",
+    source,
+    cycleTimeUs,
+    dialect,
+    allows,
+    libraries,
+  });
   const compileDurationMs = performance.now() - compileStart;
 
   if (loadMsg.type === "error") {

--- a/playground/src/types/messages.d.ts
+++ b/playground/src/types/messages.d.ts
@@ -18,12 +18,17 @@ export interface DialectOption {
   is_default: boolean;
 }
 
+// A JSON array of plain-text compatibility-library sources to activate — the
+// served `.st` files the browser fetched. Omitted (or "") activates none.
+export type Libraries = string;
+
 export interface CompileRequest {
   id: number;
   command: "compile";
   source: string;
   dialect?: Dialect;
   allows?: string;
+  libraries?: Libraries;
 }
 
 export interface RunRequest {
@@ -40,6 +45,7 @@ export interface RunSourceRequest {
   scans: number;
   dialect?: Dialect;
   allows?: string;
+  libraries?: Libraries;
 }
 
 export interface LoadProgramRequest {
@@ -49,6 +55,7 @@ export interface LoadProgramRequest {
   cycleTimeUs: number;
   dialect?: Dialect;
   allows?: string;
+  libraries?: Libraries;
 }
 
 export interface StepRequest {

--- a/playground/src/types/wasm.d.ts
+++ b/playground/src/types/wasm.d.ts
@@ -10,26 +10,44 @@ declare module "*/pkg/ironplc_playground.js" {
   /** Installs a panic hook that forwards Rust panics to console.error. */
   export function init_panic_hook(): void;
 
-  /** Returns a JSON-encoded compilation result (diagnostics + bytecode). */
-  export function compile(source: string, dialect: string, allows: string): string;
+  /**
+   * Returns a JSON-encoded compilation result (diagnostics + bytecode).
+   *
+   * `libraries` is a JSON array of plain-text compatibility-library sources
+   * (the served `.st` files the browser fetched) to activate, or `""` for none.
+   */
+  export function compile(
+    source: string,
+    dialect: string,
+    allows: string,
+    libraries: string,
+  ): string;
 
   /** Runs previously compiled bytecode for `scans` cycles. Returns JSON. */
   export function run(bytecodeBase64: string, scans: number): string;
 
-  /** Compiles and runs source in one step. Returns JSON. */
+  /**
+   * Compiles and runs source in one step. Returns JSON. `libraries` is a JSON
+   * array of compatibility-library sources to activate, or `""` for none.
+   */
   export function run_source(
     source: string,
     scans: number,
     dialect: string,
     allows: string,
+    libraries: string,
   ): string;
 
-  /** Loads a program into the persistent session. Returns JSON. */
+  /**
+   * Loads a program into the persistent session. Returns JSON. `libraries` is a
+   * JSON array of compatibility-library sources to activate, or `""` for none.
+   */
   export function load_program(
     source: string,
     cycleTimeUs: number,
     dialect: string,
     allows: string,
+    libraries: string,
   ): string;
 
   /** Steps the current session by `scans` cycles. Returns JSON. */

--- a/playground/src/worker.ts
+++ b/playground/src/worker.ts
@@ -65,16 +65,28 @@ self.onmessage = (e: MessageEvent) => {
     let json: string;
     switch (data.command) {
       case "compile":
-        json = compile(data.source, data.dialect || "", data.allows || "");
+        json = compile(data.source, data.dialect || "", data.allows || "", data.libraries || "");
         break;
       case "run":
         json = run(data.bytecodeBase64, data.scans);
         break;
       case "run_source":
-        json = run_source(data.source, data.scans, data.dialect || "", data.allows || "");
+        json = run_source(
+          data.source,
+          data.scans,
+          data.dialect || "",
+          data.allows || "",
+          data.libraries || "",
+        );
         break;
       case "load_program":
-        json = load_program(data.source, data.cycleTimeUs || 100000, data.dialect || "", data.allows || "");
+        json = load_program(
+          data.source,
+          data.cycleTimeUs || 100000,
+          data.dialect || "",
+          data.allows || "",
+          data.libraries || "",
+        );
         break;
       case "step":
         json = step(data.scans);

--- a/specs/plans/2026-08-04-compatibility-libraries.md
+++ b/specs/plans/2026-08-04-compatibility-libraries.md
@@ -165,11 +165,11 @@ source**, so a user declaration shadows a library declaration of the same name
 - [x] `cd compiler && just` green
 
 ### Phase 3 — Round-trip fidelity + playground
-- [ ] `plc2plc` emits user source unchanged; injected library declarations are never rendered — **REQ-CL-plc2plc-001**
-- [ ] Wire `plc2plc` `build.rs` + `spec_conformance`; add the round-trip test
-- [ ] Playground: serve library files as plain text, load as sources, activate — **REQ-CL-playground-001**
-- [ ] Wire `playground` `build.rs` + spec test; update `playground/` frontend to fetch library files
-- [ ] `cd compiler && just` green
+- [x] `plc2plc` emits user source unchanged; injected library declarations are never rendered — **REQ-CL-plc2plc-001**
+- [x] Wire `plc2plc` `build.rs` + `spec_conformance`; add the round-trip test
+- [x] Playground: serve library files as plain text, load as sources, activate — **REQ-CL-playground-001**
+- [x] Wire `playground` `build.rs` + spec test; update `playground/` frontend to fetch library files
+- [x] `cd compiler && just` green
 
 ### Phase 4 — Provenance policy enforcement
 - [ ] Conformance test in `sources` walks every bundled manifest and asserts it records a non-empty `references` list (a factual record, no legal judgment) — **REQ-CL-sources-007**


### PR DESCRIPTION
Deliver Phase 3 of the compatibility-libraries plan.

plc2plc round-trip (REQ-CL-plc2plc-001): an activated library injects its
declarations into semantic analysis as a separate Library that is never handed
to plc2plc, so rendering user source reproduces it unchanged and never emits the
injected declarations. Implements the spec test (previously #[ignore]d).

Playground (REQ-CL-playground-001): the WASM compile/run_source/load_program
entry points take a `libraries` argument — a JSON array of plain-text library
sources — parsed and injected ahead of user source (base stdlib -> library ->
user), matching the CLI/project activation path. The frontend fetches the served
library files via a build-generated `libs/index.json` and activates libraries
named in the `libraries` URL parameter. Implements the spec test (previously
#[ignore]d).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015TDFE8LFWChCzb7gY4o6hb