### PR TITLE
Reduce test count via property-test subsumption and rstest parametrization

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -981,6 +981,7 @@ version = "0.233.0"
 dependencies = [
  "blake3",
  "ironplc-spec-requirements-gen",
+ "rstest",
  "spec_test_macro",
 ]
 
@@ -994,6 +995,7 @@ dependencies = [
  "logos",
  "paste",
  "regex",
+ "rstest",
  "time",
 ]
 
@@ -1095,6 +1097,7 @@ dependencies = [
  "ironplc-problems",
  "ironplc-sources",
  "log",
+ "rstest",
  "serde_json",
  "tempfile",
 ]
@@ -1136,6 +1139,7 @@ dependencies = [
  "ironplc-spec-requirements-gen",
  "ironplc-vm",
  "proptest",
+ "rstest",
  "spec_test_macro",
 ]
 

--- a/compiler/analyzer/src/rule_bit_access_range.rs
+++ b/compiler/analyzer/src/rule_bit_access_range.rs
@@ -312,6 +312,7 @@ mod tests {
     use crate::test_helpers::parse_and_resolve_types_with_context;
     use ironplc_dsl::core::FileId;
     use ironplc_parser::{options::CompilerOptions, parse_program};
+    use rstest::rstest;
 
     use super::*;
 
@@ -332,353 +333,68 @@ mod tests {
         );
     }
 
-    // --- BYTE (8 bits): valid range 0..7 ---
+    // --- Bit access boundary tests across all bit-sized types ---
+    //
+    // For each type: the highest valid bit index is OK, and one past the
+    // highest is an error. BYTE additionally covers bit 0 as the low bound.
 
-    #[test]
-    fn apply_when_byte_bit_0_then_ok() {
-        assert_bit_access_ok(
+    #[rstest]
+    // BYTE (8 bits): valid range 0..7
+    #[case::byte_bit_0("BYTE", 0, true)]
+    #[case::byte_bit_7("BYTE", 7, true)]
+    #[case::byte_bit_8("BYTE", 8, false)]
+    // WORD (16 bits): valid range 0..15
+    #[case::word_bit_15("WORD", 15, true)]
+    #[case::word_bit_16("WORD", 16, false)]
+    // DWORD (32 bits): valid range 0..31
+    #[case::dword_bit_31("DWORD", 31, true)]
+    #[case::dword_bit_32("DWORD", 32, false)]
+    // LWORD (64 bits): valid range 0..63
+    #[case::lword_bit_63("LWORD", 63, true)]
+    #[case::lword_bit_64("LWORD", 64, false)]
+    // SINT (8 bits): valid range 0..7
+    #[case::sint_bit_7("SINT", 7, true)]
+    #[case::sint_bit_8("SINT", 8, false)]
+    // INT (16 bits): valid range 0..15
+    #[case::int_bit_15("INT", 15, true)]
+    #[case::int_bit_16("INT", 16, false)]
+    // DINT (32 bits): valid range 0..31
+    #[case::dint_bit_31("DINT", 31, true)]
+    #[case::dint_bit_32("DINT", 32, false)]
+    // LINT (64 bits): valid range 0..63
+    #[case::lint_bit_63("LINT", 63, true)]
+    #[case::lint_bit_64("LINT", 64, false)]
+    // USINT (8 bits): valid range 0..7
+    #[case::usint_bit_7("USINT", 7, true)]
+    #[case::usint_bit_8("USINT", 8, false)]
+    // UINT (16 bits): valid range 0..15
+    #[case::uint_bit_15("UINT", 15, true)]
+    #[case::uint_bit_16("UINT", 16, false)]
+    // UDINT (32 bits): valid range 0..31
+    #[case::udint_bit_31("UDINT", 31, true)]
+    #[case::udint_bit_32("UDINT", 32, false)]
+    // ULINT (64 bits): valid range 0..63
+    #[case::ulint_bit_63("ULINT", 63, true)]
+    #[case::ulint_bit_64("ULINT", 64, false)]
+    fn apply_when_bit_index_at_boundary_then_ok_or_err(
+        #[case] type_name: &str,
+        #[case] bit: u32,
+        #[case] expected_ok: bool,
+    ) {
+        let program = format!(
             "FUNCTION_BLOCK FB1
 VAR
-    x : BYTE;
+    x : {type_name};
     y : BOOL;
 END_VAR
-    y := x.0;
-END_FUNCTION_BLOCK",
+    y := x.{bit};
+END_FUNCTION_BLOCK"
         );
-    }
-
-    #[test]
-    fn apply_when_byte_bit_7_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : BYTE;
-    y : BOOL;
-END_VAR
-    y := x.7;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_byte_bit_8_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : BYTE;
-    y : BOOL;
-END_VAR
-    y := x.8;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- WORD (16 bits): valid range 0..15 ---
-
-    #[test]
-    fn apply_when_word_bit_15_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : WORD;
-    y : BOOL;
-END_VAR
-    y := x.15;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_word_bit_16_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : WORD;
-    y : BOOL;
-END_VAR
-    y := x.16;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- DWORD (32 bits): valid range 0..31 ---
-
-    #[test]
-    fn apply_when_dword_bit_31_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : DWORD;
-    y : BOOL;
-END_VAR
-    y := x.31;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_dword_bit_32_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : DWORD;
-    y : BOOL;
-END_VAR
-    y := x.32;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- LWORD (64 bits): valid range 0..63 ---
-
-    #[test]
-    fn apply_when_lword_bit_63_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : LWORD;
-    y : BOOL;
-END_VAR
-    y := x.63;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_lword_bit_64_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : LWORD;
-    y : BOOL;
-END_VAR
-    y := x.64;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- SINT (8 bits): valid range 0..7 ---
-
-    #[test]
-    fn apply_when_sint_bit_7_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : SINT;
-    y : BOOL;
-END_VAR
-    y := x.7;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_sint_bit_8_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : SINT;
-    y : BOOL;
-END_VAR
-    y := x.8;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- INT (16 bits): valid range 0..15 ---
-
-    #[test]
-    fn apply_when_int_bit_15_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : INT;
-    y : BOOL;
-END_VAR
-    y := x.15;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_int_bit_16_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : INT;
-    y : BOOL;
-END_VAR
-    y := x.16;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- DINT (32 bits): valid range 0..31 ---
-
-    #[test]
-    fn apply_when_dint_bit_31_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : DINT;
-    y : BOOL;
-END_VAR
-    y := x.31;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_dint_bit_32_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : DINT;
-    y : BOOL;
-END_VAR
-    y := x.32;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- LINT (64 bits): valid range 0..63 ---
-
-    #[test]
-    fn apply_when_lint_bit_63_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : LINT;
-    y : BOOL;
-END_VAR
-    y := x.63;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_lint_bit_64_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : LINT;
-    y : BOOL;
-END_VAR
-    y := x.64;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- USINT (8 bits): valid range 0..7 ---
-
-    #[test]
-    fn apply_when_usint_bit_7_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : USINT;
-    y : BOOL;
-END_VAR
-    y := x.7;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_usint_bit_8_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : USINT;
-    y : BOOL;
-END_VAR
-    y := x.8;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- UINT (16 bits): valid range 0..15 ---
-
-    #[test]
-    fn apply_when_uint_bit_15_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : UINT;
-    y : BOOL;
-END_VAR
-    y := x.15;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_uint_bit_16_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : UINT;
-    y : BOOL;
-END_VAR
-    y := x.16;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- UDINT (32 bits): valid range 0..31 ---
-
-    #[test]
-    fn apply_when_udint_bit_31_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : UDINT;
-    y : BOOL;
-END_VAR
-    y := x.31;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_udint_bit_32_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : UDINT;
-    y : BOOL;
-END_VAR
-    y := x.32;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    // --- ULINT (64 bits): valid range 0..63 ---
-
-    #[test]
-    fn apply_when_ulint_bit_63_then_ok() {
-        assert_bit_access_ok(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : ULINT;
-    y : BOOL;
-END_VAR
-    y := x.63;
-END_FUNCTION_BLOCK",
-        );
-    }
-
-    #[test]
-    fn apply_when_ulint_bit_64_then_err() {
-        assert_bit_access_err(
-            "FUNCTION_BLOCK FB1
-VAR
-    x : ULINT;
-    y : BOOL;
-END_VAR
-    y := x.64;
-END_FUNCTION_BLOCK",
-        );
+        if expected_ok {
+            assert_bit_access_ok(&program);
+        } else {
+            assert_bit_access_err(&program);
+        }
     }
 
     // --- Bit access on assignment target ---

--- a/compiler/codegen/tests/it/end_to_end_concat.rs
+++ b/compiler/codegen/tests/it/end_to_end_concat.rs
@@ -4,6 +4,7 @@ use ironplc_parser::options::CompilerOptions;
 
 use crate::common::parse_and_run;
 use ironplc_container::STRING_HEADER_BYTES;
+use proptest::prelude::*;
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -24,6 +25,20 @@ fn string_offset(preceding_max_lengths: &[u16]) -> usize {
         .sum()
 }
 
+/// Generates printable ASCII strings safe for IEC 61131-3 string literals.
+/// Excludes single quote (0x27) and dollar sign (0x24, the escape character).
+/// Length is bounded to 0..=127 so the concatenated result stays <= 254 and
+/// never triggers the STRING[254] truncation branch.
+fn safe_string_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        (0x20u8..=0x7Eu8).prop_filter("exclude quote and dollar", |&b| b != b'\'' && b != b'$'),
+        0..=127,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(|b| b as char).collect())
+}
+
+// --- Deterministic anchors ---
+
 #[test]
 fn end_to_end_when_concat_two_strings_then_correct_result() {
     let source = "
@@ -43,116 +58,6 @@ END_PROGRAM
 }
 
 #[test]
-fn end_to_end_when_concat_single_chars_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'A';
-    s2 : STRING := 'B';
-    result : STRING;
-  END_VAR
-  result := CONCAT(s1, s2);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "AB");
-}
-
-#[test]
-fn end_to_end_when_concat_empty_first_then_second_string() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING;
-    s2 : STRING := 'World';
-    result : STRING;
-  END_VAR
-  result := CONCAT(s1, s2);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "World");
-}
-
-#[test]
-fn end_to_end_when_concat_empty_second_then_first_string() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello';
-    s2 : STRING;
-    result : STRING;
-  END_VAR
-  result := CONCAT(s1, s2);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello");
-}
-
-#[test]
-fn end_to_end_when_concat_both_empty_then_empty() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING;
-    s2 : STRING;
-    result : STRING;
-  END_VAR
-  result := CONCAT(s1, s2);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "");
-}
-
-#[test]
-fn end_to_end_when_concat_longer_strings_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'The quick brown ';
-    s2 : STRING := 'fox jumps over';
-    result : STRING;
-  END_VAR
-  result := CONCAT(s1, s2);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(
-        read_string(&bufs.data_region, result_offset),
-        "The quick brown fox jumps over"
-    );
-}
-
-#[test]
-fn end_to_end_when_concat_same_variable_then_doubled() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABC';
-    result : STRING;
-  END_VAR
-  result := CONCAT(s1, s1);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABCABC");
-}
-
-#[test]
 fn end_to_end_when_concat_two_literals_then_correct_result() {
     let source = "
 PROGRAM main
@@ -169,52 +74,30 @@ END_PROGRAM
     assert_eq!(read_string(&bufs.data_region, result_offset), "Hello World");
 }
 
-#[test]
-fn end_to_end_when_concat_literal_and_variable_then_correct_result() {
-    let source = "
+// --- Property test: CONCAT(s1, s2) == s1 followed by s2 ---
+// Inputs are bounded so the concatenation stays <= 254 (no truncation). Oracle
+// is pure Rust. The literal-argument lowering path is pinned by the anchor above.
+proptest! {
+    #[test]
+    fn end_to_end_when_concat_of_arbitrary_strings_then_appends(
+        s1 in safe_string_strategy(),
+        s2 in safe_string_strategy(),
+    ) {
+        let expected = format!("{s1}{s2}");
+        let source = format!(
+            "
 PROGRAM main
   VAR
-    s1 : STRING := 'World';
+    s1 : STRING := '{s1}';
+    s2 : STRING := '{s2}';
     result : STRING;
   END_VAR
-  result := CONCAT('Hello ', s1);
+  result := CONCAT(s1, s2);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello World");
-}
-
-#[test]
-fn end_to_end_when_concat_variable_and_literal_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello';
-    result : STRING;
-  END_VAR
-  result := CONCAT(s1, ' World');
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello World");
-}
-
-#[test]
-fn end_to_end_when_concat_single_char_literals_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    result : STRING;
-  END_VAR
-  result := CONCAT('A', 'B');
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "AB");
+"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        let result_offset = string_offset(&[254, 254]);
+        prop_assert_eq!(read_string(&bufs.data_region, result_offset), expected);
+    }
 }

--- a/compiler/codegen/tests/it/end_to_end_delete.rs
+++ b/compiler/codegen/tests/it/end_to_end_delete.rs
@@ -4,6 +4,7 @@ use ironplc_parser::options::CompilerOptions;
 
 use crate::common::parse_and_run;
 use ironplc_container::STRING_HEADER_BYTES;
+use proptest::prelude::*;
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -24,6 +25,18 @@ fn string_offset(preceding_max_lengths: &[u16]) -> usize {
         .sum()
 }
 
+/// Generates printable ASCII strings safe for IEC 61131-3 string literals.
+/// Excludes single quote (0x27) and dollar sign (0x24, the escape character).
+fn safe_string_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        (0x20u8..=0x7Eu8).prop_filter("exclude quote and dollar", |&b| b != b'\'' && b != b'$'),
+        0..=254,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(|b| b as char).collect())
+}
+
+// --- Deterministic anchors ---
+
 #[test]
 fn end_to_end_when_delete_middle_then_correct_result() {
     let source = "
@@ -40,60 +53,6 @@ END_PROGRAM
     // Delete 6 chars starting at position 1: remove 'Hello ' -> 'World'
     let result_offset = string_offset(&[254]);
     assert_eq!(read_string(&bufs.data_region, result_offset), "World");
-}
-
-#[test]
-fn end_to_end_when_delete_at_end_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello World';
-    result : STRING;
-  END_VAR
-  result := DELETE(s1, 6, 6);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete 6 chars starting at position 6: remove ' World' -> 'Hello'
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello");
-}
-
-#[test]
-fn end_to_end_when_delete_all_then_empty_string() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := DELETE(s1, 5, 1);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete all 5 chars starting at position 1.
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "");
-}
-
-#[test]
-fn end_to_end_when_delete_zero_length_then_unchanged() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := DELETE(s1, 0, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete 0 chars: nothing changes.
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABCDE");
 }
 
 #[test]
@@ -114,40 +73,37 @@ END_PROGRAM
     assert_eq!(read_string(&bufs.data_region, result_offset), "AB");
 }
 
-#[test]
-fn end_to_end_when_delete_with_integer_vars_then_correct_result() {
-    let source = "
+// --- Property test: DELETE(s, n, p) == remove n chars from 1-based position p ---
+// Inputs are bounded to a non-empty s with a valid 1-based position p; n may
+// exceed the remaining length (the oracle clamps like the VM). Oracle is pure
+// Rust. The clamp branch is also pinned by the deterministic anchor above.
+proptest! {
+    #[test]
+    fn end_to_end_when_delete_of_arbitrary_string_then_removes_range(
+        (s, n, p) in safe_string_strategy()
+            .prop_filter("non-empty", |s| !s.is_empty())
+            .prop_flat_map(|s| {
+                let len = s.chars().count();
+                (Just(s), 0usize..=260, 1usize..=len)
+            }),
+    ) {
+        let c: Vec<char> = s.chars().collect();
+        let a = p - 1;
+        let b = (a + n).min(c.len());
+        let expected: String = c[..a].iter().chain(c[b..].iter()).collect();
+        let source = format!(
+            "
 PROGRAM main
   VAR
-    s1 : STRING := 'Hello Beautiful World';
-    n_len : INT := 10;
-    n_pos : INT := 6;
+    s1 : STRING := '{s}';
     result : STRING;
   END_VAR
-  result := DELETE(s1, n_len, n_pos);
+  result := DELETE(s1, {n}, {p});
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete 10 chars starting at position 6: remove 'Beautiful ' -> 'Hello World'
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello World");
-}
-
-#[test]
-fn end_to_end_when_delete_single_char_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := DELETE(s1, 1, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete 1 char at position 3: remove 'C' -> 'ABDE'
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABDE");
+"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        let result_offset = string_offset(&[254]);
+        prop_assert_eq!(read_string(&bufs.data_region, result_offset), expected);
+    }
 }

--- a/compiler/codegen/tests/it/end_to_end_insert.rs
+++ b/compiler/codegen/tests/it/end_to_end_insert.rs
@@ -4,6 +4,7 @@ use ironplc_parser::options::CompilerOptions;
 
 use crate::common::parse_and_run;
 use ironplc_container::STRING_HEADER_BYTES;
+use proptest::prelude::*;
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -23,6 +24,20 @@ fn string_offset(preceding_max_lengths: &[u16]) -> usize {
         .map(|&ml| STRING_HEADER_BYTES + ml as usize)
         .sum()
 }
+
+/// Generates printable ASCII strings safe for IEC 61131-3 string literals.
+/// Excludes single quote (0x27) and dollar sign (0x24, the escape character).
+/// Length is bounded to 0..=127 so a combined two-string result stays <= 254
+/// and never triggers the STRING[254] truncation branch.
+fn safe_string_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        (0x20u8..=0x7Eu8).prop_filter("exclude quote and dollar", |&b| b != b'\'' && b != b'$'),
+        0..=127,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(|b| b as char).collect())
+}
+
+// --- Deterministic anchors ---
 
 #[test]
 fn end_to_end_when_insert_in_middle_then_correct_result() {
@@ -44,101 +59,6 @@ END_PROGRAM
 }
 
 #[test]
-fn end_to_end_when_insert_at_start_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'World';
-    s2 : STRING := 'Hello ';
-    result : STRING;
-  END_VAR
-  result := INSERT(s1, s2, 0);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Insert 'Hello ' at position 0 (before everything): 'Hello World'
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello World");
-}
-
-#[test]
-fn end_to_end_when_insert_at_end_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello';
-    s2 : STRING := ' World';
-    result : STRING;
-  END_VAR
-  result := INSERT(s1, s2, 5);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Insert ' World' after position 5 (end of string): 'Hello World'
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello World");
-}
-
-#[test]
-fn end_to_end_when_insert_empty_string_then_unchanged() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    s2 : STRING;
-    result : STRING;
-  END_VAR
-  result := INSERT(s1, s2, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Inserting empty string changes nothing.
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABCDE");
-}
-
-#[test]
-fn end_to_end_when_insert_into_empty_string_then_returns_inserted() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING;
-    s2 : STRING := 'Hello';
-    result : STRING;
-  END_VAR
-  result := INSERT(s1, s2, 0);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hello");
-}
-
-#[test]
-fn end_to_end_when_insert_with_integer_var_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    s2 : STRING := 'XY';
-    n_pos : INT := 2;
-    result : STRING;
-  END_VAR
-  result := INSERT(s1, s2, n_pos);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Insert 'XY' after position 2: AB + XY + CDE = 'ABXYCDE'
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABXYCDE");
-}
-
-#[test]
 fn end_to_end_when_insert_result_truncated_by_short_destination_then_truncates() {
     let source = "
 PROGRAM main
@@ -156,4 +76,41 @@ END_PROGRAM
     // But result is STRING[6], so it truncates to 'ABXXXX' (6 chars).
     let result_offset = string_offset(&[254, 254]);
     assert_eq!(read_string(&bufs.data_region, result_offset), "ABXXXX");
+}
+
+// --- Property test: INSERT(s1, s2, p) == insert s2 after 1-based position p ---
+// Inputs are bounded so the combined result stays <= 254 (no truncation), and p
+// is a valid 0..=len(s1) insertion point. Oracle is pure Rust. The truncation
+// branch is pinned by the deterministic anchor above.
+proptest! {
+    #[test]
+    fn end_to_end_when_insert_of_arbitrary_strings_then_splices(
+        (s1, s2, p) in (safe_string_strategy(), safe_string_strategy())
+            .prop_flat_map(|(s1, s2)| {
+                let len = s1.chars().count();
+                (Just(s1), Just(s2), 0usize..=len)
+            }),
+    ) {
+        let expected: String = s1
+            .chars()
+            .take(p)
+            .chain(s2.chars())
+            .chain(s1.chars().skip(p))
+            .collect();
+        let source = format!(
+            "
+PROGRAM main
+  VAR
+    s1 : STRING := '{s1}';
+    s2 : STRING := '{s2}';
+    result : STRING;
+  END_VAR
+  result := INSERT(s1, s2, {p});
+END_PROGRAM
+"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        let result_offset = string_offset(&[254, 254]);
+        prop_assert_eq!(read_string(&bufs.data_region, result_offset), expected);
+    }
 }

--- a/compiler/codegen/tests/it/end_to_end_left.rs
+++ b/compiler/codegen/tests/it/end_to_end_left.rs
@@ -4,6 +4,7 @@ use ironplc_parser::options::CompilerOptions;
 
 use crate::common::parse_and_run;
 use ironplc_container::STRING_HEADER_BYTES;
+use proptest::prelude::*;
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -23,6 +24,18 @@ fn string_offset(preceding_max_lengths: &[u16]) -> usize {
         .map(|&ml| STRING_HEADER_BYTES + ml as usize)
         .sum()
 }
+
+/// Generates printable ASCII strings safe for IEC 61131-3 string literals.
+/// Excludes single quote (0x27) and dollar sign (0x24, the escape character).
+fn safe_string_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        (0x20u8..=0x7Eu8).prop_filter("exclude quote and dollar", |&b| b != b'\'' && b != b'$'),
+        0..=254,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(|b| b as char).collect())
+}
+
+// --- Deterministic anchors ---
 
 #[test]
 fn end_to_end_when_left_partial_then_correct_result() {
@@ -60,88 +73,29 @@ END_PROGRAM
     assert_eq!(read_string(&bufs.data_region, result_offset), "Hi");
 }
 
-#[test]
-fn end_to_end_when_left_zero_then_empty_string() {
-    let source = "
+// --- Property test: LEFT(s, n) == first min(n, len(s)) characters ---
+// Oracle is Rust `chars().take(n)`, independent of the VM implementation. The
+// two anchors above pin the nominal and clamp branches deterministically.
+proptest! {
+    #[test]
+    fn end_to_end_when_left_of_arbitrary_string_then_takes_prefix(
+        s in safe_string_strategy(),
+        n in 0usize..=260,
+    ) {
+        let expected: String = s.chars().take(n).collect();
+        let source = format!(
+            "
 PROGRAM main
   VAR
-    s1 : STRING := 'Hello';
+    s1 : STRING := '{s}';
     result : STRING;
   END_VAR
-  result := LEFT(s1, 0);
+  result := LEFT(s1, {n});
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "");
-}
-
-#[test]
-fn end_to_end_when_left_single_char_then_first_char() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := LEFT(s1, 1);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "A");
-}
-
-#[test]
-fn end_to_end_when_left_exact_length_then_entire_string() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := LEFT(s1, 5);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABCDE");
-}
-
-#[test]
-fn end_to_end_when_left_with_integer_var_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello World';
-    n : INT := 3;
-    result : STRING;
-  END_VAR
-  result := LEFT(s1, n);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hel");
-}
-
-#[test]
-fn end_to_end_when_left_empty_string_then_empty() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING;
-    result : STRING;
-  END_VAR
-  result := LEFT(s1, 5);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "");
+"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        let result_offset = string_offset(&[254]);
+        prop_assert_eq!(read_string(&bufs.data_region, result_offset), expected);
+    }
 }

--- a/compiler/codegen/tests/it/end_to_end_mid.rs
+++ b/compiler/codegen/tests/it/end_to_end_mid.rs
@@ -4,6 +4,7 @@ use ironplc_parser::options::CompilerOptions;
 
 use crate::common::parse_and_run;
 use ironplc_container::STRING_HEADER_BYTES;
+use proptest::prelude::*;
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -24,6 +25,18 @@ fn string_offset(preceding_max_lengths: &[u16]) -> usize {
         .sum()
 }
 
+/// Generates printable ASCII strings safe for IEC 61131-3 string literals.
+/// Excludes single quote (0x27) and dollar sign (0x24, the escape character).
+fn safe_string_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        (0x20u8..=0x7Eu8).prop_filter("exclude quote and dollar", |&b| b != b'\'' && b != b'$'),
+        0..=254,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(|b| b as char).collect())
+}
+
+// --- Deterministic anchors ---
+
 #[test]
 fn end_to_end_when_mid_beginning_then_correct_result() {
     let source = "
@@ -43,114 +56,6 @@ END_PROGRAM
 }
 
 #[test]
-fn end_to_end_when_mid_end_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello World';
-    result : STRING;
-  END_VAR
-  result := MID(s1, 5, 7);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // MID 5 chars starting at position 7 -> 'World'
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "World");
-}
-
-#[test]
-fn end_to_end_when_mid_middle_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDEFGH';
-    result : STRING;
-  END_VAR
-  result := MID(s1, 3, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // MID 3 chars starting at position 3 -> 'CDE'
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "CDE");
-}
-
-#[test]
-fn end_to_end_when_mid_exceeds_length_then_clamps() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := MID(s1, 100, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // MID 100 chars from position 3, but only 3 remain -> 'CDE'
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "CDE");
-}
-
-#[test]
-fn end_to_end_when_mid_zero_length_then_empty() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := MID(s1, 0, 2);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "");
-}
-
-#[test]
-fn end_to_end_when_mid_single_char_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := MID(s1, 1, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "C");
-}
-
-#[test]
-fn end_to_end_when_mid_with_integer_vars_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello Beautiful World';
-    n_len : INT := 9;
-    n_pos : INT := 7;
-    result : STRING;
-  END_VAR
-  result := MID(s1, n_len, n_pos);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // MID 9 chars starting at position 7 -> 'Beautiful'
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Beautiful");
-}
-
-#[test]
 fn end_to_end_when_mid_position_beyond_end_then_empty() {
     let source = "
 PROGRAM main
@@ -166,4 +71,41 @@ END_PROGRAM
     // Position 10 is beyond end of 3-char string -> empty
     let result_offset = string_offset(&[254]);
     assert_eq!(read_string(&bufs.data_region, result_offset), "");
+}
+
+// --- Property test: MID(s, n, p) == n chars from 1-based position p ---
+// Inputs are bounded to the unambiguous in-range domain (non-empty s, p a valid
+// 1-based position, n within the remaining length). Oracle is pure Rust. The
+// out-of-range/clamp branch is pinned by the deterministic anchor above.
+proptest! {
+    #[test]
+    fn end_to_end_when_mid_of_arbitrary_string_then_takes_substring(
+        (s, n, p) in safe_string_strategy()
+            .prop_filter("non-empty", |s| !s.is_empty())
+            .prop_flat_map(|s| {
+                let len = s.chars().count();
+                (Just(s), 1usize..=len)
+            })
+            .prop_flat_map(|(s, p)| {
+                let len = s.chars().count();
+                let max_n = len - p + 1;
+                (Just(s), 0usize..=max_n, Just(p))
+            }),
+    ) {
+        let expected: String = s.chars().skip(p - 1).take(n).collect();
+        let source = format!(
+            "
+PROGRAM main
+  VAR
+    s1 : STRING := '{s}';
+    result : STRING;
+  END_VAR
+  result := MID(s1, {n}, {p});
+END_PROGRAM
+"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        let result_offset = string_offset(&[254]);
+        prop_assert_eq!(read_string(&bufs.data_region, result_offset), expected);
+    }
 }

--- a/compiler/codegen/tests/it/end_to_end_mux.rs
+++ b/compiler/codegen/tests/it/end_to_end_mux.rs
@@ -1,42 +1,11 @@
 //! End-to-end integration tests for the MUX function.
 
-e2e_i32!(
-    end_to_end_when_mux_k0_then_returns_in0,
-    "PROGRAM main VAR y : DINT; END_VAR y := MUX(0, 10, 20, 30); END_PROGRAM",
-    &[(0, 10)],
-);
+use ironplc_parser::options::CompilerOptions;
 
-e2e_i32!(
-    end_to_end_when_mux_k1_then_returns_in1,
-    "PROGRAM main VAR y : DINT; END_VAR y := MUX(1, 10, 20, 30); END_PROGRAM",
-    &[(0, 20)],
-);
+use crate::common::parse_and_run;
+use proptest::prelude::*;
 
-e2e_i32!(
-    end_to_end_when_mux_k2_then_returns_in2,
-    "PROGRAM main VAR y : DINT; END_VAR y := MUX(2, 10, 20, 30); END_PROGRAM",
-    &[(0, 30)],
-);
-
-// K=5 is out of range (only 3 inputs), clamps to last = 30.
-e2e_i32!(
-    end_to_end_when_mux_k_out_of_range_then_clamps_to_last,
-    "PROGRAM main VAR y : DINT; END_VAR y := MUX(5, 10, 20, 30); END_PROGRAM",
-    &[(0, 30)],
-);
-
-// K=-1 clamps to 0 = first input = 10.
-e2e_i32!(
-    end_to_end_when_mux_k_negative_then_clamps_to_first,
-    "PROGRAM main VAR k : DINT; y : DINT; END_VAR k := -1; y := MUX(k, 10, 20, 30); END_PROGRAM",
-    &[(1, 10)],
-);
-
-e2e_i32!(
-    end_to_end_when_mux_with_variable_selector_then_selects,
-    "PROGRAM main VAR k : DINT; y : DINT; END_VAR k := 1; y := MUX(k, 100, 200, 300); END_PROGRAM",
-    &[(0, 1), (1, 200)],
-);
+// --- Deterministic anchors: distinct variadic arities + clamp branch ---
 
 e2e_i32!(
     end_to_end_when_mux_2_inputs_then_works,
@@ -56,21 +25,34 @@ e2e_i32!(
     &[(0, 16)],
 );
 
+// K=5 is out of range (only 3 inputs), clamps to last = 30.
 e2e_i32!(
-    end_to_end_when_mux_16_inputs_k0_then_selects_first,
-    "PROGRAM main VAR y : DINT; END_VAR y := MUX(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16); END_PROGRAM",
-    &[(0, 1)],
-);
-
-e2e_i32!(
-    end_to_end_when_mux_16_inputs_k7_then_selects_middle,
-    "PROGRAM main VAR y : DINT; END_VAR y := MUX(7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16); END_PROGRAM",
-    &[(0, 8)],
-);
-
-// K=3 with 3 inputs (indices 0..2), should clamp to IN2.
-e2e_i32!(
-    end_to_end_when_mux_k_equals_input_count_then_clamps_to_last,
-    "PROGRAM main VAR y : DINT; END_VAR y := MUX(3, 10, 20, 30); END_PROGRAM",
+    end_to_end_when_mux_k_out_of_range_then_clamps_to_last,
+    "PROGRAM main VAR y : DINT; END_VAR y := MUX(5, 10, 20, 30); END_PROGRAM",
     &[(0, 30)],
 );
+
+// --- Property test: MUX(k, a, b, c, d) selects inputs[clamp(k, 0, 3)] ---
+// Fixed arity 4. k ranges past both ends to exercise the clamp in both
+// directions (negative -> first, >= n -> last), pinned deterministically by
+// the anchors above. Oracle is pure Rust.
+proptest! {
+    #[test]
+    fn end_to_end_when_mux_4_inputs_over_range_then_selects_clamped(
+        a in any::<i32>(),
+        b in any::<i32>(),
+        c in any::<i32>(),
+        d in any::<i32>(),
+        k in -2i32..=6,
+    ) {
+        let inputs = [a, b, c, d];
+        let expected = inputs[k.clamp(0, 3) as usize];
+        // k is declared as a variable (matching the negative-selector lowering),
+        // so y is the second declared variable at slot 1.
+        let source = format!(
+            "PROGRAM main VAR k : DINT; y : DINT; END_VAR k := {k}; y := MUX(k, {a}, {b}, {c}, {d}); END_PROGRAM"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        prop_assert_eq!(bufs.vars[1].as_i32(), expected);
+    }
+}

--- a/compiler/codegen/tests/it/end_to_end_replace.rs
+++ b/compiler/codegen/tests/it/end_to_end_replace.rs
@@ -4,6 +4,7 @@ use ironplc_parser::options::CompilerOptions;
 
 use crate::common::parse_and_run;
 use ironplc_container::STRING_HEADER_BYTES;
+use proptest::prelude::*;
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -23,6 +24,20 @@ fn string_offset(preceding_max_lengths: &[u16]) -> usize {
         .map(|&ml| STRING_HEADER_BYTES + ml as usize)
         .sum()
 }
+
+/// Generates printable ASCII strings safe for IEC 61131-3 string literals.
+/// Excludes single quote (0x27) and dollar sign (0x24, the escape character).
+/// Length is bounded to 0..=127 so a combined two-string result stays <= 254
+/// and never triggers the STRING[254] truncation branch.
+fn safe_string_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        (0x20u8..=0x7Eu8).prop_filter("exclude quote and dollar", |&b| b != b'\'' && b != b'$'),
+        0..=127,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(|b| b as char).collect())
+}
+
+// --- Deterministic anchors ---
 
 #[test]
 fn end_to_end_when_replace_middle_then_correct_result() {
@@ -45,110 +60,6 @@ END_PROGRAM
 }
 
 #[test]
-fn end_to_end_when_replace_insert_only_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    s2 : STRING := 'XY';
-    result : STRING;
-  END_VAR
-  result := REPLACE(s1, s2, 0, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // L=0 means no deletion, just insert XY at position 3.
-    // Result: AB + XY + CDE = ABXYCDE
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABXYCDE");
-}
-
-#[test]
-fn end_to_end_when_replace_at_start_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello';
-    s2 : STRING := 'Hi';
-    result : STRING;
-  END_VAR
-  result := REPLACE(s1, s2, 5, 1);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete 5 chars from position 1 (all of 'Hello'), insert 'Hi'.
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hi");
-}
-
-#[test]
-fn end_to_end_when_replace_delete_only_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    s2 : STRING;
-    result : STRING;
-  END_VAR
-  result := REPLACE(s1, s2, 2, 2);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete 2 chars at position 2 ('BC'), insert empty string.
-    // Result: A + DE = ADE
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ADE");
-}
-
-#[test]
-fn end_to_end_when_replace_at_end_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    s2 : STRING := 'XYZ';
-    result : STRING;
-  END_VAR
-  result := REPLACE(s1, s2, 2, 4);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Delete 2 chars at position 4 ('DE'), insert 'XYZ'.
-    // Result: ABC + XYZ = ABCXYZ
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABCXYZ");
-}
-
-#[test]
-fn end_to_end_when_replace_with_integer_vars_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello World';
-    s2 : STRING := 'Beautiful ';
-    n_len : INT := 0;
-    n_pos : INT := 7;
-    result : STRING;
-  END_VAR
-  result := REPLACE(s1, s2, n_len, n_pos);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Insert 'Beautiful ' at position 7, delete 0 chars.
-    // Result: Hello Beautiful World
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(
-        read_string(&bufs.data_region, result_offset),
-        "Hello Beautiful World"
-    );
-}
-
-#[test]
 fn end_to_end_when_replace_result_truncated_by_short_destination_then_truncates() {
     let source = "
 PROGRAM main
@@ -168,60 +79,46 @@ END_PROGRAM
     assert_eq!(read_string(&bufs.data_region, result_offset), "ABXXXX");
 }
 
-#[test]
-fn end_to_end_when_replace_result_fits_exactly_in_destination_then_no_truncation() {
-    let source = "
+// --- Property test: REPLACE(s1, s2, n, p) == replace n chars of s1 from
+// 1-based position p with s2. Inputs are bounded so the replaced range lies
+// fully inside s1 and the combined result stays <= 254 (no truncation). Oracle
+// is pure Rust. The truncation branch is pinned by the anchor above.
+proptest! {
+    #[test]
+    fn end_to_end_when_replace_of_arbitrary_strings_then_substitutes(
+        (s1, s2, n, p) in (safe_string_strategy(), safe_string_strategy())
+            .prop_filter("non-empty s1", |(s1, _)| !s1.is_empty())
+            .prop_flat_map(|(s1, s2)| {
+                let len = s1.chars().count();
+                (Just(s1), Just(s2), Just(len), 1usize..=len)
+            })
+            .prop_flat_map(|(s1, s2, len, p)| {
+                let max_n = len - p + 1;
+                (Just(s1), Just(s2), 0usize..=max_n, Just(p))
+            }),
+    ) {
+        let c: Vec<char> = s1.chars().collect();
+        let a = p - 1;
+        let b = a + n;
+        let expected: String = c[..a]
+            .iter()
+            .chain(s2.chars().collect::<Vec<char>>().iter())
+            .chain(c[b..].iter())
+            .collect();
+        let source = format!(
+            "
 PROGRAM main
   VAR
-    s1 : STRING := 'ABCDE';
-    s2 : STRING := 'XY';
-    result : STRING[6];
+    s1 : STRING := '{s1}';
+    s2 : STRING := '{s2}';
+    result : STRING;
   END_VAR
-  result := REPLACE(s1, s2, 1, 3);
+  result := REPLACE(s1, s2, {n}, {p});
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Result: AB + XY + DE = ABXYDE (6 chars) — fits exactly in STRING[6].
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABXYDE");
-}
-
-#[test]
-fn end_to_end_when_replace_result_exceeds_destination_by_one_then_truncates() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    s2 : STRING := 'XYZ';
-    result : STRING[6];
-  END_VAR
-  result := REPLACE(s1, s2, 1, 3);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Result: AB + XYZ + DE = ABXYZDE (7 chars) — truncated to 'ABXYZD' (6 chars).
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABXYZD");
-}
-
-#[test]
-fn end_to_end_when_replace_into_very_short_destination_then_heavily_truncated() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello World';
-    s2 : STRING := 'Earth';
-    result : STRING[3];
-  END_VAR
-  result := REPLACE(s1, s2, 5, 7);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    // Full result would be 'Hello Earth' (11 chars).
-    // STRING[3] truncates to 'Hel'.
-    let result_offset = string_offset(&[254, 254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "Hel");
+"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        let result_offset = string_offset(&[254, 254]);
+        prop_assert_eq!(read_string(&bufs.data_region, result_offset), expected);
+    }
 }

--- a/compiler/codegen/tests/it/end_to_end_right.rs
+++ b/compiler/codegen/tests/it/end_to_end_right.rs
@@ -4,6 +4,7 @@ use ironplc_parser::options::CompilerOptions;
 
 use crate::common::parse_and_run;
 use ironplc_container::STRING_HEADER_BYTES;
+use proptest::prelude::*;
 
 /// Reads a STRING value from the data region at the given byte offset.
 fn read_string(data_region: &[u8], data_offset: usize) -> String {
@@ -23,6 +24,18 @@ fn string_offset(preceding_max_lengths: &[u16]) -> usize {
         .map(|&ml| STRING_HEADER_BYTES + ml as usize)
         .sum()
 }
+
+/// Generates printable ASCII strings safe for IEC 61131-3 string literals.
+/// Excludes single quote (0x27) and dollar sign (0x24, the escape character).
+fn safe_string_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        (0x20u8..=0x7Eu8).prop_filter("exclude quote and dollar", |&b| b != b'\'' && b != b'$'),
+        0..=254,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(|b| b as char).collect())
+}
+
+// --- Deterministic anchors ---
 
 #[test]
 fn end_to_end_when_right_partial_then_correct_result() {
@@ -60,88 +73,30 @@ END_PROGRAM
     assert_eq!(read_string(&bufs.data_region, result_offset), "Hi");
 }
 
-#[test]
-fn end_to_end_when_right_zero_then_empty_string() {
-    let source = "
+// --- Property test: RIGHT(s, n) == last min(n, len(s)) characters ---
+// Oracle is pure Rust, independent of the VM implementation. The two anchors
+// above pin the nominal and clamp branches deterministically.
+proptest! {
+    #[test]
+    fn end_to_end_when_right_of_arbitrary_string_then_takes_suffix(
+        s in safe_string_strategy(),
+        n in 0usize..=260,
+    ) {
+        let l = s.chars().count();
+        let expected: String = s.chars().skip(l.saturating_sub(n)).collect();
+        let source = format!(
+            "
 PROGRAM main
   VAR
-    s1 : STRING := 'Hello';
+    s1 : STRING := '{s}';
     result : STRING;
   END_VAR
-  result := RIGHT(s1, 0);
+  result := RIGHT(s1, {n});
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "");
-}
-
-#[test]
-fn end_to_end_when_right_single_char_then_last_char() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := RIGHT(s1, 1);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "E");
-}
-
-#[test]
-fn end_to_end_when_right_exact_length_then_entire_string() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'ABCDE';
-    result : STRING;
-  END_VAR
-  result := RIGHT(s1, 5);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "ABCDE");
-}
-
-#[test]
-fn end_to_end_when_right_with_integer_var_then_correct_result() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING := 'Hello World';
-    n : INT := 3;
-    result : STRING;
-  END_VAR
-  result := RIGHT(s1, n);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "rld");
-}
-
-#[test]
-fn end_to_end_when_right_empty_string_then_empty() {
-    let source = "
-PROGRAM main
-  VAR
-    s1 : STRING;
-    result : STRING;
-  END_VAR
-  result := RIGHT(s1, 5);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result_offset = string_offset(&[254]);
-    assert_eq!(read_string(&bufs.data_region, result_offset), "");
+"
+        );
+        let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+        let result_offset = string_offset(&[254]);
+        prop_assert_eq!(read_string(&bufs.data_region, result_offset), expected);
+    }
 }

--- a/compiler/container/Cargo.toml
+++ b/compiler/container/Cargo.toml
@@ -19,6 +19,7 @@ ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
 
 [dev-dependencies]
 spec_test_macro = { path = "../spec_test_macro" }
+rstest = "0.26"
 
 [lints]
 workspace = true

--- a/compiler/container/src/constant_pool.rs
+++ b/compiler/container/src/constant_pool.rs
@@ -242,6 +242,7 @@ impl ConstantPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::io::Cursor;
     use std::vec::Vec;
 
@@ -333,74 +334,36 @@ mod tests {
         assert!(!pool.is_empty());
     }
 
-    #[test]
-    fn constant_pool_get_i32_when_type_mismatch_then_returns_error() {
+    // Each case stores one constant of the "wrong" type, then reads it through
+    // a typed accessor that should reject the type mismatch.
+    #[rstest]
+    #[case::i32_accessor_on_f32(
+        (|| ConstEntry::primitive_le(ConstType::F32, &1.0f32.to_le_bytes())) as fn() -> ConstEntry,
+        (|p: &ConstantPool| matches!(p.get_i32(ConstantIndex::new(0)), Err(ContainerError::InvalidConstantType(_)))) as fn(&ConstantPool) -> bool
+    )]
+    #[case::f32_accessor_on_i32(
+        (|| ConstEntry::primitive_le(ConstType::I32, &1i32.to_le_bytes())) as fn() -> ConstEntry,
+        (|p: &ConstantPool| matches!(p.get_f32(ConstantIndex::new(0)), Err(ContainerError::InvalidConstantType(_)))) as fn(&ConstantPool) -> bool
+    )]
+    #[case::f64_accessor_on_i32(
+        (|| ConstEntry::primitive_le(ConstType::I32, &1i32.to_le_bytes())) as fn() -> ConstEntry,
+        (|p: &ConstantPool| matches!(p.get_f64(ConstantIndex::new(0)), Err(ContainerError::InvalidConstantType(_)))) as fn(&ConstantPool) -> bool
+    )]
+    #[case::i64_accessor_on_f64(
+        (|| ConstEntry::primitive_le(ConstType::F64, &1.0f64.to_le_bytes())) as fn() -> ConstEntry,
+        (|p: &ConstantPool| matches!(p.get_i64(ConstantIndex::new(0)), Err(ContainerError::InvalidConstantType(_)))) as fn(&ConstantPool) -> bool
+    )]
+    #[case::str_accessor_on_i32(
+        (|| ConstEntry::primitive_le(ConstType::I32, &1i32.to_le_bytes())) as fn() -> ConstEntry,
+        (|p: &ConstantPool| matches!(p.get_str(ConstantIndex::new(0)), Err(ContainerError::InvalidConstantType(_)))) as fn(&ConstantPool) -> bool
+    )]
+    fn constant_pool_get_when_type_mismatch_then_returns_error(
+        #[case] make_entry: fn() -> ConstEntry,
+        #[case] accessor_errors: fn(&ConstantPool) -> bool,
+    ) {
         let mut pool = ConstantPool::default();
-        pool.push(ConstEntry::primitive_le(
-            ConstType::F32,
-            &1.0f32.to_le_bytes(),
-        ));
-
-        assert!(matches!(
-            pool.get_i32(ConstantIndex::new(0)),
-            Err(ContainerError::InvalidConstantType(_))
-        ));
-    }
-
-    #[test]
-    fn constant_pool_get_f32_when_type_mismatch_then_returns_error() {
-        let mut pool = ConstantPool::default();
-        pool.push(ConstEntry::primitive_le(
-            ConstType::I32,
-            &1i32.to_le_bytes(),
-        ));
-
-        assert!(matches!(
-            pool.get_f32(ConstantIndex::new(0)),
-            Err(ContainerError::InvalidConstantType(_))
-        ));
-    }
-
-    #[test]
-    fn constant_pool_get_f64_when_type_mismatch_then_returns_error() {
-        let mut pool = ConstantPool::default();
-        pool.push(ConstEntry::primitive_le(
-            ConstType::I32,
-            &1i32.to_le_bytes(),
-        ));
-
-        assert!(matches!(
-            pool.get_f64(ConstantIndex::new(0)),
-            Err(ContainerError::InvalidConstantType(_))
-        ));
-    }
-
-    #[test]
-    fn constant_pool_get_i64_when_type_mismatch_then_returns_error() {
-        let mut pool = ConstantPool::default();
-        pool.push(ConstEntry::primitive_le(
-            ConstType::F64,
-            &1.0f64.to_le_bytes(),
-        ));
-
-        assert!(matches!(
-            pool.get_i64(ConstantIndex::new(0)),
-            Err(ContainerError::InvalidConstantType(_))
-        ));
-    }
-
-    #[test]
-    fn constant_pool_get_str_when_type_mismatch_then_returns_error() {
-        let mut pool = ConstantPool::default();
-        pool.push(ConstEntry::primitive_le(
-            ConstType::I32,
-            &1i32.to_le_bytes(),
-        ));
-
-        assert!(matches!(
-            pool.get_str(ConstantIndex::new(0)),
-            Err(ContainerError::InvalidConstantType(_))
-        ));
+        pool.push(make_entry());
+        assert!(accessor_errors(&pool));
     }
 
     #[test]

--- a/compiler/container/src/container_ref.rs
+++ b/compiler/container/src/container_ref.rs
@@ -326,6 +326,7 @@ impl<'a> ContainerRef<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::vec;
     use std::vec::Vec;
 
@@ -365,25 +366,73 @@ mod tests {
         assert_eq!(cref.header().max_stack_depth, 2);
     }
 
-    #[test]
-    fn container_ref_from_slice_when_invalid_magic_then_error() {
-        let mut data = steel_thread_bytes();
-        // Corrupt magic bytes
-        data[0] = 0xFF;
-        data[1] = 0xFF;
-        data[2] = 0xFF;
-        data[3] = 0xFF;
+    // A corruption applied to the steel-thread bytes, and a predicate that
+    // recognizes the error `from_slice` should return for that corruption.
+    #[rstest]
+    #[case::invalid_magic(
+        (|mut data: Vec<u8>| { data[0..4].copy_from_slice(&[0xFF; 4]); data }) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::InvalidMagic)) as fn(&ContainerError) -> bool
+    )]
+    #[case::truncated(
+        (|_: Vec<u8>| vec![0u8; 100]) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::const_section_offset_past_end(
+        (|data: Vec<u8>| { let n = data.len() as u32; with_tampered_header(&data, |h| h.const_section_size = n * 2) }) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::code_section_offset_past_end(
+        (|data: Vec<u8>| { let n = data.len() as u32; with_tampered_header(&data, |h| h.code_section_size = n * 2) }) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::func_dir_larger_than_code(
+        (|data: Vec<u8>| with_tampered_header(&data, |h| h.num_functions = 999)) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::task_section_offset_past_end(
+        (|data: Vec<u8>| { let n = data.len() as u32; with_tampered_header(&data, |h| h.task_section_size = n * 2) }) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::const_section_only_one_byte(
+        (|data: Vec<u8>| with_tampered_header(&data, |h| h.const_section_size = 1)) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::const_section_truncates_entry_header(
+        (|data: Vec<u8>| with_tampered_header(&data, |h| h.const_section_size = 5)) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::const_section_entry_value_truncated(
+        (|data: Vec<u8>| with_tampered_header(&data, |h| h.const_section_size = 6)) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::task_section_smaller_than_header(
+        (|data: Vec<u8>| with_tampered_header(&data, |h| h.task_section_size = 3)) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    #[case::const_entry_value_size_bytes_corrupted(
+        (|data: Vec<u8>| {
+            let header =
+                FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
+            let const_start = header.const_section_offset as usize;
+            let mut data = data;
+            // Const section layout: [count: u16][entry0: type(1) reserved(1) size(2) value(n)].
+            // Blow up the declared value size so it overruns the const pool.
+            let size_offset = const_start + 2 + 2;
+            data[size_offset] = 0xFF;
+            data[size_offset + 1] = 0xFF;
+            data
+        }) as fn(Vec<u8>) -> Vec<u8>,
+        (|e: &ContainerError| matches!(e, ContainerError::SectionSizeMismatch)) as fn(&ContainerError) -> bool
+    )]
+    fn container_ref_from_slice_when_corrupted_then_error(
+        #[case] tamper: fn(Vec<u8>) -> Vec<u8>,
+        #[case] expect_err: fn(&ContainerError) -> bool,
+    ) {
+        let data = tamper(steel_thread_bytes());
         let mut offsets = vec![0u32; 16];
         let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::InvalidMagic)));
-    }
-
-    #[test]
-    fn container_ref_from_slice_when_truncated_then_error() {
-        let data = vec![0u8; 100];
-        let mut offsets = vec![0u32; 16];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
+        let err = result.expect_err("expected corruption to be rejected");
+        assert!(expect_err(&err), "unexpected error: {err:?}");
     }
 
     #[test]
@@ -508,80 +557,6 @@ mod tests {
     }
 
     #[test]
-    fn container_ref_from_slice_when_const_section_offset_past_end_then_errors() {
-        let mut data = steel_thread_bytes();
-
-        // Inflate const_section_size so const_end > data.len().
-        let mut header =
-            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
-        header.const_section_size = data.len() as u32 * 2;
-
-        let mut tampered = Vec::with_capacity(data.len());
-        header.write_to(&mut tampered).unwrap();
-        tampered.extend_from_slice(&data[HEADER_SIZE..]);
-        data = tampered;
-
-        let mut offsets = vec![0u32; 16];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
-    fn container_ref_from_slice_when_code_section_offset_past_end_then_errors() {
-        let mut data = steel_thread_bytes();
-
-        let mut header =
-            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
-        header.code_section_size = data.len() as u32 * 2;
-
-        let mut tampered = Vec::with_capacity(data.len());
-        header.write_to(&mut tampered).unwrap();
-        tampered.extend_from_slice(&data[HEADER_SIZE..]);
-        data = tampered;
-
-        let mut offsets = vec![0u32; 16];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
-    fn container_ref_from_slice_when_func_dir_larger_than_code_then_errors() {
-        let mut data = steel_thread_bytes();
-
-        let mut header =
-            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
-        // Inflate num_functions so func_dir_size > code_section.len().
-        header.num_functions = 999;
-
-        let mut tampered = Vec::with_capacity(data.len());
-        header.write_to(&mut tampered).unwrap();
-        tampered.extend_from_slice(&data[HEADER_SIZE..]);
-        data = tampered;
-
-        let mut offsets = vec![0u32; 16];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
-    fn container_ref_from_slice_when_task_section_offset_past_end_then_errors() {
-        let mut data = steel_thread_bytes();
-
-        let mut header =
-            FileHeader::read_from(&mut std::io::Cursor::new(&data[..HEADER_SIZE])).unwrap();
-        header.task_section_size = data.len() as u32 * 2;
-
-        let mut tampered = Vec::with_capacity(data.len());
-        header.write_to(&mut tampered).unwrap();
-        tampered.extend_from_slice(&data[HEADER_SIZE..]);
-        data = tampered;
-
-        let mut offsets = vec![0u32; 16];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
     fn container_ref_get_i32_constant_when_type_mismatch_then_errors() {
         let data = f32_constant_bytes();
         let count = ContainerRef::const_count(&data).unwrap();
@@ -695,57 +670,6 @@ mod tests {
     }
 
     #[test]
-    fn container_ref_from_slice_when_const_section_only_one_byte_then_errors() {
-        // Set const_section_size = 1 so const_section.len() < 2 and the
-        // count-read bounds check returns SectionSizeMismatch.
-        let data = with_tampered_header(&steel_thread_bytes(), |h| {
-            h.const_section_size = 1;
-        });
-        let mut offsets = vec![0u32; 4];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
-    fn container_ref_from_slice_when_const_section_truncates_entry_header_then_errors() {
-        // Original const section has 2 entries; clip the section_size so the
-        // entry-header bounds check fails during the pre-scan loop.
-        let data = with_tampered_header(&steel_thread_bytes(), |h| {
-            // 2 (count) + 3 bytes = less than one full 4-byte entry header.
-            h.const_section_size = 5;
-        });
-        let mut offsets = vec![0u32; 4];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
-    fn container_ref_from_slice_when_const_section_entry_value_truncated_then_errors() {
-        // Header claims an entry larger than the remaining const section,
-        // so the "pos > const_pool_bytes.len()" check after advancing fires.
-        let data = with_tampered_header(&steel_thread_bytes(), |h| {
-            // Just enough for the count and the first entry header, but the
-            // declared value size will overrun the truncated section.
-            h.const_section_size = 6;
-        });
-        let mut offsets = vec![0u32; 4];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
-    fn container_ref_from_slice_when_task_section_smaller_than_header_then_errors() {
-        // A non-zero but tiny task_section_size forces the header-length
-        // bounds check in from_slice to return SectionSizeMismatch.
-        let data = with_tampered_header(&steel_thread_bytes(), |h| {
-            h.task_section_size = 3;
-        });
-        let mut offsets = vec![0u32; 4];
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
-    }
-
-    #[test]
     fn container_ref_num_programs_and_shared_globals_when_valid_then_return_fields() {
         let data = steel_thread_bytes();
         let count = ContainerRef::const_count(&data).unwrap();
@@ -770,30 +694,5 @@ mod tests {
         assert_eq!(cref.num_tasks(), 0);
         assert_eq!(cref.num_programs(), 0);
         assert_eq!(cref.shared_globals_size(), 0);
-    }
-
-    #[test]
-    fn container_ref_get_i32_constant_when_value_bytes_truncated_then_errors() {
-        // Tamper the container so the first constant's declared value length
-        // would run past the end of the const pool bytes. The pre-scan
-        // already validates this, so we need a direct-crafted buffer.
-        let base = steel_thread_bytes();
-        // Locate the const section by rereading the header.
-        let header =
-            FileHeader::read_from(&mut std::io::Cursor::new(&base[..HEADER_SIZE])).unwrap();
-        let const_start = header.const_section_offset as usize;
-
-        let mut data = base.clone();
-        // Set the first entry's declared value size to a huge number.
-        // Const section layout: [count: u16][entry0: type(1) reserved(1) size(2) value(n)]
-        let size_offset = const_start + 2 + 2;
-        data[size_offset] = 0xFF;
-        data[size_offset + 1] = 0xFF;
-
-        let mut offsets = vec![0u32; 4];
-        // from_slice itself will detect the overrun and error, exercising the
-        // same bounds-check code path.
-        let result = ContainerRef::from_slice(&data, &mut offsets);
-        assert!(matches!(result, Err(ContainerError::SectionSizeMismatch)));
     }
 }

--- a/compiler/dsl/Cargo.toml
+++ b/compiler/dsl/Cargo.toml
@@ -19,5 +19,8 @@ logos = "0.16.1"
 regex = "1.12.3"
 lazy_static = "1.5.0"
 
+[dev-dependencies]
+rstest = "0.26"
+
 [lints]
 workspace = true

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -3628,302 +3628,78 @@ mod tests {
         assert_eq!(si.value.value, 7);
     }
 
-    #[test]
-    fn can_widen_to_when_sint_to_int_then_true() {
-        assert!(ElementaryTypeName::SINT.can_widen_to(&ElementaryTypeName::INT));
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::sint_to_int(ElementaryTypeName::SINT, ElementaryTypeName::INT, true)]
+    #[case::sint_to_dint(ElementaryTypeName::SINT, ElementaryTypeName::DINT, true)]
+    #[case::sint_to_lint(ElementaryTypeName::SINT, ElementaryTypeName::LINT, true)]
+    #[case::int_to_dint(ElementaryTypeName::INT, ElementaryTypeName::DINT, true)]
+    #[case::dint_to_lint(ElementaryTypeName::DINT, ElementaryTypeName::LINT, true)]
+    #[case::usint_to_uint(ElementaryTypeName::USINT, ElementaryTypeName::UINT, true)]
+    #[case::usint_to_ulint(ElementaryTypeName::USINT, ElementaryTypeName::ULINT, true)]
+    #[case::uint_to_udint(ElementaryTypeName::UINT, ElementaryTypeName::UDINT, true)]
+    #[case::usint_to_int(ElementaryTypeName::USINT, ElementaryTypeName::INT, true)]
+    #[case::uint_to_dint(ElementaryTypeName::UINT, ElementaryTypeName::DINT, true)]
+    #[case::udint_to_lint(ElementaryTypeName::UDINT, ElementaryTypeName::LINT, true)]
+    #[case::dint_to_int(ElementaryTypeName::DINT, ElementaryTypeName::INT, false)]
+    #[case::lint_to_dint(ElementaryTypeName::LINT, ElementaryTypeName::DINT, false)]
+    #[case::int_to_uint(ElementaryTypeName::INT, ElementaryTypeName::UINT, false)]
+    #[case::int_to_int(ElementaryTypeName::INT, ElementaryTypeName::INT, false)]
+    #[case::uint_to_int(ElementaryTypeName::UINT, ElementaryTypeName::INT, false)]
+    #[case::sint_to_real(ElementaryTypeName::SINT, ElementaryTypeName::REAL, true)]
+    #[case::int_to_real(ElementaryTypeName::INT, ElementaryTypeName::REAL, true)]
+    #[case::usint_to_real(ElementaryTypeName::USINT, ElementaryTypeName::REAL, true)]
+    #[case::uint_to_real(ElementaryTypeName::UINT, ElementaryTypeName::REAL, true)]
+    #[case::dint_to_real(ElementaryTypeName::DINT, ElementaryTypeName::REAL, false)]
+    #[case::lint_to_real(ElementaryTypeName::LINT, ElementaryTypeName::REAL, false)]
+    #[case::udint_to_real(ElementaryTypeName::UDINT, ElementaryTypeName::REAL, false)]
+    #[case::ulint_to_real(ElementaryTypeName::ULINT, ElementaryTypeName::REAL, false)]
+    #[case::sint_to_lreal(ElementaryTypeName::SINT, ElementaryTypeName::LREAL, true)]
+    #[case::lint_to_lreal(ElementaryTypeName::LINT, ElementaryTypeName::LREAL, true)]
+    #[case::ulint_to_lreal(ElementaryTypeName::ULINT, ElementaryTypeName::LREAL, true)]
+    #[case::real_to_int(ElementaryTypeName::REAL, ElementaryTypeName::INT, false)]
+    #[case::lreal_to_dint(ElementaryTypeName::LREAL, ElementaryTypeName::DINT, false)]
+    #[case::real_to_lreal(ElementaryTypeName::REAL, ElementaryTypeName::LREAL, true)]
+    #[case::lreal_to_real(ElementaryTypeName::LREAL, ElementaryTypeName::REAL, false)]
+    #[case::real_to_real(ElementaryTypeName::REAL, ElementaryTypeName::REAL, false)]
+    #[case::byte_to_word(ElementaryTypeName::BYTE, ElementaryTypeName::WORD, true)]
+    #[case::byte_to_dword(ElementaryTypeName::BYTE, ElementaryTypeName::DWORD, true)]
+    #[case::byte_to_lword(ElementaryTypeName::BYTE, ElementaryTypeName::LWORD, true)]
+    #[case::word_to_dword(ElementaryTypeName::WORD, ElementaryTypeName::DWORD, true)]
+    #[case::dword_to_lword(ElementaryTypeName::DWORD, ElementaryTypeName::LWORD, true)]
+    #[case::word_to_byte(ElementaryTypeName::WORD, ElementaryTypeName::BYTE, false)]
+    #[case::byte_to_byte(ElementaryTypeName::BYTE, ElementaryTypeName::BYTE, false)]
+    #[case::bool_to_byte(ElementaryTypeName::BOOL, ElementaryTypeName::BYTE, false)]
+    #[case::byte_to_int(ElementaryTypeName::BYTE, ElementaryTypeName::INT, false)]
+    #[case::int_to_byte(ElementaryTypeName::INT, ElementaryTypeName::BYTE, false)]
+    fn can_widen_to_when_source_and_target_then_matches_expected(
+        #[case] from: ElementaryTypeName,
+        #[case] to: ElementaryTypeName,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(from.can_widen_to(&to), expected);
     }
 
-    #[test]
-    fn can_widen_to_when_sint_to_dint_then_true() {
-        assert!(ElementaryTypeName::SINT.can_widen_to(&ElementaryTypeName::DINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_sint_to_lint_then_true() {
-        assert!(ElementaryTypeName::SINT.can_widen_to(&ElementaryTypeName::LINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_int_to_dint_then_true() {
-        assert!(ElementaryTypeName::INT.can_widen_to(&ElementaryTypeName::DINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_dint_to_lint_then_true() {
-        assert!(ElementaryTypeName::DINT.can_widen_to(&ElementaryTypeName::LINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_usint_to_uint_then_true() {
-        assert!(ElementaryTypeName::USINT.can_widen_to(&ElementaryTypeName::UINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_usint_to_ulint_then_true() {
-        assert!(ElementaryTypeName::USINT.can_widen_to(&ElementaryTypeName::ULINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_uint_to_udint_then_true() {
-        assert!(ElementaryTypeName::UINT.can_widen_to(&ElementaryTypeName::UDINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_usint_to_int_then_true() {
-        assert!(ElementaryTypeName::USINT.can_widen_to(&ElementaryTypeName::INT));
-    }
-
-    #[test]
-    fn can_widen_to_when_uint_to_dint_then_true() {
-        assert!(ElementaryTypeName::UINT.can_widen_to(&ElementaryTypeName::DINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_udint_to_lint_then_true() {
-        assert!(ElementaryTypeName::UDINT.can_widen_to(&ElementaryTypeName::LINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_dint_to_int_then_false() {
-        assert!(!ElementaryTypeName::DINT.can_widen_to(&ElementaryTypeName::INT));
-    }
-
-    #[test]
-    fn can_widen_to_when_lint_to_dint_then_false() {
-        assert!(!ElementaryTypeName::LINT.can_widen_to(&ElementaryTypeName::DINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_int_to_uint_then_false() {
-        assert!(!ElementaryTypeName::INT.can_widen_to(&ElementaryTypeName::UINT));
-    }
-
-    #[test]
-    fn can_widen_to_when_int_to_int_then_false() {
-        assert!(!ElementaryTypeName::INT.can_widen_to(&ElementaryTypeName::INT));
-    }
-
-    #[test]
-    fn can_widen_to_when_uint_to_int_then_false() {
-        assert!(!ElementaryTypeName::UINT.can_widen_to(&ElementaryTypeName::INT));
-    }
-
-    // Integer → REAL (lossless: ≤16-bit integers)
-
-    #[test]
-    fn can_widen_to_when_sint_to_real_then_true() {
-        assert!(ElementaryTypeName::SINT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_int_to_real_then_true() {
-        assert!(ElementaryTypeName::INT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_usint_to_real_then_true() {
-        assert!(ElementaryTypeName::USINT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_uint_to_real_then_true() {
-        assert!(ElementaryTypeName::UINT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_dint_to_real_then_false() {
-        assert!(!ElementaryTypeName::DINT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_lint_to_real_then_false() {
-        assert!(!ElementaryTypeName::LINT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_udint_to_real_then_false() {
-        assert!(!ElementaryTypeName::UDINT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_ulint_to_real_then_false() {
-        assert!(!ElementaryTypeName::ULINT.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    // Integer → LREAL (always lossless)
-
-    #[test]
-    fn can_widen_to_when_sint_to_lreal_then_true() {
-        assert!(ElementaryTypeName::SINT.can_widen_to(&ElementaryTypeName::LREAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_lint_to_lreal_then_true() {
-        assert!(ElementaryTypeName::LINT.can_widen_to(&ElementaryTypeName::LREAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_ulint_to_lreal_then_true() {
-        assert!(ElementaryTypeName::ULINT.can_widen_to(&ElementaryTypeName::LREAL));
-    }
-
-    // Real → Integer: never allowed
-
-    #[test]
-    fn can_widen_to_when_real_to_int_then_false() {
-        assert!(!ElementaryTypeName::REAL.can_widen_to(&ElementaryTypeName::INT));
-    }
-
-    #[test]
-    fn can_widen_to_when_lreal_to_dint_then_false() {
-        assert!(!ElementaryTypeName::LREAL.can_widen_to(&ElementaryTypeName::DINT));
-    }
-
-    // REAL <-> LREAL: widening allowed, narrowing not
-
-    #[test]
-    fn can_widen_to_when_real_to_lreal_then_true() {
-        assert!(ElementaryTypeName::REAL.can_widen_to(&ElementaryTypeName::LREAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_lreal_to_real_then_false() {
-        assert!(!ElementaryTypeName::LREAL.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    #[test]
-    fn can_widen_to_when_real_to_real_then_false() {
-        assert!(!ElementaryTypeName::REAL.can_widen_to(&ElementaryTypeName::REAL));
-    }
-
-    // Bit-string widening within ANY_BIT
-
-    #[test]
-    fn can_widen_to_when_byte_to_word_then_true() {
-        assert!(ElementaryTypeName::BYTE.can_widen_to(&ElementaryTypeName::WORD));
-    }
-
-    #[test]
-    fn can_widen_to_when_byte_to_dword_then_true() {
-        assert!(ElementaryTypeName::BYTE.can_widen_to(&ElementaryTypeName::DWORD));
-    }
-
-    #[test]
-    fn can_widen_to_when_byte_to_lword_then_true() {
-        assert!(ElementaryTypeName::BYTE.can_widen_to(&ElementaryTypeName::LWORD));
-    }
-
-    #[test]
-    fn can_widen_to_when_word_to_dword_then_true() {
-        assert!(ElementaryTypeName::WORD.can_widen_to(&ElementaryTypeName::DWORD));
-    }
-
-    #[test]
-    fn can_widen_to_when_dword_to_lword_then_true() {
-        assert!(ElementaryTypeName::DWORD.can_widen_to(&ElementaryTypeName::LWORD));
-    }
-
-    #[test]
-    fn can_widen_to_when_word_to_byte_then_false() {
-        assert!(!ElementaryTypeName::WORD.can_widen_to(&ElementaryTypeName::BYTE));
-    }
-
-    #[test]
-    fn can_widen_to_when_byte_to_byte_then_false() {
-        assert!(!ElementaryTypeName::BYTE.can_widen_to(&ElementaryTypeName::BYTE));
-    }
-
-    #[test]
-    fn can_widen_to_when_bool_to_byte_then_false() {
-        assert!(!ElementaryTypeName::BOOL.can_widen_to(&ElementaryTypeName::BYTE));
-    }
-
-    // Cross-family: not allowed in standard can_widen_to
-
-    #[test]
-    fn can_widen_to_when_byte_to_int_then_false() {
-        assert!(!ElementaryTypeName::BYTE.can_widen_to(&ElementaryTypeName::INT));
-    }
-
-    #[test]
-    fn can_widen_to_when_int_to_byte_then_false() {
-        assert!(!ElementaryTypeName::INT.can_widen_to(&ElementaryTypeName::BYTE));
-    }
-
-    // Cross-family widening (separate method, requires flag)
-
-    #[test]
-    fn can_widen_cross_family_to_when_byte_to_int_then_true() {
-        assert!(ElementaryTypeName::BYTE.can_widen_cross_family_to(&ElementaryTypeName::INT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_byte_to_uint_then_true() {
-        assert!(ElementaryTypeName::BYTE.can_widen_cross_family_to(&ElementaryTypeName::UINT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_word_to_dint_then_true() {
-        assert!(ElementaryTypeName::WORD.can_widen_cross_family_to(&ElementaryTypeName::DINT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_dword_to_lint_then_true() {
-        assert!(ElementaryTypeName::DWORD.can_widen_cross_family_to(&ElementaryTypeName::LINT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_byte_to_sint_then_false() {
-        // Same width, not strictly wider
-        assert!(!ElementaryTypeName::BYTE.can_widen_cross_family_to(&ElementaryTypeName::SINT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_word_to_int_then_false() {
-        // Same width, not strictly wider
-        assert!(!ElementaryTypeName::WORD.can_widen_cross_family_to(&ElementaryTypeName::INT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_int_to_byte_then_false() {
-        // Integer → bit-string: never allowed
-        assert!(!ElementaryTypeName::INT.can_widen_cross_family_to(&ElementaryTypeName::BYTE));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_udint_to_dword_then_true() {
-        // Verified permissive against real TcXaeShell despite equal width
-        // and despite Beckhoff's own docs -- see twincat-status.md.
-        assert!(ElementaryTypeName::UDINT.can_widen_cross_family_to(&ElementaryTypeName::DWORD));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_dword_to_udint_then_true() {
-        assert!(ElementaryTypeName::DWORD.can_widen_cross_family_to(&ElementaryTypeName::UDINT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_dint_to_dword_then_false() {
-        // Signed integer, equal width -- not verified, must stay rejected.
-        assert!(!ElementaryTypeName::DINT.can_widen_cross_family_to(&ElementaryTypeName::DWORD));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_dword_to_dint_then_false() {
-        assert!(!ElementaryTypeName::DWORD.can_widen_cross_family_to(&ElementaryTypeName::DINT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_word_to_uint_then_false() {
-        // Different pair, same width class -- not verified, must stay
-        // rejected. The UDINT<->DWORD exception is scoped to that exact
-        // pair, not generalized to every equal-width bit-string/unsigned-
-        // integer pair.
-        assert!(!ElementaryTypeName::WORD.can_widen_cross_family_to(&ElementaryTypeName::UINT));
-    }
-
-    #[test]
-    fn can_widen_cross_family_to_when_uint_to_word_then_false() {
-        assert!(!ElementaryTypeName::UINT.can_widen_cross_family_to(&ElementaryTypeName::WORD));
+    #[rstest]
+    #[case::byte_to_int(ElementaryTypeName::BYTE, ElementaryTypeName::INT, true)]
+    #[case::byte_to_uint(ElementaryTypeName::BYTE, ElementaryTypeName::UINT, true)]
+    #[case::word_to_dint(ElementaryTypeName::WORD, ElementaryTypeName::DINT, true)]
+    #[case::dword_to_lint(ElementaryTypeName::DWORD, ElementaryTypeName::LINT, true)]
+    #[case::byte_to_sint(ElementaryTypeName::BYTE, ElementaryTypeName::SINT, false)]
+    #[case::word_to_int(ElementaryTypeName::WORD, ElementaryTypeName::INT, false)]
+    #[case::int_to_byte(ElementaryTypeName::INT, ElementaryTypeName::BYTE, false)]
+    #[case::udint_to_dword(ElementaryTypeName::UDINT, ElementaryTypeName::DWORD, true)]
+    #[case::dword_to_udint(ElementaryTypeName::DWORD, ElementaryTypeName::UDINT, true)]
+    #[case::dint_to_dword(ElementaryTypeName::DINT, ElementaryTypeName::DWORD, false)]
+    #[case::dword_to_dint(ElementaryTypeName::DWORD, ElementaryTypeName::DINT, false)]
+    #[case::word_to_uint(ElementaryTypeName::WORD, ElementaryTypeName::UINT, false)]
+    #[case::uint_to_word(ElementaryTypeName::UINT, ElementaryTypeName::WORD, false)]
+    fn can_widen_cross_family_to_when_source_and_target_then_matches_expected(
+        #[case] from: ElementaryTypeName,
+        #[case] to: ElementaryTypeName,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(from.can_widen_cross_family_to(&to), expected);
     }
 }

--- a/compiler/project/Cargo.toml
+++ b/compiler/project/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0"
 tempfile = "3"
 ctor = "1.0"
 env_logger = "0.11"
+rstest = "0.26"
 
 [lints]
 workspace = true

--- a/compiler/project/src/disassemble.rs
+++ b/compiler/project/src/disassemble.rs
@@ -685,6 +685,7 @@ fn hex_string(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use ironplc_container::{ContainerBuilder, FunctionId};
+    use rstest::rstest;
     use std::io::Cursor;
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -992,120 +993,33 @@ mod tests {
     // decode_instructions: no-operand opcodes
     // ---------------------------------------------------------------
 
-    #[test]
-    fn decode_when_load_true_then_opcode_name_and_empty_operands() {
-        let instr = first_instruction(vec![opcode::LOAD_TRUE, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "LOAD_TRUE");
+    #[rstest]
+    #[case::load_true(opcode::LOAD_TRUE, "LOAD_TRUE")]
+    #[case::load_false(opcode::LOAD_FALSE, "LOAD_FALSE")]
+    #[case::sub_i32(opcode::SUB_I32, "SUB_I32")]
+    #[case::mul_i32(opcode::MUL_I32, "MUL_I32")]
+    #[case::div_i32(opcode::DIV_I32, "DIV_I32")]
+    #[case::mod_i32(opcode::MOD_I32, "MOD_I32")]
+    #[case::neg_i32(opcode::NEG_I32, "NEG_I32")]
+    #[case::eq_i32(opcode::EQ_I32, "EQ_I32")]
+    #[case::ne_i32(opcode::NE_I32, "NE_I32")]
+    #[case::lt_i32(opcode::LT_I32, "LT_I32")]
+    #[case::le_i32(opcode::LE_I32, "LE_I32")]
+    #[case::gt_i32(opcode::GT_I32, "GT_I32")]
+    #[case::ge_i32(opcode::GE_I32, "GE_I32")]
+    #[case::bool_and(opcode::BOOL_AND, "BOOL_AND")]
+    #[case::bool_or(opcode::BOOL_OR, "BOOL_OR")]
+    #[case::bool_xor(opcode::BOOL_XOR, "BOOL_XOR")]
+    #[case::bool_not(opcode::BOOL_NOT, "BOOL_NOT")]
+    #[case::dup(opcode::DUP, "DUP")]
+    #[case::swap(opcode::SWAP, "SWAP")]
+    fn decode_when_no_operand_opcode_then_opcode_name_and_empty_operands(
+        #[case] opcode_byte: u8,
+        #[case] expected_name: &str,
+    ) {
+        let instr = first_instruction(vec![opcode_byte, opcode::RET_VOID]);
+        assert_eq!(instr["opcode"], expected_name);
         assert_eq!(instr["operands"], "");
-    }
-
-    #[test]
-    fn decode_when_load_false_then_opcode_name_and_empty_operands() {
-        let instr = first_instruction(vec![opcode::LOAD_FALSE, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "LOAD_FALSE");
-        assert_eq!(instr["operands"], "");
-    }
-
-    #[test]
-    fn decode_when_sub_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::SUB_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "SUB_I32");
-    }
-
-    #[test]
-    fn decode_when_mul_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::MUL_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "MUL_I32");
-    }
-
-    #[test]
-    fn decode_when_div_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::DIV_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "DIV_I32");
-    }
-
-    #[test]
-    fn decode_when_mod_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::MOD_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "MOD_I32");
-    }
-
-    #[test]
-    fn decode_when_neg_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::NEG_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "NEG_I32");
-    }
-
-    #[test]
-    fn decode_when_eq_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::EQ_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "EQ_I32");
-    }
-
-    #[test]
-    fn decode_when_ne_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::NE_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "NE_I32");
-    }
-
-    #[test]
-    fn decode_when_lt_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::LT_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "LT_I32");
-    }
-
-    #[test]
-    fn decode_when_le_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::LE_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "LE_I32");
-    }
-
-    #[test]
-    fn decode_when_gt_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::GT_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "GT_I32");
-    }
-
-    #[test]
-    fn decode_when_ge_i32_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::GE_I32, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "GE_I32");
-    }
-
-    #[test]
-    fn decode_when_bool_and_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::BOOL_AND, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "BOOL_AND");
-    }
-
-    #[test]
-    fn decode_when_bool_or_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::BOOL_OR, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "BOOL_OR");
-    }
-
-    #[test]
-    fn decode_when_bool_xor_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::BOOL_XOR, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "BOOL_XOR");
-    }
-
-    #[test]
-    fn decode_when_bool_not_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::BOOL_NOT, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "BOOL_NOT");
-    }
-
-    #[test]
-    fn decode_when_dup_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::DUP, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "DUP");
-    }
-
-    #[test]
-    fn decode_when_swap_then_opcode_name() {
-        let instr = first_instruction(vec![opcode::SWAP, opcode::RET_VOID]);
-        assert_eq!(instr["opcode"], "SWAP");
     }
 
     // ---------------------------------------------------------------
@@ -1149,105 +1063,39 @@ mod tests {
         first_instruction(vec![opcode::BUILTIN, id[0], id[1], opcode::RET_VOID])
     }
 
-    #[test]
-    fn decode_when_builtin_expt_i32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::EXPT_I32);
-        assert_eq!(instr["operands"], "EXPT_I32 (0x0340)");
+    #[rstest]
+    #[case::expt_i32(opcode::builtin::EXPT_I32, "EXPT_I32 (0x0340)")]
+    #[case::abs_i32(opcode::builtin::ABS_I32, "ABS_I32 (0x0343)")]
+    #[case::min_i32(opcode::builtin::MIN_I32, "MIN_I32 (0x0344)")]
+    #[case::max_f64(opcode::builtin::MAX_F64, "MAX_F64 (0x0359)")]
+    #[case::limit_f32(opcode::builtin::LIMIT_F32, "LIMIT_F32 (0x035A)")]
+    #[case::sel_i32(opcode::builtin::SEL_I32, "SEL_I32 (0x0347)")]
+    #[case::shl_i32(opcode::builtin::SHL_I32, "SHL_I32 (0x0348)")]
+    #[case::rol_u8(opcode::builtin::ROL_U8, "ROL_U8 (0x0350)")]
+    #[case::bcd_to_int_32(opcode::builtin::BCD_TO_INT_32, "BCD_TO_INT_32 (0x0393)")]
+    #[case::int_to_bcd_64(opcode::builtin::INT_TO_BCD_64, "INT_TO_BCD_64 (0x0398)")]
+    #[case::sqrt_f32(opcode::builtin::SQRT_F32, "SQRT_F32 (0x035E)")]
+    #[case::unknown_id(0x00FF, "0x00FF")]
+    fn decode_when_builtin_then_operand_shows_name(
+        #[case] func_id: u16,
+        #[case] expected_operands: &str,
+    ) {
+        let instr = builtin_instruction(func_id);
+        assert_eq!(instr["operands"], expected_operands);
     }
 
-    #[test]
-    fn decode_when_builtin_abs_i32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::ABS_I32);
-        assert_eq!(instr["operands"], "ABS_I32 (0x0343)");
-    }
-
-    #[test]
-    fn decode_when_builtin_min_i32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::MIN_I32);
-        assert_eq!(instr["operands"], "MIN_I32 (0x0344)");
-    }
-
-    #[test]
-    fn decode_when_builtin_max_f64_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::MAX_F64);
-        assert_eq!(instr["operands"], "MAX_F64 (0x0359)");
-    }
-
-    #[test]
-    fn decode_when_builtin_limit_f32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::LIMIT_F32);
-        assert_eq!(instr["operands"], "LIMIT_F32 (0x035A)");
-    }
-
-    #[test]
-    fn decode_when_builtin_sel_i32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::SEL_I32);
-        assert_eq!(instr["operands"], "SEL_I32 (0x0347)");
-    }
-
-    #[test]
-    fn decode_when_builtin_shl_i32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::SHL_I32);
-        assert_eq!(instr["operands"], "SHL_I32 (0x0348)");
-    }
-
-    #[test]
-    fn decode_when_builtin_rol_u8_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::ROL_U8);
-        assert_eq!(instr["operands"], "ROL_U8 (0x0350)");
-    }
-
-    #[test]
-    fn decode_when_builtin_bcd_to_int_32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::BCD_TO_INT_32);
-        assert_eq!(instr["operands"], "BCD_TO_INT_32 (0x0393)");
-    }
-
-    #[test]
-    fn decode_when_builtin_int_to_bcd_64_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::INT_TO_BCD_64);
-        assert_eq!(instr["operands"], "INT_TO_BCD_64 (0x0398)");
-    }
-
-    #[test]
-    fn decode_when_builtin_sqrt_f32_then_operand_shows_name() {
-        let instr = builtin_instruction(opcode::builtin::SQRT_F32);
-        assert_eq!(instr["operands"], "SQRT_F32 (0x035E)");
-    }
-
-    #[test]
-    fn decode_when_builtin_mux_i32_then_operand_shows_width_and_n() {
-        // MUX_I32_BASE + 3 = MUX with 3 inputs
-        let instr = builtin_instruction(opcode::builtin::MUX_I32_BASE + 3);
+    #[rstest]
+    #[case::mux_i32(opcode::builtin::MUX_I32_BASE + 3, "MUX_I32(3)")]
+    #[case::mux_i64(opcode::builtin::MUX_I64_BASE + 2, "MUX_I64(2)")]
+    #[case::mux_f32(opcode::builtin::MUX_F32_BASE + 4, "MUX_F32(4)")]
+    #[case::mux_f64(opcode::builtin::MUX_F64_BASE + 5, "MUX_F64(5)")]
+    fn decode_when_builtin_mux_then_operand_shows_width_and_n(
+        #[case] func_id: u16,
+        #[case] expected_prefix: &str,
+    ) {
+        let instr = builtin_instruction(func_id);
         let operands = instr["operands"].as_str().unwrap();
-        assert!(operands.starts_with("MUX_I32(3)"), "got: {operands}");
-    }
-
-    #[test]
-    fn decode_when_builtin_mux_i64_then_operand_shows_width_and_n() {
-        let instr = builtin_instruction(opcode::builtin::MUX_I64_BASE + 2);
-        let operands = instr["operands"].as_str().unwrap();
-        assert!(operands.starts_with("MUX_I64(2)"), "got: {operands}");
-    }
-
-    #[test]
-    fn decode_when_builtin_mux_f32_then_operand_shows_width_and_n() {
-        let instr = builtin_instruction(opcode::builtin::MUX_F32_BASE + 4);
-        let operands = instr["operands"].as_str().unwrap();
-        assert!(operands.starts_with("MUX_F32(4)"), "got: {operands}");
-    }
-
-    #[test]
-    fn decode_when_builtin_mux_f64_then_operand_shows_width_and_n() {
-        let instr = builtin_instruction(opcode::builtin::MUX_F64_BASE + 5);
-        let operands = instr["operands"].as_str().unwrap();
-        assert!(operands.starts_with("MUX_F64(5)"), "got: {operands}");
-    }
-
-    #[test]
-    fn decode_when_builtin_unknown_id_then_operand_shows_hex() {
-        let instr = builtin_instruction(0x00FF);
-        assert_eq!(instr["operands"], "0x00FF");
+        assert!(operands.starts_with(expected_prefix), "got: {operands}");
     }
 
     // ---------------------------------------------------------------

--- a/compiler/vm/Cargo.toml
+++ b/compiler/vm/Cargo.toml
@@ -17,6 +17,7 @@ ironplc-container = { path = "../container", version = "0.233.0" }
 [dev-dependencies]
 ironplc-vm = { path = ".", features = ["test-support"] }
 proptest = "1"
+rstest = "0.26"
 spec_test_macro = { path = "../spec_test_macro" }
 
 [build-dependencies]

--- a/compiler/vm/src/error.rs
+++ b/compiler/vm/src/error.rs
@@ -121,222 +121,98 @@ impl fmt::Display for Trap {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn trap_display_when_divide_by_zero_then_expected() {
-        assert_eq!(format!("{}", Trap::DivideByZero), "divide by zero");
+    #[rstest]
+    #[case(Trap::DivideByZero, "divide by zero")]
+    #[case(Trap::StackOverflow, "stack overflow")]
+    #[case(Trap::StackUnderflow, "stack underflow")]
+    #[case(Trap::InvalidInstruction(0xAB), "invalid instruction: 0xAB")]
+    #[case(
+        Trap::InvalidConstantIndex(ConstantIndex::new(5)),
+        "invalid constant index: 5"
+    )]
+    #[case(
+        Trap::InvalidVariableIndex(VarIndex::new(7)),
+        "invalid variable index: 7"
+    )]
+    #[case(Trap::InvalidFunctionId(FunctionId::new(3)), "invalid function ID: 3")]
+    #[case(Trap::WatchdogTimeout(TaskId::new(3)), "watchdog timeout on task 3")]
+    #[case(Trap::NegativeExponent, "negative exponent")]
+    #[case(Trap::NullDereference, "null reference dereference")]
+    #[case(
+        Trap::InvalidBuiltinFunction(FunctionId::new(0x0101)),
+        "invalid built-in function: 0x0101"
+    )]
+    #[case(
+        Trap::DataRegionOutOfBounds(42),
+        "data region access out of bounds at offset 42"
+    )]
+    #[case(Trap::TempBufferExhausted, "temporary buffer pool exhausted")]
+    #[case(
+        Trap::InvalidFbTypeId(FbTypeId::new(0x0010)),
+        "invalid FB type ID: 0x0010"
+    )]
+    #[case(
+        Trap::ArrayIndexOutOfBounds {
+            var_index: VarIndex::new(2),
+            index: 10,
+            total_elements: 5,
+        },
+        "array index out of bounds: index 10 for array variable 2 with 5 elements"
+    )]
+    #[case(Trap::UnexpectedEndOfBytecode, "bytecode ended mid-instruction")]
+    #[case(Trap::CallStackOverflow, "call stack overflow")]
+    #[case(Trap::InvalidCmpOp(0x07), "invalid comparison operator code: 0x07")]
+    #[case(
+        Trap::EncodingMismatch { expected: 1, actual: 2 },
+        "string encoding mismatch: expected char_width 1, got 2"
+    )]
+    #[case(
+        Trap::InvalidCharWidth(7),
+        "invalid char_width byte: 7 (expected 1 or 2)"
+    )]
+    #[case(
+        Trap::ProgramExceedsCallDepth { required: 64, capacity: 32 },
+        "program declares call depth 64 but VM frame buffer holds at most 32"
+    )]
+    #[case(Trap::ZeroCallDepth, "container declares a maximum call depth of zero")]
+    fn trap_display_when_variant_then_expected(#[case] trap: Trap, #[case] expected: &str) {
+        assert_eq!(format!("{trap}"), expected);
     }
 
-    #[test]
-    fn trap_display_when_stack_overflow_then_expected() {
-        assert_eq!(format!("{}", Trap::StackOverflow), "stack overflow");
-    }
-
-    #[test]
-    fn trap_display_when_stack_underflow_then_expected() {
-        assert_eq!(format!("{}", Trap::StackUnderflow), "stack underflow");
-    }
-
-    #[test]
-    fn trap_display_when_invalid_instruction_then_includes_hex_opcode() {
-        assert_eq!(
-            format!("{}", Trap::InvalidInstruction(0xAB)),
-            "invalid instruction: 0xAB"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_invalid_constant_index_then_includes_index() {
-        assert_eq!(
-            format!("{}", Trap::InvalidConstantIndex(ConstantIndex::new(5))),
-            "invalid constant index: 5"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_invalid_variable_index_then_includes_index() {
-        assert_eq!(
-            format!("{}", Trap::InvalidVariableIndex(VarIndex::new(7))),
-            "invalid variable index: 7"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_invalid_function_id_then_includes_id() {
-        assert_eq!(
-            format!("{}", Trap::InvalidFunctionId(FunctionId::new(3))),
-            "invalid function ID: 3"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_watchdog_timeout_then_includes_task_id() {
-        let trap = Trap::WatchdogTimeout(TaskId::new(3));
-        assert_eq!(format!("{trap}"), "watchdog timeout on task 3");
-    }
-
-    #[test]
-    fn trap_display_when_negative_exponent_then_expected() {
-        assert_eq!(format!("{}", Trap::NegativeExponent), "negative exponent");
-    }
-
-    #[test]
-    fn trap_display_when_null_dereference_then_expected() {
-        assert_eq!(
-            format!("{}", Trap::NullDereference),
-            "null reference dereference"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_invalid_builtin_function_then_includes_hex_id() {
-        assert_eq!(
-            format!("{}", Trap::InvalidBuiltinFunction(FunctionId::new(0x0101))),
-            "invalid built-in function: 0x0101"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_data_region_out_of_bounds_then_includes_offset() {
-        assert_eq!(
-            format!("{}", Trap::DataRegionOutOfBounds(42)),
-            "data region access out of bounds at offset 42"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_temp_buffer_exhausted_then_expected() {
-        assert_eq!(
-            format!("{}", Trap::TempBufferExhausted),
-            "temporary buffer pool exhausted"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_invalid_fb_type_id_then_includes_hex_id() {
-        assert_eq!(
-            format!("{}", Trap::InvalidFbTypeId(FbTypeId::new(0x0010))),
-            "invalid FB type ID: 0x0010"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_array_index_out_of_bounds_then_includes_details() {
-        assert_eq!(
-            format!(
-                "{}",
-                Trap::ArrayIndexOutOfBounds {
-                    var_index: VarIndex::new(2),
-                    index: 10,
-                    total_elements: 5,
-                }
-            ),
-            "array index out of bounds: index 10 for array variable 2 with 5 elements"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_unexpected_end_of_bytecode_then_expected() {
-        assert_eq!(
-            format!("{}", Trap::UnexpectedEndOfBytecode),
-            "bytecode ended mid-instruction"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_call_stack_overflow_then_expected() {
-        assert_eq!(
-            format!("{}", Trap::CallStackOverflow),
-            "call stack overflow"
-        );
-    }
-
-    #[test]
-    fn v_code_when_divide_by_zero_then_v4001() {
-        assert_eq!(Trap::DivideByZero.v_code(), "V4001");
-    }
-
-    #[test]
-    fn v_code_when_negative_exponent_then_v4002() {
-        assert_eq!(Trap::NegativeExponent.v_code(), "V4002");
-    }
-
-    #[test]
-    fn v_code_when_watchdog_timeout_then_v4003() {
-        assert_eq!(Trap::WatchdogTimeout(TaskId::new(0)).v_code(), "V4003");
-    }
-
-    #[test]
-    fn v_code_when_stack_overflow_then_v9001() {
-        assert_eq!(Trap::StackOverflow.v_code(), "V9001");
-    }
-
-    #[test]
-    fn v_code_when_stack_underflow_then_v9002() {
-        assert_eq!(Trap::StackUnderflow.v_code(), "V9002");
-    }
-
-    #[test]
-    fn v_code_when_invalid_instruction_then_v9003() {
-        assert_eq!(Trap::InvalidInstruction(0xFF).v_code(), "V9003");
-    }
-
-    #[test]
-    fn v_code_when_invalid_constant_index_then_v9004() {
-        assert_eq!(
-            Trap::InvalidConstantIndex(ConstantIndex::new(42)).v_code(),
-            "V9004"
-        );
-    }
-
-    #[test]
-    fn v_code_when_invalid_variable_index_then_v9005() {
-        assert_eq!(
-            Trap::InvalidVariableIndex(VarIndex::new(7)).v_code(),
-            "V9005"
-        );
-    }
-
-    #[test]
-    fn v_code_when_invalid_function_id_then_v9006() {
-        assert_eq!(
-            Trap::InvalidFunctionId(FunctionId::new(3)).v_code(),
-            "V9006"
-        );
-    }
-
-    #[test]
-    fn v_code_when_invalid_builtin_function_then_v9007() {
-        assert_eq!(
-            Trap::InvalidBuiltinFunction(FunctionId::new(0x0101)).v_code(),
-            "V9007"
-        );
-    }
-
-    #[test]
-    fn v_code_when_null_dereference_then_v4004() {
-        assert_eq!(Trap::NullDereference.v_code(), "V4004");
-    }
-
-    #[test]
-    fn v_code_when_array_index_out_of_bounds_then_v4005() {
-        assert_eq!(
-            Trap::ArrayIndexOutOfBounds {
-                var_index: VarIndex::new(0),
-                index: 10,
-                total_elements: 5,
-            }
-            .v_code(),
-            "V4005"
-        );
-    }
-
-    #[test]
-    fn v_code_when_invalid_fb_type_id_then_v9010() {
-        assert_eq!(
-            Trap::InvalidFbTypeId(FbTypeId::new(0x0010)).v_code(),
-            "V9010"
-        );
+    #[rstest]
+    #[case(Trap::DivideByZero, "V4001")]
+    #[case(Trap::NegativeExponent, "V4002")]
+    #[case(Trap::WatchdogTimeout(TaskId::new(0)), "V4003")]
+    #[case(Trap::NullDereference, "V4004")]
+    #[case(
+        Trap::ArrayIndexOutOfBounds {
+            var_index: VarIndex::new(0),
+            index: 10,
+            total_elements: 5,
+        },
+        "V4005"
+    )]
+    #[case(Trap::StackOverflow, "V9001")]
+    #[case(Trap::StackUnderflow, "V9002")]
+    #[case(Trap::InvalidInstruction(0xFF), "V9003")]
+    #[case(Trap::InvalidConstantIndex(ConstantIndex::new(42)), "V9004")]
+    #[case(Trap::InvalidVariableIndex(VarIndex::new(7)), "V9005")]
+    #[case(Trap::InvalidFunctionId(FunctionId::new(3)), "V9006")]
+    #[case(Trap::InvalidBuiltinFunction(FunctionId::new(0x0101)), "V9007")]
+    #[case(Trap::InvalidFbTypeId(FbTypeId::new(0x0010)), "V9010")]
+    #[case(Trap::UnexpectedEndOfBytecode, "V9011")]
+    #[case(Trap::InvalidCmpOp(0xFF), "V9013")]
+    #[case(Trap::EncodingMismatch { expected: 1, actual: 2 }, "V9014")]
+    #[case(Trap::InvalidCharWidth(7), "V9015")]
+    #[case(
+        Trap::ProgramExceedsCallDepth { required: 64, capacity: 32 },
+        "V9016"
+    )]
+    #[case(Trap::ZeroCallDepth, "V9017")]
+    fn v_code_when_variant_then_expected(#[case] trap: Trap, #[case] expected: &str) {
+        assert_eq!(trap.v_code(), expected);
     }
 
     #[test]
@@ -354,102 +230,6 @@ mod tests {
             .exit_code(),
             1
         );
-    }
-
-    #[test]
-    fn v_code_when_unexpected_end_of_bytecode_then_v9011() {
-        assert_eq!(Trap::UnexpectedEndOfBytecode.v_code(), "V9011");
-    }
-
-    #[test]
-    fn trap_display_when_invalid_cmp_op_then_includes_hex_code() {
-        assert_eq!(
-            format!("{}", Trap::InvalidCmpOp(0x07)),
-            "invalid comparison operator code: 0x07"
-        );
-    }
-
-    #[test]
-    fn v_code_when_invalid_cmp_op_then_v9013() {
-        assert_eq!(Trap::InvalidCmpOp(0xFF).v_code(), "V9013");
-    }
-
-    #[test]
-    fn trap_display_when_encoding_mismatch_then_includes_widths() {
-        assert_eq!(
-            format!(
-                "{}",
-                Trap::EncodingMismatch {
-                    expected: 1,
-                    actual: 2,
-                }
-            ),
-            "string encoding mismatch: expected char_width 1, got 2"
-        );
-    }
-
-    #[test]
-    fn v_code_when_encoding_mismatch_then_v9014() {
-        assert_eq!(
-            Trap::EncodingMismatch {
-                expected: 1,
-                actual: 2,
-            }
-            .v_code(),
-            "V9014"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_invalid_char_width_then_includes_value() {
-        assert_eq!(
-            format!("{}", Trap::InvalidCharWidth(7)),
-            "invalid char_width byte: 7 (expected 1 or 2)"
-        );
-    }
-
-    #[test]
-    fn v_code_when_invalid_char_width_then_v9015() {
-        assert_eq!(Trap::InvalidCharWidth(7).v_code(), "V9015");
-    }
-
-    #[test]
-    fn trap_display_when_program_exceeds_call_depth_then_includes_required_and_capacity() {
-        assert_eq!(
-            format!(
-                "{}",
-                Trap::ProgramExceedsCallDepth {
-                    required: 64,
-                    capacity: 32,
-                }
-            ),
-            "program declares call depth 64 but VM frame buffer holds at most 32"
-        );
-    }
-
-    #[test]
-    fn v_code_when_program_exceeds_call_depth_then_v9016() {
-        assert_eq!(
-            Trap::ProgramExceedsCallDepth {
-                required: 64,
-                capacity: 32,
-            }
-            .v_code(),
-            "V9016"
-        );
-    }
-
-    #[test]
-    fn trap_display_when_zero_call_depth_then_expected() {
-        assert_eq!(
-            format!("{}", Trap::ZeroCallDepth),
-            "container declares a maximum call depth of zero"
-        );
-    }
-
-    #[test]
-    fn v_code_when_zero_call_depth_then_v9017() {
-        assert_eq!(Trap::ZeroCallDepth.v_code(), "V9017");
     }
 
     #[test]

--- a/compiler/vm/src/value.rs
+++ b/compiler/vm/src/value.rs
@@ -89,47 +89,10 @@ mod tests {
     }
 
     #[test]
-    fn slot_from_i32_when_positive_then_roundtrips() {
-        let slot = Slot::from_i32(42);
-        assert_eq!(slot.as_i32(), 42);
-        assert_eq!(slot.0, 42);
-    }
-
-    #[test]
     fn slot_from_i64_when_negative_then_roundtrips() {
         let slot = Slot::from_i64(-1);
         assert_eq!(slot.as_i64(), -1);
         assert_eq!(slot.0, 0xFFFFFFFFFFFFFFFF);
-    }
-
-    #[test]
-    fn slot_from_i64_when_large_positive_then_roundtrips() {
-        let slot = Slot::from_i64(i64::MAX);
-        assert_eq!(slot.as_i64(), i64::MAX);
-    }
-
-    #[test]
-    fn slot_from_f32_when_positive_then_roundtrips() {
-        let slot = Slot::from_f32(std::f32::consts::PI);
-        assert_eq!(slot.as_f32(), std::f32::consts::PI);
-    }
-
-    #[test]
-    fn slot_from_f32_when_negative_then_roundtrips() {
-        let slot = Slot::from_f32(-2.5);
-        assert_eq!(slot.as_f32(), -2.5_f32);
-    }
-
-    #[test]
-    fn slot_from_f64_when_positive_then_roundtrips() {
-        let slot = Slot::from_f64(std::f64::consts::PI);
-        assert_eq!(slot.as_f64(), std::f64::consts::PI);
-    }
-
-    #[test]
-    fn slot_from_f64_when_negative_then_roundtrips() {
-        let slot = Slot::from_f64(-1.23e10);
-        assert_eq!(slot.as_f64(), -1.23e10_f64);
     }
 
     #[test]

--- a/compiler/vm/tests/it/execute_arith_f32.rs
+++ b/compiler/vm/tests/it/execute_arith_f32.rs
@@ -1,61 +1,12 @@
 //! Integration tests for f32 arithmetic opcodes.
+//!
+//! Deterministic anchors pin the non-finite behaviours a random oracle cannot
+//! check (div-by-zero → ±∞, NaN propagation, negation). A property test
+//! cross-checks the binary opcodes against Rust `+ - * /` over finite inputs.
 
-#[test]
-fn execute_when_add_f32_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]  (1.5)
-        0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1]  (2.25)
-        0x22,              // ADD_F32
-        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f32(&bytecode, 1, &[1.5, 2.25]);
-    assert_eq!(result, 3.75);
-}
+use proptest::prelude::*;
 
-#[test]
-fn execute_when_sub_f32_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]  (10.0)
-        0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1]  (3.5)
-        0x26,              // SUB_F32
-        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f32(&bytecode, 1, &[10.0, 3.5]);
-    assert_eq!(result, 6.5);
-}
-
-#[test]
-fn execute_when_mul_f32_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]  (4.0)
-        0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1]  (2.5)
-        0x2A,              // MUL_F32
-        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f32(&bytecode, 1, &[4.0, 2.5]);
-    assert_eq!(result, 10.0);
-}
-
-#[test]
-fn execute_when_div_f32_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]  (7.5)
-        0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1]  (2.5)
-        0x32,              // DIV_F32
-        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f32(&bytecode, 1, &[7.5, 2.5]);
-    assert_eq!(result, 3.0);
-}
-
+// Anchor: 1.0 / 0.0 → +∞ (a random oracle over finite inputs can't reach this).
 #[test]
 fn execute_when_div_f32_by_zero_then_positive_infinity() {
     #[rustfmt::skip]
@@ -70,6 +21,22 @@ fn execute_when_div_f32_by_zero_then_positive_infinity() {
     assert!(result.is_infinite() && result.is_sign_positive());
 }
 
+// Anchor: NaN propagates through arithmetic.
+#[test]
+fn execute_when_add_f32_nan_then_nan() {
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]  (NaN)
+        0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1]  (1.0)
+        0x22,              // ADD_F32
+        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0x8C,              // RET_VOID
+    ];
+    let result = crate::common::run_and_read_f32(&bytecode, 1, &[f32::NAN, 1.0]);
+    assert!(result.is_nan());
+}
+
+// Anchor: NEG_F32 negates (not exercised by the binary-op property test).
 #[test]
 fn execute_when_neg_f32_then_correct() {
     #[rustfmt::skip]
@@ -83,29 +50,35 @@ fn execute_when_neg_f32_then_correct() {
     assert_eq!(result, -5.5);
 }
 
-#[test]
-fn execute_when_neg_f32_negative_then_positive() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]  (-3.25)
-        0x2E,              // NEG_F32
-        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f32(&bytecode, 1, &[-3.25]);
-    assert_eq!(result, 3.25);
-}
-
-#[test]
-fn execute_when_add_f32_nan_then_nan() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]  (NaN)
-        0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1]  (1.0)
-        0x22,              // ADD_F32
-        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f32(&bytecode, 1, &[f32::NAN, 1.0]);
-    assert!(result.is_nan());
+// Property: cross-check ADD/SUB/MUL/DIV_F32 against Rust arithmetic. Inputs are
+// finite so the oracle is well-defined; overflow to ±∞ and 0/0 → NaN are still
+// possible results, so NaN is compared structurally.
+proptest! {
+    #[test]
+    fn execute_when_arith_f32_finite_then_matches_rust(
+        a in any::<f32>().prop_filter("finite", |v| v.is_finite()),
+        b in any::<f32>().prop_filter("finite", |v| v.is_finite()),
+        op in 0usize..4,
+    ) {
+        let (opcode, expected): (u8, f32) = match op {
+            0 => (0x22, a + b), // ADD_F32
+            1 => (0x26, a - b), // SUB_F32
+            2 => (0x2A, a * b), // MUL_F32
+            _ => (0x32, a / b), // DIV_F32
+        };
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0] (a)
+            0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1] (b)
+            opcode,            // arithmetic
+            0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+            0x8C,              // RET_VOID
+        ];
+        let result = crate::common::run_and_read_f32(&bytecode, 1, &[a, b]);
+        if expected.is_nan() {
+            prop_assert!(result.is_nan());
+        } else {
+            prop_assert_eq!(result, expected);
+        }
+    }
 }

--- a/compiler/vm/tests/it/execute_arith_f64.rs
+++ b/compiler/vm/tests/it/execute_arith_f64.rs
@@ -1,61 +1,12 @@
 //! Integration tests for f64 arithmetic opcodes.
+//!
+//! Deterministic anchors pin the non-finite behaviours a random oracle cannot
+//! check (div-by-zero → ±∞, NaN propagation, negation). A property test
+//! cross-checks the binary opcodes against Rust `+ - * /` over finite inputs.
 
-#[test]
-fn execute_when_add_f64_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]  (1.5)
-        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]  (2.25)
-        0x23,              // ADD_F64
-        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f64(&bytecode, 1, &[1.5, 2.25]);
-    assert_eq!(result, 3.75);
-}
+use proptest::prelude::*;
 
-#[test]
-fn execute_when_sub_f64_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]  (100.0)
-        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]  (0.001)
-        0x27,              // SUB_F64
-        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f64(&bytecode, 1, &[100.0, 0.001]);
-    assert_eq!(result, 99.999);
-}
-
-#[test]
-fn execute_when_mul_f64_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]  (3.0)
-        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]  (7.0)
-        0x2B,              // MUL_F64
-        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f64(&bytecode, 1, &[3.0, 7.0]);
-    assert_eq!(result, 21.0);
-}
-
-#[test]
-fn execute_when_div_f64_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]  (22.0)
-        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]  (7.0)
-        0x33,              // DIV_F64
-        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f64(&bytecode, 1, &[22.0, 7.0]);
-    assert!((result - 3.142857142857143).abs() < 1e-12);
-}
-
+// Anchor: 1.0 / 0.0 → +∞ (a random oracle over finite inputs can't reach this).
 #[test]
 fn execute_when_div_f64_by_zero_then_positive_infinity() {
     #[rustfmt::skip]
@@ -70,6 +21,22 @@ fn execute_when_div_f64_by_zero_then_positive_infinity() {
     assert!(result.is_infinite() && result.is_sign_positive());
 }
 
+// Anchor: NaN propagates through arithmetic.
+#[test]
+fn execute_when_sub_f64_nan_then_nan() {
+    #[rustfmt::skip]
+    let bytecode: Vec<u8> = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]  (NaN)
+        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]  (5.0)
+        0x27,              // SUB_F64
+        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0x8C,              // RET_VOID
+    ];
+    let result = crate::common::run_and_read_f64(&bytecode, 1, &[f64::NAN, 5.0]);
+    assert!(result.is_nan());
+}
+
+// Anchor: NEG_F64 negates (not exercised by the binary-op property test).
 #[test]
 fn execute_when_neg_f64_then_correct() {
     #[rustfmt::skip]
@@ -83,30 +50,35 @@ fn execute_when_neg_f64_then_correct() {
     assert_eq!(result, -42.5);
 }
 
-#[test]
-fn execute_when_mul_f64_large_values_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]  (1e200)
-        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]  (1e200)
-        0x2B,              // MUL_F64
-        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f64(&bytecode, 1, &[1e200, 1e200]);
-    assert!(result.is_infinite());
-}
-
-#[test]
-fn execute_when_sub_f64_nan_then_nan() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]  (NaN)
-        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]  (5.0)
-        0x27,              // SUB_F64
-        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    let result = crate::common::run_and_read_f64(&bytecode, 1, &[f64::NAN, 5.0]);
-    assert!(result.is_nan());
+// Property: cross-check ADD/SUB/MUL/DIV_F64 against Rust arithmetic. Inputs are
+// finite so the oracle is well-defined; overflow to ±∞ and 0/0 → NaN are still
+// possible results, so NaN is compared structurally.
+proptest! {
+    #[test]
+    fn execute_when_arith_f64_finite_then_matches_rust(
+        a in any::<f64>().prop_filter("finite", |v| v.is_finite()),
+        b in any::<f64>().prop_filter("finite", |v| v.is_finite()),
+        op in 0usize..4,
+    ) {
+        let (opcode, expected): (u8, f64) = match op {
+            0 => (0x23, a + b), // ADD_F64
+            1 => (0x27, a - b), // SUB_F64
+            2 => (0x2B, a * b), // MUL_F64
+            _ => (0x33, a / b), // DIV_F64
+        };
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0] (a)
+            0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1] (b)
+            opcode,            // arithmetic
+            0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+            0x8C,              // RET_VOID
+        ];
+        let result = crate::common::run_and_read_f64(&bytecode, 1, &[a, b]);
+        if expected.is_nan() {
+            prop_assert!(result.is_nan());
+        } else {
+            prop_assert_eq!(result, expected);
+        }
+    }
 }

--- a/compiler/vm/tests/it/execute_bitwise.rs
+++ b/compiler/vm/tests/it/execute_bitwise.rs
@@ -1,13 +1,14 @@
 //! Integration tests for bitwise opcodes (BIT_AND_32, BIT_OR_32, BIT_XOR_32,
 //! BIT_NOT_32, BIT_AND_64, BIT_OR_64, BIT_XOR_64, BIT_NOT_64).
+//!
+//! One deterministic anchor per width pins a known bit pattern; property tests
+//! cross-check every operator against Rust's `& | ^ !` over the full range.
 
-// ---------------------------------------------------------------
-// BIT_AND_32
-// ---------------------------------------------------------------
+use proptest::prelude::*;
 
+// Anchor (32-bit): 0xFF AND 0x0F → 0x0F.
 #[test]
 fn execute_when_bit_and_32_then_bitwise_and() {
-    // 0xFF AND 0x0F → 0x0F
     #[rustfmt::skip]
     let bytecode: Vec<u8> = vec![
         0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0xFF = 255)
@@ -22,75 +23,9 @@ fn execute_when_bit_and_32_then_bitwise_and() {
     );
 }
 
-// ---------------------------------------------------------------
-// BIT_OR_32
-// ---------------------------------------------------------------
-
-#[test]
-fn execute_when_bit_or_32_then_bitwise_or() {
-    // 0xF0 OR 0x0F → 0xFF
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0xF0 = 240)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (0x0F = 15)
-        0x6C,              // BIT_OR_32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[0xF0, 0x0F]),
-        0xFF
-    );
-}
-
-// ---------------------------------------------------------------
-// BIT_XOR_32
-// ---------------------------------------------------------------
-
-#[test]
-fn execute_when_bit_xor_32_then_bitwise_xor() {
-    // 0xFF XOR 0x0F → 0xF0
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0xFF = 255)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (0x0F = 15)
-        0x70,              // BIT_XOR_32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[0xFF, 0x0F]),
-        0xF0
-    );
-}
-
-// ---------------------------------------------------------------
-// BIT_NOT_32
-// ---------------------------------------------------------------
-
-#[test]
-fn execute_when_bit_not_32_then_bitwise_not() {
-    // NOT 0x0F → 0xFFFFFFF0 (as i32: -16)
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (0x0F = 15)
-        0x74,              // BIT_NOT_32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[0x0F]),
-        !0x0F_i32
-    );
-}
-
-// ---------------------------------------------------------------
-// BIT_AND_64
-// ---------------------------------------------------------------
-
+// Anchor (64-bit): 0xFF AND 0x0F → 0x0F.
 #[test]
 fn execute_when_bit_and_64_then_bitwise_and() {
-    // 0xFF_i64 AND 0x0F_i64 → 0x0F_i64
     #[rustfmt::skip]
     let bytecode: Vec<u8> = vec![
         0x01, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0xFF)
@@ -105,61 +40,77 @@ fn execute_when_bit_and_64_then_bitwise_and() {
     );
 }
 
-// ---------------------------------------------------------------
-// BIT_OR_64
-// ---------------------------------------------------------------
+// Property: cross-check the 32-bit bitwise opcodes against Rust `& | ^ !`.
+proptest! {
+    #[test]
+    fn execute_when_bitwise_32_any_then_matches_rust(
+        a in any::<i32>(),
+        b in any::<i32>(),
+        op in 0usize..4,
+    ) {
+        let (opcode, expected): (u8, i32) = match op {
+            0 => (0x68, a & b), // BIT_AND_32
+            1 => (0x6C, a | b), // BIT_OR_32
+            2 => (0x70, a ^ b), // BIT_XOR_32
+            _ => (0x74, !a),    // BIT_NOT_32 (unary)
+        };
+        let bytecode: Vec<u8> = if op == 3 {
+            #[rustfmt::skip]
+            let bc = vec![
+                0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (a)
+                0x74,              // BIT_NOT_32
+                0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+                0x8C,              // RET_VOID
+            ];
+            bc
+        } else {
+            #[rustfmt::skip]
+            let bc = vec![
+                0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (a)
+                0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (b)
+                opcode,            // bitwise op
+                0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+                0x8C,              // RET_VOID
+            ];
+            bc
+        };
+        let result = crate::common::run_and_read_i32(&bytecode, 1, &[a, b]);
+        prop_assert_eq!(result, expected);
+    }
 
-#[test]
-fn execute_when_bit_or_64_then_bitwise_or() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x01, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0xF0)
-        0x01, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (0x0F)
-        0x6D,              // BIT_OR_64
-        0x11, 0x00, 0x00,  // STORE_VAR_I64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i64(&bytecode, 1, &[0xF0, 0x0F]),
-        0xFF
-    );
-}
-
-// ---------------------------------------------------------------
-// BIT_XOR_64
-// ---------------------------------------------------------------
-
-#[test]
-fn execute_when_bit_xor_64_then_bitwise_xor() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x01, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0xFF)
-        0x01, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (0x0F)
-        0x71,              // BIT_XOR_64
-        0x11, 0x00, 0x00,  // STORE_VAR_I64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i64(&bytecode, 1, &[0xFF, 0x0F]),
-        0xF0
-    );
-}
-
-// ---------------------------------------------------------------
-// BIT_NOT_64
-// ---------------------------------------------------------------
-
-#[test]
-fn execute_when_bit_not_64_then_bitwise_not() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x01, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (0x0F)
-        0x75,              // BIT_NOT_64
-        0x11, 0x00, 0x00,  // STORE_VAR_I64 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i64(&bytecode, 1, &[0x0F]),
-        !0x0F_i64
-    );
+    #[test]
+    fn execute_when_bitwise_64_any_then_matches_rust(
+        a in any::<i64>(),
+        b in any::<i64>(),
+        op in 0usize..4,
+    ) {
+        let (opcode, expected): (u8, i64) = match op {
+            0 => (0x69, a & b), // BIT_AND_64
+            1 => (0x6D, a | b), // BIT_OR_64
+            2 => (0x71, a ^ b), // BIT_XOR_64
+            _ => (0x75, !a),    // BIT_NOT_64 (unary)
+        };
+        let bytecode: Vec<u8> = if op == 3 {
+            #[rustfmt::skip]
+            let bc = vec![
+                0x01, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (a)
+                0x75,              // BIT_NOT_64
+                0x11, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+                0x8C,              // RET_VOID
+            ];
+            bc
+        } else {
+            #[rustfmt::skip]
+            let bc = vec![
+                0x01, 0x00, 0x00,  // LOAD_CONST_I64 pool[0] (a)
+                0x01, 0x01, 0x00,  // LOAD_CONST_I64 pool[1] (b)
+                opcode,            // bitwise op
+                0x11, 0x00, 0x00,  // STORE_VAR_I64 var[0]
+                0x8C,              // RET_VOID
+            ];
+            bc
+        };
+        let result = crate::common::run_and_read_i64(&bytecode, 1, &[a, b]);
+        prop_assert_eq!(result, expected);
+    }
 }

--- a/compiler/vm/tests/it/execute_bool.rs
+++ b/compiler/vm/tests/it/execute_bool.rs
@@ -1,11 +1,15 @@
 //! VM-specific edge case tests for boolean opcodes (BOOL_AND, BOOL_OR, BOOL_XOR, BOOL_NOT).
 //!
 //! Basic correctness is covered by end_to_end_bool.rs.
-//! These tests cover non-zero integer coercion to boolean that cannot be expressed in IEC 61131-3 source.
+//! These tests cover non-zero integer coercion to boolean that cannot be
+//! expressed in IEC 61131-3 source, plus a property test cross-checking every
+//! boolean opcode against Rust's `(a != 0) op (b != 0)` coercion.
 
+use proptest::prelude::*;
+
+// Anchor: 5 AND 3 → 1 (both non-zero, coerced to true).
 #[test]
 fn execute_when_bool_and_nonzero_coercion_then_one() {
-    // 5 AND 3 → 1 (both non-zero, coerced to true)
     #[rustfmt::skip]
     let bytecode: Vec<u8> = vec![
         0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
@@ -17,43 +21,43 @@ fn execute_when_bool_and_nonzero_coercion_then_one() {
     assert_eq!(crate::common::run_and_read_i32(&bytecode, 1, &[5, 3]), 1);
 }
 
-#[test]
-fn execute_when_bool_or_nonzero_coercion_then_one() {
-    // 5 OR 0 → 1 (5 coerced to true)
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (0)
-        0x79,              // BOOL_OR
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(crate::common::run_and_read_i32(&bytecode, 1, &[5, 0]), 1);
-}
-
-#[test]
-fn execute_when_bool_xor_nonzero_coercion_then_zero() {
-    // 5 XOR 3 → 0 (both coerced to true, same → XOR is 0)
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (3)
-        0x7A,              // BOOL_XOR
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(crate::common::run_and_read_i32(&bytecode, 1, &[5, 3]), 0);
-}
-
-#[test]
-fn execute_when_bool_not_nonzero_coercion_then_zero() {
-    // NOT 5 → 0 (5 coerced to true, NOT true = 0)
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (5)
-        0x7B,              // BOOL_NOT
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(crate::common::run_and_read_i32(&bytecode, 1, &[5]), 0);
+// Property: cross-check the boolean opcodes against Rust's coercion semantics,
+// where any non-zero operand is `true` and the result is `1`/`0`.
+proptest! {
+    #[test]
+    fn execute_when_bool_op_any_then_matches_rust(
+        a in any::<i32>(),
+        b in any::<i32>(),
+        op in 0usize..4,
+    ) {
+        let (ba, bb) = (a != 0, b != 0);
+        let (opcode, expected): (u8, i32) = match op {
+            0 => (0x78, i32::from(ba && bb)), // BOOL_AND
+            1 => (0x79, i32::from(ba || bb)), // BOOL_OR
+            2 => (0x7A, i32::from(ba ^ bb)),  // BOOL_XOR
+            _ => (0x7B, i32::from(!ba)),      // BOOL_NOT (unary)
+        };
+        let bytecode: Vec<u8> = if op == 3 {
+            #[rustfmt::skip]
+            let bc = vec![
+                0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (a)
+                0x7B,              // BOOL_NOT
+                0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+                0x8C,              // RET_VOID
+            ];
+            bc
+        } else {
+            #[rustfmt::skip]
+            let bc = vec![
+                0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (a)
+                0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (b)
+                opcode,            // boolean op
+                0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+                0x8C,              // RET_VOID
+            ];
+            bc
+        };
+        let result = crate::common::run_and_read_i32(&bytecode, 1, &[a, b]);
+        prop_assert_eq!(result, expected);
+    }
 }

--- a/compiler/vm/tests/it/execute_cmp_i32.rs
+++ b/compiler/vm/tests/it/execute_cmp_i32.rs
@@ -1,9 +1,14 @@
 //! VM-specific edge case tests for comparison opcodes (EQ_I32, NE_I32, LT_I32, LE_I32, GT_I32, GE_I32).
 //!
 //! Basic correctness is covered by end_to_end_cmp.rs.
-//! These tests cover boundary comparisons with i32::MIN and i32::MAX that cannot be expressed in IEC 61131-3 source.
+//! These tests cover boundary comparisons with i32::MIN and i32::MAX that cannot
+//! be expressed in IEC 61131-3 source, plus a property test that cross-checks
+//! all six comparison opcodes against Rust's operators over the full i32 range.
 
-// i32::MIN < i32::MAX → 1
+use proptest::prelude::*;
+
+// Boundary anchor: i32::MIN < i32::MAX → 1. Pins signed comparison across the
+// extreme operands the random oracle only samples.
 #[test]
 fn execute_when_lt_i32_min_vs_max_then_one() {
     #[rustfmt::skip]
@@ -20,53 +25,32 @@ fn execute_when_lt_i32_min_vs_max_then_one() {
     );
 }
 
-// i32::MAX > i32::MIN → 1
-#[test]
-fn execute_when_gt_i32_max_vs_min_then_one() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (i32::MAX)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (i32::MIN)
-        0x50,              // GT_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MAX, i32::MIN]),
-        1
-    );
-}
-
-// i32::MIN == i32::MIN → 1
-#[test]
-fn execute_when_eq_i32_min_vs_min_then_one() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (i32::MIN)
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (i32::MIN)
-        0x40,              // EQ_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MIN]),
-        1
-    );
-}
-
-// i32::MIN != i32::MAX → 1
-#[test]
-fn execute_when_ne_i32_min_vs_max_then_one() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (i32::MIN)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (i32::MAX)
-        0x44,              // NE_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MIN, i32::MAX]),
-        1
-    );
+// Property: cross-check all six comparison opcodes against Rust's `<, <=, >, >=,
+// ==, !=`, which produce the 1/0 result the VM is expected to push.
+proptest! {
+    #[test]
+    fn execute_when_cmp_i32_any_then_matches_rust(
+        a in any::<i32>(),
+        b in any::<i32>(),
+        op in 0usize..6,
+    ) {
+        let (opcode, expected): (u8, i32) = match op {
+            0 => (0x40, i32::from(a == b)), // EQ_I32
+            1 => (0x44, i32::from(a != b)), // NE_I32
+            2 => (0x48, i32::from(a < b)),  // LT_I32
+            3 => (0x4C, i32::from(a <= b)), // LE_I32
+            4 => (0x50, i32::from(a > b)),  // GT_I32
+            _ => (0x54, i32::from(a >= b)), // GE_I32
+        };
+        #[rustfmt::skip]
+        let bytecode: Vec<u8> = vec![
+            0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0] (a)
+            0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1] (b)
+            opcode,            // comparison
+            0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
+            0x8C,              // RET_VOID
+        ];
+        let result = crate::common::run_and_read_i32(&bytecode, 1, &[a, b]);
+        prop_assert_eq!(result, expected);
+    }
 }

--- a/compiler/vm/tests/it/execute_mul_i32.rs
+++ b/compiler/vm/tests/it/execute_mul_i32.rs
@@ -1,116 +1,61 @@
 //! VM-specific edge case tests for the MUL_I32 opcode.
 //!
 //! Basic correctness is covered by end_to_end_mul.rs.
-//! These tests cover overflow wrapping and stack underflow traps that cannot be expressed in IEC 61131-3 source.
+//! These tests cover overflow wrapping and stack underflow traps that cannot be
+//! expressed in IEC 61131-3 source, plus a property test that cross-checks the
+//! opcode against Rust `wrapping_mul` over the full i32 range.
 
 use ironplc_vm::error::Trap;
+use proptest::prelude::*;
 
-// Overflow: i32::MAX * 2 wraps to -2
+// LOAD_CONST_I32 pool[0], LOAD_CONST_I32 pool[1], MUL_I32, STORE_VAR_I32 var[0], RET_VOID
+#[rustfmt::skip]
+const MUL_BYTECODE: [u8; 11] = [
+    0x00, 0x00, 0x00,
+    0x00, 0x01, 0x00,
+    0x28,
+    0x10, 0x00, 0x00,
+    0x8C,
+];
+
+// Nominal anchor: a straightforward product with no overflow.
+#[test]
+fn execute_when_mul_i32_nominal_then_product() {
+    assert_eq!(
+        crate::common::run_and_read_i32(&MUL_BYTECODE, 1, &[6, 7]),
+        42
+    );
+}
+
+// Overflow anchor: i32::MAX * 2 wraps to -2. A random oracle exercises this
+// class, but keeping a deterministic case pins the exact wrapping behaviour.
 #[test]
 fn execute_when_mul_i32_max_times_two_then_wraps() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MAX)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (2)
-        0x28,              // MUL_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
     assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MAX, 2]),
+        crate::common::run_and_read_i32(&MUL_BYTECODE, 1, &[i32::MAX, 2]),
         -2
     );
 }
 
-// Overflow: i32::MIN * 2 wraps to 0
-#[test]
-fn execute_when_mul_i32_min_times_two_then_wraps_to_zero() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MIN)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (2)
-        0x28,              // MUL_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MIN, 2]),
-        0
-    );
-}
-
-// Overflow: i32::MIN * -1 wraps to i32::MIN (negation of MIN overflows)
-#[test]
-fn execute_when_mul_i32_min_times_neg_one_then_wraps() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MIN)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (-1)
-        0x28,              // MUL_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MIN, -1]),
-        i32::MIN
-    );
-}
-
-// Overflow: i32::MAX * i32::MAX wraps
-#[test]
-fn execute_when_mul_i32_max_times_max_then_wraps() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MAX)
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MAX)
-        0x28,              // MUL_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MAX]),
-        i32::MAX.wrapping_mul(i32::MAX)
-    );
-}
-
-// Overflow: i32::MIN * i32::MIN wraps to 0
-#[test]
-fn execute_when_mul_i32_min_times_min_then_wraps() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MIN)
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MIN)
-        0x28,              // MUL_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MIN]),
-        i32::MIN.wrapping_mul(i32::MIN)
-    );
-}
-
-// Overflow: i32::MAX * i32::MIN wraps
-#[test]
-fn execute_when_mul_i32_max_times_min_then_wraps() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MAX)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (i32::MIN)
-        0x28,              // MUL_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MAX, i32::MIN]),
-        i32::MAX.wrapping_mul(i32::MIN)
-    );
-}
-
+// Trap anchor: MUL with an empty stack underflows.
 #[test]
 fn execute_when_mul_i32_stack_underflow_then_trap() {
     assert_eq!(
         crate::common::run_and_expect_trap_i32(&[0x28], 0, &[]),
         Trap::StackUnderflow
     );
+}
+
+// Property: cross-check MUL_I32 against Rust `wrapping_mul` over the full i32
+// range. These tests already assert wrapping as ground truth, so the oracle is
+// exact for every input pair.
+proptest! {
+    #[test]
+    fn execute_when_mul_i32_any_then_matches_wrapping_mul(
+        a in any::<i32>(),
+        b in any::<i32>(),
+    ) {
+        let result = crate::common::run_and_read_i32(&MUL_BYTECODE, 1, &[a, b]);
+        prop_assert_eq!(result, a.wrapping_mul(b));
+    }
 }

--- a/compiler/vm/tests/it/execute_sub_i32.rs
+++ b/compiler/vm/tests/it/execute_sub_i32.rs
@@ -1,99 +1,61 @@
 //! VM-specific edge case tests for the SUB_I32 opcode.
 //!
 //! Basic subtraction correctness is covered by end_to_end_sub.rs.
-//! These tests cover overflow wrapping and trap behavior.
+//! These tests cover overflow wrapping and trap behavior that cannot be
+//! expressed in IEC 61131-3 source, plus a property test that cross-checks the
+//! opcode against Rust `wrapping_sub` over the full i32 range.
 
 use ironplc_vm::error::Trap;
+use proptest::prelude::*;
 
-// Overflow: i32::MIN - 1 wraps to i32::MAX
+// LOAD_CONST_I32 pool[0], LOAD_CONST_I32 pool[1], SUB_I32, STORE_VAR_I32 var[0], RET_VOID
+#[rustfmt::skip]
+const SUB_BYTECODE: [u8; 11] = [
+    0x00, 0x00, 0x00,
+    0x00, 0x01, 0x00,
+    0x24,
+    0x10, 0x00, 0x00,
+    0x8C,
+];
+
+// Nominal anchor: a straightforward difference with no overflow.
+#[test]
+fn execute_when_sub_i32_nominal_then_difference() {
+    assert_eq!(
+        crate::common::run_and_read_i32(&SUB_BYTECODE, 1, &[10, 3]),
+        7
+    );
+}
+
+// Overflow anchor: i32::MIN - 1 wraps to i32::MAX. A deterministic case pins
+// the exact wrapping behaviour the random oracle only samples.
 #[test]
 fn execute_when_sub_i32_wraps_at_min_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MIN)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (1)
-        0x24,              // SUB_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
     assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MIN, 1]),
+        crate::common::run_and_read_i32(&SUB_BYTECODE, 1, &[i32::MIN, 1]),
         i32::MAX
     );
 }
 
-// Overflow: i32::MAX - (-1) wraps to i32::MIN
-#[test]
-fn execute_when_sub_i32_wraps_at_max_then_correct() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MAX)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (-1)
-        0x24,              // SUB_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MAX, -1]),
-        i32::MIN
-    );
-}
-
-// Overflow: i32::MIN - i32::MAX wraps to 1
-#[test]
-fn execute_when_sub_i32_min_minus_max_then_wraps_to_one() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MIN)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (i32::MAX)
-        0x24,              // SUB_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MIN, i32::MAX]),
-        1
-    );
-}
-
-// Overflow: i32::MAX - i32::MIN wraps to -1
-#[test]
-fn execute_when_sub_i32_max_minus_min_then_wraps_to_neg_one() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (i32::MAX)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (i32::MIN)
-        0x24,              // SUB_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[i32::MAX, i32::MIN]),
-        -1
-    );
-}
-
-// Edge: 0 - i32::MIN wraps to i32::MIN (since -i32::MIN overflows)
-#[test]
-fn execute_when_sub_i32_zero_minus_min_then_wraps() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        0x00, 0x00, 0x00,  // LOAD_CONST_I32 pool[0]  (0)
-        0x00, 0x01, 0x00,  // LOAD_CONST_I32 pool[1]  (i32::MIN)
-        0x24,              // SUB_I32
-        0x10, 0x00, 0x00,  // STORE_VAR_I32 var[0]
-        0x8C,              // RET_VOID
-    ];
-    assert_eq!(
-        crate::common::run_and_read_i32(&bytecode, 1, &[0, i32::MIN]),
-        i32::MIN
-    );
-}
-
+// Trap anchor: SUB with an empty stack underflows.
 #[test]
 fn execute_when_sub_i32_stack_underflow_then_trap() {
     assert_eq!(
         crate::common::run_and_expect_trap_i32(&[0x24], 0, &[]),
         Trap::StackUnderflow
     );
+}
+
+// Property: cross-check SUB_I32 against Rust `wrapping_sub` over the full i32
+// range. These tests already assert wrapping as ground truth, so the oracle is
+// exact for every input pair.
+proptest! {
+    #[test]
+    fn execute_when_sub_i32_any_then_matches_wrapping_sub(
+        a in any::<i32>(),
+        b in any::<i32>(),
+    ) {
+        let result = crate::common::run_and_read_i32(&SUB_BYTECODE, 1, &[a, b]);
+        prop_assert_eq!(result, a.wrapping_sub(b));
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to the test-redundancy work (#1325). That change cut duplicated test *code* but kept the running-test count flat. This one actually reduces the number of tests, using two levers, while holding coverage.

**Property-test subsumption** — replace clusters of example tests with 1–2 deterministic anchors + one property test against an independent Rust oracle:

| Cluster | Before → after | Oracle |
|---|---|---|
| Codegen strings LEFT/RIGHT/MID/DELETE/INSERT/REPLACE/CONCAT | ~55 → 21 | Rust string slicing |
| Codegen MUX | 12 → 5 | `inputs[clamp(k)]` |
| VM i32 mul/sub/cmp | ~17 → 10 | `wrapping_*`, comparisons |
| VM f32/f64 arithmetic | 16 → 8 | IEEE Rust `+ - * /` |
| VM bitwise/bool | 12 → 6 | Rust `& \| ^ !` |
| VM `value.rs` slot round-trips | −6 | (existing proptest) |

Every property test passed on the first run, validating each oracle against the VM across its whole domain — no VM bugs surfaced, and no cluster was left un-subsumed. Anchors pin the nominal / clamp / truncation / trap / NaN / bit-pattern edge branches so those lines stay deterministically covered.

Net: **codegen `it` 1101 → 1058, vm 323 → 296 (~70 fewer running tests)**, adding ~15 property tests that each exercise a far wider input space than the examples they replace.

**rstest parametrization** — collapse near-identical single-assert tests into `#[case]` tables (every input preserved; runtime count and coverage unchanged, ~160 fewer test *functions*):

- `dsl/src/common.rs` — `can_widen_to` (42) + `can_widen_cross_family_to` (13) → 2 tables
- `vm/src/error.rs` — `trap_display` (22) + `v_code` (19) → 2 tables
- `project/src/disassemble.rs` — opcode / builtin / mux decode → 3 tables (35 → 3 fns)
- `analyzer/src/rule_bit_access_range.rs` — bit-boundary tests (25 → 1 fn)
- `container/src/{container_ref,constant_pool}.rs` — corruption (11 → 1) and type-mismatch (5 → 1)

`rstest` added as a dev-dependency to `dsl`, `vm`, `project`, and `container`.

## Coverage

Production `src` missed lines **4,979 → 4,972** (7 fewer — equal-or-slightly-better). The full `just` pipeline passes: compile, coverage (≥ 85% floor), lint, dupes. The small aggregate-percent dip is the denominator artifact of removing covered example-test code, not a source regression.

## Deliberately out of scope

- The 178 build-enforced `#[spec_test(REQ_…)]` conformance tests — untouched.
- Parser numeric/duration/time-literal tests — the parser *is* the oracle, so no independent check exists.
- FB timer (TON/TOF/TP) state-machine tests — behavioral, no simple oracle.
- `analyzer/src/intermediate_type.rs` — skipped after confirming its structure vs function-block size functions are independent implementations, not shared code, so merging them would weaken the tests.

## Verification

- `cd compiler && just` (compile + coverage + lint + dupes) — green.
- Every property test passes with proptest's default case count; anchors preserve edge-branch coverage.
- Parametrized crates keep an identical runtime test count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019vU1G5crSM1YNDgbq8upHQ)_