### PR TITLE
feat(libraries): compatibility libraries phase 4 — provenance enforcement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ steering files under `specs/steering/`. These apply to all contributors:
 * **[Compiler Architecture](specs/steering/compiler-architecture.md)** - Patterns for implementing language features and semantic analysis
 * **[Problem Code Management](specs/steering/problem-code-management.md)** - Guidelines for error handling and diagnostic creation
 * **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules
+* **[Compatibility Library Authoring](specs/steering/compatibility-library-authoring.md)** - Licensing risk tiers, allowed/forbidden inputs, and the clean-room provenance record required for bundled compatibility libraries
 * **[Common Tasks](specs/steering/common-tasks.md)** - Full command reference for day-to-day development
 
 The steering files provide the detailed implementation guidance; this

--- a/compiler/CONTRIBUTING.md
+++ b/compiler/CONTRIBUTING.md
@@ -11,6 +11,7 @@ The compiler follows specific architectural patterns and coding standards define
 * [Problem Code Management](../specs/steering/problem-code-management.md) - Error handling patterns and diagnostic creation
 * [IEC 61131-3 Compliance](../specs/steering/iec-61131-3-compliance.md) - Standard compliance validation and type system rules
 * [Syntax Support Guide](../specs/steering/syntax-support-guide.md) - Checklist for adding new syntax (relevant for parser, codegen, and plc2plc work)
+* [Compatibility Library Authoring](../specs/steering/compatibility-library-authoring.md) - Licensing risk tiers, allowed/forbidden inputs, and the clean-room provenance record required when adding a bundled compatibility library under `sources/resources/libs/`
 
 These steering files provide detailed implementation guidance that complements the development workflow described below.
 

--- a/compiler/sources/src/libraries/mod.rs
+++ b/compiler/sources/src/libraries/mod.rs
@@ -150,6 +150,25 @@ impl LibraryRegistry {
         self.has_exact_dir(name) && self.manifest_path(name).is_file()
     }
 
+    /// Every bundled library available under the registry root.
+    ///
+    /// A library is an immediate subdirectory that holds a `library.toml`
+    /// manifest; the returned names are sorted so a walk over them is stable.
+    /// Used by the provenance conformance test to enforce the authoring policy
+    /// across every bundled manifest (`REQ-CL-sources-007`).
+    pub fn library_names(&self) -> Vec<LibraryName> {
+        let mut names: Vec<LibraryName> = match fs::read_dir(&self.root) {
+            Ok(entries) => entries
+                .filter_map(Result::ok)
+                .filter(|entry| entry.path().join("library.toml").is_file())
+                .filter_map(|entry| entry.file_name().to_str().map(LibraryName::from))
+                .collect(),
+            Err(_) => Vec::new(),
+        };
+        names.sort();
+        names
+    }
+
     fn manifest_path(&self, name: &LibraryName) -> PathBuf {
         self.root.join(name.as_str()).join("library.toml")
     }

--- a/compiler/sources/src/spec_conformance.rs
+++ b/compiler/sources/src/spec_conformance.rs
@@ -341,6 +341,34 @@ fn sources_spec_req_cl_004_diagnoses_unshipped_library() {
 /// REQ-CL-sources-007: The manifest records the public references the library
 /// was authored from (a non-empty `references` list), enforced as a provenance
 /// conformance test that walks every bundled manifest.
+///
+/// This is the machine-checkable half of the authoring policy in
+/// `specs/steering/compatibility-library-authoring.md`: every bundled library
+/// must record a factual, non-empty list of the public references it was
+/// authored from. The human-only half (no forbidden input was used, clearance
+/// was performed) stays a reviewer responsibility.
 #[spec_test(REQ_CL_sources_007)]
-#[ignore = "phase 4: provenance walk over every bundled manifest"]
-fn sources_spec_req_cl_007_provenance_references_recorded() {}
+fn sources_spec_req_cl_007_provenance_references_recorded() {
+    let registry = LibraryRegistry::bundled();
+    let names = registry.library_names();
+
+    // There is at least one bundled library to vouch for (guards against the
+    // walk silently passing over an empty or misrooted registry).
+    assert!(
+        !names.is_empty(),
+        "expected at least one bundled compatibility library"
+    );
+
+    for name in &names {
+        // Loading validates the manifest is well-formed (`from_toml` rejects a
+        // malformed or field-missing manifest) and, in particular, that its
+        // `references` list is non-empty.
+        let loaded = registry.load(name).unwrap_or_else(|diagnostic| {
+            panic!("bundled library `{name}` must load: {diagnostic:?}")
+        });
+        assert!(
+            !loaded.manifest.references.is_empty(),
+            "bundled library `{name}` must record a non-empty `references` list"
+        );
+    }
+}

--- a/specs/plans/2026-08-04-compatibility-libraries.md
+++ b/specs/plans/2026-08-04-compatibility-libraries.md
@@ -172,9 +172,9 @@ source**, so a user declaration shadows a library declaration of the same name
 - [x] `cd compiler && just` green
 
 ### Phase 4 — Provenance policy enforcement
-- [ ] Conformance test in `sources` walks every bundled manifest and asserts it records a non-empty `references` list (a factual record, no legal judgment) — **REQ-CL-sources-007**
-- [ ] Un-ignore sources-007; confirm the [authoring policy](../steering/compatibility-library-authoring.md) — the reviewer checklist and the non-squashed clean-room-spec-commit rule — is referenced from contribution docs
-- [ ] `cd compiler && just` green
+- [x] Conformance test in `sources` walks every bundled manifest and asserts it records a non-empty `references` list (a factual record, no legal judgment) — **REQ-CL-sources-007**
+- [x] Un-ignore sources-007; confirm the [authoring policy](../steering/compatibility-library-authoring.md) — the reviewer checklist and the non-squashed clean-room-spec-commit rule — is referenced from contribution docs
+- [x] `cd compiler && just` green
 
 ### Deferred / out of scope (see the design's *Non-Goals* and *Future Goals*)
 - **Bindings** (per-version manifest table), non-ST implementations (VM


### PR DESCRIPTION
Implement the machine-checkable half of the compatibility-library authoring
policy (REQ-CL-sources-007): a `sources` conformance test now walks every
bundled library manifest and asserts each records a non-empty `references`
list, so a bundled library cannot ship without a factual record of the
public references it was authored from.

- Add `LibraryRegistry::library_names` to enumerate bundled libraries so the
  provenance walk is stable and rooted at the installed/bundled directory.
- Un-ignore `sources_spec_req_cl_007_provenance_references_recorded` and load
  each bundled library, which validates the manifest is well-formed and its
  `references` list is non-empty.
- Reference the authoring policy from the top-level and compiler
  CONTRIBUTING docs so contributors adding a bundled library find the
  reviewer checklist and clean-room provenance record requirement.
- Mark Phase 4 complete in the plan.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WjvDVok9ZChjA4CiQK3yaw