### PR TITLE
feat(libraries): ship compatibility-library files in the installers

### DIFF
--- a/.github/workflows/partial_library_e2e.yaml
+++ b/.github/workflows/partial_library_e2e.yaml
@@ -48,8 +48,26 @@ jobs:
       # Configure the execution environment.
       - uses: taiki-e/install-action@01159adff8f38113be7211e869405f6f6abf02d7 # just
 
-      # Install the published compiler with the real OS installer and compile a
-      # program that depends on the bundled Tc2_System library. The [unix] and
-      # [windows] variants of the recipe select the right installer per OS.
+      # Install the published compiler with the real OS installer, then compile
+      # and run a program that depends on the bundled Tc2_System library. The
+      # [unix] and [windows] recipe variants select the right installer per OS.
       - name: Library installer end-to-end test
         run: just library-e2e "${{ inputs.compiler-version }}"
+
+  # macOS additionally ships through Homebrew, whose formula installs to a
+  # different layout (libexec + symlinked binaries). This job exercises that
+  # installer, separate from the tarball leg above.
+  library-e2e-brew:
+    name: Library Installer E2E (macOS Homebrew)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: taiki-e/install-action@01159adff8f38113be7211e869405f6f6abf02d7 # just
+
+      # Install via `brew install` from the repository's formula, then compile
+      # and run the library-dependent program on the Homebrew-installed toolchain.
+      - name: Homebrew library installer end-to-end test
+        run: just library-e2e-brew "${{ inputs.compiler-version }}"

--- a/.github/workflows/partial_library_e2e.yaml
+++ b/.github/workflows/partial_library_e2e.yaml
@@ -1,0 +1,55 @@
+name: Library Installer E2E
+# Extended end-to-end test for the compatibility-library installers. Installs the
+# published compiler with the real OS installer (tarball + install.sh on Unix, the
+# NSIS installer on Windows) and compiles a program that depends on the bundled
+# Tc2_System library. This verifies the installer ships resources/libs beside the
+# binary and the compiler resolves library symbols from the installed location.
+#
+# The installers place files differently per OS, so this runs on Linux, macOS, and
+# Windows. The bulk of the test lives in the `library-e2e` justfile recipe, so a
+# workflow_dispatch run exercises branch changes directly.
+#
+# NOTE: this partial is intentionally NOT wired into deployment.yaml or
+# integration.yaml yet. Run it manually via the Actions tab (workflow_dispatch) or
+# locally with `just library-e2e <version>`.
+on:
+  workflow_call:
+    inputs:
+      compiler-version:
+        required: true
+        type: string
+        description: 'The version number to test with (without the "v" prefix). Empty string uses the latest release.'
+  # Allow running manually against any branch from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      compiler-version:
+        required: false
+        type: string
+        default: ""
+        description: 'The version number to test with (without the "v" prefix). Empty string uses the latest release. Must be a release that ships the compatibility libraries.'
+
+permissions:
+  contents: read
+
+jobs:
+  library-e2e:
+    name: Library Installer E2E (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2025]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Fetch the test fixture and justfile recipes.
+      - name: Checkout HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Configure the execution environment.
+      - uses: taiki-e/install-action@01159adff8f38113be7211e869405f6f6abf02d7 # just
+
+      # Install the published compiler with the real OS installer and compile a
+      # program that depends on the bundled Tc2_System library. The [unix] and
+      # [windows] variants of the recipe select the right installer per OS.
+      - name: Library installer end-to-end test
+        run: just library-e2e "${{ inputs.compiler-version }}"

--- a/.github/workflows/partial_library_e2e.yaml
+++ b/.github/workflows/partial_library_e2e.yaml
@@ -18,15 +18,14 @@ on:
       compiler-version:
         required: true
         type: string
-        description: 'The version number to test with (without the "v" prefix). Empty string uses the latest release.'
+        description: 'Bare release version to test, without the "v" prefix (e.g. 0.234.0). Must be a release that ships the compatibility libraries.'
   # Allow running manually against any branch from the Actions tab.
   workflow_dispatch:
     inputs:
       compiler-version:
-        required: false
+        required: true
         type: string
-        default: ""
-        description: 'The version number to test with (without the "v" prefix). Empty string uses the latest release. Must be a release that ships the compatibility libraries.'
+        description: 'Bare release version to test, without the "v" prefix (e.g. 0.234.0). Must be a release that ships the compatibility libraries.'
 
 permissions:
   contents: read

--- a/compiler/homebrew/Formula/ironplc.rb
+++ b/compiler/homebrew/Formula/ironplc.rb
@@ -28,12 +28,14 @@ class Ironplc < Formula
     end
   
     def install
-      bin.install "ironplcc"
-      bin.install "ironplcvm"
-      bin.install "ironplcmcp"
-      # Compatibility libraries ship beside the binaries; the compiler reads
-      # them from <bindir>/resources/libs at runtime. current_exe() resolves the
-      # Homebrew symlink to the Cellar bin, so this is where the loader looks.
-      (bin/"resources").install "resources/libs"
+      # Keep the binaries and their runtime resources together in libexec, then
+      # symlink the executables onto the PATH. The compiler reads its bundled
+      # compatibility libraries from <exedir>/resources/libs at runtime, and
+      # current_exe() resolves the bin symlink back to libexec -- so the
+      # libraries must sit beside the real binaries here, not in bin.
+      libexec.install "ironplcc", "ironplcvm", "ironplcmcp", "resources"
+      bin.install_symlink libexec/"ironplcc"
+      bin.install_symlink libexec/"ironplcvm"
+      bin.install_symlink libexec/"ironplcmcp"
     end
   end

--- a/compiler/homebrew/Formula/ironplc.rb
+++ b/compiler/homebrew/Formula/ironplc.rb
@@ -31,5 +31,9 @@ class Ironplc < Formula
       bin.install "ironplcc"
       bin.install "ironplcvm"
       bin.install "ironplcmcp"
+      # Compatibility libraries ship beside the binaries; the compiler reads
+      # them from <bindir>/resources/libs at runtime. current_exe() resolves the
+      # Homebrew symlink to the Cellar bin, so this is where the loader looks.
+      (bin/"resources").install "resources/libs"
     end
   end

--- a/compiler/install.sh
+++ b/compiler/install.sh
@@ -335,6 +335,16 @@ install_binaries() {
         fi
     done
 
+    # Compatibility libraries ship beside the binaries; the compiler reads them
+    # from <bindir>/resources/libs at runtime. Replace any prior copy so a
+    # reinstall does not leave stale library files behind.
+    if [ -d "${_tmp}/resources" ]; then
+        rm -rf "${INSTALL_DIR}/bin/resources"
+        mv -f "${_tmp}/resources" "${INSTALL_DIR}/bin/resources"
+    else
+        warn "archive does not include compatibility libraries (released before they existed); skipping"
+    fi
+
     # macOS may set com.apple.quarantine on extracted binaries. Best-effort removal.
     if [ "$PLATFORM_OS" = "macos" ] && have xattr; then
         xattr -dr com.apple.quarantine "${INSTALL_DIR}/bin" 2>/dev/null || true

--- a/compiler/justfile
+++ b/compiler/justfile
@@ -66,13 +66,23 @@ _package-windows version filename target:
 _package-macos version filename target:
   cargo build --release --target {{target}}
   cp bom.cdx.json target/{{target}}/release/bom.cdx.json
-  tar -czvf {{filename}} --directory=target/{{target}}/release ironplcc ironplcvm ironplcmcp bom.cdx.json
+  # Stage the compatibility libraries so they ship beside the binaries; the
+  # loader reads them from `<bindir>/resources/libs` at runtime.
+  rm -rf target/{{target}}/release/resources/libs
+  mkdir -p target/{{target}}/release/resources
+  cp -R sources/resources/libs target/{{target}}/release/resources/libs
+  tar -czvf {{filename}} --directory=target/{{target}}/release ironplcc ironplcvm ironplcmcp bom.cdx.json resources
   shasum -a 256 {{filename}} > {{filename}}.sha256
 
 _package-linux version filename target:
   cargo build --release --target {{target}}
   cp bom.cdx.json target/{{target}}/release/bom.cdx.json
-  tar -czvf {{filename}} --directory=target/{{target}}/release ironplcc ironplcvm ironplcmcp bom.cdx.json
+  # Stage the compatibility libraries so they ship beside the binaries; the
+  # loader reads them from `<bindir>/resources/libs` at runtime.
+  rm -rf target/{{target}}/release/resources/libs
+  mkdir -p target/{{target}}/release/resources
+  cp -R sources/resources/libs target/{{target}}/release/resources/libs
+  tar -czvf {{filename}} --directory=target/{{target}}/release ironplcc ironplcvm ironplcmcp bom.cdx.json resources
   sha256sum {{filename}} > {{filename}}.sha256
 
 # Builds the Homebrew repository to release for Mac and Linux

--- a/compiler/setup.nsi
+++ b/compiler/setup.nsi
@@ -94,6 +94,11 @@ Section "Program files"
     File "${ARTIFACTSDIR}\${VMFILE}"
     File "${ARTIFACTSDIR}\${MCPFILE}"
 
+    ; Compatibility libraries ship beside the binaries; the compiler reads them
+    ; from <bindir>\resources\libs at runtime. `/r` preserves the `libs` tree.
+    SetOutPath "$INSTDIR\bin\resources"
+    File /r "sources\resources\libs"
+
     SetOutPath "$INSTDIR\examples"
     File "..\examples\getting_started.st"
 

--- a/justfile
+++ b/justfile
@@ -293,19 +293,21 @@ install-script-smoke compiler-version="":
 
 # Library installer end-to-end test.
 #
-# Installs the published compiler with the *real* OS installer -- the tarball +
-# install.sh on Unix, the NSIS installer on Windows -- then compiles a program
-# that depends on the bundled Tc2_System compatibility library. This is the one
-# test that proves the installer ships resources/libs beside the binary and that
-# the compiler resolves library symbols (PI) from the *installed* location, not
-# the dev-tree fallback. The two installers place files differently, so the check
-# runs per OS via the [unix]/[windows] recipe variants below.
+# Installs the published compiler with the *real* OS installer, then compiles AND
+# runs a program that depends on the bundled Tc2_System compatibility library:
+# it computes 2 * PI * 10.0 and the VM dumps the result after one scan. This is
+# the one test that proves the installer ships resources/libs beside the binary,
+# the compiler resolves library symbols (PI) from the *installed* location (not
+# the dev-tree fallback), and the whole toolchain (compile -> run) works on the
+# shipped binaries. Each OS installs differently, so the flow runs per OS:
+#   [unix]      -- tarball + install.sh          -> $HOME/.ironplc/bin
+#   [windows]   -- NSIS installer                -> %LOCALAPPDATA%\...\bin
+#   [macos]     -- Homebrew formula (library-e2e-brew) -> libexec (symlinked)
 #
 # Structured like endtoend-smoke: the top recipe orchestrates a `-download`
-# (acquire + install) step and a `-test` (verify) step. Splitting them lets you
-# reinstall once and re-run the verification repeatedly. Install lives in the
-# download step because the Unix install.sh fuses fetch and install; the test
-# step is then pure verification on both platforms.
+# (acquire + install) step and a `-test` (compile + run + verify) step. Splitting
+# them lets you reinstall once and re-run the verification repeatedly. Install
+# lives in the download step because the Unix install.sh fuses fetch and install.
 #
 # Unlike install-script-smoke (which stays green against older releases), the
 # library check here is a HARD assertion: this test exists to catch a release
@@ -327,23 +329,89 @@ library-e2e-download compiler-version="":
   @just _install-script-smoke-clean
   @just _install-script-smoke-run "{{compiler-version}}"
 
-# Verify the installed compiler resolves the bundled library.
+# Compile the library-dependent program with the installed compiler, run one scan
+# on the installed VM, and assert it computed 2 * PI * 10.0 from the library PI.
 [unix]
 library-e2e-test:
   #!/usr/bin/env sh
   set -eu
   BIN="$HOME/.ironplc/bin"
-  LIB="$BIN/resources/libs/Tc2_System/library.toml"
-  # The installer must ship the library files beside the binary.
-  if [ ! -f "$LIB" ]; then
-    echo "FAIL: compatibility library not installed at $LIB" >&2
+  just _library-e2e-run-installed "$BIN/ironplcc" "$BIN/ironplcvm" "$BIN/resources/libs/Tc2_System/library.toml"
+
+# macOS additionally ships through Homebrew, whose formula installs to libexec and
+# symlinks the executables onto the PATH -- a different layout from the tarball.
+# This variant tests that path. It is named separately so macOS can run both the
+# tarball (library-e2e) and Homebrew (library-e2e-brew) installers.
+[macos]
+library-e2e-brew compiler-version="":
+  @just library-e2e-brew-download "{{compiler-version}}"
+  @just library-e2e-brew-test
+
+# Fill the Homebrew formula for the target release and install from the local
+# file. Uses sed (not `just publish`) so it needs no envsubst/gettext on macOS;
+# the formula content is the same template the release tap publishes. The mac
+# tarball is chosen to match the runner architecture -- the formula's install
+# logic (libexec + symlinks + resources) is identical regardless of arch.
+[macos]
+library-e2e-brew-download compiler-version="":
+  #!/usr/bin/env sh
+  set -eu
+  if [ -n "{{compiler-version}}" ]; then
+    VER="{{compiler-version}}"
+  else
+    VER="$(curl -fsSL https://api.github.com/repos/ironplc/ironplc/releases/latest \
+      | grep '"tag_name"' | head -1 | sed -E 's/.*"v?([^"]+)".*/\1/')"
+  fi
+  echo "Using release v$VER"
+  case "$(uname -m)" in
+    arm64|aarch64) MACFILE="ironplcc-aarch64-macos.tar.gz" ;;
+    *)             MACFILE="ironplcc-x86_64-macos.tar.gz" ;;
+  esac
+  LINUXFILE="ironplcc-x86_64-linux-musl.tar.gz"
+  BASE="https://github.com/ironplc/ironplc/releases/download/v${VER}"
+  MACSHA="$(curl -fsSL "${BASE}/${MACFILE}.sha256" | cut -d' ' -f1)"
+  LINUXSHA="$(curl -fsSL "${BASE}/${LINUXFILE}.sha256" | cut -d' ' -f1)"
+  mkdir -p compiler/target/homebrew/Formula
+  sed -e "s#\${VERSION}#${VER}#g" \
+      -e "s#\${MACFILENAME}#${MACFILE}#g" \
+      -e "s#\${MACSHA256}#${MACSHA}#g" \
+      -e "s#\${LINUXFILENAME}#${LINUXFILE}#g" \
+      -e "s#\${LINUXSHA256}#${LINUXSHA}#g" \
+      compiler/homebrew/Formula/ironplc.rb > compiler/target/homebrew/Formula/ironplc.rb
+  # Reinstall cleanly so reruns start fresh.
+  brew uninstall --force ironplc >/dev/null 2>&1 || true
+  brew install --formula compiler/target/homebrew/Formula/ironplc.rb
+
+# Compile + run against the Homebrew keg: binaries are symlinked into the keg bin
+# and current_exe() resolves them back to libexec, where resources/libs lives.
+[macos]
+library-e2e-brew-test:
+  #!/usr/bin/env sh
+  set -eu
+  PREFIX="$(brew --prefix ironplc)"
+  just _library-e2e-run-installed "$PREFIX/bin/ironplcc" "$PREFIX/bin/ironplcvm" "$PREFIX/libexec/resources/libs/Tc2_System/library.toml"
+
+# Shared verification (Unix + macOS): assert the library shipped, compile the
+# fixture, run one scan, and assert the VM computed 2 * PI * 10.0 = 62.8318...
+[unix]
+_library-e2e-run-installed ironplcc ironplcvm libfile:
+  #!/usr/bin/env sh
+  set -eu
+  if [ ! -f "{{libfile}}" ]; then
+    echo "FAIL: compatibility library not installed at {{libfile}}" >&2
     echo "      (the target release must be one that ships the libraries)" >&2
     exit 1
   fi
-  # A program that depends on the library must compile against the installed files.
-  "$BIN/ironplcc" check --dialect twincat --allow-constant-initializer-expressions \
-    --library Tc2_System tests/e2e/library/uses_pi.st
-  echo "PASS: installed compiler resolved Tc2_System PI from the installed library"
+  WORK="$(mktemp -d)"
+  "{{ironplcc}}" compile --dialect twincat --library Tc2_System \
+    --output "$WORK/prog.iplc" tests/e2e/library/uses_pi.st
+  OUT="$("{{ironplcvm}}" run "$WORK/prog.iplc" --scans 1 --dump-vars -)"
+  echo "$OUT"
+  if ! echo "$OUT" | grep -q "62.8318"; then
+    echo "FAIL: VM did not compute 2 * PI * 10.0 from the library PI" >&2
+    exit 1
+  fi
+  echo "PASS: installed compiler + VM computed 2 * PI * 10.0 using the library PI"
 
 # Windows uses the NSIS installer, which installs to a fixed Program Files path.
 # Each line is a separate PowerShell process (set windows-shell), so each step is
@@ -363,14 +431,17 @@ library-e2e-download compiler-version="":
   # Install silently.
   Start-Process ironplcc-setup.exe -ArgumentList "/S" -PassThru | Wait-Process -Timeout 120
 
-# Verify the installed compiler resolves the bundled library.
+# Compile the library-dependent program with the installed compiler, run one scan
+# on the installed VM, and assert it computed 2 * PI * 10.0 from the library PI.
 [windows]
 library-e2e-test:
   # The installer must ship the library files beside the binary.
   if (-not (Test-Path "{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\resources\libs\Tc2_System\library.toml")) { Write-Error "FAIL: compatibility library not installed (the target release must be one that ships the libraries)"; exit 1 }
-  # A program that depends on the library must compile against the installed files.
-  &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcc.exe" check --dialect twincat --allow-constant-initializer-expressions --library Tc2_System "tests\e2e\library\uses_pi.st"; if ($LASTEXITCODE -ne 0) { Write-Error "FAIL: installed compiler could not compile the library-dependent program"; exit 1 }
-  Write-Host "PASS: installed compiler resolved Tc2_System PI from the installed library"
+  # Compile the library-dependent program against the installed files.
+  &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcc.exe" compile --dialect twincat --library Tc2_System --output "$env:TEMP\prog.iplc" "tests\e2e\library\uses_pi.st"; if ($LASTEXITCODE -ne 0) { Write-Error "FAIL: installed compiler could not compile the library-dependent program"; exit 1 }
+  # Run one scan on the installed VM and assert it computed 2 * PI * 10.0.
+  $out = &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcvm.exe" run "$env:TEMP\prog.iplc" --scans 1 --dump-vars -; Write-Host $out; if ($out -notmatch "62.8318") { Write-Error "FAIL: VM did not compute 2 * PI * 10.0 from the library PI"; exit 1 }
+  Write-Host "PASS: installed compiler + VM computed 2 * PI * 10.0 using the library PI"
 
 # OpenCode integration end-to-end test - Unix only.
 #

--- a/justfile
+++ b/justfile
@@ -423,11 +423,12 @@ library-e2e compiler-version="":
 
 # Download + install the published compiler via the NSIS installer. The x86_64
 # asset name is hard-coded because the GitHub runner is x86_64; pass a different
-# version to target another release.
+# version to target another release. An empty version uses GitHub's
+# `latest/download` redirect, so no API call or tag resolution is needed.
 [windows]
 library-e2e-download compiler-version="":
-  # Resolve the release tag (empty -> latest) and download the NSIS installer.
-  $v="{{compiler-version}}"; $tag= if([string]::IsNullOrEmpty($v)){(Invoke-RestMethod -Uri "https://api.github.com/repos/ironplc/ironplc/releases/latest").tag_name}else{"v$v"}; Write-Host "Using release $tag"; Invoke-WebRequest -Uri "https://github.com/ironplc/ironplc/releases/download/$tag/ironplcc-x86_64-windows.exe" -OutFile ironplcc-setup.exe
+  # Download the NSIS installer for the requested (or latest) release.
+  Invoke-WebRequest -Uri "https://github.com/ironplc/ironplc/releases/{{ if compiler-version == "" { "latest/download" } else { "download/v" + compiler-version } }}/ironplcc-x86_64-windows.exe" -OutFile ironplcc-setup.exe
   # Install silently.
   Start-Process ironplcc-setup.exe -ArgumentList "/S" -PassThru | Wait-Process -Timeout 120
 

--- a/justfile
+++ b/justfile
@@ -291,6 +291,64 @@ install-script-smoke compiler-version="":
   @echo "install-script-smoke is Unix-only; use endtoend-smoke on Windows"
   exit 1
 
+# Library installer end-to-end test.
+#
+# Installs the published compiler with the *real* OS installer -- the tarball +
+# install.sh on Unix, the NSIS installer on Windows -- then compiles a program
+# that depends on the bundled Tc2_System compatibility library. This is the one
+# test that proves the installer ships resources/libs beside the binary and that
+# the compiler resolves library symbols (PI) from the *installed* location, not
+# the dev-tree fallback. The two installers place files differently, so the check
+# runs per OS via the [unix]/[windows] recipe variants below.
+#
+# Unlike install-script-smoke (which stays green against older releases), the
+# library check here is a HARD assertion: this test exists to catch a release
+# that fails to ship the libraries, so the target release must be one that does.
+#
+# NOT wired into CI yet -- run it manually, or from the Actions tab via
+# partial_library_e2e.yaml's workflow_dispatch.
+#
+# compiler-version: empty to use the latest release; otherwise a bare version
+#                   like "0.234.0" (without the leading "v").
+[unix]
+library-e2e compiler-version="":
+  @just _install-script-smoke-clean
+  @just _install-script-smoke-run "{{compiler-version}}"
+  @just _library-e2e-verify-unix
+
+[unix]
+_library-e2e-verify-unix:
+  #!/usr/bin/env sh
+  set -eu
+  BIN="$HOME/.ironplc/bin"
+  LIB="$BIN/resources/libs/Tc2_System/library.toml"
+  # The installer must ship the library files beside the binary.
+  if [ ! -f "$LIB" ]; then
+    echo "FAIL: compatibility library not installed at $LIB" >&2
+    echo "      (the target release must be one that ships the libraries)" >&2
+    exit 1
+  fi
+  # A program that depends on the library must compile against the installed files.
+  "$BIN/ironplcc" check --dialect twincat --allow-constant-initializer-expressions \
+    --library Tc2_System tests/e2e/library/uses_pi.st
+  echo "PASS: installed compiler resolved Tc2_System PI from the installed library"
+
+# Windows uses the NSIS installer, which installs to a fixed Program Files path.
+# The x86_64 asset name is hard-coded because the GitHub runner is x86_64; pass a
+# different version to target another release. Each line is a separate PowerShell
+# process (set windows-shell), so each step is a self-contained statement.
+[windows]
+library-e2e compiler-version="":
+  # Resolve the release tag (empty -> latest) and download the NSIS installer.
+  $v="{{compiler-version}}"; $tag= if([string]::IsNullOrEmpty($v)){(Invoke-RestMethod -Uri "https://api.github.com/repos/ironplc/ironplc/releases/latest").tag_name}else{"v$v"}; Write-Host "Using release $tag"; Invoke-WebRequest -Uri "https://github.com/ironplc/ironplc/releases/download/$tag/ironplcc-x86_64-windows.exe" -OutFile ironplcc-setup.exe
+  # Install silently.
+  Start-Process ironplcc-setup.exe -ArgumentList "/S" -PassThru | Wait-Process -Timeout 120
+  # The installer must ship the library files beside the binary.
+  if (-not (Test-Path "{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\resources\libs\Tc2_System\library.toml")) { Write-Error "FAIL: compatibility library not installed (the target release must be one that ships the libraries)"; exit 1 }
+  # A program that depends on the library must compile against the installed files.
+  &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcc.exe" check --dialect twincat --allow-constant-initializer-expressions --library Tc2_System "tests\e2e\library\uses_pi.st"; if ($LASTEXITCODE -ne 0) { Write-Error "FAIL: installed compiler could not compile the library-dependent program"; exit 1 }
+  Write-Host "PASS: installed compiler resolved Tc2_System PI from the installed library"
+
 # OpenCode integration end-to-end test - Unix only.
 #
 # Installs the published IronPLC compiler (which provides ironplcmcp), then

--- a/justfile
+++ b/justfile
@@ -261,6 +261,20 @@ _install-script-smoke-verify:
   "$BIN/ironplcc" version
   "$BIN/ironplcc" help
 
+  # Compatibility libraries ship beside the binaries so the loader finds them at
+  # <bindir>/resources/libs. When present, verify a program reading the bundled
+  # Tc2_System `PI` constant actually compiles -- this exercises the shipped
+  # files, not the dev-tree fallback. The files are optional here because this
+  # recipe also runs against the latest published release, which predates library
+  # shipping; a release that ships them makes this a hard check on every later run.
+  if [ -f "$BIN/resources/libs/Tc2_System/library.toml" ]; then
+    _pi_src="$(mktemp -d)/pi.st"
+    printf '%s\n' 'FUNCTION_BLOCK FB_Angle VAR d2r : LREAL := PI/180.0; END_VAR END_FUNCTION_BLOCK' > "$_pi_src"
+    "$BIN/ironplcc" check --dialect twincat --allow-constant-initializer-expressions --library Tc2_System "$_pi_src"
+  else
+    echo "warning: compatibility libraries not installed (release predates library shipping); skipping PI check" >&2
+  fi
+
   # ironplcvm and ironplcmcp are optional (older releases may not include them).
   if [ -x "$BIN/ironplcmcp" ]; then
     # MCP handshake: initialize -> notifications/initialized -> tools/list.

--- a/justfile
+++ b/justfile
@@ -301,6 +301,12 @@ install-script-smoke compiler-version="":
 # the dev-tree fallback. The two installers place files differently, so the check
 # runs per OS via the [unix]/[windows] recipe variants below.
 #
+# Structured like endtoend-smoke: the top recipe orchestrates a `-download`
+# (acquire + install) step and a `-test` (verify) step. Splitting them lets you
+# reinstall once and re-run the verification repeatedly. Install lives in the
+# download step because the Unix install.sh fuses fetch and install; the test
+# step is then pure verification on both platforms.
+#
 # Unlike install-script-smoke (which stays green against older releases), the
 # library check here is a HARD assertion: this test exists to catch a release
 # that fails to ship the libraries, so the target release must be one that does.
@@ -312,12 +318,18 @@ install-script-smoke compiler-version="":
 #                   like "0.234.0" (without the leading "v").
 [unix]
 library-e2e compiler-version="":
+  @just library-e2e-download "{{compiler-version}}"
+  @just library-e2e-test
+
+# Download + install the published compiler via the tarball installer (install.sh).
+[unix]
+library-e2e-download compiler-version="":
   @just _install-script-smoke-clean
   @just _install-script-smoke-run "{{compiler-version}}"
-  @just _library-e2e-verify-unix
 
+# Verify the installed compiler resolves the bundled library.
 [unix]
-_library-e2e-verify-unix:
+library-e2e-test:
   #!/usr/bin/env sh
   set -eu
   BIN="$HOME/.ironplc/bin"
@@ -334,15 +346,26 @@ _library-e2e-verify-unix:
   echo "PASS: installed compiler resolved Tc2_System PI from the installed library"
 
 # Windows uses the NSIS installer, which installs to a fixed Program Files path.
-# The x86_64 asset name is hard-coded because the GitHub runner is x86_64; pass a
-# different version to target another release. Each line is a separate PowerShell
-# process (set windows-shell), so each step is a self-contained statement.
+# Each line is a separate PowerShell process (set windows-shell), so each step is
+# a self-contained statement.
 [windows]
 library-e2e compiler-version="":
+  @just library-e2e-download "{{compiler-version}}"
+  @just library-e2e-test
+
+# Download + install the published compiler via the NSIS installer. The x86_64
+# asset name is hard-coded because the GitHub runner is x86_64; pass a different
+# version to target another release.
+[windows]
+library-e2e-download compiler-version="":
   # Resolve the release tag (empty -> latest) and download the NSIS installer.
   $v="{{compiler-version}}"; $tag= if([string]::IsNullOrEmpty($v)){(Invoke-RestMethod -Uri "https://api.github.com/repos/ironplc/ironplc/releases/latest").tag_name}else{"v$v"}; Write-Host "Using release $tag"; Invoke-WebRequest -Uri "https://github.com/ironplc/ironplc/releases/download/$tag/ironplcc-x86_64-windows.exe" -OutFile ironplcc-setup.exe
   # Install silently.
   Start-Process ironplcc-setup.exe -ArgumentList "/S" -PassThru | Wait-Process -Timeout 120
+
+# Verify the installed compiler resolves the bundled library.
+[windows]
+library-e2e-test:
   # The installer must ship the library files beside the binary.
   if (-not (Test-Path "{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\resources\libs\Tc2_System\library.toml")) { Write-Error "FAIL: compatibility library not installed (the target release must be one that ships the libraries)"; exit 1 }
   # A program that depends on the library must compile against the installed files.

--- a/justfile
+++ b/justfile
@@ -316,16 +316,17 @@ install-script-smoke compiler-version="":
 # NOT wired into CI yet -- run it manually, or from the Actions tab via
 # partial_library_e2e.yaml's workflow_dispatch.
 #
-# compiler-version: empty to use the latest release; otherwise a bare version
-#                   like "0.234.0" (without the leading "v").
+# compiler-version: a required, bare release version like "0.234.0" (no leading
+#                   "v"). The version is always explicit -- never resolved to
+#                   "latest" -- so a run always targets a known release.
 [unix]
-library-e2e compiler-version="":
+library-e2e compiler-version:
   @just library-e2e-download "{{compiler-version}}"
   @just library-e2e-test
 
 # Download + install the published compiler via the tarball installer (install.sh).
 [unix]
-library-e2e-download compiler-version="":
+library-e2e-download compiler-version:
   @just _install-script-smoke-clean
   @just _install-script-smoke-run "{{compiler-version}}"
 
@@ -336,51 +337,37 @@ library-e2e-test:
   #!/usr/bin/env sh
   set -eu
   BIN="$HOME/.ironplc/bin"
-  just _library-e2e-run-installed "$BIN/ironplcc" "$BIN/ironplcvm" "$BIN/resources/libs/Tc2_System/library.toml"
+  just _library-e2e-run-installed "$BIN/ironplcc" "$BIN/ironplcvm"
 
 # macOS additionally ships through Homebrew, whose formula installs to libexec and
 # symlinks the executables onto the PATH -- a different layout from the tarball.
 # This variant tests that path. It is named separately so macOS can run both the
 # tarball (library-e2e) and Homebrew (library-e2e-brew) installers.
 [macos]
-library-e2e-brew compiler-version="":
+library-e2e-brew compiler-version:
   @just library-e2e-brew-download "{{compiler-version}}"
   @just library-e2e-brew-test
 
-# Fill the Homebrew formula for the target release and install from the local
-# file. Uses sed (not `just publish`) so it needs no envsubst/gettext on macOS;
-# the formula content is the same template the release tap publishes. The mac
-# tarball is chosen to match the runner architecture -- the formula's install
-# logic (libexec + symlinks + resources) is identical regardless of arch.
+# Fill the repository's Homebrew formula for the requested release and install it.
+# Homebrew has no way to pin a version on a plain tap, so we fill the formula
+# template with the release's tarball + checksum and install that. `sed` (not
+# `just publish`) avoids an envsubst/gettext dependency on macOS. The mac tarball
+# matches the runner architecture; the install logic under test is arch-agnostic.
 [macos]
-library-e2e-brew-download compiler-version="":
+library-e2e-brew-download compiler-version:
   #!/usr/bin/env sh
   set -eu
-  if [ -n "{{compiler-version}}" ]; then
-    VER="{{compiler-version}}"
-  else
-    VER="$(curl -fsSL https://api.github.com/repos/ironplc/ironplc/releases/latest \
-      | grep '"tag_name"' | head -1 | sed -E 's/.*"v?([^"]+)".*/\1/')"
-  fi
-  echo "Using release v$VER"
   case "$(uname -m)" in
-    arm64|aarch64) MACFILE="ironplcc-aarch64-macos.tar.gz" ;;
-    *)             MACFILE="ironplcc-x86_64-macos.tar.gz" ;;
+    arm64|aarch64) MAC="ironplcc-aarch64-macos.tar.gz" ;;
+    *)             MAC="ironplcc-x86_64-macos.tar.gz" ;;
   esac
-  LINUXFILE="ironplcc-x86_64-linux-musl.tar.gz"
-  BASE="https://github.com/ironplc/ironplc/releases/download/v${VER}"
-  MACSHA="$(curl -fsSL "${BASE}/${MACFILE}.sha256" | cut -d' ' -f1)"
-  LINUXSHA="$(curl -fsSL "${BASE}/${LINUXFILE}.sha256" | cut -d' ' -f1)"
-  mkdir -p compiler/target/homebrew/Formula
-  sed -e "s#\${VERSION}#${VER}#g" \
-      -e "s#\${MACFILENAME}#${MACFILE}#g" \
-      -e "s#\${MACSHA256}#${MACSHA}#g" \
-      -e "s#\${LINUXFILENAME}#${LINUXFILE}#g" \
-      -e "s#\${LINUXSHA256}#${LINUXSHA}#g" \
-      compiler/homebrew/Formula/ironplc.rb > compiler/target/homebrew/Formula/ironplc.rb
-  # Reinstall cleanly so reruns start fresh.
+  URL="https://github.com/ironplc/ironplc/releases/download/v{{compiler-version}}"
+  SHA="$(curl -fsSL "$URL/$MAC.sha256" | cut -d' ' -f1)"
+  sed -e "s#\${VERSION}#{{compiler-version}}#g" -e "s#\${MACFILENAME}#$MAC#g" \
+      -e "s#\${MACSHA256}#$SHA#g" -e "s#\${LINUXFILENAME}#$MAC#g" -e "s#\${LINUXSHA256}#$SHA#g" \
+      compiler/homebrew/Formula/ironplc.rb > /tmp/ironplc-e2e.rb
   brew uninstall --force ironplc >/dev/null 2>&1 || true
-  brew install --formula compiler/target/homebrew/Formula/ironplc.rb
+  brew install --formula /tmp/ironplc-e2e.rb
 
 # Compile + run against the Homebrew keg: binaries are symlinked into the keg bin
 # and current_exe() resolves them back to libexec, where resources/libs lives.
@@ -389,19 +376,15 @@ library-e2e-brew-test:
   #!/usr/bin/env sh
   set -eu
   PREFIX="$(brew --prefix ironplc)"
-  just _library-e2e-run-installed "$PREFIX/bin/ironplcc" "$PREFIX/bin/ironplcvm" "$PREFIX/libexec/resources/libs/Tc2_System/library.toml"
+  just _library-e2e-run-installed "$PREFIX/bin/ironplcc" "$PREFIX/bin/ironplcvm"
 
-# Shared verification (Unix + macOS): assert the library shipped, compile the
-# fixture, run one scan, and assert the VM computed 2 * PI * 10.0 = 62.8318...
+# Shared verification (Unix + macOS): compile the fixture, run one scan, and
+# assert the VM computed 2 * PI * 10.0 = 62.8318... A release that failed to ship
+# the library would fail the compile here, so no separate file check is needed.
 [unix]
-_library-e2e-run-installed ironplcc ironplcvm libfile:
+_library-e2e-run-installed ironplcc ironplcvm:
   #!/usr/bin/env sh
   set -eu
-  if [ ! -f "{{libfile}}" ]; then
-    echo "FAIL: compatibility library not installed at {{libfile}}" >&2
-    echo "      (the target release must be one that ships the libraries)" >&2
-    exit 1
-  fi
   WORK="$(mktemp -d)"
   "{{ironplcc}}" compile --dialect twincat --library Tc2_System \
     --output "$WORK/prog.iplc" tests/e2e/library/uses_pi.st
@@ -417,18 +400,16 @@ _library-e2e-run-installed ironplcc ironplcvm libfile:
 # Each line is a separate PowerShell process (set windows-shell), so each step is
 # a self-contained statement.
 [windows]
-library-e2e compiler-version="":
+library-e2e compiler-version:
   @just library-e2e-download "{{compiler-version}}"
   @just library-e2e-test
 
 # Download + install the published compiler via the NSIS installer. The x86_64
-# asset name is hard-coded because the GitHub runner is x86_64; pass a different
-# version to target another release. An empty version uses GitHub's
-# `latest/download` redirect, so no API call or tag resolution is needed.
+# asset name is hard-coded because the GitHub runner is x86_64.
 [windows]
-library-e2e-download compiler-version="":
-  # Download the NSIS installer for the requested (or latest) release.
-  Invoke-WebRequest -Uri "https://github.com/ironplc/ironplc/releases/{{ if compiler-version == "" { "latest/download" } else { "download/v" + compiler-version } }}/ironplcc-x86_64-windows.exe" -OutFile ironplcc-setup.exe
+library-e2e-download compiler-version:
+  # Download the NSIS installer for the requested release.
+  Invoke-WebRequest -Uri "https://github.com/ironplc/ironplc/releases/download/v{{compiler-version}}/ironplcc-x86_64-windows.exe" -OutFile ironplcc-setup.exe
   # Install silently.
   Start-Process ironplcc-setup.exe -ArgumentList "/S" -PassThru | Wait-Process -Timeout 120
 
@@ -436,9 +417,7 @@ library-e2e-download compiler-version="":
 # on the installed VM, and assert it computed 2 * PI * 10.0 from the library PI.
 [windows]
 library-e2e-test:
-  # The installer must ship the library files beside the binary.
-  if (-not (Test-Path "{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\resources\libs\Tc2_System\library.toml")) { Write-Error "FAIL: compatibility library not installed (the target release must be one that ships the libraries)"; exit 1 }
-  # Compile the library-dependent program against the installed files.
+  # Compile the library-dependent program against the installed compiler.
   &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcc.exe" compile --dialect twincat --library Tc2_System --output "$env:TEMP\prog.iplc" "tests\e2e\library\uses_pi.st"; if ($LASTEXITCODE -ne 0) { Write-Error "FAIL: installed compiler could not compile the library-dependent program"; exit 1 }
   # Run one scan on the installed VM and assert it computed 2 * PI * 10.0.
   $out = &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcvm.exe" run "$env:TEMP\prog.iplc" --scans 1 --dump-vars -; Write-Host $out; if ($out -notmatch "62.8318") { Write-Error "FAIL: VM did not compute 2 * PI * 10.0 from the library PI"; exit 1 }

--- a/specs/design/compatibility-library-format.md
+++ b/specs/design/compatibility-library-format.md
@@ -92,9 +92,10 @@ The install location is `resources/libs/` **beside the compiler executable**
 tree only for development and test builds. Every installer therefore ships
 `resources/libs/` next to the binaries: the Linux/macOS tarball carries it, the
 Windows NSIS installer writes it under `bin\resources\libs`, and the Homebrew
-formula installs it into `#{bin}/resources/libs` (`current_exe()` resolves the
-Homebrew symlink to the Cellar `bin`, so the loader finds it there). The
-discovery/search mechanism beyond this fixed location is **not part of this
+formula keeps the binaries and `resources/libs` together in `libexec` and
+symlinks the executables onto the `PATH` (`current_exe()` resolves the symlink
+back to `libexec`, so the loader finds the libraries beside the real binary).
+The discovery/search mechanism beyond this fixed location is **not part of this
 format** and is defined separately when needed.
 
 ## Future

--- a/specs/design/compatibility-library-format.md
+++ b/specs/design/compatibility-library-format.md
@@ -86,8 +86,16 @@ Libraries are **installed on disk** as directories in this format and read by th
 compiler at runtime — they are *not* embedded into the compiler binary. The same
 files are served as plain text to the playground.
 
-The install location and the discovery/search mechanism are **not part of this
-format** and are defined separately when needed.
+The install location is `resources/libs/` **beside the compiler executable**
+(i.e. `<bindir>/resources/libs/<LibraryName>/…`); the loader
+(`installed_libraries_root`) reads from there and falls back to the crate source
+tree only for development and test builds. Every installer therefore ships
+`resources/libs/` next to the binaries: the Linux/macOS tarball carries it, the
+Windows NSIS installer writes it under `bin\resources\libs`, and the Homebrew
+formula installs it into `#{bin}/resources/libs` (`current_exe()` resolves the
+Homebrew symlink to the Cellar `bin`, so the loader finds it there). The
+discovery/search mechanism beyond this fixed location is **not part of this
+format** and is defined separately when needed.
 
 ## Future
 

--- a/specs/plans/2026-08-05-ship-compatibility-libraries-in-installers.md
+++ b/specs/plans/2026-08-05-ship-compatibility-libraries-in-installers.md
@@ -1,0 +1,80 @@
+# Plan: Ship compatibility-library files in the installers
+
+## Goal
+
+Close a packaging gap left by the [Compatibility Libraries](../design/compatibility-libraries.md)
+increment: the runtime loader reads bundled libraries from `resources/libs`
+*beside the compiler executable*
+(`compiler/sources/src/libraries/mod.rs::installed_libraries_root`), but **no
+distribution artifact ships that directory**. Every real install therefore fails
+to resolve library symbols — most visibly, `PI` for TwinCAT — even though it
+works in dev/test via the `CARGO_MANIFEST_DIR` fallback.
+
+The fix is to ship `compiler/sources/resources/libs/` in each distribution so it
+lands at `<bindir>/resources/libs`, exactly where the loader looks.
+
+## Background
+
+`installed_libraries_root()` prefers `<exe_dir>/resources/libs` and only falls
+back to the crate source tree when that directory is absent (development/test).
+The four distribution paths and where each puts the executable:
+
+| Distribution        | Executable location        | Loader expects                    |
+|---------------------|----------------------------|-----------------------------------|
+| Linux/macOS tarball | `$INSTALL_DIR/bin/`        | `$INSTALL_DIR/bin/resources/libs` |
+| Windows NSIS        | `$INSTDIR\bin\`            | `$INSTDIR\bin\resources\libs`     |
+| Homebrew            | Cellar `bin/` (symlinked)  | `#{bin}/resources/libs`           |
+
+`current_exe()` resolves symlinks, so the Homebrew symlink on `PATH` resolves to
+the Cellar `bin`, making `#{bin}/resources/libs` the correct target there too.
+
+**Contract:** libraries install to `<bindir>/resources/libs`, uniformly across
+all three installers. The design doc's *Installation* section previously left the
+install location "defined separately when needed"; it is now needed and this plan
+defines it.
+
+## Non-goals
+
+- Changing the loader search logic or the on-disk package format (unchanged).
+- A user-facing library-install command or an external library search path.
+- Shipping any new library; only the already-bundled `Tc2_System` travels.
+
+## File map
+
+**Modified — packaging**
+- `compiler/justfile` — `_package-linux` and `_package-macos` stage
+  `sources/resources/libs` into the release dir and add `resources/` to the
+  tarball. (Windows reads the source tree directly from `setup.nsi`.)
+- `compiler/setup.nsi` — install `resources\libs` into `$INSTDIR\bin\resources`.
+- `compiler/install.sh` — place the extracted `resources/` dir next to the
+  installed binaries; warn (not fail) when an older release omits it.
+- `compiler/homebrew/Formula/ironplc.rb` — install `resources/libs` into
+  `#{bin}/resources`.
+
+**Modified — verification**
+- `justfile` (root) — `_install-script-smoke-verify` asserts the library files
+  shipped and that a `PI`-using program compiles with `--library Tc2_System`.
+
+**Modified — docs**
+- `specs/design/compatibility-library-format.md` — define the install location
+  (`<bindir>/resources/libs`) in the *Installation* section.
+
+## Testing strategy
+
+- `cd compiler && just` green (compile, coverage ≥85%, clippy, fmt, dupes).
+- Local tarball assembly check: run the `tar` step and assert the archive
+  contains `resources/libs/Tc2_System/library.toml`.
+- The install-script smoke test (CI, Linux + macOS) additionally asserts, after a
+  real install, that `resources/libs/Tc2_System/library.toml` exists beside the
+  binaries and that `ironplcc check --library Tc2_System` compiles a program that
+  reads `PI`. This exercises the *shipped* artifact, not the dev fallback.
+
+## Tasks
+
+- [x] Stage `resources/libs` into the tarball (`_package-linux`, `_package-macos`)
+- [x] Install `resources\libs` from `setup.nsi` (Windows)
+- [x] Place `resources/` beside the binaries in `install.sh`
+- [x] Install `resources/libs` in the Homebrew formula
+- [x] Assert shipped files + `PI` compile in the install-script smoke verify
+- [x] Define the install location in the format design doc
+- [x] `cd compiler && just` green

--- a/specs/plans/2026-08-05-ship-compatibility-libraries-in-installers.md
+++ b/specs/plans/2026-08-05-ship-compatibility-libraries-in-installers.md
@@ -23,10 +23,12 @@ The four distribution paths and where each puts the executable:
 |---------------------|----------------------------|-----------------------------------|
 | Linux/macOS tarball | `$INSTALL_DIR/bin/`        | `$INSTALL_DIR/bin/resources/libs` |
 | Windows NSIS        | `$INSTDIR\bin\`            | `$INSTDIR\bin\resources\libs`     |
-| Homebrew            | Cellar `bin/` (symlinked)  | `#{bin}/resources/libs`           |
+| Homebrew            | `libexec/` (symlinked)     | `#{libexec}/resources/libs`       |
 
-`current_exe()` resolves symlinks, so the Homebrew symlink on `PATH` resolves to
-the Cellar `bin`, making `#{bin}/resources/libs` the correct target there too.
+`current_exe()` resolves symlinks, so a `bin` symlink on `PATH` resolves back to
+the real binary. The idiomatic Homebrew layout keeps the binaries and their
+resources together in `libexec` and symlinks the executables onto the `PATH`, so
+the loader finds `#{libexec}/resources/libs` beside the resolved binary.
 
 **Contract:** libraries install to `<bindir>/resources/libs`, uniformly across
 all three installers. The design doc's *Installation* section previously left the
@@ -48,8 +50,8 @@ defines it.
 - `compiler/setup.nsi` — install `resources\libs` into `$INSTDIR\bin\resources`.
 - `compiler/install.sh` — place the extracted `resources/` dir next to the
   installed binaries; warn (not fail) when an older release omits it.
-- `compiler/homebrew/Formula/ironplc.rb` — install `resources/libs` into
-  `#{bin}/resources`.
+- `compiler/homebrew/Formula/ironplc.rb` — install the binaries and
+  `resources/libs` into `libexec` and symlink the executables into `bin`.
 
 **Modified — verification**
 - `justfile` (root) — `_install-script-smoke-verify` asserts the library files

--- a/tests/e2e/library/README.md
+++ b/tests/e2e/library/README.md
@@ -2,38 +2,52 @@
 
 This fixture backs the `library-e2e` test, which verifies that the **installers
 actually ship the bundled compatibility libraries** and that the installed
-compiler resolves library symbols from beside the binary.
+toolchain resolves library symbols from beside the binary.
 
 The compiler reads bundled libraries from `resources/libs` next to its
 executable. Unit tests can't catch a packaging miss because they fall back to the
-crate source tree; only a real install can. `uses_pi.st` depends on the
-`Tc2_System` library's `PI` constant, so it compiles **only** when the installer
-placed `resources/libs/Tc2_System/...` beside the binary.
+crate source tree; only a real install can. `uses_pi.st` is a minimal program
+that depends on the `Tc2_System` library's `PI` constant — it computes
+`2 * PI * 10.0` — so it compiles and runs **only** when the installer placed
+`resources/libs/Tc2_System/...` beside the binary.
+
+The test installs with the real OS installer, then:
+
+1. compiles the program with the installed `ironplcc` (`--library Tc2_System`),
+2. runs one scan on the installed `ironplcvm` (`--scans 1 --dump-vars -`),
+3. asserts the dump shows `circumference` = `62.83185307179586`.
+
+That end-to-end path proves the library `PI` resolved from the installed location
+and the VM computed with it.
 
 ## Running it
 
-Against a published release (empty = latest; must be a release that ships the
-libraries):
+Each OS installs differently, so there are per-OS recipes (empty version = latest;
+must be a release that ships the libraries):
 
 ```sh
-# Linux / macOS — installs via the tarball + install.sh
+# Linux / macOS — tarball + install.sh
 just library-e2e 0.234.0
 
-# Windows — installs via the NSIS installer
+# Windows — NSIS installer
 just library-e2e 0.234.0
+
+# macOS — Homebrew formula (libexec layout; separate from the tarball path)
+just library-e2e-brew 0.234.0
 ```
 
-The recipe installs the real OS installer, asserts the library files landed
-beside the binary, then compiles `uses_pi.st` against the installed compiler.
-
-Like the VS Code `endtoend-smoke` test, it is split into a download step and a
+Like the VS Code `endtoend-smoke` test, each is split into a download step and a
 test step, so you can install once and re-run the verification repeatedly:
 
 ```sh
-just library-e2e-download 0.234.0   # acquire + install
-just library-e2e-test               # verify (repeatable)
+just library-e2e-download 0.234.0   # acquire + install (tarball/NSIS)
+just library-e2e-test               # compile + run + verify (repeatable)
+
+just library-e2e-brew-download 0.234.0   # acquire + install (Homebrew)
+just library-e2e-brew-test               # compile + run + verify (repeatable)
 ```
 
 In CI this is `partial_library_e2e.yaml`, runnable from the Actions tab
-(`workflow_dispatch`) across Linux, macOS, and Windows. It is intentionally not
-wired into the release or PR pipelines yet.
+(`workflow_dispatch`): a Linux/macOS/Windows matrix for the tarball + NSIS
+installers, plus a dedicated macOS job for the Homebrew installer. It is
+intentionally not wired into the release or PR pipelines yet.

--- a/tests/e2e/library/README.md
+++ b/tests/e2e/library/README.md
@@ -26,6 +26,14 @@ just library-e2e 0.234.0
 The recipe installs the real OS installer, asserts the library files landed
 beside the binary, then compiles `uses_pi.st` against the installed compiler.
 
+Like the VS Code `endtoend-smoke` test, it is split into a download step and a
+test step, so you can install once and re-run the verification repeatedly:
+
+```sh
+just library-e2e-download 0.234.0   # acquire + install
+just library-e2e-test               # verify (repeatable)
+```
+
 In CI this is `partial_library_e2e.yaml`, runnable from the Actions tab
 (`workflow_dispatch`) across Linux, macOS, and Windows. It is intentionally not
 wired into the release or PR pipelines yet.

--- a/tests/e2e/library/README.md
+++ b/tests/e2e/library/README.md
@@ -22,8 +22,8 @@ and the VM computed with it.
 
 ## Running it
 
-Each OS installs differently, so there are per-OS recipes (empty version = latest;
-must be a release that ships the libraries):
+Each OS installs differently, so there are per-OS recipes. The release version is
+required (no "latest" resolution) and must be one that ships the libraries:
 
 ```sh
 # Linux / macOS — tarball + install.sh

--- a/tests/e2e/library/README.md
+++ b/tests/e2e/library/README.md
@@ -1,0 +1,31 @@
+# Library installer end-to-end test
+
+This fixture backs the `library-e2e` test, which verifies that the **installers
+actually ship the bundled compatibility libraries** and that the installed
+compiler resolves library symbols from beside the binary.
+
+The compiler reads bundled libraries from `resources/libs` next to its
+executable. Unit tests can't catch a packaging miss because they fall back to the
+crate source tree; only a real install can. `uses_pi.st` depends on the
+`Tc2_System` library's `PI` constant, so it compiles **only** when the installer
+placed `resources/libs/Tc2_System/...` beside the binary.
+
+## Running it
+
+Against a published release (empty = latest; must be a release that ships the
+libraries):
+
+```sh
+# Linux / macOS — installs via the tarball + install.sh
+just library-e2e 0.234.0
+
+# Windows — installs via the NSIS installer
+just library-e2e 0.234.0
+```
+
+The recipe installs the real OS installer, asserts the library files landed
+beside the binary, then compiles `uses_pi.st` against the installed compiler.
+
+In CI this is `partial_library_e2e.yaml`, runnable from the Actions tab
+(`workflow_dispatch`) across Linux, macOS, and Windows. It is intentionally not
+wired into the release or PR pipelines yet.

--- a/tests/e2e/library/uses_pi.st
+++ b/tests/e2e/library/uses_pi.st
@@ -1,21 +1,23 @@
 (* End-to-end installer test fixture.
 
-   This program depends on the bundled `Tc2_System` compatibility library: `PI`
-   is a global constant that the library provides, not a language built-in. The
-   program therefore compiles only if the installer shipped the library files
-   (`resources/libs/Tc2_System/...`) beside the compiler binary and the compiler
-   resolves them from that installed location.
+   A minimal runnable program that depends on the bundled `Tc2_System`
+   compatibility library: `PI` is a global constant the library provides, not a
+   language built-in. The program compiles and runs only if the installer
+   shipped the library files (`resources/libs/Tc2_System/...`) beside the
+   compiler binary and the compiler resolves them from that installed location.
 
-   Compile with:
-     ironplcc check --dialect twincat \
-       --allow-constant-initializer-expressions \
-       --library Tc2_System tests/e2e/library/uses_pi.st
+   Compile, then run one scan and dump the variables:
+     ironplcc compile --dialect twincat --library Tc2_System \
+       --output prog.iplc tests/e2e/library/uses_pi.st
+     ironplcvm run prog.iplc --scans 1 --dump-vars -
 
-   `--dialect twincat` permits the library's top-level VAR_GLOBAL, and
-   `--allow-constant-initializer-expressions` permits the `PI / 180.0`
-   initializer. See the `library-e2e` recipe in the repository-root justfile. *)
-FUNCTION_BLOCK FB_Angle
+   After one scan `circumference` holds 2 * PI * 10.0 = 62.83185307179586, so the
+   dump proves the library `PI` resolved and the VM computed with it end to end.
+   `--dialect twincat` permits the library's top-level VAR_GLOBAL. See the
+   `library-e2e` recipe in the repository-root justfile. *)
+PROGRAM main
     VAR
-        degrees_to_radians : LREAL := PI / 180.0;
+        circumference : LREAL;
     END_VAR
-END_FUNCTION_BLOCK
+    circumference := 2.0 * PI * 10.0;
+END_PROGRAM

--- a/tests/e2e/library/uses_pi.st
+++ b/tests/e2e/library/uses_pi.st
@@ -1,0 +1,21 @@
+(* End-to-end installer test fixture.
+
+   This program depends on the bundled `Tc2_System` compatibility library: `PI`
+   is a global constant that the library provides, not a language built-in. The
+   program therefore compiles only if the installer shipped the library files
+   (`resources/libs/Tc2_System/...`) beside the compiler binary and the compiler
+   resolves them from that installed location.
+
+   Compile with:
+     ironplcc check --dialect twincat \
+       --allow-constant-initializer-expressions \
+       --library Tc2_System tests/e2e/library/uses_pi.st
+
+   `--dialect twincat` permits the library's top-level VAR_GLOBAL, and
+   `--allow-constant-initializer-expressions` permits the `PI / 180.0`
+   initializer. See the `library-e2e` recipe in the repository-root justfile. *)
+FUNCTION_BLOCK FB_Angle
+    VAR
+        degrees_to_radians : LREAL := PI / 180.0;
+    END_VAR
+END_FUNCTION_BLOCK


### PR DESCRIPTION
## Summary

The compatibility-library increment left a packaging gap: the runtime loader reads bundled libraries from `resources/libs` **beside the compiler executable** (`installed_libraries_root`), but no distribution artifact shipped that directory. Every real install therefore failed to resolve library symbols — most visibly `PI` for TwinCAT — even though it worked in dev/test via the `CARGO_MANIFEST_DIR` fallback.

This ships `compiler/sources/resources/libs/` in each distribution so it lands at `<bindir>/resources/libs`, exactly where the loader looks. The format design previously left the install location *"defined separately when needed"*; it is now needed and defined here.

## Changes

**Packaging — ship `resources/libs` next to the binaries**
- **Tarball** (`_package-linux`, `_package-macos`): stage the libraries into the release dir and add `resources/` to the archive.
- **Windows NSIS** (`setup.nsi`): install `resources\libs` under `$INSTDIR\bin\resources`.
- **`install.sh`**: place the extracted `resources/` beside the installed binaries, replacing any prior copy; warns (does not fail) for older releases that omit it.
- **Homebrew formula**: idiomatic layout — install the binaries and `resources/libs` into `libexec` and symlink the executables onto the `PATH`. `current_exe()` resolves the symlink back to `libexec`, so the loader finds the libraries beside the real binary (no non-executables under `bin`).

**Verification**
- The install-script smoke test now asserts the bundled `Tc2_System` files installed and that a `PI`-using program compiles against the *shipped* files (`ironplcc check --dialect twincat --allow-constant-initializer-expressions --library Tc2_System`). It stays tolerant when the files are absent, because the recipe also runs against the latest published release, which predates library shipping; once a release ships them, this becomes a hard check on every later run.

**Docs**
- Define the install location (`<bindir>/resources/libs`) in `specs/design/compatibility-library-format.md`.
- Plan: `specs/plans/2026-08-05-ship-compatibility-libraries-in-installers.md`.

## Testing

- `cd compiler && just` green (compile, coverage ≥85%, clippy, fmt, dupes).
- Simulated tarball assembly + `install.sh` placement locally → confirmed `bin/resources/libs/Tc2_System/library.toml`, the exact path the loader expects.
- Confirmed the smoke invocation actually compiles the `PI` program.
- `shellcheck -s sh compiler/install.sh` clean; both justfiles parse; Homebrew formula `ruby -c` clean.

The Windows/macOS/Homebrew packaging legs can't be exercised in a Linux dev environment — those run in the release/integration workflows; the file layout and logic are verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjvDVok9ZChjA4CiQK3yaw)_