### PR TITLE
test: replace redundant .expect messages with .unwrap in tests

### DIFF
--- a/compiler/analyzer/src/extractors.rs
+++ b/compiler/analyzer/src/extractors.rs
@@ -280,9 +280,8 @@ mod tests {
     fn analyze_source(source: &str) -> SemanticContext {
         let options = CompilerOptions::default();
         let file_id = FileId::from_string("test.st");
-        let library =
-            ironplc_parser::parse_program(source, &file_id, &options).expect("parse failed");
-        let (_lib, ctx) = analyze(&[&library], &options).expect("semantic analysis failed");
+        let library = ironplc_parser::parse_program(source, &file_id, &options).unwrap();
+        let (_lib, ctx) = analyze(&[&library], &options).unwrap();
         ctx
     }
 
@@ -353,15 +352,12 @@ mod tests {
             "FUNCTION_BLOCK fb\nVAR_INPUT i : INT; END_VAR\nEND_FUNCTION_BLOCK\nPROGRAM p\nVAR inst : fb; END_VAR\nEND_PROGRAM",
         );
         let fbs = ctx.function_blocks();
-        let fb = fbs
-            .iter()
-            .find(|f| f.name.to_string() == "fb")
-            .expect("fb missing");
+        let fb = fbs.iter().find(|f| f.name.to_string() == "fb").unwrap();
         let input = fb
             .variables
             .iter()
             .find(|v| v.name.to_string() == "i")
-            .expect("input missing");
+            .unwrap();
         assert_eq!(input.direction, VariableDirection::In);
     }
 
@@ -374,8 +370,8 @@ mod tests {
         let f = funcs
             .iter()
             .find(|fv| fv.signature.name.to_string() == "f")
-            .expect("function f missing");
-        let return_type = f.return_type_name().expect("return type missing");
+            .unwrap();
+        let return_type = f.return_type_name().unwrap();
         assert_eq!(return_type.to_string().to_uppercase(), "INT");
         let params: Vec<_> = f.parameters().collect();
         assert_eq!(params.len(), 1);
@@ -396,7 +392,7 @@ mod tests {
         let t = types
             .iter()
             .find(|t| t.name.to_string().to_lowercase() == "myenum")
-            .expect("MyEnum missing");
+            .unwrap();
         assert_eq!(t.kind, TypeSymbolKind::Enumeration);
     }
 

--- a/compiler/analyzer/src/intermediates/enumeration.rs
+++ b/compiler/analyzer/src/intermediates/enumeration.rs
@@ -122,8 +122,8 @@ mod tests {
     }
 
     fn value_with(name: &str, explicit: i64) -> EnumeratedValue {
-        let explicit_value = SignedInteger::new(&explicit.to_string(), SourceSpan::default())
-            .expect("valid integer literal");
+        let explicit_value =
+            SignedInteger::new(&explicit.to_string(), SourceSpan::default()).unwrap();
         EnumeratedValue {
             explicit_value: Some(explicit_value),
             ..EnumeratedValue::new(name)

--- a/compiler/analyzer/src/rule_case_bit_string_label.rs
+++ b/compiler/analyzer/src/rule_case_bit_string_label.rs
@@ -148,7 +148,7 @@ END_FUNCTION_BLOCK";
         let context = SemanticContextBuilder::new().build().unwrap();
         let result = apply(&library, &context, &CompilerOptions::default());
 
-        let diagnostics = result.expect_err("both bit-string labels must be flagged");
+        let diagnostics = result.unwrap_err();
         assert_eq!(diagnostics.len(), 2);
     }
 

--- a/compiler/analyzer/src/rule_function_block_call_unsupported.rs
+++ b/compiler/analyzer/src/rule_function_block_call_unsupported.rs
@@ -94,7 +94,7 @@ END_FUNCTION_BLOCK";
         let context = SemanticContextBuilder::new().build().unwrap();
         let result = apply(&input, &context, &CompilerOptions::default());
 
-        let diagnostics = result.expect_err("call-style initializer must be flagged");
+        let diagnostics = result.unwrap_err();
         assert_eq!(diagnostics.len(), 1);
         // P9999 == Problem::NotImplemented; the enum variant is #[deprecated]
         // (must be constructed via Diagnostic::not_implemented), so assert on

--- a/compiler/analyzer/src/rule_struct_initializer_expression_allowed.rs
+++ b/compiler/analyzer/src/rule_struct_initializer_expression_allowed.rs
@@ -126,7 +126,7 @@ END_PROGRAM";
         let context = SemanticContextBuilder::new().build().unwrap();
         let result = apply(&library, &context, &opts_ref_to());
 
-        let diagnostics = result.expect_err("expression-valued struct init must be flagged");
+        let diagnostics = result.unwrap_err();
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
             diagnostics[0].code,

--- a/compiler/analyzer/src/spec_conformance.rs
+++ b/compiler/analyzer/src/spec_conformance.rs
@@ -39,8 +39,8 @@ fn reference_to_options() -> CompilerOptions {
 
 /// Analyze a program and return the set of problem codes it produced.
 fn analyze_codes(program: &str, options: &CompilerOptions) -> Vec<String> {
-    let library = parse_program(program, &FileId::default(), options).expect("program parses");
-    let (_library, context) = analyze(&[&library], options).expect("analysis returns a context");
+    let library = parse_program(program, &FileId::default(), options).unwrap();
+    let (_library, context) = analyze(&[&library], options).unwrap();
     context
         .diagnostics()
         .iter()
@@ -114,10 +114,9 @@ END_VAR
     r REF= x;
     r := 5;
 END_PROGRAM";
-    let library =
-        parse_program(source, &FileId::default(), &reference_to_options()).expect("program parses");
-    let folded = crate::xform_insert_implicit_deref::apply(library, &reference_to_options())
-        .expect("transform succeeds");
+    let library = parse_program(source, &FileId::default(), &reference_to_options()).unwrap();
+    let folded =
+        crate::xform_insert_implicit_deref::apply(library, &reference_to_options()).unwrap();
     let statements = program_statements(&folded);
     let assignments: Vec<&Assignment> = statements
         .iter()
@@ -209,7 +208,7 @@ fn pi_library(options: &CompilerOptions) -> Library {
         &FileId::default(),
         options,
     )
-    .expect("PI library parses")
+    .unwrap()
 }
 
 /// The folded `LREAL` initializer value of `var_name` in `fb_name`, if it
@@ -250,10 +249,10 @@ fn analyzer_spec_req_cl_001_library_dormant_until_activated() {
         &FileId::default(),
         &options,
     )
-    .expect("program parses");
+    .unwrap();
 
     // Not activated: PI is not in scope, so the initializer cannot resolve.
-    let (_lib, ctx) = analyze(&[&user], &options).expect("analysis returns a context");
+    let (_lib, ctx) = analyze(&[&user], &options).unwrap();
     assert!(
         ctx.has_diagnostics(),
         "PI must be undefined when the library is dormant"
@@ -261,7 +260,7 @@ fn analyzer_spec_req_cl_001_library_dormant_until_activated() {
 
     // Activated: injecting the library makes PI resolve cleanly.
     let library = pi_library(&options);
-    let (_lib, ctx) = analyze(&[&library, &user], &options).expect("analysis returns a context");
+    let (_lib, ctx) = analyze(&[&library, &user], &options).unwrap();
     assert!(
         !ctx.has_diagnostics(),
         "unexpected diagnostics once activated: {:?}",
@@ -281,14 +280,14 @@ fn analyzer_spec_req_cl_002_symbols_resolve_flat() {
         &FileId::default(),
         &options,
     )
-    .expect("program parses");
-    let (analyzed, ctx) = analyze(&[&library, &user], &options).expect("context");
+    .unwrap();
+    let (analyzed, ctx) = analyze(&[&library, &user], &options).unwrap();
     assert!(
         !ctx.has_diagnostics(),
         "bare `PI` must resolve flat: {:?}",
         ctx.diagnostics()
     );
-    let value = folded_lreal(&analyzed, "FB_Example", "half").expect("half folds to a literal");
+    let value = folded_lreal(&analyzed, "FB_Example", "half").unwrap();
     assert!(
         (value - std::f64::consts::PI / 2.0).abs() < 1e-9,
         "flat `PI` did not resolve to the library value, got {value}"
@@ -306,14 +305,14 @@ fn analyzer_spec_req_cl_003_pi_folds_in_initializer() {
         &FileId::default(),
         &options,
     )
-    .expect("program parses");
-    let (analyzed, ctx) = analyze(&[&library, &user], &options).expect("context");
+    .unwrap();
+    let (analyzed, ctx) = analyze(&[&library, &user], &options).unwrap();
     assert!(
         !ctx.has_diagnostics(),
         "unexpected diagnostics: {:?}",
         ctx.diagnostics()
     );
-    let value = folded_lreal(&analyzed, "FB_Example", "d2r").expect("d2r folds to a literal");
+    let value = folded_lreal(&analyzed, "FB_Example", "d2r").unwrap();
     assert!(
         (value - std::f64::consts::PI / 180.0).abs() < 1e-9,
         "PI/180.0 did not fold to the expected value, got {value}"
@@ -335,14 +334,14 @@ fn analyzer_spec_req_cl_004_user_declaration_shadows_library() {
         &FileId::default(),
         &options,
     )
-    .expect("program parses");
-    let (analyzed, ctx) = analyze(&[&library, &user], &options).expect("context");
+    .unwrap();
+    let (analyzed, ctx) = analyze(&[&library, &user], &options).unwrap();
     assert!(
         !ctx.has_diagnostics(),
         "a user declaration shadowing a library one must not error: {:?}",
         ctx.diagnostics()
     );
-    let value = folded_lreal(&analyzed, "FB_Example", "d2r").expect("d2r folds to a literal");
+    let value = folded_lreal(&analyzed, "FB_Example", "d2r").unwrap();
     // The local PI (2.0) shadowed the library global (3.14159...).
     assert!(
         (value - 2.0 / 180.0).abs() < 1e-12,
@@ -363,8 +362,8 @@ fn analyzer_spec_req_cl_006_dialect_does_not_activate_library() {
         &FileId::default(),
         &options,
     )
-    .expect("program parses");
-    let (_lib, ctx) = analyze(&[&user], &options).expect("context");
+    .unwrap();
+    let (_lib, ctx) = analyze(&[&user], &options).unwrap();
     assert!(
         ctx.has_diagnostics(),
         "selecting a dialect must not activate the library"

--- a/compiler/analyzer/src/xform_int_to_bool_initializer.rs
+++ b/compiler/analyzer/src/xform_int_to_bool_initializer.rs
@@ -118,7 +118,7 @@ mod tests {
 
         let mut finder = InitFinder { result: None };
         finder.walk(library).unwrap();
-        finder.result.expect("No initializer found")
+        finder.result.unwrap()
     }
 
     #[test]

--- a/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
@@ -515,7 +515,7 @@ END_FUNCTION_BLOCK
                 }
                 _ => None,
             })
-            .expect("FB_B should still be present");
+            .unwrap();
 
         assert!(matches!(
             &fb_b.variables[0].initializer,
@@ -559,7 +559,7 @@ END_FUNCTION_BLOCK
                 }
                 _ => None,
             })
-            .expect("FB_A should still be present");
+            .unwrap();
 
         assert!(matches!(
             &fb_a.variables[1].initializer,

--- a/compiler/codegen/src/spec_conformance.rs
+++ b/compiler/codegen/src/spec_conformance.rs
@@ -704,7 +704,7 @@ fn compile_and_run_with(
     source: &str,
     options: &CompilerOptions,
 ) -> (ironplc_container::Container, VmBuffers) {
-    compile_and_try_run_with(source, options).expect("VM execution trapped unexpectedly")
+    compile_and_try_run_with(source, options).unwrap()
 }
 
 /// Like [`compile_and_run_with`] but returns `Err` on a VM trap.

--- a/compiler/codegen/tests/it/codegen_max_call_depth.rs
+++ b/compiler/codegen/tests/it/codegen_max_call_depth.rs
@@ -10,8 +10,7 @@ use ironplc_parser::options::CompilerOptions;
 use crate::common::try_parse_and_compile;
 
 fn compile_for_depth(source: &str) -> u16 {
-    let container =
-        try_parse_and_compile(source, &CompilerOptions::default()).expect("source should compile");
+    let container = try_parse_and_compile(source, &CompilerOptions::default()).unwrap();
     container.header.max_call_depth
 }
 

--- a/compiler/codegen/tests/it/common/mod.rs
+++ b/compiler/codegen/tests/it/common/mod.rs
@@ -599,8 +599,7 @@ pub fn try_parse_and_compile(
 /// Parses, analyzes, compiles, and runs one scan cycle.
 /// Returns the container and buffers so callers can inspect variable values.
 pub fn parse_and_run(source: &str, options: &CompilerOptions) -> (Container, VmBuffers) {
-    let (container, bufs) =
-        parse_and_try_run(source, options).expect("VM execution trapped unexpectedly");
+    let (container, bufs) = parse_and_try_run(source, options).unwrap();
     (container, bufs)
 }
 

--- a/compiler/codegen/tests/it/compile_array.rs
+++ b/compiler/codegen/tests/it/compile_array.rs
@@ -28,7 +28,7 @@ END_PROGRAM
     let load_array_pos = bytecode
         .iter()
         .position(|&b| b == opcode::LOAD_ARRAY)
-        .expect("LOAD_ARRAY opcode not found");
+        .unwrap();
     // Before LOAD_ARRAY should be LOAD_CONST_I32 with flat index 2
     assert!(load_array_pos >= 3);
     // Preceding byte should be LOAD_CONST_I32
@@ -65,7 +65,7 @@ END_PROGRAM
     let store_array_pos = bytecode
         .iter()
         .position(|&b| b == opcode::STORE_ARRAY)
-        .expect("STORE_ARRAY opcode not found");
+        .unwrap();
     // Before STORE_ARRAY should be LOAD_CONST_I32 with flat index 2
     assert!(store_array_pos >= 3);
     assert_eq!(bytecode[store_array_pos - 3], opcode::LOAD_CONST_I32); // LOAD_CONST_I32
@@ -158,7 +158,7 @@ END_PROGRAM
     let load_array_pos = bytecode
         .iter()
         .position(|&b| b == opcode::LOAD_ARRAY)
-        .expect("LOAD_ARRAY opcode not found");
+        .unwrap();
     assert!(load_array_pos >= 3);
     assert_eq!(bytecode[load_array_pos - 3], opcode::LOAD_CONST_I32); // LOAD_CONST_I32
     let const_idx =
@@ -193,7 +193,7 @@ END_PROGRAM
     let load_array_pos = bytecode
         .iter()
         .position(|&b| b == opcode::LOAD_ARRAY)
-        .expect("LOAD_ARRAY opcode not found");
+        .unwrap();
     assert!(load_array_pos >= 3);
     assert_eq!(bytecode[load_array_pos - 3], opcode::LOAD_CONST_I32); // LOAD_CONST_I32
     let const_idx =
@@ -263,11 +263,11 @@ END_PROGRAM
     let trunc_pos = bytecode
         .iter()
         .position(|&b| b == opcode::TRUNC_I8)
-        .expect("TRUNC_I8 not found");
+        .unwrap();
     let store_pos = bytecode
         .iter()
         .position(|&b| b == opcode::STORE_ARRAY)
-        .expect("STORE_ARRAY not found");
+        .unwrap();
     assert!(
         trunc_pos < store_pos,
         "TRUNC_I8 should come before STORE_ARRAY"
@@ -296,7 +296,7 @@ END_PROGRAM
     let load_array_pos = bytecode
         .iter()
         .position(|&b| b == opcode::LOAD_ARRAY)
-        .expect("LOAD_ARRAY not found");
+        .unwrap();
     // The TRUNC should appear after LOAD_ARRAY (for the final STORE_VAR), not before it.
     // There may or may not be a TRUNC — the key is LOAD_ARRAY itself doesn't truncate.
     // Just verify LOAD_ARRAY is present.

--- a/compiler/codegen/tests/it/compile_mux_float.rs
+++ b/compiler/codegen/tests/it/compile_mux_float.rs
@@ -26,7 +26,7 @@ END_PROGRAM
     let builtin_pos = bytecode
         .windows(3)
         .position(|w| w[0] == 0x94 && w[1] == 0x43 && w[2] == 0x04)
-        .expect("should contain BUILTIN MUX_F32(3)");
+        .unwrap();
     assert!(builtin_pos > 0);
 }
 
@@ -50,6 +50,6 @@ END_PROGRAM
     let builtin_pos = bytecode
         .windows(3)
         .position(|w| w[0] == 0x94 && w[1] == 0x62 && w[2] == 0x04)
-        .expect("should contain BUILTIN MUX_F64(2)");
+        .unwrap();
     assert!(builtin_pos > 0);
 }

--- a/compiler/codegen/tests/it/compile_mux_lint.rs
+++ b/compiler/codegen/tests/it/compile_mux_lint.rs
@@ -26,6 +26,6 @@ END_PROGRAM
     let builtin_pos = bytecode
         .windows(3)
         .position(|w| w[0] == 0x94 && w[1] == 0x23 && w[2] == 0x04)
-        .expect("should contain BUILTIN MUX_I64(3)");
+        .unwrap();
     assert!(builtin_pos > 0);
 }

--- a/compiler/codegen/tests/it/end_to_end_debug_line_map.rs
+++ b/compiler/codegen/tests/it/end_to_end_debug_line_map.rs
@@ -58,10 +58,7 @@ fn line_map_when_program_has_assignment_statements_then_each_gets_an_entry() {
     let source =
         "PROGRAM main\n  VAR x : DINT; y : DINT; END_VAR\n  x := 10;\n  y := 20;\nEND_PROGRAM\n";
     let (container, _) = compile_with_source(source);
-    let debug = container
-        .debug_section
-        .as_ref()
-        .expect("debug section present");
+    let debug = container.debug_section.as_ref().unwrap();
 
     // SOURCE_FILE_TABLE: one entry for the program's file, BLAKE3
     // hash matches the source bytes.
@@ -115,7 +112,7 @@ fn line_map_when_empty_program_then_source_file_table_still_populated_with_zero_
         &ironplc_codegen::EmptyLookup,
     )
     .unwrap();
-    let debug = container.debug_section.as_ref().expect("debug section");
+    let debug = container.debug_section.as_ref().unwrap();
 
     // Source file is still registered (so file_ids resolve) but the
     // hash is all-zero.
@@ -142,16 +139,13 @@ fn line_map_when_optimizer_runs_then_bytecode_offsets_are_on_instruction_boundar
     // bytecode.
     let source = "PROGRAM main\n  VAR x : DINT; END_VAR\n  x := 10;\n  x := x + 5;\nEND_PROGRAM\n";
     let (container, _) = compile_with_source(source);
-    let debug = container
-        .debug_section
-        .as_ref()
-        .expect("debug section present");
+    let debug = container.debug_section.as_ref().unwrap();
 
     for entry in &debug.line_map {
         let bytecode = container
             .code
             .get_function_bytecode(entry.function_id)
-            .expect("function bytecode present");
+            .unwrap();
         let offset = entry.bytecode_offset as usize;
         assert!(
             offset < bytecode.len(),

--- a/compiler/codegen/tests/it/end_to_end_debug_var_names.rs
+++ b/compiler/codegen/tests/it/end_to_end_debug_var_names.rs
@@ -14,10 +14,7 @@ use ironplc_parser::options::CompilerOptions;
 /// Resolves the `function_id` assigned to a user POU by looking it up in the
 /// FUNC_NAME table by name (case-insensitive). Panics if absent.
 fn function_id_of(container: &ironplc_container::Container, name: &str) -> FunctionId {
-    let debug = container
-        .debug_section
-        .as_ref()
-        .expect("debug section present");
+    let debug = container.debug_section.as_ref().unwrap();
     debug
         .func_names
         .iter()
@@ -28,10 +25,7 @@ fn function_id_of(container: &ironplc_container::Container, name: &str) -> Funct
 
 /// Collects the VAR_NAME entries owned by a given function id.
 fn vars_for(container: &ironplc_container::Container, owner: FunctionId) -> Vec<&VarNameEntry> {
-    let debug = container
-        .debug_section
-        .as_ref()
-        .expect("debug section present");
+    let debug = container.debug_section.as_ref().unwrap();
     debug
         .var_names
         .iter()

--- a/compiler/codegen/tests/it/end_to_end_enum.rs
+++ b/compiler/codegen/tests/it/end_to_end_enum.rs
@@ -179,7 +179,7 @@ END_PROGRAM
         .enum_defs
         .iter()
         .find(|e| e.type_name == "COLOR")
-        .expect("COLOR enum def should be present");
+        .unwrap();
     assert_eq!(color_def.values, vec!["RED", "GREEN", "BLUE"]);
 }
 

--- a/compiler/codegen/tests/it/end_to_end_user_fb.rs
+++ b/compiler/codegen/tests/it/end_to_end_user_fb.rs
@@ -140,8 +140,7 @@ PROGRAM main
   c();
 END_PROGRAM
 ";
-    let _ = crate::common::try_parse_and_compile(source, &CompilerOptions::default())
-        .expect("FB calling user function should compile");
+    let _ = crate::common::try_parse_and_compile(source, &CompilerOptions::default()).unwrap();
 }
 
 #[test]

--- a/compiler/codegen/tests/it/wire_format.rs
+++ b/compiler/codegen/tests/it/wire_format.rs
@@ -576,7 +576,7 @@ END_PROGRAM
             let bc = container.code.get_function_bytecode(entry.function_id)?;
             bc.iter().position(|&b| b == opcode::CALL).map(|p| (bc, p))
         })
-        .expect("CALL opcode present in some function");
+        .unwrap();
     assert_eq!(opcode::instruction_size(opcode::CALL), 5);
     assert!(
         call_pos + 5 <= call_bc.len(),
@@ -610,10 +610,7 @@ END_PROGRAM
         .unwrap();
     // Find STR_INIT (0xB8). Validate the 7 trailing operand bytes
     // decode as LE u32 + LE u16 + u8.
-    let pos = init_bc
-        .iter()
-        .position(|&b| b == 0xB8)
-        .expect("STR_INIT opcode present in program init");
+    let pos = init_bc.iter().position(|&b| b == 0xB8).unwrap();
     assert_eq!(opcode::instruction_size(opcode::STR_INIT), 8);
     assert!(
         pos + 8 <= init_bc.len(),
@@ -648,10 +645,7 @@ PROGRAM main
 END_PROGRAM
 ",
     );
-    let pos = bc
-        .iter()
-        .position(|&b| b == 0xC4)
-        .expect("LEN_STR opcode present");
+    let pos = bc.iter().position(|&b| b == 0xC4).unwrap();
     assert_eq!(opcode::instruction_size(opcode::LEN_STR), 5);
     assert!(pos + 5 <= bc.len(), "LEN_STR has 4 trailing u32 bytes");
     let _data_offset = u32::from_le_bytes([bc[pos + 1], bc[pos + 2], bc[pos + 3], bc[pos + 4]]);
@@ -673,10 +667,7 @@ PROGRAM main
 END_PROGRAM
 ",
     );
-    let pos = bc
-        .iter()
-        .position(|&b| b == 0xC8)
-        .expect("FIND_STR opcode present");
+    let pos = bc.iter().position(|&b| b == 0xC8).unwrap();
     assert_eq!(opcode::instruction_size(opcode::FIND_STR), 9);
     assert!(pos + 9 <= bc.len(), "FIND_STR has 8 trailing u32 bytes");
     let _in1 = u32::from_le_bytes([bc[pos + 1], bc[pos + 2], bc[pos + 3], bc[pos + 4]]);

--- a/compiler/container/src/builder.rs
+++ b/compiler/container/src/builder.rs
@@ -570,7 +570,7 @@ mod tests {
             .add_line_map_entry(entry)
             .build();
 
-        let debug = container.debug_section.expect("debug section present");
+        let debug = container.debug_section.unwrap();
         assert_eq!(debug.line_map.len(), 1);
         assert_eq!(debug.line_map[0], entry);
     }
@@ -611,7 +611,7 @@ mod tests {
             .add_line_map_entry(entries[2])
             .build();
 
-        let debug = container.debug_section.expect("debug section present");
+        let debug = container.debug_section.unwrap();
         let keys: Vec<_> = debug
             .line_map
             .iter()
@@ -640,7 +640,7 @@ mod tests {
             })
             .build();
 
-        let debug = container.debug_section.expect("debug section present");
+        let debug = container.debug_section.unwrap();
         assert_eq!(debug.source_files.len(), 2);
         // Insertion order = file_id order (a → 0, b → 1).
         assert_eq!(debug.source_files[0].path, "a.st");
@@ -673,7 +673,7 @@ mod tests {
             .add_source_files(entries.clone())
             .build();
 
-        let debug = container.debug_section.expect("debug section present");
+        let debug = container.debug_section.unwrap();
         assert_eq!(debug.source_files, entries);
     }
 
@@ -695,7 +695,7 @@ mod tests {
             .add_fb_type(desc.clone())
             .build();
 
-        let ts = container.type_section.expect("type section present");
+        let ts = container.type_section.unwrap();
         assert_eq!(ts.fb_types.len(), 1);
         assert_eq!(ts.fb_types[0], desc);
     }

--- a/compiler/container/src/debug_format.rs
+++ b/compiler/container/src/debug_format.rs
@@ -123,11 +123,11 @@ mod tests {
 
         let map = build_var_debug_map(&container);
         assert_eq!(map.len(), 2);
-        let counter = map.get(&0).expect("var index 0 present");
+        let counter = map.get(&0).unwrap();
         assert_eq!(counter.name, "counter");
         assert_eq!(counter.type_name, "DINT");
         assert_eq!(counter.iec_type_tag, iec_type_tag::DINT);
-        let flag = map.get(&2).expect("var index 2 present");
+        let flag = map.get(&2).unwrap();
         assert_eq!(flag.name, "flag");
         assert_eq!(flag.type_name, "BOOL");
         assert_eq!(flag.iec_type_tag, iec_type_tag::BOOL);

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -419,12 +419,9 @@ mod tests {
         // The `enum` array must list exactly the dialect cli_names, in order.
         let enum_values: Vec<&str> = dialect["enum"]
             .as_array()
-            .expect("ironplc.dialect.enum must be an array")
+            .unwrap()
             .iter()
-            .map(|v| {
-                v.as_str()
-                    .expect("ironplc.dialect.enum entries must be strings")
-            })
+            .map(|v| v.as_str().unwrap())
             .collect();
         assert_eq!(
             enum_values, expected_names,
@@ -447,9 +444,7 @@ mod tests {
         }
 
         // The prose description must mention every dialect by cli_name.
-        let markdown = dialect["markdownDescription"]
-            .as_str()
-            .expect("ironplc.dialect.markdownDescription must be a string");
+        let markdown = dialect["markdownDescription"].as_str().unwrap();
         for name in &expected_names {
             assert!(
                 markdown.contains(name),

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -673,20 +673,16 @@ mod test {
 
         fn receive_response<T: DeserializeOwned>(&mut self, request_id: RequestId) -> T {
             self.receive();
-            let response = self.responses.get(&request_id).expect("No request");
+            let response = self.responses.get(&request_id).unwrap();
             // `response_result` is `Ok(value)` for a successful response and
             // `Err(..)` for a failure, so `expect` asserts success here.
-            let result = response
-                .response_result
-                .as_ref()
-                .expect("Expected successful response")
-                .clone();
+            let result = response.response_result.as_ref().unwrap().clone();
             serde_json::from_value::<T>(result).unwrap()
         }
 
         fn receive_notification<T: DeserializeOwned>(&mut self) -> T {
             self.receive();
-            let notification = self.notifications.pop().expect("Must have notification");
+            let notification = self.notifications.pop().unwrap();
             serde_json::from_value::<T>(notification.params).unwrap()
         }
 

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -867,7 +867,7 @@ mod test {
             "PROGRAM Main\nVAR\nx : BOOL;\nEND_VAR\nEND_PROGRAM".to_owned(),
         );
 
-        let tokens = proj.tokenize(&url).expect("expected tokens");
+        let tokens = proj.tokenize(&url).unwrap();
         assert!(!tokens.is_empty(), "expected tokens, got none");
 
         // Reconstruct absolute positions from the deltas.
@@ -951,7 +951,7 @@ mod test {
         let url = Uri::from_str(FAKE_PATH).unwrap();
         proj.change_text_document(&url, source.to_owned());
 
-        let tokens = proj.tokenize(&url).expect("expected tokens");
+        let tokens = proj.tokenize(&url).unwrap();
         let resolved = resolve_lsp_tokens(source, &tokens);
 
         // Spot-check key tokens that the user reported as broken.
@@ -976,19 +976,13 @@ mod test {
 
         // Both BOOL and INT sit on line 2; their reconstructed columns must
         // match the actual source columns.
-        let bool_pos = resolved
-            .iter()
-            .find(|(_, _, s, _)| *s == "BOOL")
-            .expect("BOOL token");
+        let bool_pos = resolved.iter().find(|(_, _, s, _)| *s == "BOOL").unwrap();
         assert_eq!(
             (bool_pos.0, bool_pos.1),
             (2, 6),
             "BOOL should be at line 2 col 6"
         );
-        let int_pos = resolved
-            .iter()
-            .find(|(_, _, s, _)| *s == "INT")
-            .expect("INT token");
+        let int_pos = resolved.iter().find(|(_, _, s, _)| *s == "INT").unwrap();
         // After the inline block comment, the next BOOL/INT must still report
         // the correct column — this is the regression that produced the
         // user's "trip"/"ain Mot" mis-coloring.
@@ -1019,7 +1013,7 @@ mod test {
             "VAR\n  a : BOOL; (* note *) b : BOOL;\nEND_VAR".to_owned(),
         );
 
-        let tokens = proj.tokenize(&url).expect("expected tokens");
+        let tokens = proj.tokenize(&url).unwrap();
         // Reconstruct absolute positions and the keyword index of each token.
         let mut line: u32 = 0;
         let mut col: u32 = 0;
@@ -1664,8 +1658,7 @@ INVALID_SYNTAX"
         let path = std::path::PathBuf::from(original.path().as_str());
         let file_id = FileId::from_path(&path);
 
-        let reconstructed =
-            UriKey::from_file_id(&file_id).expect("file id should map back to a URI key");
+        let reconstructed = UriKey::from_file_id(&file_id).unwrap();
         assert_eq!(
             reconstructed.as_str(),
             original.as_str(),

--- a/compiler/mcp/src/spec_conformance.rs
+++ b/compiler/mcp/src/spec_conformance.rs
@@ -1043,7 +1043,7 @@ fn mcp_spec_req_tol_212_project_io_entry_format() {
         .unwrap()
         .iter()
         .find(|e| e["name"] == "p.start")
-        .expect("p.start not found in inputs");
+        .unwrap();
     assert!(entry.get("name").is_some());
     assert!(entry.get("type").is_some());
     assert!(entry.get("address").is_some());
@@ -1071,20 +1071,12 @@ fn mcp_spec_req_tol_220_pou_scope_returns_variables() {
     assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
     assert!(resp.found);
 
-    let start = resp
-        .variables
-        .iter()
-        .find(|v| v.name == "start")
-        .expect("start variable missing");
+    let start = resp.variables.iter().find(|v| v.name == "start").unwrap();
     assert_eq!(start.direction, "In");
     assert_eq!(start.initial_value.as_deref(), Some("FALSE"));
     assert!(!start.type_name.is_empty());
 
-    let count = resp
-        .variables
-        .iter()
-        .find(|v| v.name == "count")
-        .expect("count variable missing");
+    let count = resp.variables.iter().find(|v| v.name == "count").unwrap();
     assert_eq!(count.direction, "Local");
     assert_eq!(count.initial_value, None);
 }
@@ -1190,36 +1182,20 @@ fn mcp_spec_req_tol_240_types_all_returns_user_defined_types() {
     let resp = tools::types_all::build_response(&sources, &options);
     assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
 
-    let motor = resp
-        .types
-        .iter()
-        .find(|t| t.name == "MotorState")
-        .expect("MotorState missing");
+    let motor = resp.types.iter().find(|t| t.name == "MotorState").unwrap();
     assert_eq!(motor.kind, "enum");
     assert!(motor.values.is_some());
 
-    let pid = resp
-        .types
-        .iter()
-        .find(|t| t.name == "PidParams")
-        .expect("PidParams missing");
+    let pid = resp.types.iter().find(|t| t.name == "PidParams").unwrap();
     assert_eq!(pid.kind, "struct");
     assert!(pid.fields.is_some());
 
-    let buf = resp
-        .types
-        .iter()
-        .find(|t| t.name == "Buf")
-        .expect("Buf missing");
+    let buf = resp.types.iter().find(|t| t.name == "Buf").unwrap();
     assert_eq!(buf.kind, "array");
     assert!(buf.element_type.is_some());
     assert!(buf.bounds.is_some());
 
-    let percent = resp
-        .types
-        .iter()
-        .find(|t| t.name == "Percent")
-        .expect("Percent missing");
+    let percent = resp.types.iter().find(|t| t.name == "Percent").unwrap();
     assert_eq!(percent.kind, "subrange");
     assert_eq!(percent.low, Some(0));
     assert_eq!(percent.high, Some(100));

--- a/compiler/mcp/src/tools/explain_diagnostic.rs
+++ b/compiler/mcp/src/tools/explain_diagnostic.rs
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn build_response_when_known_code_then_doc_url_tagged_for_mcp() {
         let resp = build_response("P0001");
-        let url = resp.doc_url.expect("known code should have a doc_url");
+        let url = resp.doc_url.unwrap();
         assert!(url.contains("/reference/compiler/problems/P0001.html"));
         assert!(url.contains("?version="));
         assert!(url.contains("&channel=mcp"));

--- a/compiler/mcp/src/tools/pou_scope.rs
+++ b/compiler/mcp/src/tools/pou_scope.rs
@@ -275,20 +275,12 @@ mod tests {
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
         assert!(resp.found);
         assert_eq!(resp.pou, "p");
-        let start = resp
-            .variables
-            .iter()
-            .find(|v| v.name == "start")
-            .expect("start not found");
+        let start = resp.variables.iter().find(|v| v.name == "start").unwrap();
         assert_eq!(start.type_name.to_uppercase(), "BOOL");
         assert_eq!(start.direction, "In");
         assert_eq!(start.initial_value.as_deref(), Some("FALSE"));
 
-        let count = resp
-            .variables
-            .iter()
-            .find(|v| v.name == "count")
-            .expect("count not found");
+        let count = resp.variables.iter().find(|v| v.name == "count").unwrap();
         assert_eq!(count.type_name.to_uppercase(), "DINT");
         assert_eq!(count.direction, "Local");
         assert_eq!(count.initial_value.as_deref(), Some("0"));
@@ -301,11 +293,7 @@ mod tests {
             "p",
         );
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
-        let entry = resp
-            .variables
-            .iter()
-            .find(|v| v.name == "run")
-            .expect("run not found");
+        let entry = resp.variables.iter().find(|v| v.name == "run").unwrap();
         assert_eq!(entry.direction, "Out");
         assert_eq!(entry.initial_value, None);
     }
@@ -318,11 +306,7 @@ mod tests {
         );
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
         assert!(resp.found);
-        let entry = resp
-            .variables
-            .iter()
-            .find(|v| v.name == "c")
-            .expect("c not found");
+        let entry = resp.variables.iter().find(|v| v.name == "c").unwrap();
         assert_eq!(entry.direction, "InOut");
     }
 
@@ -355,11 +339,7 @@ mod tests {
             "fb",
         );
         assert!(resp.found);
-        let entry = resp
-            .variables
-            .iter()
-            .find(|v| v.name == "x")
-            .expect("x not found");
+        let entry = resp.variables.iter().find(|v| v.name == "x").unwrap();
         assert_eq!(entry.type_name.to_uppercase(), "INT");
         assert_eq!(entry.direction, "In");
         assert_eq!(entry.initial_value.as_deref(), Some("5"));
@@ -372,11 +352,7 @@ mod tests {
             "f",
         );
         assert!(resp.found, "diagnostics: {:?}", resp.diagnostics);
-        let entry = resp
-            .variables
-            .iter()
-            .find(|v| v.name == "a")
-            .expect("a not found");
+        let entry = resp.variables.iter().find(|v| v.name == "a").unwrap();
         assert_eq!(entry.type_name.to_uppercase(), "INT");
         assert_eq!(entry.direction, "In");
     }

--- a/compiler/mcp/src/tools/run.rs
+++ b/compiler/mcp/src/tools/run.rs
@@ -541,8 +541,7 @@ mod tests {
         }];
         let resp = crate::tools::compile::build_response(&sources, &ed2_options(), false, cache);
         assert!(resp.ok, "compile failed: {:?}", resp.diagnostics);
-        resp.container_id
-            .expect("compile should return a container_id")
+        resp.container_id.unwrap()
     }
 
     const COUNTER_PROGRAM: &str = r#"

--- a/compiler/mcp/src/tools/symbols.rs
+++ b/compiler/mcp/src/tools/symbols.rs
@@ -381,12 +381,8 @@ mod tests {
             .function_blocks
             .iter()
             .find(|fb| fb.name == "fb")
-            .expect("fb not found");
-        let var = fb
-            .variables
-            .iter()
-            .find(|v| v.name == "x")
-            .expect("x not found");
+            .unwrap();
+        let var = fb.variables.iter().find(|v| v.name == "x").unwrap();
         assert_eq!(var.direction, "In");
         assert!(var.external);
     }
@@ -430,11 +426,7 @@ mod tests {
         }];
         let resp = build_response(&sources, &ed2_options(), None);
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
-        let t = resp
-            .types
-            .iter()
-            .find(|t| t.name == "MyEnum")
-            .expect("MyEnum not found");
+        let t = resp.types.iter().find(|t| t.name == "MyEnum").unwrap();
         assert_eq!(t.kind, "enumeration");
     }
 

--- a/compiler/mcp/src/tools/types_all.rs
+++ b/compiler/mcp/src/tools/types_all.rs
@@ -312,11 +312,7 @@ mod tests {
         let resp =
             build("TYPE MyEnum : (Stopped, Running, Fault); END_TYPE\nPROGRAM p\nEND_PROGRAM");
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
-        let entry = resp
-            .types
-            .iter()
-            .find(|t| t.name == "MyEnum")
-            .expect("MyEnum not found");
+        let entry = resp.types.iter().find(|t| t.name == "MyEnum").unwrap();
         assert_eq!(entry.kind, "enum");
         let mut values = entry.values.clone().unwrap();
         values.sort();
@@ -336,11 +332,7 @@ mod tests {
             "TYPE PidParams : STRUCT Kp : REAL; Ki : REAL; END_STRUCT; END_TYPE\nPROGRAM p\nEND_PROGRAM",
         );
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
-        let entry = resp
-            .types
-            .iter()
-            .find(|t| t.name == "PidParams")
-            .expect("PidParams not found");
+        let entry = resp.types.iter().find(|t| t.name == "PidParams").unwrap();
         assert_eq!(entry.kind, "struct");
         let fields = entry.fields.clone().unwrap();
         let names: Vec<String> = fields.iter().map(|f| f.name.clone()).collect();
@@ -352,11 +344,7 @@ mod tests {
     fn build_response_when_array_type_then_kind_array_with_bounds() {
         let resp = build("TYPE Buf : ARRAY[1..10] OF INT; END_TYPE\nPROGRAM p\nEND_PROGRAM");
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
-        let entry = resp
-            .types
-            .iter()
-            .find(|t| t.name == "Buf")
-            .expect("Buf not found");
+        let entry = resp.types.iter().find(|t| t.name == "Buf").unwrap();
         assert_eq!(entry.kind, "array");
         let bounds = entry.bounds.clone().unwrap();
         assert_eq!(bounds.len(), 1);
@@ -369,11 +357,7 @@ mod tests {
     fn build_response_when_subrange_type_then_kind_subrange_with_low_high() {
         let resp = build("TYPE Percent : INT (0..100); END_TYPE\nPROGRAM p\nEND_PROGRAM");
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
-        let entry = resp
-            .types
-            .iter()
-            .find(|t| t.name == "Percent")
-            .expect("Percent not found");
+        let entry = resp.types.iter().find(|t| t.name == "Percent").unwrap();
         assert_eq!(entry.kind, "subrange");
         assert_eq!(entry.low, Some(0));
         assert_eq!(entry.high, Some(100));
@@ -387,12 +371,8 @@ mod tests {
             "TYPE MyRec : STRUCT s : STRING; w : WSTRING; END_STRUCT; END_TYPE\nPROGRAM p\nEND_PROGRAM",
         );
         assert!(resp.ok, "diagnostics: {:?}", resp.diagnostics);
-        let entry = resp
-            .types
-            .iter()
-            .find(|t| t.name == "MyRec")
-            .expect("MyRec not found");
-        let fields = entry.fields.clone().expect("struct fields missing");
+        let entry = resp.types.iter().find(|t| t.name == "MyRec").unwrap();
+        let fields = entry.fields.clone().unwrap();
         let s = fields.iter().find(|f| f.name == "s").unwrap();
         assert_eq!(s.type_name, "STRING");
         let w = fields.iter().find(|f| f.name == "w").unwrap();

--- a/compiler/mcp/tests/cli.rs
+++ b/compiler/mcp/tests/cli.rs
@@ -399,8 +399,8 @@ fn tools_list_when_parsed_then_no_tool_uses_boolean_property_schema(
         .lines()
         .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
         .find_map(|message| message.get("result").and_then(|r| r.get("tools").cloned()))
-        .expect("a tools/list response carrying a `tools` array");
-    let tools = tools.as_array().expect("`tools` is an array");
+        .unwrap();
+    let tools = tools.as_array().unwrap();
     assert!(!tools.is_empty(), "expected at least one advertised tool");
     for tool in tools {
         let name = tool

--- a/compiler/mcp/tests/scenarios.rs
+++ b/compiler/mcp/tests/scenarios.rs
@@ -33,9 +33,7 @@ fn scenario_agent_self_heals_syntax_error() {
         "should have at least one diagnostic"
     );
 
-    let code = r1.diagnostics[0]["code"]
-        .as_str()
-        .expect("diagnostic must have a code field");
+    let code = r1.diagnostics[0]["code"].as_str().unwrap();
     assert!(!code.is_empty(), "diagnostic code must not be empty");
 
     // Step 2: agent looks up the diagnostic code

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -191,10 +191,7 @@ mod test {
             "unexpected diagnostics: {diagnostics:?}"
         );
 
-        let y = tokens
-            .iter()
-            .find(|t| t.text == "y")
-            .expect("expected `y` identifier in tokens");
+        let y = tokens.iter().find(|t| t.text == "y").unwrap();
         // `y` sits at byte offset 17 in the source, all on line 0. Without the
         // fix the column counter would still report the column where the
         // comment started (8) because the comment branch did not advance col.

--- a/compiler/parser/src/spec_conformance.rs
+++ b/compiler/parser/src/spec_conformance.rs
@@ -46,7 +46,7 @@ fn reference_to_options() -> CompilerOptions {
 }
 
 fn parse(source: &str, options: &CompilerOptions) -> Library {
-    crate::parse_program(source, &FileId::default(), options).expect("program should parse")
+    crate::parse_program(source, &FileId::default(), options).unwrap()
 }
 
 fn token_types(source: &str, options: &CompilerOptions) -> Vec<TokenType> {
@@ -126,10 +126,7 @@ END_VAR
 END_PROGRAM";
     let lib = parse(source, &CompilerOptions::default());
     let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
-    let name = prog.variables[0]
-        .identifier
-        .symbolic_id()
-        .expect("variable has a symbolic name");
+    let name = prog.variables[0].identifier.symbolic_id().unwrap();
     assert_eq!(name.to_string(), "REFERENCE");
 }
 

--- a/compiler/parser/src/tests/case.rs
+++ b/compiler/parser/src/tests/case.rs
@@ -20,8 +20,8 @@ CASE x OF
     10: y := 3;
 END_CASE;
 END_FUNCTION_BLOCK";
-    let library = parse_program(source, &FileId::default(), &with_missing_semicolon_flag())
-        .expect("empty CASE branch followed by another label must parse");
+    let library =
+        parse_program(source, &FileId::default(), &with_missing_semicolon_flag()).unwrap();
     let case = extract_case(&library);
     assert_eq!(case.statement_groups.len(), 3);
     assert!(case.statement_groups[1].statements.is_empty());
@@ -40,8 +40,8 @@ CASE x OF
     5: (* no statement here *)
 END_CASE;
 END_FUNCTION_BLOCK";
-    let library = parse_program(source, &FileId::default(), &with_missing_semicolon_flag())
-        .expect("empty CASE branch as the last one must parse");
+    let library =
+        parse_program(source, &FileId::default(), &with_missing_semicolon_flag()).unwrap();
     let case = extract_case(&library);
     assert_eq!(case.statement_groups.len(), 2);
     assert!(case.statement_groups[1].statements.is_empty());
@@ -80,8 +80,7 @@ CASE x OF
     5: y := 2;
 END_CASE;
 END_FUNCTION_BLOCK";
-    let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
-        .expect("populated CASE branch must still parse");
+    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
     let case = extract_case(&library);
     assert_eq!(case.statement_groups.len(), 2);
     assert_eq!(case.statement_groups[1].statements.len(), 1);
@@ -111,8 +110,7 @@ CASE x OF
     2#1010: y := 2;
 END_CASE;
 END_FUNCTION_BLOCK";
-    let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
-        .expect("hex/binary CASE labels must parse");
+    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
     let case = extract_case(&library);
     assert_eq!(case.statement_groups.len(), 2);
 
@@ -137,8 +135,7 @@ CASE x OF
     8#17: y := 1;
 END_CASE;
 END_FUNCTION_BLOCK";
-    let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
-        .expect("octal CASE label must parse");
+    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
     let case = extract_case(&library);
     let selector = &case.statement_groups[0].selectors[0];
     let lit = cast!(selector, CaseSelectionKind::BitStringLiteral);
@@ -159,8 +156,7 @@ CASE x OF
     5: y := 1;
 END_CASE;
 END_FUNCTION_BLOCK";
-    let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
-        .expect("plain decimal CASE label must still parse");
+    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
     let case = extract_case(&library);
     let selector = &case.statement_groups[0].selectors[0];
     assert!(matches!(selector, CaseSelectionKind::SignedInteger(_)));

--- a/compiler/parser/src/tests/common.rs
+++ b/compiler/parser/src/tests/common.rs
@@ -132,7 +132,7 @@ pub(crate) fn extract_duration(library: &Library) -> &DurationLiteral {
     );
     let initializer = &func.variables[0].initializer;
     let simple = cast!(initializer, InitialValueAssignmentKind::Simple);
-    let constant = simple.initial_value.as_ref().expect("initializer");
+    let constant = simple.initial_value.as_ref().unwrap();
     cast!(constant, ConstantKind::Duration)
 }
 
@@ -161,7 +161,7 @@ pub(crate) fn extract_case(library: &Library) -> Case {
         .elements
         .iter()
         .find(|e| matches!(e, LibraryElementKind::FunctionBlockDeclaration(_)))
-        .expect("expected a FunctionBlockDeclaration");
+        .unwrap();
     let fb = cast!(element, LibraryElementKind::FunctionBlockDeclaration);
     let stmts = cast!(&fb.body, FunctionBlockBodyKind::Statements);
     cast!(&stmts.body[0], StmtKind::Case).clone()
@@ -184,7 +184,7 @@ pub(crate) fn extract_assignment_value(library: &Library) -> Expr {
         .elements
         .iter()
         .find(|e| matches!(e, LibraryElementKind::FunctionBlockDeclaration(_)))
-        .expect("expected a FunctionBlockDeclaration");
+        .unwrap();
     let fb = cast!(element, LibraryElementKind::FunctionBlockDeclaration);
     let stmts = cast!(&fb.body, FunctionBlockBodyKind::Statements);
     let assignment = cast!(&stmts.body[0], StmtKind::Assignment);
@@ -220,6 +220,6 @@ pub(crate) fn extract_fb(library: &Library) -> &FunctionBlockDeclaration {
         .elements
         .iter()
         .find(|e| matches!(e, LibraryElementKind::FunctionBlockDeclaration(_)))
-        .expect("expected a FunctionBlockDeclaration");
+        .unwrap();
     cast!(element, LibraryElementKind::FunctionBlockDeclaration)
 }

--- a/compiler/parser/src/tests/constant_initializers.rs
+++ b/compiler/parser/src/tests/constant_initializers.rs
@@ -11,9 +11,7 @@ fn parse_when_negative_integer_initializer_then_parses_as_simple_not_simple_expr
     // handling rather than constant()'s built-in signed-literal
     // parsing. This must parse identically with or without the flag.
     let source = "PROGRAM main VAR x : INT := -123; END_VAR END_PROGRAM";
-    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).expect(
-        "negative literal initializers must not require allow_constant_initializer_expressions",
-    );
+    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
 
     let program = cast!(&library.elements[0], LibraryElementKind::ProgramDeclaration);
     let simple = cast!(
@@ -31,9 +29,7 @@ fn parse_when_negative_integer_initializer_then_parses_as_simple_not_simple_expr
 #[test]
 fn parse_when_negative_real_initializer_then_parses_as_simple() {
     let source = "PROGRAM main VAR x : LREAL := -3.5; END_VAR END_PROGRAM";
-    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).expect(
-        "negative real initializers must not require allow_constant_initializer_expressions",
-    );
+    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
 
     let program = cast!(&library.elements[0], LibraryElementKind::ProgramDeclaration);
     let simple = cast!(

--- a/compiler/parser/src/tests/fb_inheritance.rs
+++ b/compiler/parser/src/tests/fb_inheritance.rs
@@ -46,7 +46,7 @@ END_VAR
 END_FUNCTION_BLOCK";
     let library = parse_program(source, &FileId::default(), &opts_with_fb_inheritance()).unwrap();
     let fb = extract_fb(&library);
-    let oop = fb.oop.as_ref().expect("expected oop to be Some");
+    let oop = fb.oop.as_ref().unwrap();
     assert_eq!(oop.base, Some(TypeName::from("FB_Motor")));
     assert!(oop.implements.is_empty());
 }
@@ -61,7 +61,7 @@ END_VAR
 END_FUNCTION_BLOCK";
     let library = parse_program(source, &FileId::default(), &opts_with_fb_inheritance()).unwrap();
     let fb = extract_fb(&library);
-    let oop = fb.oop.as_ref().expect("expected oop to be Some");
+    let oop = fb.oop.as_ref().unwrap();
     assert_eq!(oop.base, None);
     assert_eq!(oop.implements, vec![TypeName::from("I_Drivable")]);
 }
@@ -76,7 +76,7 @@ END_VAR
 END_FUNCTION_BLOCK";
     let library = parse_program(source, &FileId::default(), &opts_with_fb_inheritance()).unwrap();
     let fb = extract_fb(&library);
-    let oop = fb.oop.as_ref().expect("expected oop to be Some");
+    let oop = fb.oop.as_ref().unwrap();
     assert_eq!(oop.base, Some(TypeName::from("FB_Motor")));
     assert_eq!(oop.implements, vec![TypeName::from("I_Drivable")]);
 }
@@ -92,7 +92,7 @@ END_VAR
 END_FUNCTION_BLOCK";
     let library = parse_program(source, &FileId::default(), &opts_with_fb_inheritance()).unwrap();
     let fb = extract_fb(&library);
-    let oop = fb.oop.as_ref().expect("expected oop to be Some");
+    let oop = fb.oop.as_ref().unwrap();
     assert_eq!(
         oop.implements,
         vec![TypeName::from("I_Hydraulics"), TypeName::from("I_Brake")]
@@ -136,7 +136,7 @@ END_VAR
 END_FUNCTION_BLOCK";
     let library = parse_program(source, &FileId::default(), &opts_with_fb_inheritance()).unwrap();
     let fb = extract_fb(&library);
-    let oop = fb.oop.as_ref().expect("expected oop to be Some");
+    let oop = fb.oop.as_ref().unwrap();
     assert!(oop.is_abstract);
     assert_eq!(oop.base, None);
     assert!(oop.implements.is_empty());
@@ -153,7 +153,7 @@ END_VAR
 END_FUNCTION_BLOCK";
     let library = parse_program(source, &FileId::default(), &opts_with_fb_inheritance()).unwrap();
     let fb = extract_fb(&library);
-    let oop = fb.oop.as_ref().expect("expected oop to be Some");
+    let oop = fb.oop.as_ref().unwrap();
     assert!(oop.is_abstract);
     assert_eq!(oop.base, Some(TypeName::from("FB_BaseAxis")));
     assert_eq!(oop.implements, vec![TypeName::from("I_Axis")]);
@@ -184,8 +184,7 @@ VAR
     bRunning : BOOL;
 END_VAR
 END_FUNCTION_BLOCK";
-    let library = parse_program(source, &FileId::default(), &CompilerOptions::default())
-        .expect("ABSTRACT must remain a valid identifier in standard mode");
+    let library = parse_program(source, &FileId::default(), &CompilerOptions::default()).unwrap();
     let fb = extract_fb(&library);
     assert_eq!(fb.name, TypeName::from("ABSTRACT"));
     assert!(fb.oop.is_none());

--- a/compiler/parser/src/tests/types_and_returns.rs
+++ b/compiler/parser/src/tests/types_and_returns.rs
@@ -315,7 +315,7 @@ END_PROGRAM",
         &FileId::default(),
         &options,
     );
-    let lib = result.expect("should parse");
+    let lib = result.unwrap();
     let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
     let spec = cast!(
         &prog.variables[0].initializer,

--- a/compiler/parser/src/xform_assign_file_id.rs
+++ b/compiler/parser/src/xform_assign_file_id.rs
@@ -78,7 +78,7 @@ END_TYPE
         let type_name_span = spans
             .iter()
             .find(|span| span.start == 6 && span.end == 11)
-            .expect("Should find the type name span");
+            .unwrap();
 
         assert_eq!(expected_fid, type_name_span.file_id);
     }

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -1330,7 +1330,7 @@ END_PROGRAM
         let json = run(&bytecode, 1);
         let result: RunResult = serde_json::from_str(&json).unwrap();
         assert!(!result.ok);
-        let error = result.error.expect("expected a runtime error");
+        let error = result.error.unwrap();
         assert_eq!(error.code.as_deref(), Some("V4001"));
         // The JSON payload carries the code as a member of the error object.
         assert!(json.contains("\"code\":\"V4001\""));
@@ -1341,7 +1341,7 @@ END_PROGRAM
         let json = run("not-valid-base64!!!", 1);
         let result: RunResult = serde_json::from_str(&json).unwrap();
         assert!(!result.ok);
-        let error = result.error.expect("expected a host error");
+        let error = result.error.unwrap();
         // Host illegal states share the internal-error code and are told apart
         // by the recorded call-site location, not by a bespoke per-error code.
         assert_eq!(error.code.as_deref(), Some("P9998"));
@@ -1355,7 +1355,7 @@ END_PROGRAM
         let bytes = BASE64.encode(b"not a container");
         let result: RunResult = serde_json::from_str(&run(&bytes, 1)).unwrap();
         assert!(!result.ok);
-        let error = result.error.expect("expected a host error");
+        let error = result.error.unwrap();
         assert_eq!(error.code.as_deref(), Some("P9998"));
         assert!(error.compiler_line > 0);
     }
@@ -1781,7 +1781,7 @@ END_PROGRAM
             .diagnostics
             .iter()
             .find(|d| d.code == "P9999")
-            .expect("expected a P9999 diagnostic");
+            .unwrap();
         assert!(
             diag.compiler_file.ends_with(".rs"),
             "expected a compiler .rs file, got {:?}",
@@ -1954,11 +1954,7 @@ END_PROGRAM
             "Expected ok but got diagnostics: {:?}, error: {:?}",
             result.diagnostics, result.error
         );
-        let s = result
-            .variables
-            .iter()
-            .find(|v| v.name == "s")
-            .expect("variable 's' present");
+        let s = result.variables.iter().find(|v| v.name == "s").unwrap();
         assert_eq!(s.value, "'hello'");
         assert!(s.valid, "expected s.valid == true for a real STRING value");
     }
@@ -2182,7 +2178,7 @@ END_PROGRAM
             .diagnostics
             .iter()
             .find(|d| d.code == "P0004")
-            .expect("expected a P0004 diagnostic");
+            .unwrap();
         assert!(!cstyle.help.is_empty());
     }
 

--- a/compiler/playground/src/spec_conformance.rs
+++ b/compiler/playground/src/spec_conformance.rs
@@ -33,7 +33,7 @@ const TC2_SYSTEM_ST: &str =
 
 fn compile_ok(source: &str, libraries: &str) -> bool {
     let json = crate::compile(source, "", "", libraries);
-    let value: Value = serde_json::from_str(&json).expect("compile returns JSON");
+    let value: Value = serde_json::from_str(&json).unwrap();
     value["ok"] == Value::Bool(true)
 }
 
@@ -50,7 +50,7 @@ fn playground_spec_req_cl_001_activates_library_from_served_files() {
     // Loading the served library file (as the browser would, passing its text
     // as a JSON array of sources) activates the library: `PI` resolves, folds
     // at compile time, and the same source compiles.
-    let libraries = serde_json::to_string(&[TC2_SYSTEM_ST]).expect("serialize library sources");
+    let libraries = serde_json::to_string(&[TC2_SYSTEM_ST]).unwrap();
     assert!(
         compile_ok(PI_PROGRAM, &libraries),
         "loading the served library file must make PI resolve"

--- a/compiler/plc2plc/src/spec_conformance.rs
+++ b/compiler/plc2plc/src/spec_conformance.rs
@@ -26,8 +26,8 @@ fn all_spec_requirements_have_tests() {
 }
 
 fn render(source: &str, options: &CompilerOptions) -> String {
-    let library = parse_program(source, &FileId::default(), options).expect("program parses");
-    write_to_string(&library).expect("library renders")
+    let library = parse_program(source, &FileId::default(), options).unwrap();
+    write_to_string(&library).unwrap()
 }
 
 fn reference_to_options() -> CompilerOptions {

--- a/compiler/plc2plc/src/tests/case.rs
+++ b/compiler/plc2plc/src/tests/case.rs
@@ -30,8 +30,7 @@ END_FUNCTION_BLOCK
     let rendered = write_to_string(&library_original).unwrap();
 
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 
@@ -68,8 +67,7 @@ END_FUNCTION_BLOCK
     assert!(rendered.contains("10"));
 
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     let rendered_again = write_to_string(&library_rendered).unwrap();
     assert_eq!(rendered, rendered_again);
 }

--- a/compiler/plc2plc/src/tests/constant_initializers.rs
+++ b/compiler/plc2plc/src/tests/constant_initializers.rs
@@ -25,7 +25,6 @@ END_PROGRAM
     assert!(rendered.contains("SCALE"));
     assert!(rendered.contains("180.5"));
 
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .expect("rendered output must parse under the same dialect");
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
     assert_eq!(library_original, library_rendered);
 }

--- a/compiler/plc2plc/src/tests/declarations.rs
+++ b/compiler/plc2plc/src/tests/declarations.rs
@@ -76,8 +76,7 @@ END_FUNCTION_BLOCK
     assert!(rendered.contains("STRING [ 255 ]"));
 
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 
@@ -108,7 +107,6 @@ END_FUNCTION_BLOCK
     assert!(rendered.contains("FB_Comm ( retries := 3 , THIS )"));
 
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     assert_eq!(library_original, library_rendered);
 }

--- a/compiler/plc2plc/src/tests/enums.rs
+++ b/compiler/plc2plc/src/tests/enums.rs
@@ -17,8 +17,7 @@ END_TYPE
     assert!(rendered.contains("English := 2"));
 
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 
@@ -36,8 +35,7 @@ END_TYPE
     assert!(rendered.contains("BYTE"));
 
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 
@@ -66,7 +64,6 @@ END_FUNCTION_BLOCK
     assert!(rendered.contains("COLOR#RED"));
 
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     assert_eq!(library_original, library_rendered);
 }

--- a/compiler/plc2plc/src/tests/fb_inheritance.rs
+++ b/compiler/plc2plc/src/tests/fb_inheritance.rs
@@ -36,8 +36,7 @@ END_FUNCTION_BLOCK
     assert!(rendered.contains("INTERFACE I_Drivable"));
     assert!(rendered.contains("END_INTERFACE"));
 
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .expect("rendered output must parse under the same dialect");
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 
@@ -60,8 +59,7 @@ END_INTERFACE
     assert!(rendered.contains("INTERFACE I_Focus"));
     assert!(rendered.contains("EXTENDS I_BaseAxis"));
 
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .expect("rendered output must parse under the same dialect");
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 
@@ -86,7 +84,6 @@ END_INTERFACE
 
     assert!(rendered.contains("FUNCTION_BLOCK ABSTRACT FB_BaseAxis"));
 
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .expect("rendered output must parse under the same dialect");
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
     assert_eq!(library_original, library_rendered);
 }

--- a/compiler/plc2plc/src/tests/mixed_vars.rs
+++ b/compiler/plc2plc/src/tests/mixed_vars.rs
@@ -33,8 +33,7 @@ END_FUNCTION_BLOCK
     // equality check against the original isn't meaningful here.
     // Instead, verify the rendered output re-parses cleanly under the
     // same flag and both variables keep their original shape.
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .expect("rendered output must parse under the same dialect");
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
 
     let fb = match &library_rendered.elements[0] {
         LibraryElementKind::FunctionBlockDeclaration(fb) => fb,
@@ -45,7 +44,7 @@ END_FUNCTION_BLOCK
             .variables
             .iter()
             .find(|v| matches!(&v.identifier, VariableIdentifier::Direct(d) if d.name.as_ref().map(|n| n.to_string()) == Some("tempSensor".to_string())))
-            .expect("tempSensor should still be a Direct (located) variable");
+            .unwrap();
     assert!(matches!(
         &temp_sensor.identifier,
         VariableIdentifier::Direct(_)
@@ -55,6 +54,6 @@ END_FUNCTION_BLOCK
             .variables
             .iter()
             .find(|v| matches!(&v.identifier, VariableIdentifier::Symbol(id) if id.to_string() == "fbComm"))
-            .expect("fbComm should still be a plain Symbol variable");
+            .unwrap();
     assert!(matches!(&fb_comm.identifier, VariableIdentifier::Symbol(_)));
 }

--- a/compiler/plc2plc/src/tests/partial_access.rs
+++ b/compiler/plc2plc/src/tests/partial_access.rs
@@ -19,8 +19,7 @@ fn plc2plc_spec_req_pab_060_percent_x_round_trips_through_short_form() {
     };
     let library_original = parse_program(&original, &FileId::default(), &options).unwrap();
     let library_rendered =
-        parse_program(&rendered, &FileId::default(), &CompilerOptions::default())
-            .expect("rendered output must parse under default (no-flag) options");
+        parse_program(&rendered, &FileId::default(), &CompilerOptions::default()).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 

--- a/compiler/plc2plc/src/tests/short_circuit.rs
+++ b/compiler/plc2plc/src/tests/short_circuit.rs
@@ -25,7 +25,6 @@ END_FUNCTION_BLOCK
     // spelling is real, externally-visible behavior in TwinCAT/CODESYS.
     assert!(rendered.contains("AND_THEN"));
 
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .expect("rendered output must parse under the same dialect");
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
     assert_eq!(library_original, library_rendered);
 }

--- a/compiler/plc2plc/src/tests/struct_init_expressions.rs
+++ b/compiler/plc2plc/src/tests/struct_init_expressions.rs
@@ -30,7 +30,6 @@ END_FUNCTION_BLOCK
     assert!(rendered.contains("pDevice"));
     assert!(rendered.contains("Delta"));
 
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .expect("rendered output must parse under the same dialect");
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
     assert_eq!(library_original, library_rendered);
 }

--- a/compiler/project/src/project.rs
+++ b/compiler/project/src/project.rs
@@ -509,7 +509,7 @@ mod test {
         );
 
         let result = project.semantic();
-        let diagnostics = result.expect_err("an unshipped library must produce a diagnostic");
+        let diagnostics = result.unwrap_err();
         assert!(
             diagnostics.iter().any(|d| d.code == "P6011"),
             "expected P6011 naming the missing library, got: {diagnostics:?}"
@@ -560,7 +560,7 @@ mod test {
         fn element_names(source_project: &mut SourceProject) -> Vec<String> {
             let (_, _, library) =
                 super::run_semantic_analysis(source_project, &CompilerOptions::default());
-            let library = library.expect("valid project must produce a merged library");
+            let library = library.unwrap();
             library
                 .elements
                 .iter()

--- a/compiler/sources/src/discovery/mod.rs
+++ b/compiler/sources/src/discovery/mod.rs
@@ -837,7 +837,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = discover(dir.path()).expect("missing entries must not abort discovery itself");
+        let result = discover(dir.path()).unwrap();
         assert_eq!(result.errors.len(), 1);
     }
 

--- a/compiler/sources/src/libraries/mod.rs
+++ b/compiler/sources/src/libraries/mod.rs
@@ -373,9 +373,7 @@ mod tests {
     #[test]
     fn load_when_tc2_system_then_provides_pi() {
         let registry = LibraryRegistry::bundled();
-        let loaded = registry
-            .load(&LibraryName::from("Tc2_System"))
-            .expect("Tc2_System loads");
+        let loaded = registry.load(&LibraryName::from("Tc2_System")).unwrap();
         assert_eq!(loaded.manifest.name, "Tc2_System");
         assert_eq!(loaded.manifest.default_version, "1.0.0");
         assert!(

--- a/compiler/sources/src/spec_conformance.rs
+++ b/compiler/sources/src/spec_conformance.rs
@@ -74,9 +74,7 @@ fn sources_spec_req_lf_001_package_layout_is_read() {
     );
 
     let registry = LibraryRegistry::with_root(dir.path());
-    let loaded = registry
-        .load(&LibraryName::from("Fixture"))
-        .expect("package loads");
+    let loaded = registry.load(&LibraryName::from("Fixture")).unwrap();
     // The declaration in the version subdirectory's `.st` file was read.
     assert!(declares_pi(&loaded.library));
 }
@@ -91,7 +89,7 @@ fn sources_spec_req_lf_002_manifest_declares_identity() {
         "name = \"Tc2_System\"\nvendor = \"Beckhoff Automation GmbH\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com\"]\n",
         &file_id,
     )
-    .expect("valid manifest parses");
+    .unwrap();
     assert_eq!(manifest.name, "Tc2_System");
     assert_eq!(manifest.vendor, "Beckhoff Automation GmbH");
     assert_eq!(manifest.default_version, "1.0.0");
@@ -101,7 +99,7 @@ fn sources_spec_req_lf_002_manifest_declares_identity() {
         "name = \"Tc2_System\"\nvendor = \"Beckhoff Automation GmbH\"\nreferences = [\"https://example.com\"]\n",
         &file_id,
     )
-    .expect_err("missing field is rejected");
+    .unwrap_err();
     assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
 }
 
@@ -114,7 +112,7 @@ fn sources_spec_req_lf_004_manifest_records_references() {
         "name = \"Tc2_System\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com/a\", \"https://example.com/b\"]\n",
         &file_id,
     )
-    .expect("valid manifest parses");
+    .unwrap();
     assert_eq!(manifest.references.len(), 2);
 
     // An empty `references` list is rejected.
@@ -122,7 +120,7 @@ fn sources_spec_req_lf_004_manifest_records_references() {
         "name = \"Tc2_System\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = []\n",
         &file_id,
     )
-    .expect_err("empty references is rejected");
+    .unwrap_err();
     assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
 }
 
@@ -146,9 +144,7 @@ fn sources_spec_req_cl_002_loader_validates_manifest_identity() {
     .unwrap();
 
     let registry = LibraryRegistry::with_root(dir.path());
-    let err = registry
-        .load(&LibraryName::from("Bad"))
-        .expect_err("invalid manifest is rejected on load");
+    let err = registry.load(&LibraryName::from("Bad")).unwrap_err();
     assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
 }
 
@@ -233,7 +229,7 @@ fn sources_spec_req_cl_001_reads_plcproj_library_references() {
     )
     .unwrap();
 
-    let discovered = discover(dir.path()).expect("discovery succeeds");
+    let discovered = discover(dir.path()).unwrap();
 
     // Both vendor references are read; the system library is skipped.
     let names: Vec<&str> = discovered

--- a/compiler/test/tests/spec_conformance_guard.rs
+++ b/compiler/test/tests/spec_conformance_guard.rs
@@ -161,21 +161,14 @@ fn every_requirement_slug_is_claimed_by_a_listing_crate() {
     // is the crate directory name (which equals CARGO_PKG_NAME minus `ironplc-`).
     let mut listings: BTreeSet<(String, String)> = BTreeSet::new();
     let mut listed_docs: BTreeSet<String> = BTreeSet::new();
-    for entry in fs::read_dir(&compiler_dir)
-        .expect("read compiler dir")
-        .flatten()
-    {
+    for entry in fs::read_dir(&compiler_dir).unwrap().flatten() {
         let dir = entry.path();
         let build_rs = dir.join("build.rs");
         if !build_rs.is_file() {
             continue;
         }
-        let slug = dir
-            .file_name()
-            .expect("crate dir name")
-            .to_string_lossy()
-            .to_string();
-        let src = fs::read_to_string(&build_rs).expect("read build.rs");
+        let slug = dir.file_name().unwrap().to_string_lossy().to_string();
+        let src = fs::read_to_string(&build_rs).unwrap();
         for md in listed_specs(&src) {
             listings.insert((slug.clone(), md.clone()));
             listed_docs.insert(md);

--- a/compiler/vm-cli/src/cli.rs
+++ b/compiler/vm-cli/src/cli.rs
@@ -496,8 +496,7 @@ mod tests {
     fn write_variable_line_when_writer_errors_then_v6006() {
         let debug_map: HashMap<u16, VarDebugInfo> = HashMap::new();
         let mut sink = FailingWriter;
-        let err = write_variable_line(&mut sink, 0, 0, &debug_map)
-            .expect_err("writer failure should surface as VmError");
+        let err = write_variable_line(&mut sink, 0, 0, &debug_map).unwrap_err();
         assert!(
             err.to_string().starts_with("V6006"),
             "expected V6006 (dump write), got {err}"

--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -896,7 +896,7 @@ mod tests {
 
     /// Index of the first message matching `pred`, for ordering assertions.
     fn index_of(out: &[Value], pred: impl Fn(&Value) -> bool) -> usize {
-        out.iter().position(pred).expect("message not found")
+        out.iter().position(pred).unwrap()
     }
 
     #[test]

--- a/compiler/vm-cli/tests/cli.rs
+++ b/compiler/vm-cli/tests/cli.rs
@@ -308,14 +308,10 @@ fn read_when_debug_source_file_table_golden_then_decodes_new_debug_fields() {
     use ironplc_container::Container;
     use std::io::Cursor;
 
-    let bytes = std::fs::read(path_to_golden_resource("debug_source_file_table.iplc"))
-        .expect("debug_source_file_table.iplc must exist; regenerate via generate_golden_files");
+    let bytes = std::fs::read(path_to_golden_resource("debug_source_file_table.iplc")).unwrap();
     let container = Container::read_from(&mut Cursor::new(&bytes)).unwrap();
 
-    let debug = container
-        .debug_section
-        .as_ref()
-        .expect("debug section present");
+    let debug = container.debug_section.as_ref().unwrap();
 
     // SOURCE_FILE_TABLE round-trip
     assert_eq!(debug.source_files.len(), 2);
@@ -782,9 +778,7 @@ fn benchmark_when_cyclic_task_then_budget_pct_in_output() -> Result<(), Box<dyn 
         .arg("5");
     let output = cmd.assert().success().get_output().stdout.clone();
     let json: serde_json::Value = serde_json::from_slice(&output)?;
-    let tasks = json["tasks"]
-        .as_array()
-        .expect("tasks must be a JSON array");
+    let tasks = json["tasks"].as_array().unwrap();
     assert!(!tasks.is_empty(), "expected at least one task entry");
     let task = &tasks[0];
     assert_eq!(task["task_type"], "Cyclic");

--- a/compiler/vm-cli/tests/dap.rs
+++ b/compiler/vm-cli/tests/dap.rs
@@ -117,18 +117,18 @@ fn parse_messages(bytes: &[u8]) -> Vec<Value> {
     let mut messages = Vec::new();
     let mut rest = bytes;
     while let Some(header_end) = find_subslice(rest, b"\r\n\r\n") {
-        let header = std::str::from_utf8(&rest[..header_end]).expect("ascii header");
+        let header = std::str::from_utf8(&rest[..header_end]).unwrap();
         let len: usize = header
             .lines()
             .find_map(|line| line.strip_prefix("Content-Length:"))
-            .expect("Content-Length header")
+            .unwrap()
             .trim()
             .parse()
-            .expect("numeric Content-Length");
+            .unwrap();
         let body_start = header_end + 4;
         let body_end = body_start + len;
         let body = &rest[body_start..body_end];
-        messages.push(serde_json::from_slice(body).expect("json body"));
+        messages.push(serde_json::from_slice(body).unwrap());
         rest = &rest[body_end..];
     }
     messages
@@ -148,20 +148,20 @@ fn run_dap(requests: &[Value]) -> Vec<Value> {
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn ironplcdap");
+        .unwrap();
 
     {
-        let mut stdin = child.stdin.take().expect("child stdin");
+        let mut stdin = child.stdin.take().unwrap();
         for request in requests {
-            stdin.write_all(&frame(request)).expect("write request");
+            stdin.write_all(&frame(request)).unwrap();
         }
         // stdin dropped here → the server sees EOF once it has drained input.
     }
 
-    let mut stdout = child.stdout.take().expect("child stdout");
+    let mut stdout = child.stdout.take().unwrap();
     let mut out = Vec::new();
-    stdout.read_to_end(&mut out).expect("read stdout");
-    child.wait().expect("wait for ironplcdap");
+    stdout.read_to_end(&mut out).unwrap();
+    child.wait().unwrap();
 
     parse_messages(&out)
 }
@@ -215,10 +215,7 @@ fn ironplcdap_when_launch_container_without_debug_then_no_debug_info() {
                "arguments": {"program": path}}),
     ]);
 
-    let launch = messages
-        .iter()
-        .find(|m| m["command"] == "launch")
-        .expect("launch response");
+    let launch = messages.iter().find(|m| m["command"] == "launch").unwrap();
     assert_eq!(launch["success"], false);
     // The failure carries the V6009 launch-no-debug-info code.
     assert!(launch["message"].as_str().unwrap().starts_with("V6009 - "));
@@ -235,10 +232,7 @@ fn ironplcdap_when_launch_multi_instance_then_multi_instance_unsupported() {
                "arguments": {"program": path}}),
     ]);
 
-    let launch = messages
-        .iter()
-        .find(|m| m["command"] == "launch")
-        .expect("launch response");
+    let launch = messages.iter().find(|m| m["command"] == "launch").unwrap();
     assert_eq!(launch["success"], false);
     // The failure carries the V6010 multi-instance code plus the descriptive text.
     let message = launch["message"].as_str().unwrap();


### PR DESCRIPTION
Throughout the compiler test suite, .expect("...") and .expect_err("...")
calls asserted a result the test already knows exactly, so the message
text never conveys anything a reader wouldn't already have from the test
itself. The strings only added noise and, in several cases, forced the
call to span multiple lines.

Replace these with .unwrap()/.unwrap_err() in test code (test modules,
tests/ directories, and spec_conformance.rs files). Production .expect()
calls, where the message documents an invariant at a real call site, are
left untouched. Descriptive assert! messages are also preserved.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QVwyD81gbjTtWWL8f6xdZE