### PR TITLE
Reduce test duplication: conversions, FB timers, and non-codegen clusters

### DIFF
--- a/compiler/analyzer/src/rule_function_call_type_check.rs
+++ b/compiler/analyzer/src/rule_function_call_type_check.rs
@@ -443,6 +443,7 @@ impl Visitor<Diagnostic> for RuleFunctionCallTypeCheck<'_> {
 mod tests {
     use super::*;
     use crate::test_helpers::parse_and_resolve_types_with_context;
+    use rstest::rstest;
 
     rule_ctx_ok!(
         apply_when_matching_types_then_ok,
@@ -1217,9 +1218,14 @@ END_PROGRAM"
 
     // --- Cross-family widening tests (ADR-0031, requires flag) ---
 
-    #[test]
-    fn apply_when_byte_arg_to_int_param_with_flag_then_ok() {
-        let program = "
+    /// Cross-family widening on function-call arguments/returns with
+    /// `--allow-cross-family-widening` enabled (ADR-0031), against a resolved
+    /// context. Each case resolves the program, applies the rule with the flag
+    /// on, and asserts the expected outcome; each row still runs as an
+    /// individually-named test.
+    #[rstest]
+    #[case::byte_arg_to_int_param_ok(
+        "
 FUNCTION TAKES_INT : INT
 VAR_INPUT
     x : INT;
@@ -1233,19 +1239,11 @@ VAR
     y : BYTE;
 END_VAR
     result := TAKES_INT(y);
-END_PROGRAM";
-        let (library, context) = parse_and_resolve_types_with_context(program);
-        let opts = CompilerOptions {
-            allow_cross_family_widening: true,
-            ..CompilerOptions::default()
-        };
-        let result = apply(&library, &context, &opts);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn apply_when_literal_zero_to_byte_param_with_flag_then_ok() {
-        let program = "
+END_PROGRAM",
+        true
+    )]
+    #[case::literal_zero_to_byte_param_ok(
+        "
 FUNCTION TAKES_BYTE : BYTE
 VAR_INPUT
     x : BYTE;
@@ -1258,14 +1256,57 @@ VAR
     result : BYTE;
 END_VAR
     result := TAKES_BYTE(0);
-END_PROGRAM";
+END_PROGRAM",
+        true
+    )]
+    #[case::byte_return_to_int_var_ok(
+        "
+FUNCTION GET_BYTE : BYTE
+VAR_INPUT
+    x : BYTE;
+END_VAR
+    GET_BYTE := x;
+END_FUNCTION
+
+PROGRAM main
+VAR
+    result : INT;
+    y : BYTE;
+END_VAR
+    result := GET_BYTE(y);
+END_PROGRAM",
+        true
+    )]
+    // Integer → bit-string is never allowed, even with flag.
+    #[case::int_arg_to_byte_param_error(
+        "
+FUNCTION TAKES_BYTE : BYTE
+VAR_INPUT
+    x : BYTE;
+END_VAR
+    TAKES_BYTE := x;
+END_FUNCTION
+
+PROGRAM main
+VAR
+    result : BYTE;
+    y : INT;
+END_VAR
+    result := TAKES_BYTE(y);
+END_PROGRAM",
+        false
+    )]
+    fn apply_when_cross_family_widening_flag_on_call_then_matches_expectation(
+        #[case] program: &str,
+        #[case] expect_ok: bool,
+    ) {
         let (library, context) = parse_and_resolve_types_with_context(program);
         let opts = CompilerOptions {
             allow_cross_family_widening: true,
             ..CompilerOptions::default()
         };
         let result = apply(&library, &context, &opts);
-        assert!(result.is_ok());
+        assert_eq!(result.is_ok(), expect_ok);
     }
 
     rule_ctx_err!(
@@ -1286,32 +1327,6 @@ END_VAR
 END_PROGRAM"
     );
 
-    #[test]
-    fn apply_when_byte_return_to_int_var_with_flag_then_ok() {
-        let program = "
-FUNCTION GET_BYTE : BYTE
-VAR_INPUT
-    x : BYTE;
-END_VAR
-    GET_BYTE := x;
-END_FUNCTION
-
-PROGRAM main
-VAR
-    result : INT;
-    y : BYTE;
-END_VAR
-    result := GET_BYTE(y);
-END_PROGRAM";
-        let (library, context) = parse_and_resolve_types_with_context(program);
-        let opts = CompilerOptions {
-            allow_cross_family_widening: true,
-            ..CompilerOptions::default()
-        };
-        let result = apply(&library, &context, &opts);
-        assert!(result.is_ok());
-    }
-
     rule_ctx_err!(
         apply_when_byte_return_to_int_var_without_flag_then_error,
         "
@@ -1330,33 +1345,6 @@ END_VAR
     result := GET_BYTE(y);
 END_PROGRAM"
     );
-
-    #[test]
-    fn apply_when_int_arg_to_byte_param_with_flag_then_error() {
-        // Integer → bit-string is never allowed, even with flag
-        let program = "
-FUNCTION TAKES_BYTE : BYTE
-VAR_INPUT
-    x : BYTE;
-END_VAR
-    TAKES_BYTE := x;
-END_FUNCTION
-
-PROGRAM main
-VAR
-    result : BYTE;
-    y : INT;
-END_VAR
-    result := TAKES_BYTE(y);
-END_PROGRAM";
-        let (library, context) = parse_and_resolve_types_with_context(program);
-        let opts = CompilerOptions {
-            allow_cross_family_widening: true,
-            ..CompilerOptions::default()
-        };
-        let result = apply(&library, &context, &opts);
-        assert!(result.is_err());
-    }
 
     // --- Standard-library argument type checks ---
 
@@ -1476,45 +1464,60 @@ END_VAR
 END_PROGRAM"
     );
 
-    #[test]
-    fn apply_when_dword_target_assigned_udint_var_with_flag_then_ok() {
-        // Verified permissive against real TcXaeShell despite equal width
-        // -- see twincat-status.md, "Resolved: UDINT -> DWORD implicit
-        // conversion".
-        let program = "
+    /// Cross-family widening on assignment statements with
+    /// `--allow-cross-family-widening` enabled (ADR-0031), against a resolved
+    /// context. Each case resolves the program, applies the rule with the flag
+    /// on, and asserts the expected outcome; each row still runs as an
+    /// individually-named test.
+    #[rstest]
+    // Verified permissive against real TcXaeShell despite equal width -- see
+    // twincat-status.md, "Resolved: UDINT -> DWORD implicit conversion".
+    #[case::dword_target_assigned_udint_var_ok(
+        "
 PROGRAM main
 VAR
     dwFromUdint : DWORD;
     udValue : UDINT;
 END_VAR
     dwFromUdint := udValue;
-END_PROGRAM";
-        let (library, context) = parse_and_resolve_types_with_context(program);
-        let opts = CompilerOptions {
-            allow_cross_family_widening: true,
-            ..CompilerOptions::default()
-        };
-        let result = apply(&library, &context, &opts);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn apply_when_udint_target_assigned_dword_var_with_flag_then_ok() {
-        let program = "
+END_PROGRAM",
+        true
+    )]
+    #[case::udint_target_assigned_dword_var_ok(
+        "
 PROGRAM main
 VAR
     udFromDword : UDINT;
     dwValue : DWORD;
 END_VAR
     udFromDword := dwValue;
-END_PROGRAM";
+END_PROGRAM",
+        true
+    )]
+    // Signed integer, equal width -- not part of the verified exception, must
+    // stay rejected even with the flag on.
+    #[case::dword_target_assigned_dint_var_error(
+        "
+PROGRAM main
+VAR
+    dwFromDint : DWORD;
+    diValue : DINT;
+END_VAR
+    dwFromDint := diValue;
+END_PROGRAM",
+        false
+    )]
+    fn apply_when_cross_family_widening_flag_on_assignment_then_matches_expectation(
+        #[case] program: &str,
+        #[case] expect_ok: bool,
+    ) {
         let (library, context) = parse_and_resolve_types_with_context(program);
         let opts = CompilerOptions {
             allow_cross_family_widening: true,
             ..CompilerOptions::default()
         };
         let result = apply(&library, &context, &opts);
-        assert!(result.is_ok());
+        assert_eq!(result.is_ok(), expect_ok);
     }
 
     rule_ctx_err!(
@@ -1528,27 +1531,6 @@ END_VAR
     dwFromUdint := udValue;
 END_PROGRAM"
     );
-
-    #[test]
-    fn apply_when_dword_target_assigned_dint_var_with_flag_then_error() {
-        // Signed integer, equal width -- not part of the verified
-        // exception, must stay rejected even with the flag on.
-        let program = "
-PROGRAM main
-VAR
-    dwFromDint : DWORD;
-    diValue : DINT;
-END_VAR
-    dwFromDint := diValue;
-END_PROGRAM";
-        let (library, context) = parse_and_resolve_types_with_context(program);
-        let opts = CompilerOptions {
-            allow_cross_family_widening: true,
-            ..CompilerOptions::default()
-        };
-        let result = apply(&library, &context, &opts);
-        assert!(result.is_err());
-    }
 
     // Temporal short/long widths are treated as one family.
     rule_ctx_ok!(

--- a/compiler/analyzer/src/rule_pou_hierarchy.rs
+++ b/compiler/analyzer/src/rule_pou_hierarchy.rs
@@ -179,27 +179,25 @@ mod tests {
         test_helpers::{parse_and_resolve_types, parse_only},
     };
     use ironplc_parser::options::CompilerOptions;
+    use rstest::rstest;
 
-    #[test]
-    fn apply_when_duplicate_function_name_then_error() {
-        let program = "
+    /// A duplicated POU name (across each declaration kind) is an error. Each
+    /// case parses without type resolution, applies the rule against a fresh
+    /// empty context, and expects an error; each row still runs as an
+    /// individually-named test.
+    #[rstest]
+    #[case::duplicate_function_name(
+        "
         FUNCTION Foo : BOOL
             Foo := FALSE;
         END_FUNCTION
 
         FUNCTION Foo : BOOL
             Foo := TRUE;
-        END_FUNCTION";
-
-        let library = parse_only(program);
-        let context = SemanticContextBuilder::new().build().unwrap();
-        let result = apply(&library, &context, &CompilerOptions::default());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn apply_when_duplicate_function_block_name_then_error() {
-        let program = "
+        END_FUNCTION"
+    )]
+    #[case::duplicate_function_block_name(
+        "
         FUNCTION_BLOCK Bar
             VAR
                 X : BOOL;
@@ -210,17 +208,10 @@ mod tests {
             VAR
                 Y : BOOL;
             END_VAR
-        END_FUNCTION_BLOCK";
-
-        let library = parse_only(program);
-        let context = SemanticContextBuilder::new().build().unwrap();
-        let result = apply(&library, &context, &CompilerOptions::default());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn apply_when_duplicate_program_name_then_error() {
-        let program = "
+        END_FUNCTION_BLOCK"
+    )]
+    #[case::duplicate_program_name(
+        "
         PROGRAM Baz
             VAR
                 X : BOOL;
@@ -231,17 +222,10 @@ mod tests {
             VAR
                 Y : BOOL;
             END_VAR
-        END_PROGRAM";
-
-        let library = parse_only(program);
-        let context = SemanticContextBuilder::new().build().unwrap();
-        let result = apply(&library, &context, &CompilerOptions::default());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn apply_when_duplicate_configuration_name_then_error() {
-        let program = "
+        END_PROGRAM"
+    )]
+    #[case::duplicate_configuration_name(
+        "
         FUNCTION_BLOCK Fb1
             VAR
                 X : BOOL;
@@ -266,8 +250,9 @@ mod tests {
                 TASK Main(INTERVAL := T#20ms, PRIORITY := 1);
                 PROGRAM P2 WITH Main : Prg1;
             END_RESOURCE
-        END_CONFIGURATION";
-
+        END_CONFIGURATION"
+    )]
+    fn apply_when_duplicate_pou_name_then_error(#[case] program: &str) {
         let library = parse_only(program);
         let context = SemanticContextBuilder::new().build().unwrap();
         let result = apply(&library, &context, &CompilerOptions::default());

--- a/compiler/codegen/tests/it/codegen_max_call_depth.rs
+++ b/compiler/codegen/tests/it/codegen_max_call_depth.rs
@@ -3,8 +3,14 @@
 //! Each test compiles a small IEC 61131-3 program and asserts the
 //! resulting container header carries the call depth the codegen
 //! analysis is supposed to produce.
+//!
+//! The depth *algorithm* (base case, linear chains of any length,
+//! diamonds/longest-path, cycles) is exhaustively unit-tested in
+//! `codegen/src/call_graph.rs`. These integration tests only cover the
+//! source -> compile -> header wiring, so we keep two representatives:
+//! one that drives function `CALL` edges through a multi-level chain, and
+//! one that drives `FB_CALL` and `CALL` edges together.
 
-use ironplc_codegen::CodegenOptions;
 use ironplc_parser::options::CompilerOptions;
 
 use crate::common::try_parse_and_compile;
@@ -12,36 +18,6 @@ use crate::common::try_parse_and_compile;
 fn compile_for_depth(source: &str) -> u16 {
     let container = try_parse_and_compile(source, &CompilerOptions::default()).unwrap();
     container.header.max_call_depth
-}
-
-#[test]
-fn compile_when_program_has_no_calls_then_max_call_depth_is_one() {
-    // SCAN does arithmetic only — no CALL, no FB_CALL. Only the
-    // entry frame is on the stack at any point, so depth = 1.
-    let source = "
-PROGRAM main
-  VAR x : INT; END_VAR
-  x := 1 + 2;
-END_PROGRAM
-";
-    assert_eq!(compile_for_depth(source), 1);
-}
-
-#[test]
-fn compile_when_program_calls_one_function_then_max_call_depth_is_two() {
-    // SCAN -> ADD_ONE. Two frames: SCAN, then ADD_ONE.
-    let source = "
-FUNCTION ADD_ONE : INT
-  VAR_INPUT x : INT; END_VAR
-  ADD_ONE := x + 1;
-END_FUNCTION
-
-PROGRAM main
-  VAR y : INT; END_VAR
-  y := ADD_ONE(x := 5);
-END_PROGRAM
-";
-    assert_eq!(compile_for_depth(source), 2);
 }
 
 #[test]
@@ -72,61 +48,9 @@ END_PROGRAM
 }
 
 #[test]
-fn compile_when_diamond_call_graph_then_max_call_depth_takes_longest() {
-    // SCAN -> {SHORT, LONG_A}
-    // SHORT returns directly                 (path length 2)
-    // LONG_A -> LONG_B -> LEAF               (path length 4)
-    // Verifies the longest path wins, not the average / first / etc.
-    let source = "
-FUNCTION SHORT : INT
-  VAR_INPUT n : INT; END_VAR
-  SHORT := n;
-END_FUNCTION
-
-FUNCTION LEAF : INT
-  VAR_INPUT n : INT; END_VAR
-  LEAF := n;
-END_FUNCTION
-
-FUNCTION LONG_B : INT
-  VAR_INPUT n : INT; END_VAR
-  LONG_B := LEAF(n := n);
-END_FUNCTION
-
-FUNCTION LONG_A : INT
-  VAR_INPUT n : INT; END_VAR
-  LONG_A := LONG_B(n := n);
-END_FUNCTION
-
-PROGRAM main
-  VAR a : INT; b : INT; END_VAR
-  a := SHORT(n := 1);
-  b := LONG_A(n := 2);
-END_PROGRAM
-";
-    assert_eq!(compile_for_depth(source), 4);
-}
-
-#[test]
-fn compile_when_program_calls_user_fb_then_fb_body_counted() {
-    // SCAN -> CTR.body. Two frames.
-    let source = "
-FUNCTION_BLOCK CTR
-  VAR n : INT; END_VAR
-  n := n + 1;
-END_FUNCTION_BLOCK
-
-PROGRAM main
-  VAR c : CTR; END_VAR
-  c();
-END_PROGRAM
-";
-    assert_eq!(compile_for_depth(source), 2);
-}
-
-#[test]
 fn compile_when_user_fb_body_calls_user_function_then_both_counted() {
     // SCAN -> CTR.body -> ADD_ONE. Three frames at the deepest point.
+    // Exercises both FB_CALL (main -> CTR) and CALL (CTR -> ADD_ONE) edges.
     let source = "
 FUNCTION ADD_ONE : INT
   VAR_INPUT x : INT; END_VAR
@@ -144,18 +68,4 @@ PROGRAM main
 END_PROGRAM
 ";
     assert_eq!(compile_for_depth(source), 3);
-}
-
-#[test]
-fn compile_when_codegen_options_default_then_header_has_max_call_depth_set() {
-    // Smoke-test the wiring: regardless of options, every compiled
-    // program ends up with a populated `max_call_depth` (>= 1).
-    let _ = CodegenOptions::default();
-    let source = "
-PROGRAM main
-  VAR x : INT; END_VAR
-  x := 0;
-END_PROGRAM
-";
-    assert!(compile_for_depth(source) >= 1);
 }

--- a/compiler/codegen/tests/it/common/mod.rs
+++ b/compiler/codegen/tests/it/common/mod.rs
@@ -653,6 +653,64 @@ pub fn parse_and_run_rounds(
     f(&mut vm);
 }
 
+/// A single step in a function-block (`TON`/`CTU`/`R_TRIG`/`RS`/…) driver
+/// scenario.
+///
+/// The timer/counter/edge/bistable end-to-end tests all share the same shape:
+/// build a program, then drive the VM across several scan rounds, writing
+/// inputs and asserting outputs along the way. Rather than repeat that
+/// `load_and_start` + `run_round` + `read_variable` scaffold in every test,
+/// each scenario is expressed as a `&[FbStep]` table and executed by
+/// [`drive_fb`]. This keeps every original scenario as one `rstest` `#[case]`
+/// while the driver lives in exactly one place.
+#[derive(Clone, Copy)]
+pub enum FbStep {
+    /// Write `value` into the variable at `index` (no scan round runs).
+    Write(u16, i32),
+    /// Run one scan round at absolute VM time `time_us` (microseconds).
+    Run(u64),
+    /// Assert the variable at `index` currently reads `value`.
+    Expect(u16, i32),
+    /// Feed `n` rising edges on the variable at `var`: for each edge, write 1
+    /// and run a round, then write 0 and run a round. Rounds run at
+    /// `time_base + i*2` and `+1`. Edge/counter FBs are edge-triggered, so the
+    /// exact time values only need to increase monotonically.
+    Pulse { var: u16, n: u64, time_base: u64 },
+}
+
+/// Compiles `source` and drives the VM through `steps`, executing each
+/// [`FbStep`] in order. See [`FbStep`] for the step semantics.
+pub fn drive_fb(source: &str, options: &CompilerOptions, steps: &[FbStep]) {
+    use ironplc_container::VarIndex;
+    parse_and_run_rounds(source, options, |vm| {
+        for step in steps {
+            match *step {
+                FbStep::Write(index, value) => {
+                    vm.write_variable(VarIndex::new(index), value).unwrap();
+                }
+                FbStep::Run(time_us) => {
+                    vm.run_round(time_us).unwrap();
+                }
+                FbStep::Expect(index, value) => {
+                    assert_eq!(
+                        vm.read_variable(VarIndex::new(index)).unwrap(),
+                        value,
+                        "vars[{index}] mismatch"
+                    );
+                }
+                FbStep::Pulse { var, n, time_base } => {
+                    for i in 0..n {
+                        vm.write_variable(VarIndex::new(var), 1).unwrap();
+                        vm.run_round(time_base + i * 2).unwrap();
+                        vm.write_variable(VarIndex::new(var), 0).unwrap();
+                        vm.run_round(time_base + i * 2 + 1).unwrap();
+                    }
+                }
+            }
+        }
+    });
+}
+
 /// Runs `source` with default options and asserts each `(var_index, expected)`
 /// pair against the corresponding `vars[i].as_i32()` slot after one scan.
 ///

--- a/compiler/codegen/tests/it/end_to_end_bcd.rs
+++ b/compiler/codegen/tests/it/end_to_end_bcd.rs
@@ -1,97 +1,65 @@
 //! End-to-end integration tests for the BCD_TO_INT and INT_TO_BCD functions.
 
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
 use crate::common::parse_and_run;
 
-#[test]
-fn end_to_end_when_bcd_to_int_byte_then_decodes() {
-    let source = "
+/// BCD_TO_INT decodes a packed-BCD bit string into its decimal value. Kept as
+/// a parametrized table rather than a property test (no verified Rust BCD
+/// oracle). Each case is (bit-string type, result type, hex BCD literal,
+/// decoded decimal).
+#[rstest]
+#[case::byte("BYTE", "USINT", "42", 42)]
+#[case::word("WORD", "UINT", "1234", 1234)]
+#[case::byte_zero("BYTE", "USINT", "00", 0)]
+fn bcd_to_int(
+    #[case] bit_ty: &str,
+    #[case] result_ty: &str,
+    #[case] hex: &str,
+    #[case] expected: i32,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    bcd_val : BYTE;
-    result : USINT;
+    bcd_val : {bit_ty};
+    result : {result_ty};
   END_VAR
-  bcd_val := BYTE#16#42;
+  bcd_val := {bit_ty}#16#{hex};
   result := BCD_TO_INT(bcd_val);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result = bufs.vars[1].as_i32() as u8;
-    assert_eq!(result, 42, "expected 42, got {result}");
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32(), expected);
 }
 
-#[test]
-fn end_to_end_when_bcd_to_int_word_then_decodes() {
-    let source = "
+/// INT_TO_BCD encodes a decimal value into a packed-BCD bit string. Each case
+/// is (input type, result bit-string type, decimal input, expected packed-BCD).
+#[rstest]
+#[case::usint("USINT", "BYTE", "42", 0x42)]
+#[case::uint("UINT", "WORD", "1234", 0x1234)]
+fn int_to_bcd(
+    #[case] int_ty: &str,
+    #[case] result_ty: &str,
+    #[case] dec: &str,
+    #[case] expected: i32,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    bcd_val : WORD;
-    result : UINT;
+    int_val : {int_ty};
+    result : {result_ty};
   END_VAR
-  bcd_val := WORD#16#1234;
-  result := BCD_TO_INT(bcd_val);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result = bufs.vars[1].as_i32() as u16;
-    assert_eq!(result, 1234, "expected 1234, got {result}");
-}
-
-#[test]
-fn end_to_end_when_bcd_to_int_byte_zero_then_zero() {
-    let source = "
-PROGRAM main
-  VAR
-    bcd_val : BYTE;
-    result : USINT;
-  END_VAR
-  bcd_val := BYTE#16#00;
-  result := BCD_TO_INT(bcd_val);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result = bufs.vars[1].as_i32() as u8;
-    assert_eq!(result, 0, "expected 0, got {result}");
-}
-
-#[test]
-fn end_to_end_when_int_to_bcd_usint_then_encodes() {
-    let source = "
-PROGRAM main
-  VAR
-    int_val : USINT;
-    result : BYTE;
-  END_VAR
-  int_val := USINT#42;
+  int_val := {int_ty}#{dec};
   result := INT_TO_BCD(int_val);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result = bufs.vars[1].as_i32() as u8;
-    assert_eq!(result, 0x42, "expected 0x42, got 0x{result:02X}");
-}
-
-#[test]
-fn end_to_end_when_int_to_bcd_uint_then_encodes() {
-    let source = "
-PROGRAM main
-  VAR
-    int_val : UINT;
-    result : WORD;
-  END_VAR
-  int_val := UINT#1234;
-  result := INT_TO_BCD(int_val);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-
-    let result = bufs.vars[1].as_i32() as u16;
-    assert_eq!(result, 0x1234, "expected 0x1234, got 0x{result:04X}");
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32(), expected);
 }
 
 #[test]

--- a/compiler/codegen/tests/it/end_to_end_conv_bool_to_int.rs
+++ b/compiler/codegen/tests/it/end_to_end_conv_bool_to_int.rs
@@ -1,177 +1,55 @@
 //! End-to-end tests for BOOL to integer type conversions.
 
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
 use crate::common::parse_and_run;
 
-#[test]
-fn end_to_end_when_bool_to_sint_true_then_returns_1() {
-    let source = "
+/// BOOL_TO_<T> for targets that fit in a 32-bit slot. TRUE -> 1, FALSE -> 0.
+#[rstest]
+#[case::sint_true("SINT", "TRUE", 1)]
+#[case::sint_false("SINT", "FALSE", 0)]
+#[case::int_true("INT", "TRUE", 1)]
+#[case::int_false("INT", "FALSE", 0)]
+#[case::dint_true("DINT", "TRUE", 1)]
+#[case::usint_true("USINT", "TRUE", 1)]
+#[case::uint_true("UINT", "TRUE", 1)]
+#[case::udint_true("UDINT", "TRUE", 1)]
+fn end_to_end_bool_to_int32(#[case] target: &str, #[case] input: &str, #[case] expected: i32) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
     x : BOOL;
-    y : SINT;
+    y : {target};
   END_VAR
-  x := TRUE;
-  y := BOOL_TO_SINT(x);
+  x := {input};
+  y := BOOL_TO_{target}(x);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as i8, 1);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32(), expected);
 }
 
-#[test]
-fn end_to_end_when_bool_to_sint_false_then_returns_0() {
-    let source = "
+/// BOOL_TO_<T> for 64-bit targets. TRUE -> 1, FALSE -> 0.
+#[rstest]
+#[case::lint_true("LINT", "TRUE", 1)]
+#[case::ulint_true("ULINT", "TRUE", 1)]
+#[case::ulint_false("ULINT", "FALSE", 0)]
+fn end_to_end_bool_to_int64(#[case] target: &str, #[case] input: &str, #[case] expected: i64) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
     x : BOOL;
-    y : SINT;
+    y : {target};
   END_VAR
-  x := FALSE;
-  y := BOOL_TO_SINT(x);
+  x := {input};
+  y := BOOL_TO_{target}(x);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as i8, 0);
-}
-
-e2e_i32!(
-    end_to_end_when_bool_to_int_true_then_returns_1,
-    "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : INT;
-  END_VAR
-  x := TRUE;
-  y := BOOL_TO_INT(x);
-END_PROGRAM
-",
-    &[(1, 1)],
-);
-
-e2e_i32!(
-    end_to_end_when_bool_to_int_false_then_returns_0,
-    "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : INT;
-  END_VAR
-  x := FALSE;
-  y := BOOL_TO_INT(x);
-END_PROGRAM
-",
-    &[(1, 0)],
-);
-
-e2e_i32!(
-    end_to_end_when_bool_to_dint_true_then_returns_1,
-    "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : DINT;
-  END_VAR
-  x := TRUE;
-  y := BOOL_TO_DINT(x);
-END_PROGRAM
-",
-    &[(1, 1)],
-);
-
-e2e_i64!(
-    end_to_end_when_bool_to_lint_true_then_returns_1,
-    "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : LINT;
-  END_VAR
-  x := TRUE;
-  y := BOOL_TO_LINT(x);
-END_PROGRAM
-",
-    &[(1, 1)],
-);
-
-#[test]
-fn end_to_end_when_bool_to_usint_true_then_returns_1() {
-    let source = "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : USINT;
-  END_VAR
-  x := TRUE;
-  y := BOOL_TO_USINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as u8, 1);
-}
-
-#[test]
-fn end_to_end_when_bool_to_uint_true_then_returns_1() {
-    let source = "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : UINT;
-  END_VAR
-  x := TRUE;
-  y := BOOL_TO_UINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as u16, 1);
-}
-
-#[test]
-fn end_to_end_when_bool_to_udint_true_then_returns_1() {
-    let source = "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : UDINT;
-  END_VAR
-  x := TRUE;
-  y := BOOL_TO_UDINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as u32, 1);
-}
-
-#[test]
-fn end_to_end_when_bool_to_ulint_true_then_returns_1() {
-    let source = "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : ULINT;
-  END_VAR
-  x := TRUE;
-  y := BOOL_TO_ULINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i64() as u64, 1);
-}
-
-#[test]
-fn end_to_end_when_bool_to_ulint_false_then_returns_0() {
-    let source = "
-PROGRAM main
-  VAR
-    x : BOOL;
-    y : ULINT;
-  END_VAR
-  x := FALSE;
-  y := BOOL_TO_ULINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i64() as u64, 0);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i64(), expected);
 }

--- a/compiler/codegen/tests/it/end_to_end_conv_int_narrowing.rs
+++ b/compiler/codegen/tests/it/end_to_end_conv_int_narrowing.rs
@@ -1,83 +1,36 @@
 //! End-to-end tests for integer narrowing type conversions.
 
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
 use crate::common::parse_and_run;
 
-e2e_i32!(
-    end_to_end_when_dint_to_int_then_narrows,
-    "
+/// <SRC>_TO_<TGT> narrowing conversions. The overflow case wraps into the
+/// target width (300 truncated to SINT = 300 mod 256 = 44).
+#[rstest]
+#[case::dint_to_int("DINT", "INT", "1000", 1000)]
+#[case::lint_to_dint("LINT", "DINT", "42", 42)]
+#[case::dint_to_sint_overflow("DINT", "SINT", "300", 44)]
+#[case::lint_to_sint("LINT", "SINT", "50", 50)]
+#[case::ulint_to_udint("ULINT", "UDINT", "1000", 1000)]
+fn end_to_end_int_narrowing(
+    #[case] src: &str,
+    #[case] tgt: &str,
+    #[case] value: &str,
+    #[case] expected: i32,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    x : DINT;
-    y : INT;
+    x : {src};
+    y : {tgt};
   END_VAR
-  x := 1000;
-  y := DINT_TO_INT(x);
+  x := {value};
+  y := {src}_TO_{tgt}(x);
 END_PROGRAM
-",
-    &[(1, 1000)],
-);
-
-e2e_i32!(
-    end_to_end_when_lint_to_dint_then_narrows,
-    "
-PROGRAM main
-  VAR
-    x : LINT;
-    y : DINT;
-  END_VAR
-  x := 42;
-  y := LINT_TO_DINT(x);
-END_PROGRAM
-",
-    &[(1, 42)],
-);
-
-#[test]
-fn end_to_end_when_dint_to_sint_overflow_then_wraps() {
-    let source = "
-PROGRAM main
-  VAR
-    x : DINT;
-    y : SINT;
-  END_VAR
-  x := 300;
-  y := DINT_TO_SINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    // 300 mod 256 = 44 (wrapping to i8 range)
-    assert_eq!(bufs.vars[1].as_i32() as i8, 44);
-}
-
-e2e_i32!(
-    end_to_end_when_lint_to_sint_then_narrows,
-    "
-PROGRAM main
-  VAR
-    x : LINT;
-    y : SINT;
-  END_VAR
-  x := 50;
-  y := LINT_TO_SINT(x);
-END_PROGRAM
-",
-    &[(1, 50)],
-);
-
-#[test]
-fn end_to_end_when_ulint_to_udint_then_narrows() {
-    let source = "
-PROGRAM main
-  VAR
-    x : ULINT;
-    y : UDINT;
-  END_VAR
-  x := 1000;
-  y := ULINT_TO_UDINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as u32, 1000);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32(), expected);
 }

--- a/compiler/codegen/tests/it/end_to_end_conv_int_widening.rs
+++ b/compiler/codegen/tests/it/end_to_end_conv_int_widening.rs
@@ -1,98 +1,60 @@
 //! End-to-end tests for integer widening type conversions.
 
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
 use crate::common::parse_and_run;
 
-e2e_i32!(
-    end_to_end_when_sint_to_int_then_widens,
-    "
+/// <SRC>_TO_<TGT> widening/reinterpret conversions read from a 32-bit slot.
+#[rstest]
+#[case::sint_to_int("SINT", "INT", "-100", -100)]
+#[case::int_to_dint("INT", "DINT", "-30000", -30000)]
+#[case::usint_to_uint("USINT", "UINT", "200", 200)]
+#[case::int_to_uint("INT", "UINT", "1000", 1000)]
+fn end_to_end_int_widening_i32(
+    #[case] src: &str,
+    #[case] tgt: &str,
+    #[case] value: &str,
+    #[case] expected: i32,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    x : SINT;
-    y : INT;
+    x : {src};
+    y : {tgt};
   END_VAR
-  x := -100;
-  y := SINT_TO_INT(x);
+  x := {value};
+  y := {src}_TO_{tgt}(x);
 END_PROGRAM
-",
-    &[(1, -100)],
-);
-
-e2e_i32!(
-    end_to_end_when_int_to_dint_then_widens,
-    "
-PROGRAM main
-  VAR
-    x : INT;
-    y : DINT;
-  END_VAR
-  x := -30000;
-  y := INT_TO_DINT(x);
-END_PROGRAM
-",
-    &[(1, -30000)],
-);
-
-e2e_i64!(
-    end_to_end_when_dint_to_lint_then_widens,
-    "
-PROGRAM main
-  VAR
-    x : DINT;
-    y : LINT;
-  END_VAR
-  x := -1000000;
-  y := DINT_TO_LINT(x);
-END_PROGRAM
-",
-    &[(1, -1000000)],
-);
-
-#[test]
-fn end_to_end_when_usint_to_uint_then_widens() {
-    let source = "
-PROGRAM main
-  VAR
-    x : USINT;
-    y : UINT;
-  END_VAR
-  x := 200;
-  y := USINT_TO_UINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as u16, 200);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32(), expected);
 }
 
-#[test]
-fn end_to_end_when_uint_to_ulint_then_widens() {
-    let source = "
+/// <SRC>_TO_<TGT> widening conversions read from a 64-bit slot.
+#[rstest]
+#[case::dint_to_lint("DINT", "LINT", "-1000000", -1_000_000)]
+#[case::uint_to_ulint("UINT", "ULINT", "50000", 50_000)]
+fn end_to_end_int_widening_i64(
+    #[case] src: &str,
+    #[case] tgt: &str,
+    #[case] value: &str,
+    #[case] expected: i64,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    x : UINT;
-    y : ULINT;
+    x : {src};
+    y : {tgt};
   END_VAR
-  x := 50000;
-  y := UINT_TO_ULINT(x);
+  x := {value};
+  y := {src}_TO_{tgt}(x);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i64() as u64, 50000);
-}
-
-#[test]
-fn end_to_end_when_int_to_uint_then_reinterprets() {
-    let source = "
-PROGRAM main
-  VAR
-    x : INT;
-    y : UINT;
-  END_VAR
-  x := 1000;
-  y := INT_TO_UINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as u16, 1000);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i64(), expected);
 }

--- a/compiler/codegen/tests/it/end_to_end_conv_real_to_int.rs
+++ b/compiler/codegen/tests/it/end_to_end_conv_real_to_int.rs
@@ -1,83 +1,63 @@
 //! End-to-end tests for real-to-integer type conversions.
+//!
+//! These stay parametrized tables rather than property tests: IEC truncation
+//! semantics do not map cleanly onto a single Rust `as` cast oracle.
 
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
 use crate::common::parse_and_run;
 
-e2e_i32!(
-    end_to_end_when_real_to_int_then_truncates,
-    "
+/// REAL/LREAL -> integer conversions that read from a 32-bit slot. Fractional
+/// parts are truncated toward zero.
+#[rstest]
+#[case::real_to_int("REAL", "INT", "3.14", 3)]
+#[case::real_to_dint_negative("REAL", "DINT", "-7.9", -7)]
+#[case::real_to_sint("REAL", "SINT", "50.7", 50)]
+#[case::lreal_to_udint("LREAL", "UDINT", "1000.0", 1000)]
+fn end_to_end_real_to_int_i32(
+    #[case] src: &str,
+    #[case] tgt: &str,
+    #[case] value: &str,
+    #[case] expected: i32,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    x : REAL;
-    y : INT;
+    x : {src};
+    y : {tgt};
   END_VAR
-  x := 3.14;
-  y := REAL_TO_INT(x);
+  x := {value};
+  y := {src}_TO_{tgt}(x);
 END_PROGRAM
-",
-    &[(1, 3)],
-);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32(), expected);
+}
 
-e2e_i32!(
-    end_to_end_when_real_to_dint_negative_then_truncates,
-    "
+/// REAL/LREAL -> integer conversions that read from a 64-bit slot.
+#[rstest]
+#[case::lreal_to_lint("LREAL", "LINT", "99.9", 99)]
+fn end_to_end_real_to_int_i64(
+    #[case] src: &str,
+    #[case] tgt: &str,
+    #[case] value: &str,
+    #[case] expected: i64,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    x : REAL;
-    y : DINT;
+    x : {src};
+    y : {tgt};
   END_VAR
-  x := -7.9;
-  y := REAL_TO_DINT(x);
+  x := {value};
+  y := {src}_TO_{tgt}(x);
 END_PROGRAM
-",
-    &[(1, -7)],
-);
-
-e2e_i64!(
-    end_to_end_when_lreal_to_lint_then_truncates,
-    "
-PROGRAM main
-  VAR
-    x : LREAL;
-    y : LINT;
-  END_VAR
-  x := 99.9;
-  y := LREAL_TO_LINT(x);
-END_PROGRAM
-",
-    &[(1, 99)],
-);
-
-e2e_i32!(
-    end_to_end_when_real_to_sint_then_truncates_to_range,
-    "
-PROGRAM main
-  VAR
-    x : REAL;
-    y : SINT;
-  END_VAR
-  x := 50.7;
-  y := REAL_TO_SINT(x);
-END_PROGRAM
-",
-    &[(1, 50)],
-);
-
-// Reads the result as u32 (via a cast), so it stays hand-written rather than
-// using the plain `as_i32()` macro.
-#[test]
-fn end_to_end_when_lreal_to_udint_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : LREAL;
-    y : UDINT;
-  END_VAR
-  x := 1000.0;
-  y := LREAL_TO_UDINT(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(bufs.vars[1].as_i32() as u32, 1000);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i64(), expected);
 }

--- a/compiler/codegen/tests/it/end_to_end_conv_string.rs
+++ b/compiler/codegen/tests/it/end_to_end_conv_string.rs
@@ -2,6 +2,7 @@
 
 use ironplc_container::STRING_HEADER_BYTES;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
 use crate::common::parse_and_run;
 
@@ -15,323 +16,79 @@ fn read_string(data_region: &[u8], data_offset: usize) -> String {
 }
 
 // =========================================================================
-// INT_TO_STRING
+// <TYPE>_TO_STRING
+//
+// Integer decimal formatting stays a parametrized table (not a property test)
+// so REAL_TO_STRING, whose decimal formatting has no clean Rust oracle, can
+// share the identical scaffold. Each case is (declared type, initial value,
+// expected decimal string).
 // =========================================================================
 
-#[test]
-fn int_to_string_when_positive_then_decimal() {
-    let source = "
+#[rstest]
+#[case::int_positive("INT", "42", "42")]
+#[case::int_negative("INT", "-123", "-123")]
+#[case::int_zero("INT", "0", "0")]
+#[case::dint_large("DINT", "2147483647", "2147483647")]
+#[case::dint_negative("DINT", "-100", "-100")]
+#[case::sint_negative("SINT", "-7", "-7")]
+#[case::usint("USINT", "255", "255")]
+#[case::uint("UINT", "65535", "65535")]
+#[case::udint_large("UDINT", "4294967295", "4294967295")]
+#[case::dword("DWORD", "255", "255")]
+#[case::word("WORD", "1000", "1000")]
+#[case::byte("BYTE", "42", "42")]
+// Rust formats 3.5_f32 as "3.5", -0.5 as "-0.5", and 100.0 as "100".
+#[case::real_positive("REAL", "3.5", "3.5")]
+#[case::real_negative("REAL", "-0.5", "-0.5")]
+#[case::real_integer_value("REAL", "100.0", "100")]
+fn num_to_string(#[case] ty: &str, #[case] value: &str, #[case] expected: &str) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    x : INT := 42;
+    x : {ty} := {value};
     s : STRING;
   END_VAR
-  s := INT_TO_STRING(x);
+  s := {ty}_TO_STRING(x);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "42");
-}
-
-#[test]
-fn int_to_string_when_negative_then_negative_decimal() {
-    let source = "
-PROGRAM main
-  VAR
-    x : INT := -123;
-    s : STRING;
-  END_VAR
-  s := INT_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "-123");
-}
-
-#[test]
-fn int_to_string_when_zero_then_zero_string() {
-    let source = "
-PROGRAM main
-  VAR
-    x : INT := 0;
-    s : STRING;
-  END_VAR
-  s := INT_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "0");
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(read_string(&bufs.data_region, 0), expected);
 }
 
 // =========================================================================
-// DINT_TO_STRING
+// STRING_TO_<INTEGER>
+//
+// Parses a STRING literal into an integer slot. Invalid input yields 0.
 // =========================================================================
 
-#[test]
-fn dint_to_string_when_large_value_then_correct() {
-    let source = "
+#[rstest]
+#[case::int_valid("INT", "123", 123)]
+#[case::int_negative("INT", "-456", -456)]
+#[case::int_invalid("INT", "abc", 0)]
+#[case::dint_large("DINT", "2147483647", 2147483647)]
+fn string_to_int(#[case] tgt: &str, #[case] input: &str, #[case] expected: i32) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    x : DINT := 2147483647;
-    s : STRING;
+    s : STRING := '{input}';
+    x : {tgt};
   END_VAR
-  s := DINT_TO_STRING(x);
+  x := STRING_TO_{tgt}(s);
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "2147483647");
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32(), expected);
 }
-
-#[test]
-fn dint_to_string_when_negative_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : DINT := -100;
-    s : STRING;
-  END_VAR
-  s := DINT_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "-100");
-}
-
-// =========================================================================
-// SINT_TO_STRING
-// =========================================================================
-
-#[test]
-fn sint_to_string_when_negative_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : SINT := -7;
-    s : STRING;
-  END_VAR
-  s := SINT_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "-7");
-}
-
-// =========================================================================
-// USINT_TO_STRING / UINT_TO_STRING / UDINT_TO_STRING
-// =========================================================================
-
-#[test]
-fn usint_to_string_when_value_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : USINT := 255;
-    s : STRING;
-  END_VAR
-  s := USINT_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "255");
-}
-
-#[test]
-fn uint_to_string_when_value_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : UINT := 65535;
-    s : STRING;
-  END_VAR
-  s := UINT_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "65535");
-}
-
-#[test]
-fn udint_to_string_when_large_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : UDINT := 4294967295;
-    s : STRING;
-  END_VAR
-  s := UDINT_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "4294967295");
-}
-
-// =========================================================================
-// DWORD_TO_STRING / WORD_TO_STRING / BYTE_TO_STRING
-// =========================================================================
-
-#[test]
-fn dword_to_string_when_value_then_unsigned_decimal() {
-    let source = "
-PROGRAM main
-  VAR
-    x : DWORD := 255;
-    s : STRING;
-  END_VAR
-  s := DWORD_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "255");
-}
-
-#[test]
-fn word_to_string_when_value_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : WORD := 1000;
-    s : STRING;
-  END_VAR
-  s := WORD_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "1000");
-}
-
-#[test]
-fn byte_to_string_when_value_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    x : BYTE := 42;
-    s : STRING;
-  END_VAR
-  s := BYTE_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "42");
-}
-
-// =========================================================================
-// REAL_TO_STRING
-// =========================================================================
-
-#[test]
-fn real_to_string_when_positive_then_decimal() {
-    let source = "
-PROGRAM main
-  VAR
-    x : REAL := 3.5;
-    s : STRING;
-  END_VAR
-  s := REAL_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "3.5");
-}
-
-#[test]
-fn real_to_string_when_negative_then_negative_decimal() {
-    let source = "
-PROGRAM main
-  VAR
-    x : REAL := -0.5;
-    s : STRING;
-  END_VAR
-  s := REAL_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert_eq!(read_string(&bufs.data_region, 0), "-0.5");
-}
-
-#[test]
-fn real_to_string_when_integer_value_then_no_trailing_dot() {
-    let source = "
-PROGRAM main
-  VAR
-    x : REAL := 100.0;
-    s : STRING;
-  END_VAR
-  s := REAL_TO_STRING(x);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    // Rust formats 100.0_f32 as "100", not "100.0"
-    assert_eq!(read_string(&bufs.data_region, 0), "100");
-}
-
-// =========================================================================
-// STRING_TO_INT
-// =========================================================================
-
-e2e_i32!(
-    string_to_int_when_valid_then_parsed,
-    "
-PROGRAM main
-  VAR
-    s : STRING := '123';
-    x : INT;
-  END_VAR
-  x := STRING_TO_INT(s);
-END_PROGRAM
-",
-    &[(1, 123)],
-);
-
-#[test]
-fn string_to_int_when_negative_then_parsed() {
-    let source = "
-PROGRAM main
-  VAR
-    s : STRING := '-456';
-    x : INT;
-  END_VAR
-  x := STRING_TO_INT(s);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    // INT is 16-bit signed, so -456 fits.
-    assert_eq!(bufs.vars[1].as_i32() as i16, -456);
-}
-
-e2e_i32!(
-    string_to_int_when_invalid_then_zero,
-    "
-PROGRAM main
-  VAR
-    s : STRING := 'abc';
-    x : INT;
-  END_VAR
-  x := STRING_TO_INT(s);
-END_PROGRAM
-",
-    &[(1, 0)],
-);
-
-// =========================================================================
-// STRING_TO_DINT
-// =========================================================================
-
-e2e_i32!(
-    string_to_dint_when_large_then_correct,
-    "
-PROGRAM main
-  VAR
-    s : STRING := '2147483647';
-    x : DINT;
-  END_VAR
-  x := STRING_TO_DINT(s);
-END_PROGRAM
-",
-    &[(1, 2147483647)],
-);
 
 // =========================================================================
 // STRING_TO_REAL
+//
+// Kept as distinct assertions: the valid case needs a tolerance compare,
+// the invalid case an exact-zero compare.
 // =========================================================================
 
 e2e_f32_near!(

--- a/compiler/codegen/tests/it/end_to_end_conv_time_date.rs
+++ b/compiler/codegen/tests/it/end_to_end_conv_time_date.rs
@@ -1,67 +1,62 @@
 //! End-to-end tests for time/date type conversions.
 
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
 use crate::common::parse_and_run;
 
-#[test]
-fn end_to_end_when_time_to_dword_then_correct() {
-    let source = "
+/// Time/date reinterpret conversions with an exact expected result. TIME is
+/// milliseconds, TOD is milliseconds since midnight. These are reinterpret
+/// casts, so they stay a parametrized table rather than a property test.
+#[rstest]
+#[case::time_to_dword("t : TIME := T#5s", "DWORD", "TIME_TO_DWORD(t)", 5000)]
+#[case::dword_to_time("dw : DWORD := 3000", "TIME", "DWORD_TO_TIME(dw)", 3000)]
+#[case::time_to_dint("t : TIME := T#5s", "DINT", "TIME_TO_DINT(t)", 5000)]
+#[case::time_to_int("t : TIME := T#2s", "INT", "TIME_TO_INT(t)", 2000)]
+// 12:30:00 = 12*3600*1000 + 30*60*1000 = 45_000_000 ms since midnight
+#[case::tod_to_dword("t : TOD := TOD#12:30:00", "DWORD", "TOD_TO_DWORD(t)", 45_000_000)]
+fn time_date_exact(
+    #[case] src_decl: &str,
+    #[case] result_type: &str,
+    #[case] call: &str,
+    #[case] expected: i32,
+) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    t : TIME := T#5s;
-    result : DWORD;
+    {src_decl};
+    result : {result_type};
   END_VAR
-  result := TIME_TO_DWORD(t);
+  result := {call};
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    // T#5s = 5000 milliseconds
-    assert_eq!(bufs.vars[1].as_i32() as u32, 5000);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert_eq!(bufs.vars[1].as_i32() as u32, expected as u32);
 }
 
-// 3000 milliseconds = T#3s
-e2e_i32!(
-    end_to_end_when_dword_to_time_then_correct,
-    "
+/// Date/datetime conversions stored as seconds since 1970-01-01; only their
+/// non-zero-ness is asserted (the absolute epoch value is not pinned).
+#[rstest]
+#[case::date_to_dword("d : DATE := D#2024-06-15", "DWORD", "DATE_TO_DWORD(d)")]
+#[case::date_to_udint("d : DATE := D#2024-06-15", "UDINT", "DATE_TO_UDINT(d)")]
+#[case::dt_to_dword("d : DT := DT#2024-06-15-12:30:00", "DWORD", "DT_TO_DWORD(d)")]
+fn time_date_nonzero(#[case] src_decl: &str, #[case] result_type: &str, #[case] call: &str) {
+    let source = format!(
+        "
 PROGRAM main
   VAR
-    dw : DWORD := 3000;
-    result : TIME;
+    {src_decl};
+    result : {result_type};
   END_VAR
-  result := DWORD_TO_TIME(dw);
+  result := {call};
 END_PROGRAM
-",
-    &[(1, 3000)],
-);
-
-e2e_i32!(
-    end_to_end_when_time_to_dint_then_correct,
-    "
-PROGRAM main
-  VAR
-    t : TIME := T#5s;
-    result : DINT;
-  END_VAR
-  result := TIME_TO_DINT(t);
-END_PROGRAM
-",
-    &[(1, 5000)],
-);
-
-e2e_i32!(
-    end_to_end_when_time_to_int_then_correct,
-    "
-PROGRAM main
-  VAR
-    t : TIME := T#2s;
-    result : INT;
-  END_VAR
-  result := TIME_TO_INT(t);
-END_PROGRAM
-",
-    &[(1, 2000)],
-);
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    assert!(bufs.vars[1].as_i32() as u32 > 0);
+}
 
 e2e_f32_near!(
     end_to_end_when_time_to_real_then_correct,
@@ -77,67 +72,3 @@ END_PROGRAM
 ",
     &[(1, 5000.0)],
 );
-
-#[test]
-fn end_to_end_when_date_to_dword_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    d : DATE := D#2024-06-15;
-    result : DWORD;
-  END_VAR
-  result := DATE_TO_DWORD(d);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    // DATE is stored as unsigned seconds since 1970-01-01
-    assert!(bufs.vars[1].as_i32() as u32 > 0);
-}
-
-#[test]
-fn end_to_end_when_date_to_udint_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    d : DATE := D#2024-06-15;
-    result : UDINT;
-  END_VAR
-  result := DATE_TO_UDINT(d);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    assert!(bufs.vars[1].as_i32() as u32 > 0);
-}
-
-#[test]
-fn end_to_end_when_tod_to_dword_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    t : TOD := TOD#12:30:00;
-    result : DWORD;
-  END_VAR
-  result := TOD_TO_DWORD(t);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    // TOD is stored as unsigned milliseconds since midnight
-    // 12:30:00 = 12*3600*1000 + 30*60*1000 = 45_000_000
-    assert_eq!(bufs.vars[1].as_i32() as u32, 45_000_000);
-}
-
-#[test]
-fn end_to_end_when_dt_to_dword_then_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    d : DT := DT#2024-06-15-12:30:00;
-    result : DWORD;
-  END_VAR
-  result := DT_TO_DWORD(d);
-END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(source, &CompilerOptions::default());
-    // DT is stored as unsigned seconds since 1970-01-01
-    assert!(bufs.vars[1].as_i32() as u32 > 0);
-}

--- a/compiler/codegen/tests/it/end_to_end_fb_ctd.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_ctd.rs
@@ -3,10 +3,10 @@
 //! These tests verify the complete pipeline: parse IEC 61131-3 source with
 //! a CTD function block instance, compile to bytecode, and execute on the VM.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::parse_and_run_rounds;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
 const CTD_PROGRAM: &str = "
 PROGRAM main
@@ -21,106 +21,7 @@ PROGRAM main
 END_PROGRAM
 ";
 
-/// Generates `n` rising edges on variable `var_idx` starting at `time_base`.
-fn pulse_n(vm: &mut ironplc_vm::VmRunning<'_>, var_idx: VarIndex, n: u64, time_base: u64) {
-    for i in 0..n {
-        vm.write_variable(var_idx, 1).unwrap();
-        vm.run_round(time_base + i * 2).unwrap();
-        vm.write_variable(var_idx, 0).unwrap();
-        vm.run_round(time_base + i * 2 + 1).unwrap();
-    }
-}
-
-#[test]
-fn end_to_end_when_ctd_not_loaded_then_q_is_true() {
-    // CV starts at 0, Q = (CV <= 0) should be TRUE
-    parse_and_run_rounds(CTD_PROGRAM, &CompilerOptions::default(), |vm| {
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q should be TRUE when CV <= 0"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctd_loaded_then_cv_equals_pv() {
-    parse_and_run_rounds(CTD_PROGRAM, &CompilerOptions::default(), |vm| {
-        vm.write_variable(VarIndex::new(2), 1).unwrap(); // LD = TRUE
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            3,
-            "CV should be PV (3) after load"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "Q should be FALSE when CV > 0"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctd_counts_to_zero_then_q_is_true() {
-    parse_and_run_rounds(CTD_PROGRAM, &CompilerOptions::default(), |vm| {
-        // Load PV
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(0).unwrap();
-        vm.write_variable(VarIndex::new(2), 0).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            3,
-            "CV should be 3 after load"
-        );
-
-        // Count down 3 times
-        pulse_n(vm, VarIndex::new(1), 3, 2);
-
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            0,
-            "CV should be 0 after 3 counts"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q should be TRUE when CV <= 0"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctd_above_zero_then_q_is_false() {
-    parse_and_run_rounds(CTD_PROGRAM, &CompilerOptions::default(), |vm| {
-        // Load PV=3
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(0).unwrap();
-        vm.write_variable(VarIndex::new(2), 0).unwrap();
-        vm.run_round(1).unwrap();
-
-        // Count down once (CV=2)
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(2).unwrap();
-
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "Q should be FALSE when CV > 0"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            2,
-            "CV should be 2"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctd_dint_variant_then_compiles_and_runs() {
-    let source = "
+const CTD_DINT_PROGRAM: &str = "
 PROGRAM main
   VAR
     counter : CTD_DINT;
@@ -130,12 +31,27 @@ PROGRAM main
   counter(CD := FALSE, LD := TRUE, PV := 10, Q => result, CV => count);
 END_PROGRAM
 ";
-    parse_and_run_rounds(source, &CompilerOptions::default(), |vm| {
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            10,
-            "CV should be 10 after load"
-        );
-    });
+
+#[rstest]
+// CV starts at 0, Q = (CV <= 0) is TRUE.
+#[case::not_loaded(CTD_PROGRAM, &[Run(0), Expect(3, 1)])]
+// LD loads CV=PV=3; Q FALSE because CV > 0.
+#[case::loaded(CTD_PROGRAM, &[
+    Write(2, 1), Run(0), Expect(4, 3), Expect(3, 0),
+])]
+// Load then count down 3 times to CV=0: Q TRUE.
+#[case::counts_to_zero(CTD_PROGRAM, &[
+    Write(2, 1), Run(0), Write(2, 0), Run(1), Expect(4, 3),
+    Pulse { var: 1, n: 3, time_base: 2 },
+    Expect(4, 0), Expect(3, 1),
+])]
+// Load then count down once to CV=2: Q FALSE.
+#[case::above_zero(CTD_PROGRAM, &[
+    Write(2, 1), Run(0), Write(2, 0), Run(1),
+    Write(1, 1), Run(2), Expect(3, 0), Expect(4, 2),
+])]
+// CTD_DINT variant compiles and runs; load sets CV=10.
+#[case::dint_variant(CTD_DINT_PROGRAM, &[Run(0), Expect(2, 10)])]
+fn end_to_end_fb_ctd(#[case] source: &str, #[case] steps: &[FbStep]) {
+    drive_fb(source, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_ctu.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_ctu.rs
@@ -3,11 +3,10 @@
 //! These tests verify the complete pipeline: parse IEC 61131-3 source with
 //! a CTU function block instance, compile to bytecode, and execute on the VM.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::parse_and_run;
-use crate::common::parse_and_run_rounds;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
 const CTU_PROGRAM: &str = "
 PROGRAM main
@@ -22,85 +21,7 @@ PROGRAM main
 END_PROGRAM
 ";
 
-/// Generates `n` rising edges on variable `var_idx` (pulse TRUE then FALSE).
-fn pulse_n(vm: &mut ironplc_vm::VmRunning<'_>, var_idx: VarIndex, n: u64) {
-    for i in 0..n {
-        vm.write_variable(var_idx, 1).unwrap();
-        vm.run_round(i * 2).unwrap();
-        vm.write_variable(var_idx, 0).unwrap();
-        vm.run_round(i * 2 + 1).unwrap();
-    }
-}
-
-#[test]
-fn end_to_end_when_ctu_not_triggered_then_q_is_false() {
-    let (_container, bufs) = parse_and_run(CTU_PROGRAM, &CompilerOptions::default());
-    assert_eq!(
-        bufs.vars[3].as_i32(),
-        0,
-        "Q should be FALSE when CU is FALSE"
-    );
-}
-
-#[test]
-fn end_to_end_when_ctu_counts_to_pv_then_q_is_true() {
-    parse_and_run_rounds(CTU_PROGRAM, &CompilerOptions::default(), |vm| {
-        pulse_n(vm, VarIndex::new(1), 3);
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q should be TRUE after 3 counts"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            3,
-            "CV should be 3"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctu_reset_then_cv_is_zero() {
-    parse_and_run_rounds(CTU_PROGRAM, &CompilerOptions::default(), |vm| {
-        pulse_n(vm, VarIndex::new(1), 2);
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            2,
-            "CV should be 2 after 2 pulses"
-        );
-
-        // Reset
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(4).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            0,
-            "CV should be 0 after reset"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "Q should be FALSE after reset"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctu_below_pv_then_q_is_false() {
-    parse_and_run_rounds(CTU_PROGRAM, &CompilerOptions::default(), |vm| {
-        pulse_n(vm, VarIndex::new(1), 2);
-        // PV=3, CV=2 => Q should be FALSE
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "Q should be FALSE when CV < PV"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctu_dint_variant_then_compiles_and_runs() {
-    let source = "
+const CTU_DINT_PROGRAM: &str = "
 PROGRAM main
   VAR
     counter : CTU_DINT;
@@ -110,17 +31,26 @@ PROGRAM main
   counter(CU := TRUE, R := FALSE, PV := 1, Q => result, CV => count);
 END_PROGRAM
 ";
-    parse_and_run_rounds(source, &CompilerOptions::default(), |vm| {
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Q should be TRUE"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "CV should be 1"
-        );
-    });
+
+#[rstest]
+// CU never pulses: Q stays FALSE.
+#[case::not_triggered(CTU_PROGRAM, &[Run(0), Expect(3, 0)])]
+// Three counts reach PV=3: Q TRUE, CV=3.
+#[case::counts_to_pv(CTU_PROGRAM, &[
+    Pulse { var: 1, n: 3, time_base: 0 },
+    Expect(3, 1), Expect(4, 3),
+])]
+// Reset zeroes CV and clears Q after two counts.
+#[case::reset(CTU_PROGRAM, &[
+    Pulse { var: 1, n: 2, time_base: 0 }, Expect(4, 2),
+    Write(2, 1), Run(4), Expect(4, 0), Expect(3, 0),
+])]
+// CV=2 < PV=3: Q FALSE.
+#[case::below_pv(CTU_PROGRAM, &[
+    Pulse { var: 1, n: 2, time_base: 0 }, Expect(3, 0),
+])]
+// CTU_DINT variant compiles and runs; one count reaches PV=1.
+#[case::dint_variant(CTU_DINT_PROGRAM, &[Run(0), Expect(1, 1), Expect(2, 1)])]
+fn end_to_end_fb_ctu(#[case] source: &str, #[case] steps: &[FbStep]) {
+    drive_fb(source, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_ctud.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_ctud.rs
@@ -3,11 +3,10 @@
 //! These tests verify the complete pipeline: parse IEC 61131-3 source with
 //! a CTUD function block instance, compile to bytecode, and execute on the VM.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::parse_and_run;
-use crate::common::parse_and_run_rounds;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
 const CTUD_PROGRAM: &str = "
 PROGRAM main
@@ -26,97 +25,7 @@ PROGRAM main
 END_PROGRAM
 ";
 
-/// Generates `n` rising edges on variable `var_idx` starting at `time_base`.
-fn pulse_n(vm: &mut ironplc_vm::VmRunning<'_>, var_idx: VarIndex, n: u64, time_base: u64) {
-    for i in 0..n {
-        vm.write_variable(var_idx, 1).unwrap();
-        vm.run_round(time_base + i * 2).unwrap();
-        vm.write_variable(var_idx, 0).unwrap();
-        vm.run_round(time_base + i * 2 + 1).unwrap();
-    }
-}
-
-#[test]
-fn end_to_end_when_ctud_not_triggered_then_outputs_at_defaults() {
-    // CV=0, PV=3: QU = (0 >= 3) = FALSE, QD = (0 <= 0) = TRUE
-    let (_container, bufs) = parse_and_run(CTUD_PROGRAM, &CompilerOptions::default());
-    assert_eq!(bufs.vars[5].as_i32(), 0, "QU should be FALSE");
-    assert_eq!(bufs.vars[6].as_i32(), 1, "QD should be TRUE (CV=0 <= 0)");
-}
-
-#[test]
-fn end_to_end_when_ctud_counts_up_to_pv_then_qu_is_true() {
-    parse_and_run_rounds(CTUD_PROGRAM, &CompilerOptions::default(), |vm| {
-        pulse_n(vm, VarIndex::new(1), 3, 0); // 3 rising edges on CU
-        assert_eq!(
-            vm.read_variable(VarIndex::new(7)).unwrap(),
-            3,
-            "CV should be 3"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(5)).unwrap(),
-            1,
-            "QU should be TRUE (CV >= PV)"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctud_counts_down_then_qd_is_true() {
-    parse_and_run_rounds(CTUD_PROGRAM, &CompilerOptions::default(), |vm| {
-        // CV starts at 0, counting down goes to -1
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(7)).unwrap(),
-            -1,
-            "CV should be -1"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(6)).unwrap(),
-            1,
-            "QD should be TRUE (CV <= 0)"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctud_reset_then_cv_is_zero() {
-    parse_and_run_rounds(CTUD_PROGRAM, &CompilerOptions::default(), |vm| {
-        pulse_n(vm, VarIndex::new(1), 2, 0); // Count up twice
-        assert_eq!(
-            vm.read_variable(VarIndex::new(7)).unwrap(),
-            2,
-            "CV should be 2 after 2 counts"
-        );
-
-        // Reset
-        vm.write_variable(VarIndex::new(3), 1).unwrap();
-        vm.run_round(4).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(7)).unwrap(),
-            0,
-            "CV should be 0 after reset"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctud_load_then_cv_equals_pv() {
-    parse_and_run_rounds(CTUD_PROGRAM, &CompilerOptions::default(), |vm| {
-        vm.write_variable(VarIndex::new(4), 1).unwrap(); // LD = TRUE
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(7)).unwrap(),
-            3,
-            "CV should be PV (3) after load"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_ctud_dint_variant_then_compiles_and_runs() {
-    let source = "
+const CTUD_DINT_PROGRAM: &str = "
 PROGRAM main
   VAR
     counter : CTUD_DINT;
@@ -126,17 +35,28 @@ PROGRAM main
   counter(CU := TRUE, CD := FALSE, R := FALSE, LD := FALSE, PV := 1, QU => qu_out, CV => cv_out);
 END_PROGRAM
 ";
-    parse_and_run_rounds(source, &CompilerOptions::default(), |vm| {
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "QU should be TRUE"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "CV should be 1"
-        );
-    });
+
+#[rstest]
+// CV=0, PV=3: QU = (0 >= 3) FALSE, QD = (0 <= 0) TRUE.
+#[case::not_triggered(CTUD_PROGRAM, &[Run(0), Expect(5, 0), Expect(6, 1)])]
+// Three up-counts reach PV: CV=3, QU TRUE.
+#[case::counts_up(CTUD_PROGRAM, &[
+    Pulse { var: 1, n: 3, time_base: 0 },
+    Expect(7, 3), Expect(5, 1),
+])]
+// One down-count from 0: CV=-1, QD TRUE.
+#[case::counts_down(CTUD_PROGRAM, &[
+    Write(2, 1), Run(0), Expect(7, -1), Expect(6, 1),
+])]
+// Reset zeroes CV after two up-counts.
+#[case::reset(CTUD_PROGRAM, &[
+    Pulse { var: 1, n: 2, time_base: 0 }, Expect(7, 2),
+    Write(3, 1), Run(4), Expect(7, 0),
+])]
+// Load sets CV=PV=3.
+#[case::load(CTUD_PROGRAM, &[Write(4, 1), Run(0), Expect(7, 3)])]
+// CTUD_DINT variant compiles and runs; one up-count reaches PV=1.
+#[case::dint_variant(CTUD_DINT_PROGRAM, &[Run(0), Expect(1, 1), Expect(2, 1)])]
+fn end_to_end_fb_ctud(#[case] source: &str, #[case] steps: &[FbStep]) {
+    drive_fb(source, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_f_trig.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_f_trig.rs
@@ -1,10 +1,9 @@
 //! End-to-end tests for F_TRIG (falling edge detector) function block.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::parse_and_run;
-use crate::common::parse_and_run_rounds;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
 const PROGRAM: &str = "
 PROGRAM main
@@ -17,76 +16,27 @@ PROGRAM main
 END_PROGRAM
 ";
 
-#[test]
-fn end_to_end_when_f_trig_clk_false_then_q_false() {
-    let (_container, bufs) = parse_and_run(PROGRAM, &CompilerOptions::default());
-    assert_eq!(bufs.vars[2].as_i32(), 0, "Q should be FALSE");
-}
-
-#[test]
-fn end_to_end_when_f_trig_falling_edge_then_q_true() {
-    parse_and_run_rounds(PROGRAM, &CompilerOptions::default(), |vm| {
-        // CLK=TRUE first
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q FALSE while CLK rising"
-        );
-        // Falling edge: CLK=FALSE
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE on falling edge"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_f_trig_clk_stays_false_then_q_false_next_scan() {
-    parse_and_run_rounds(PROGRAM, &CompilerOptions::default(), |vm| {
-        // CLK=TRUE then FALSE (falling edge)
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q TRUE on falling edge"
-        );
-        // CLK stays FALSE
-        vm.run_round(2).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE when CLK stays FALSE"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_f_trig_second_falling_edge_then_q_true_again() {
-    parse_and_run_rounds(PROGRAM, &CompilerOptions::default(), |vm| {
-        // First cycle: TRUE then FALSE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1);
-        // Second cycle: TRUE then FALSE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(2).unwrap();
-        assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0);
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(3).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE on second falling edge"
-        );
-    });
+#[rstest]
+// CLK stays FALSE across the first scan: no falling edge, Q FALSE.
+#[case::clk_false(&[Run(0), Expect(2, 0)])]
+// Falling edge on CLK: Q pulses TRUE for one scan.
+#[case::falling_edge(&[
+    Write(1, 1), Run(0), Expect(2, 0),
+    Write(1, 0), Run(1), Expect(2, 1),
+])]
+// CLK held FALSE after the edge: Q returns to FALSE on the next scan.
+#[case::clk_stays_false(&[
+    Write(1, 1), Run(0),
+    Write(1, 0), Run(1), Expect(2, 1),
+    Run(2), Expect(2, 0),
+])]
+// A second falling edge makes Q pulse TRUE again.
+#[case::second_falling_edge(&[
+    Write(1, 1), Run(0),
+    Write(1, 0), Run(1), Expect(2, 1),
+    Write(1, 1), Run(2), Expect(2, 0),
+    Write(1, 0), Run(3), Expect(2, 1),
+])]
+fn end_to_end_fb_f_trig(#[case] steps: &[FbStep]) {
+    drive_fb(PROGRAM, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_r_trig.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_r_trig.rs
@@ -1,10 +1,9 @@
 //! End-to-end tests for R_TRIG (rising edge detector) function block.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::parse_and_run;
-use crate::common::parse_and_run_rounds;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
 const PROGRAM: &str = "
 PROGRAM main
@@ -17,67 +16,19 @@ PROGRAM main
 END_PROGRAM
 ";
 
-#[test]
-fn end_to_end_when_r_trig_clk_false_then_q_false() {
-    let (_container, bufs) = parse_and_run(PROGRAM, &CompilerOptions::default());
-    assert_eq!(bufs.vars[2].as_i32(), 0, "Q should be FALSE");
-}
-
-#[test]
-fn end_to_end_when_r_trig_rising_edge_then_q_true() {
-    parse_and_run_rounds(PROGRAM, &CompilerOptions::default(), |vm| {
-        // First scan: CLK=FALSE
-        vm.run_round(0).unwrap();
-        // Rising edge: CLK=TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE on rising edge"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_r_trig_clk_stays_true_then_q_false_next_scan() {
-    parse_and_run_rounds(PROGRAM, &CompilerOptions::default(), |vm| {
-        // Rising edge
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q TRUE on rising edge"
-        );
-        // CLK stays TRUE — Q should return to FALSE
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE when CLK stays TRUE"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_r_trig_second_rising_edge_then_q_true_again() {
-    parse_and_run_rounds(PROGRAM, &CompilerOptions::default(), |vm| {
-        // First rising edge
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1);
-        // CLK falls
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0);
-        // Second rising edge
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(2).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE on second rising edge"
-        );
-    });
+#[rstest]
+// CLK stays FALSE across the first scan: no rising edge, Q FALSE.
+#[case::clk_false(&[Run(0), Expect(2, 0)])]
+// Rising edge on CLK: Q pulses TRUE for one scan.
+#[case::rising_edge(&[Run(0), Write(1, 1), Run(1), Expect(2, 1)])]
+// CLK held TRUE after the edge: Q returns to FALSE on the next scan.
+#[case::clk_stays_true(&[Write(1, 1), Run(0), Expect(2, 1), Run(1), Expect(2, 0)])]
+// A second rising edge (after CLK falls) makes Q pulse TRUE again.
+#[case::second_rising_edge(&[
+    Write(1, 1), Run(0), Expect(2, 1),
+    Write(1, 0), Run(1), Expect(2, 0),
+    Write(1, 1), Run(2), Expect(2, 1),
+])]
+fn end_to_end_fb_r_trig(#[case] steps: &[FbStep]) {
+    drive_fb(PROGRAM, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_rs.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_rs.rs
@@ -3,11 +3,10 @@
 //! These tests verify the complete pipeline: parse IEC 61131-3 source with
 //! an RS function block instance, compile to bytecode, and execute on the VM.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::parse_and_run;
-use crate::common::parse_and_run_rounds;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
 const RS_PROGRAM: &str = "
 PROGRAM main
@@ -21,69 +20,23 @@ PROGRAM main
 END_PROGRAM
 ";
 
-#[test]
-fn end_to_end_when_rs_both_false_then_q1_stays_false() {
-    let (_container, bufs) = parse_and_run(RS_PROGRAM, &CompilerOptions::default());
-    assert_eq!(bufs.vars[3].as_i32(), 0, "Q1 should be FALSE");
-}
-
-#[test]
-fn end_to_end_when_rs_set_then_q1_latches() {
-    parse_and_run_rounds(RS_PROGRAM, &CompilerOptions::default(), |vm| {
-        // Set S = TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q1 should be TRUE after set"
-        );
-
-        // Remove S, Q1 should latch (stay TRUE)
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q1 should stay TRUE (latched)"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_rs_reset_after_set_then_q1_is_false() {
-    parse_and_run_rounds(RS_PROGRAM, &CompilerOptions::default(), |vm| {
-        // Set
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q1 should be TRUE"
-        );
-
-        // Remove set, apply reset
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "Q1 should be FALSE after reset"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_rs_both_true_then_reset_dominates() {
-    parse_and_run_rounds(RS_PROGRAM, &CompilerOptions::default(), |vm| {
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "Q1 should be FALSE (reset dominates)"
-        );
-    });
+#[rstest]
+// Both inputs FALSE: Q1 stays FALSE.
+#[case::both_false(&[Run(0), Expect(3, 0)])]
+// S alone latches Q1 TRUE, and it stays TRUE after S is removed.
+#[case::set_latches(&[
+    Write(1, 1), Run(0), Expect(3, 1),
+    Write(1, 0), Run(1), Expect(3, 1),
+])]
+// Reset after set clears Q1.
+#[case::reset_after_set(&[
+    Write(1, 1), Run(0), Expect(3, 1),
+    Write(1, 0), Write(2, 1), Run(1), Expect(3, 0),
+])]
+// Both TRUE: reset dominates for RS, so Q1 is FALSE.
+#[case::both_true_reset_dominates(&[
+    Write(1, 1), Write(2, 1), Run(0), Expect(3, 0),
+])]
+fn end_to_end_fb_rs(#[case] steps: &[FbStep]) {
+    drive_fb(RS_PROGRAM, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_sr.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_sr.rs
@@ -3,11 +3,10 @@
 //! These tests verify the complete pipeline: parse IEC 61131-3 source with
 //! an SR function block instance, compile to bytecode, and execute on the VM.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::parse_and_run;
-use crate::common::parse_and_run_rounds;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
 const SR_PROGRAM: &str = "
 PROGRAM main
@@ -21,69 +20,23 @@ PROGRAM main
 END_PROGRAM
 ";
 
-#[test]
-fn end_to_end_when_sr_both_false_then_q1_stays_false() {
-    let (_container, bufs) = parse_and_run(SR_PROGRAM, &CompilerOptions::default());
-    assert_eq!(bufs.vars[3].as_i32(), 0, "Q1 should be FALSE");
-}
-
-#[test]
-fn end_to_end_when_sr_set_then_q1_latches() {
-    parse_and_run_rounds(SR_PROGRAM, &CompilerOptions::default(), |vm| {
-        // Set S1 = TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q1 should be TRUE after set"
-        );
-
-        // Remove S1, Q1 should latch (stay TRUE)
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q1 should stay TRUE (latched)"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_sr_reset_after_set_then_q1_is_false() {
-    parse_and_run_rounds(SR_PROGRAM, &CompilerOptions::default(), |vm| {
-        // Set
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q1 should be TRUE"
-        );
-
-        // Remove set, apply reset
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(1).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "Q1 should be FALSE after reset"
-        );
-    });
-}
-
-#[test]
-fn end_to_end_when_sr_both_true_then_set_dominates() {
-    parse_and_run_rounds(SR_PROGRAM, &CompilerOptions::default(), |vm| {
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "Q1 should be TRUE (set dominates)"
-        );
-    });
+#[rstest]
+// Both inputs FALSE: Q1 stays FALSE.
+#[case::both_false(&[Run(0), Expect(3, 0)])]
+// S1 alone latches Q1 TRUE, and it stays TRUE after S1 is removed.
+#[case::set_latches(&[
+    Write(1, 1), Run(0), Expect(3, 1),
+    Write(1, 0), Run(1), Expect(3, 1),
+])]
+// Reset after set clears Q1.
+#[case::reset_after_set(&[
+    Write(1, 1), Run(0), Expect(3, 1),
+    Write(1, 0), Write(2, 1), Run(1), Expect(3, 0),
+])]
+// Both TRUE: set dominates for SR, so Q1 is TRUE.
+#[case::both_true_set_dominates(&[
+    Write(1, 1), Write(2, 1), Run(0), Expect(3, 1),
+])]
+fn end_to_end_fb_sr(#[case] steps: &[FbStep]) {
+    drive_fb(SR_PROGRAM, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_tof.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_tof.rs
@@ -6,15 +6,13 @@
 //! TIME values are 32-bit signed integers in milliseconds.
 //! The VM cycle_time is in microseconds; timer intrinsics convert to ms internally.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::{parse_and_compile, VmBuffers};
-use ironplc_vm::test_support::load_and_start;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
-#[test]
-fn end_to_end_when_tof_in_true_then_q_is_true() {
-    let source = "
+// timer=var0, result=var1.
+const TOF_IN_TRUE: &str = "
 PROGRAM main
   VAR
     timer : TOF;
@@ -23,20 +21,9 @@ PROGRAM main
   timer(IN := TRUE, PT := T#5s, Q => result);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-        vm.run_round(0).unwrap();
-    }
 
-    // Q should be TRUE when IN is TRUE
-    assert_eq!(bufs.vars[1].as_i32(), 1);
-}
-
-#[test]
-fn end_to_end_when_tof_in_false_before_pt_then_q_is_true() {
-    let source = "
+// timer=var0, enable=var1, result=var2.
+const TOF_ENABLE: &str = "
 PROGRAM main
   VAR
     timer : TOF;
@@ -46,72 +33,9 @@ PROGRAM main
   timer(IN := enable, PT := T#5s, Q => result);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1 at t=0: enable=TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE when IN is TRUE"
-        );
-
-        // Round 2 at t=1s: enable=FALSE, falling edge starts timing
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1_000_000).unwrap();
-
-        // Round 3 at t=3s: 2s elapsed, still before PT (5s)
-        vm.run_round(3_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should still be TRUE during off-delay"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tof_in_false_after_pt_then_q_is_false() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TOF;
-    enable : BOOL;
-    result : BOOL;
-  END_VAR
-  timer(IN := enable, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1: enable=TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-
-        // Round 2: enable=FALSE, falling edge
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1_000_000).unwrap();
-
-        // Round 3 at t=7s: 6s elapsed > 5s PT, Q should be FALSE
-        vm.run_round(7_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE after PT elapsed"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tof_reads_et_then_elapsed_time_correct() {
-    let source = "
+// timer=var0, enable=var1, elapsed=var2.
+const TOF_ENABLE_ET: &str = "
 PROGRAM main
   VAR
     timer : TOF;
@@ -121,33 +45,9 @@ PROGRAM main
   timer(IN := enable, PT := T#10s, ET => elapsed);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1: enable=TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-
-        // Round 2: enable=FALSE, falling edge starts timing
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1_000_000).unwrap();
-
-        // Round 3 at t=4s: ET should be 3000 ms (3 seconds)
-        // elapsed is var[2] (timer=var[0], enable=var[1], elapsed=var[2])
-        vm.run_round(4_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            3000,
-            "ET should be 3000 ms (3 seconds)"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tof_in_rises_during_timing_then_resets() {
-    let source = "
+// timer=var0, enable=var1, result=var2, elapsed=var3.
+const TOF_ENABLE_Q_ET: &str = "
 PROGRAM main
   VAR
     timer : TOF;
@@ -158,106 +58,9 @@ PROGRAM main
   timer(IN := enable, PT := T#5s, Q => result, ET => elapsed);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1 at t=0: enable=TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE"
-        );
-
-        // Round 2 at t=1s: enable=FALSE, falling edge
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1_000_000).unwrap();
-
-        // Round 3 at t=3s: 2s elapsed, still timing
-        vm.run_round(3_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE during timing"
-        );
-
-        // Round 4 at t=4s: enable=TRUE again, reset
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(4_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "ET should be 0 after reset"
-        );
-
-        // Round 5 at t=5s: enable=FALSE again, new falling edge
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(5_000_000).unwrap();
-
-        // Round 6 at t=8s: 3s since new falling edge, still before PT
-        vm.run_round(8_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE, only 3s since new falling edge"
-        );
-
-        // Round 7 at t=11s: 6s since new falling edge, past PT
-        vm.run_round(11_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE, past PT since new falling edge"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tof_at_exact_pt_then_q_is_false() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TOF;
-    enable : BOOL;
-    result : BOOL;
-  END_VAR
-  timer(IN := enable, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1: enable=TRUE
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-
-        // Round 2 at t=1s: enable=FALSE, falling edge
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(1_000_000).unwrap();
-
-        // Round 3 at exactly t=6s: ET == PT (5s), Q should be FALSE
-        vm.run_round(6_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE when ET equals PT exactly"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_two_tof_timers_then_independent() {
-    let source = "
+// timer1=var0, timer2=var1, enable=var2, q1=var3, q2=var4.
+const TOF_TWO: &str = "
 PROGRAM main
   VAR
     timer1 : TOF;
@@ -270,53 +73,51 @@ PROGRAM main
   timer2(IN := enable, PT := T#7s, Q => q2);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1: enable=TRUE
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "q1 should be TRUE"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            1,
-            "q2 should be TRUE"
-        );
-
-        // Round 2 at t=1s: enable=FALSE, both start timing
-        vm.write_variable(VarIndex::new(2), 0).unwrap();
-        vm.run_round(1_000_000).unwrap();
-
-        // Round 3 at t=5s: timer1 (3s) done, timer2 (7s) still running
-        vm.run_round(5_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "q1 should be FALSE at t=5s"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            1,
-            "q2 should be TRUE at t=5s"
-        );
-
-        // Round 4 at t=9s: both done
-        vm.run_round(9_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "q1 should be FALSE at t=9s"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            0,
-            "q2 should be FALSE at t=9s"
-        );
-    }
+#[rstest]
+// IN TRUE: Q is TRUE immediately.
+#[case::in_true(TOF_IN_TRUE, &[Run(0), Expect(1, 1)])]
+// After the falling edge, Q stays TRUE while still within PT.
+#[case::in_false_before_pt(TOF_ENABLE, &[
+    Write(1, 1), Run(0), Expect(2, 1),
+    Write(1, 0), Run(1_000_000),
+    Run(3_000_000), Expect(2, 1),
+])]
+// Past PT after the falling edge: Q goes FALSE.
+#[case::in_false_after_pt(TOF_ENABLE, &[
+    Write(1, 1), Run(0),
+    Write(1, 0), Run(1_000_000),
+    Run(7_000_000), Expect(2, 0),
+])]
+// ET reports 3s of off-delay elapsed.
+#[case::reads_et(TOF_ENABLE_ET, &[
+    Write(1, 1), Run(0),
+    Write(1, 0), Run(1_000_000),
+    Run(4_000_000), Expect(2, 3000),
+])]
+// IN rising during timing resets; a new falling edge restarts the delay.
+#[case::in_rises_resets(TOF_ENABLE_Q_ET, &[
+    Write(1, 1), Run(0), Expect(2, 1),
+    Write(1, 0), Run(1_000_000),
+    Run(3_000_000), Expect(2, 1),
+    Write(1, 1), Run(4_000_000), Expect(2, 1), Expect(3, 0),
+    Write(1, 0), Run(5_000_000),
+    Run(8_000_000), Expect(2, 1),
+    Run(11_000_000), Expect(2, 0),
+])]
+// ET == PT exactly: Q is FALSE.
+#[case::at_exact_pt(TOF_ENABLE, &[
+    Write(1, 1), Run(0),
+    Write(1, 0), Run(1_000_000),
+    Run(6_000_000), Expect(2, 0),
+])]
+// Two TOF timers with different PT run independently.
+#[case::two_timers(TOF_TWO, &[
+    Write(2, 1), Run(0), Expect(3, 1), Expect(4, 1),
+    Write(2, 0), Run(1_000_000),
+    Run(5_000_000), Expect(3, 0), Expect(4, 1),
+    Run(9_000_000), Expect(3, 0), Expect(4, 0),
+])]
+fn end_to_end_fb_tof(#[case] source: &str, #[case] steps: &[FbStep]) {
+    drive_fb(source, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_ton.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_ton.rs
@@ -6,11 +6,187 @@
 //! TIME values are 32-bit signed integers in milliseconds.
 //! The VM cycle_time is in microseconds; timer intrinsics convert to ms internally.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::{parse_and_compile, VmBuffers};
-use ironplc_vm::test_support::load_and_start;
+use crate::common::{drive_fb, parse_and_compile, FbStep, FbStep::*};
+
+// Plain TIME variable (no timer): elapsed=var0.
+const TON_TIME_ONLY: &str = "
+PROGRAM main
+  VAR
+    elapsed : TIME;
+  END_VAR
+  elapsed := T#5s;
+END_PROGRAM
+";
+
+// timer=var0, result=var1, with IN wired FALSE.
+const TON_IN_FALSE: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    result : BOOL;
+  END_VAR
+  timer(IN := FALSE, PT := T#5s, Q => result);
+END_PROGRAM
+";
+
+// timer=var0, result=var1, with IN wired TRUE.
+const TON_IN_TRUE: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    result : BOOL;
+  END_VAR
+  timer(IN := TRUE, PT := T#5s, Q => result);
+END_PROGRAM
+";
+
+// timer=var0, elapsed=var1.
+const TON_ET: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    elapsed : TIME;
+  END_VAR
+  timer(IN := TRUE, PT := T#10s, ET => elapsed);
+END_PROGRAM
+";
+
+// timer=var0, enable=var1, result=var2, elapsed=var3.
+const TON_ENABLE: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    enable : BOOL;
+    result : BOOL;
+    elapsed : TIME;
+  END_VAR
+  timer(IN := enable, PT := T#5s, Q => result, ET => elapsed);
+END_PROGRAM
+";
+
+// timer1=var0, timer2=var1, q1=var2, q2=var3.
+const TON_TWO: &str = "
+PROGRAM main
+  VAR
+    timer1 : TON;
+    timer2 : TON;
+    q1 : BOOL;
+    q2 : BOOL;
+  END_VAR
+  timer1(IN := TRUE, PT := T#3s, Q => q1);
+  timer2(IN := TRUE, PT := T#7s, Q => q2);
+END_PROGRAM
+";
+
+// Dot-access read of Q: Button=var0, Buzzer=var1, PulseTimer=var2.
+const TON_DOT_READ_Q: &str = "
+PROGRAM main
+  VAR
+    Button : BOOL;
+    Buzzer : BOOL;
+    PulseTimer : TON;
+  END_VAR
+  PulseTimer(IN := NOT Button, PT := T#500ms);
+  Buzzer := PulseTimer.Q;
+END_PROGRAM
+";
+
+// Dot-access read of ET: timer=var0, elapsed=var1.
+const TON_DOT_READ_ET: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    elapsed : TIME;
+  END_VAR
+  timer(IN := TRUE, PT := T#10s);
+  elapsed := timer.ET;
+END_PROGRAM
+";
+
+// Dot-access writes of inputs, bare call, dot-access read: timer=var0, Buzzer=var1.
+const TON_DOT_WRITE_500MS: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    Buzzer : BOOL;
+  END_VAR
+  timer.IN := TRUE;
+  timer.PT := T#500ms;
+  timer();
+  Buzzer := timer.Q;
+END_PROGRAM
+";
+
+// Same as above but PT set to 2s via dot-access: timer=var0, Buzzer=var1.
+const TON_DOT_WRITE_2S: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    Buzzer : BOOL;
+  END_VAR
+  timer.IN := TRUE;
+  timer.PT := T#2s;
+  timer();
+  Buzzer := timer.Q;
+END_PROGRAM
+";
+
+#[rstest]
+// Plain TIME literal assignment: T#5s stored as 5000 ms (i32).
+#[case::time_value_i32_ms(TON_TIME_ONLY, &[Run(0), Expect(0, 5000)])]
+// IN FALSE: Q stays FALSE.
+#[case::not_triggered(TON_IN_FALSE, &[Run(0), Expect(1, 0)])]
+// Before PT elapses, Q is FALSE.
+#[case::triggered_before_pt(TON_IN_TRUE, &[
+    Run(0), Expect(1, 0), Run(2_000_000), Expect(1, 0),
+])]
+// After PT elapses, Q is TRUE.
+#[case::triggered_after_pt(TON_IN_TRUE, &[Run(0), Run(6_000_000), Expect(1, 1)])]
+// ET reports 3s of elapsed on-delay.
+#[case::reads_et(TON_ET, &[Run(0), Run(3_000_000), Expect(1, 3000)])]
+// IN dropping resets the timer, which then restarts from the new rising edge.
+#[case::in_reset_restarts(TON_ENABLE, &[
+    Write(1, 1), Run(0), Expect(2, 0),
+    Run(3_000_000), Expect(2, 0),
+    Write(1, 0), Run(4_000_000), Expect(2, 0), Expect(3, 0),
+    Write(1, 1), Run(6_000_000), Expect(2, 0),
+    Run(10_000_000), Expect(2, 0),
+    Run(12_000_000), Expect(2, 1),
+])]
+// ET == PT exactly: Q is TRUE.
+#[case::at_exact_pt(TON_IN_TRUE, &[Run(0), Run(5_000_000), Expect(1, 1)])]
+// Two TON timers with different PT run independently.
+#[case::two_timers(TON_TWO, &[
+    Run(0), Expect(2, 0), Expect(3, 0),
+    Run(4_000_000), Expect(2, 1), Expect(3, 0),
+    Run(8_000_000), Expect(2, 1), Expect(3, 1),
+])]
+// Dot-access read of Q returns TRUE after PT elapses.
+#[case::dot_access_reads_q_after_pt(TON_DOT_READ_Q, &[
+    Run(0), Expect(1, 0), Run(600_000), Expect(1, 1),
+])]
+// Dot-access read of Q stays FALSE before PT elapses.
+#[case::dot_access_reads_q_before_pt(TON_DOT_READ_Q, &[
+    Run(0), Run(100_000), Expect(1, 0),
+])]
+// Dot-access read of a non-BOOL field (ET) returns elapsed ms.
+#[case::dot_access_reads_et(TON_DOT_READ_ET, &[
+    Run(0), Run(3_000_000), Expect(1, 3000),
+])]
+// Dot-access writes of inputs + bare call + dot-access read of Q.
+#[case::dot_access_writes_inputs(TON_DOT_WRITE_500MS, &[
+    Run(0), Expect(1, 0), Run(600_000), Expect(1, 1),
+])]
+// Dot-access write of PT uses the new (longer) period.
+#[case::dot_access_writes_pt(TON_DOT_WRITE_2S, &[
+    Run(0), Run(1_000_000), Expect(1, 0), Run(3_000_000), Expect(1, 1),
+])]
+fn end_to_end_fb_ton(#[case] source: &str, #[case] steps: &[FbStep]) {
+    drive_fb(source, &CompilerOptions::default(), steps);
+}
 
 #[test]
 fn end_to_end_when_time_variable_then_debug_type_name_is_time() {
@@ -34,482 +210,4 @@ END_PROGRAM
         "TIME variable should have type_name TIME, got {}",
         elapsed_entry.type_name
     );
-}
-
-#[test]
-fn end_to_end_when_time_variable_then_value_is_i32_milliseconds() {
-    let source = "
-PROGRAM main
-  VAR
-    elapsed : TIME;
-  END_VAR
-  elapsed := T#5s;
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-        vm.run_round(0).unwrap();
-        // T#5s = 5000 milliseconds as i32
-        assert_eq!(
-            vm.read_variable(VarIndex::new(0)).unwrap(),
-            5000,
-            "TIME value should be 5000 ms"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_not_triggered_then_q_is_false() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    result : BOOL;
-  END_VAR
-  timer(IN := FALSE, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-        vm.run_round(0).unwrap();
-    }
-
-    // Q should be FALSE when IN is FALSE
-    assert_eq!(bufs.vars[1].as_i32(), 0);
-}
-
-#[test]
-fn end_to_end_when_ton_triggered_before_pt_then_q_is_false() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    result : BOOL;
-  END_VAR
-  timer(IN := TRUE, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0us: IN goes TRUE, starts timing
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Q should be FALSE before PT elapsed"
-        );
-
-        // Round 2 at t=2s (2_000_000 us): still before PT (5s = 5000 ms)
-        vm.run_round(2_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Q should still be FALSE at t=2s"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_triggered_after_pt_then_q_is_true() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    result : BOOL;
-  END_VAR
-  timer(IN := TRUE, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: IN goes TRUE, starts timing
-        vm.run_round(0).unwrap();
-
-        // Round 2 at t=6s: past PT (5s = 5000 ms), Q should be TRUE
-        vm.run_round(6_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Q should be TRUE after PT elapsed"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_reads_et_then_elapsed_time_correct() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    elapsed : TIME;
-  END_VAR
-  timer(IN := TRUE, PT := T#10s, ET => elapsed);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: IN goes TRUE, starts timing
-        vm.run_round(0).unwrap();
-
-        // Round 2 at t=3s: ET should be 3000 ms (i32)
-        vm.run_round(3_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            3000,
-            "ET should be 3000 ms (3 seconds)"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_in_reset_then_timer_restarts() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    enable : BOOL;
-    result : BOOL;
-    elapsed : TIME;
-  END_VAR
-  timer(IN := enable, PT := T#5s, Q => result, ET => elapsed);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: enable=TRUE, timer starts
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE"
-        );
-
-        // Round 2 at t=3s: still timing, not yet at PT
-        vm.run_round(3_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE at t=3s"
-        );
-
-        // Round 3 at t=4s: enable=FALSE, reset timer
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(4_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE after reset"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "ET should be 0 after reset"
-        );
-
-        // Round 4 at t=6s: enable=TRUE again, timer restarts from here
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(6_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE, timer just restarted"
-        );
-
-        // Round 5 at t=10s: only 4s since restart, not yet at PT (5s)
-        vm.run_round(10_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE, only 4s since restart"
-        );
-
-        // Round 6 at t=12s: 6s since restart, past PT (5s)
-        vm.run_round(12_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE, 6s since restart > PT"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_at_exact_pt_then_q_is_true() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    result : BOOL;
-  END_VAR
-  timer(IN := TRUE, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: IN goes TRUE, starts timing
-        vm.run_round(0).unwrap();
-
-        // Round 2 at exactly t=5s: ET == PT (5000 ms), Q should be TRUE
-        vm.run_round(5_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Q should be TRUE when ET equals PT exactly"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_two_ton_timers_then_independent() {
-    let source = "
-PROGRAM main
-  VAR
-    timer1 : TON;
-    timer2 : TON;
-    q1 : BOOL;
-    q2 : BOOL;
-  END_VAR
-  timer1(IN := TRUE, PT := T#3s, Q => q1);
-  timer2(IN := TRUE, PT := T#7s, Q => q2);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: both start
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "q1 should be FALSE"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "q2 should be FALSE"
-        );
-
-        // Round 2 at t=4s: timer1 (3s) done, timer2 (7s) still running
-        vm.run_round(4_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "q1 should be TRUE at t=4s"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "q2 should be FALSE at t=4s"
-        );
-
-        // Round 3 at t=8s: both done
-        vm.run_round(8_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "q1 should be TRUE at t=8s"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "q2 should be TRUE at t=8s"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_dot_access_reads_q_after_pt_then_true() {
-    // Reproduces the user's original program that previously failed codegen
-    // with P9999 "Variable 'PulseTimer' is not a structure".
-    let source = "
-PROGRAM main
-  VAR
-    Button : BOOL;
-    Buzzer : BOOL;
-    PulseTimer : TON;
-  END_VAR
-  PulseTimer(IN := NOT Button, PT := T#500ms);
-  Buzzer := PulseTimer.Q;
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Button stays FALSE → IN is TRUE. Start timing at t=0.
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Buzzer should be FALSE before PT elapsed"
-        );
-
-        // At t=600ms, past PT (500ms). Dot-access read should see Q = TRUE.
-        vm.run_round(600_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Buzzer should be TRUE via dot-access after PT elapsed"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_dot_access_reads_q_before_pt_then_false() {
-    let source = "
-PROGRAM main
-  VAR
-    Button : BOOL;
-    Buzzer : BOOL;
-    PulseTimer : TON;
-  END_VAR
-  PulseTimer(IN := NOT Button, PT := T#500ms);
-  Buzzer := PulseTimer.Q;
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        vm.run_round(0).unwrap();
-        // t=100ms: well before PT=500ms, Q must remain FALSE.
-        vm.run_round(100_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Buzzer should be FALSE via dot-access before PT elapsed"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_dot_access_reads_et_then_elapsed_time_correct() {
-    // Exercises dot-access on a non-BOOL field (ET is TIME/i32 ms).
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    elapsed : TIME;
-  END_VAR
-  timer(IN := TRUE, PT := T#10s);
-  elapsed := timer.ET;
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        vm.run_round(0).unwrap();
-        vm.run_round(3_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            3000,
-            "elapsed should be 3000 ms via dot-access"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_dot_access_writes_inputs_then_timer_runs() {
-    // Reproduces the issue's original program: writing TON inputs via
-    // dot-access, calling the FB bare, then reading Q via dot-access.
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    Buzzer : BOOL;
-  END_VAR
-  timer.IN := TRUE;
-  timer.PT := T#500ms;
-  timer();
-  Buzzer := timer.Q;
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round at t=0 latches the rising edge but Q is still FALSE.
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Buzzer should be FALSE before PT elapsed"
-        );
-
-        // At t=600ms, past PT (500ms): Q must be TRUE.
-        vm.run_round(600_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Buzzer should be TRUE via dot-access write+read after PT elapsed"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_ton_dot_access_writes_pt_then_uses_new_period() {
-    // Set PT via dot-access to a longer period and verify Q stays FALSE
-    // past the previous (shorter) PT but flips after the new threshold.
-    let source = "
-PROGRAM main
-  VAR
-    timer : TON;
-    Buzzer : BOOL;
-  END_VAR
-  timer.IN := TRUE;
-  timer.PT := T#2s;
-  timer();
-  Buzzer := timer.Q;
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        vm.run_round(0).unwrap();
-
-        // At t=1s: well before PT=2s, Q must remain FALSE.
-        vm.run_round(1_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Buzzer should be FALSE at t=1s with PT=2s"
-        );
-
-        // At t=3s: past PT=2s, Q must be TRUE.
-        vm.run_round(3_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Buzzer should be TRUE at t=3s with PT=2s"
-        );
-    }
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_tp.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_tp.rs
@@ -6,15 +6,13 @@
 //! TIME values are 32-bit signed integers in milliseconds.
 //! The VM cycle_time is in microseconds; timer intrinsics convert to ms internally.
 
-use ironplc_container::VarIndex;
 use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
 
-use crate::common::{parse_and_compile, VmBuffers};
-use ironplc_vm::test_support::load_and_start;
+use crate::common::{drive_fb, FbStep, FbStep::*};
 
-#[test]
-fn end_to_end_when_tp_triggered_then_q_is_true() {
-    let source = "
+// timer=var0, result=var1.
+const TP_IN_TRUE: &str = "
 PROGRAM main
   VAR
     timer : TP;
@@ -23,82 +21,9 @@ PROGRAM main
   timer(IN := TRUE, PT := T#5s, Q => result);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1 at t=0: IN goes TRUE, pulse starts, Q should be TRUE
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Q should be TRUE when pulse starts"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tp_before_pt_then_q_is_true() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TP;
-    result : BOOL;
-  END_VAR
-  timer(IN := TRUE, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: pulse starts
-        vm.run_round(0).unwrap();
-
-        // Round 2 at t=2s: still before PT (5s)
-        vm.run_round(2_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            1,
-            "Q should be TRUE at t=2s"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tp_after_pt_then_q_is_false() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TP;
-    result : BOOL;
-  END_VAR
-  timer(IN := TRUE, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: pulse starts
-        vm.run_round(0).unwrap();
-
-        // Round 2 at t=6s: past PT (5s), pulse expired
-        vm.run_round(6_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Q should be FALSE after PT elapsed"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tp_reads_et_then_elapsed_time_correct() {
-    let source = "
+// timer=var0, elapsed=var1.
+const TP_ET: &str = "
 PROGRAM main
   VAR
     timer : TP;
@@ -107,28 +32,9 @@ PROGRAM main
   timer(IN := TRUE, PT := T#10s, ET => elapsed);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1 at t=0: pulse starts
-        vm.run_round(0).unwrap();
-
-        // Round 2 at t=3s: ET should be 3000 ms (3 seconds)
-        vm.run_round(3_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            3000,
-            "ET should be 3000 ms (3 seconds)"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tp_in_falls_during_pulse_then_q_stays_true() {
-    // TP-specific: IN goes FALSE during pulse, but Q stays TRUE until PT expires.
-    let source = "
+// timer=var0, enable=var1, result=var2, elapsed=var3.
+const TP_ENABLE_Q_ET: &str = "
 PROGRAM main
   VAR
     timer : TP;
@@ -139,76 +45,9 @@ PROGRAM main
   timer(IN := enable, PT := T#5s, Q => result, ET => elapsed);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1 at t=0: enable=TRUE, pulse starts
-        vm.write_variable(VarIndex::new(1), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should be TRUE"
-        );
-
-        // Round 2 at t=2s: enable=FALSE, but pulse continues
-        vm.write_variable(VarIndex::new(1), 0).unwrap();
-        vm.run_round(2_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            1,
-            "Q should still be TRUE (pulse ignores IN)"
-        );
-
-        // Round 3 at t=6s: pulse expired
-        vm.run_round(6_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(2)).unwrap(),
-            0,
-            "Q should be FALSE after pulse expired"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            5000,
-            "ET should be clamped to PT (5000 ms)"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_tp_at_exact_pt_then_q_is_false() {
-    let source = "
-PROGRAM main
-  VAR
-    timer : TP;
-    result : BOOL;
-  END_VAR
-  timer(IN := TRUE, PT := T#5s, Q => result);
-END_PROGRAM
-";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
-
-        // Round 1 at t=0: pulse starts
-        vm.run_round(0).unwrap();
-
-        // Round 2 at exactly t=5s: ET == PT, pulse should end
-        vm.run_round(5_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(1)).unwrap(),
-            0,
-            "Q should be FALSE when ET equals PT exactly"
-        );
-    }
-}
-
-#[test]
-fn end_to_end_when_two_tp_timers_then_independent() {
-    let source = "
+// timer1=var0, timer2=var1, enable=var2, q1=var3, q2=var4.
+const TP_TWO: &str = "
 PROGRAM main
   VAR
     timer1 : TP;
@@ -221,53 +60,31 @@ PROGRAM main
   timer2(IN := enable, PT := T#7s, Q => q2);
 END_PROGRAM
 ";
-    let container = parse_and_compile(source, &CompilerOptions::default());
-    let mut bufs = VmBuffers::from_container(&container);
-    {
-        let mut vm = load_and_start(&container, &mut bufs).unwrap();
 
-        // Round 1 at t=0: enable=TRUE, both start pulsing
-        // enable is var index 2 (after timer1=0, timer2=1)
-        vm.write_variable(VarIndex::new(2), 1).unwrap();
-        vm.run_round(0).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            1,
-            "q1 should be TRUE"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            1,
-            "q2 should be TRUE"
-        );
-
-        // Drop enable so pulses don't retrigger after expiry
-        vm.write_variable(VarIndex::new(2), 0).unwrap();
-
-        // Round 2 at t=4s: timer1 (3s) pulse expired, timer2 (7s) still pulsing
-        vm.run_round(4_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "q1 should be FALSE at t=4s"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            1,
-            "q2 should be TRUE at t=4s"
-        );
-
-        // Round 3 at t=8s: both pulses expired
-        vm.run_round(8_000_000).unwrap();
-        assert_eq!(
-            vm.read_variable(VarIndex::new(3)).unwrap(),
-            0,
-            "q1 should be FALSE at t=8s"
-        );
-        assert_eq!(
-            vm.read_variable(VarIndex::new(4)).unwrap(),
-            0,
-            "q2 should be FALSE at t=8s"
-        );
-    }
+#[rstest]
+// Pulse starts on the rising edge: Q TRUE.
+#[case::triggered(TP_IN_TRUE, &[Run(0), Expect(1, 1)])]
+// Within PT the pulse stays TRUE.
+#[case::before_pt(TP_IN_TRUE, &[Run(0), Run(2_000_000), Expect(1, 1)])]
+// Past PT the pulse ends: Q FALSE.
+#[case::after_pt(TP_IN_TRUE, &[Run(0), Run(6_000_000), Expect(1, 0)])]
+// ET reports 3s of pulse elapsed.
+#[case::reads_et(TP_ET, &[Run(0), Run(3_000_000), Expect(1, 3000)])]
+// IN falling during the pulse does not cut it short; ET clamps to PT.
+#[case::in_falls_during_pulse(TP_ENABLE_Q_ET, &[
+    Write(1, 1), Run(0), Expect(2, 1),
+    Write(1, 0), Run(2_000_000), Expect(2, 1),
+    Run(6_000_000), Expect(2, 0), Expect(3, 5000),
+])]
+// ET == PT exactly: pulse has ended, Q FALSE.
+#[case::at_exact_pt(TP_IN_TRUE, &[Run(0), Run(5_000_000), Expect(1, 0)])]
+// Two TP timers with different PT run independently.
+#[case::two_timers(TP_TWO, &[
+    Write(2, 1), Run(0), Expect(3, 1), Expect(4, 1),
+    Write(2, 0),
+    Run(4_000_000), Expect(3, 0), Expect(4, 1),
+    Run(8_000_000), Expect(3, 0), Expect(4, 0),
+])]
+fn end_to_end_fb_tp(#[case] source: &str, #[case] steps: &[FbStep]) {
+    drive_fb(source, &CompilerOptions::default(), steps);
 }

--- a/compiler/codegen/tests/it/end_to_end_ldate.rs
+++ b/compiler/codegen/tests/it/end_to_end_ldate.rs
@@ -8,66 +8,54 @@
 //! - LTOD (LTIME_OF_DAY): stored as u64 milliseconds since midnight
 //! - LDT (LDATE_AND_TIME): stored as u64 seconds since 1970-01-01 00:00:00
 
-use crate::common::parse_and_run;
 use ironplc_parser::options::{CompilerOptions, Dialect};
+use rstest::rstest;
 
-#[test]
-fn end_to_end_when_ldate_assignment_then_value_is_i64_seconds_since_epoch() {
-    let source = "
+use crate::common::assert_run_i64_with;
+
+#[rstest]
+// LDATE#2024-01-01: 19723 days * 86400 = 1704067200 seconds since epoch.
+#[case::ldate_assignment(
+    "
 PROGRAM main
   VAR
     d : LDATE;
   END_VAR
   d := LDATE#2024-01-01;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    // 2024-01-01 is 19723 days after 1970-01-01 = 19723 * 86400 = 1704067200
-    assert_eq!(bufs.vars[0].as_i64() as u64, 1_704_067_200);
-}
-
-#[test]
-fn end_to_end_when_ltod_assignment_then_value_is_i64_milliseconds_since_midnight() {
-    let source = "
+",
+    0,
+    1_704_067_200
+)]
+// LTOD#12:30:00: 12h * 3600000 + 30m * 60000 = 45000000 ms since midnight.
+#[case::ltod_assignment(
+    "
 PROGRAM main
   VAR
     t : LTOD;
   END_VAR
   t := LTOD#12:30:00;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    // 12h * 3600000 + 30m * 60000 = 45000000 ms
-    assert_eq!(bufs.vars[0].as_i64() as u64, 45_000_000);
-}
-
-#[test]
-fn end_to_end_when_ldt_assignment_then_value_is_i64_seconds_since_epoch() {
-    let source = "
+",
+    0,
+    45_000_000
+)]
+// LDT#2024-01-01-12:30:00: 1704067200 + 45000 = 1704112200 seconds since epoch.
+#[case::ldt_assignment(
+    "
 PROGRAM main
   VAR
     my_dt : LDT;
   END_VAR
   my_dt := LDT#2024-01-01-12:30:00;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    // 1704067200 (date) + 12*3600 + 30*60 = 1704067200 + 45000 = 1704112200
-    assert_eq!(bufs.vars[0].as_i64() as u64, 1_704_112_200);
-}
-
-#[test]
-fn end_to_end_when_ldate_comparison_then_correct() {
-    let source = "
+",
+    0,
+    1_704_112_200
+)]
+// LDATE comparison (2024-06-15 > 2024-01-01 is TRUE).
+#[case::ldate_comparison(
+    "
 PROGRAM main
   VAR
     a : LDATE;
@@ -82,46 +70,40 @@ PROGRAM main
     result := 0;
   END_IF;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    assert_eq!(bufs.vars[2].as_i64(), 1);
-}
-
-#[test]
-fn end_to_end_when_ltod_with_long_form_type_name_then_correct() {
-    let source = "
+",
+    2,
+    1
+)]
+// LTIME_OF_DAY long-form type name: LTOD#18:00:00 = 64800000 ms.
+#[case::ltod_long_form(
+    "
 PROGRAM main
   VAR
     t : LTIME_OF_DAY;
   END_VAR
   t := LTOD#18:00:00;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    // 18h * 3600000 = 64800000 ms
-    assert_eq!(bufs.vars[0].as_i64() as u64, 64_800_000);
-}
-
-#[test]
-fn end_to_end_when_ldt_with_long_form_type_name_then_correct() {
-    let source = "
+",
+    0,
+    64_800_000
+)]
+// LDATE_AND_TIME long-form type name: 19723 days * 86400 = 1704067200 s.
+#[case::ldt_long_form(
+    "
 PROGRAM main
   VAR
     my_dt : LDATE_AND_TIME;
   END_VAR
   my_dt := LDT#2024-01-01-00:00:00;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
+",
+    0,
+    1_704_067_200
+)]
+fn end_to_end_ldate(#[case] source: &str, #[case] index: usize, #[case] expected: i64) {
+    assert_run_i64_with(
         source,
         &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
+        &[(index, expected)],
     );
-    // 19723 days * 86400 = 1704067200 seconds
-    assert_eq!(bufs.vars[0].as_i64() as u64, 1_704_067_200);
 }

--- a/compiler/codegen/tests/it/end_to_end_ltime.rs
+++ b/compiler/codegen/tests/it/end_to_end_ltime.rs
@@ -5,46 +5,41 @@
 //! Edition 3 (2013) feature that stores durations as 64-bit signed
 //! integers in milliseconds.
 
-use crate::common::parse_and_run;
 use ironplc_parser::options::{CompilerOptions, Dialect};
+use rstest::rstest;
 
-#[test]
-fn end_to_end_when_ltime_assignment_then_value_is_i64_milliseconds() {
-    let source = "
+use crate::common::assert_run_i64_with;
+
+#[rstest]
+// LTIME#100ms stored as 100 ms (i64).
+#[case::assignment_ms(
+    "
 PROGRAM main
   VAR
     t : LTIME;
   END_VAR
   t := LTIME#100ms;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    assert_eq!(bufs.vars[0].as_i64(), 100);
-}
-
-#[test]
-fn end_to_end_when_ltime_seconds_then_correct_milliseconds() {
-    let source = "
+",
+    0,
+    100
+)]
+// LTIME#5s stored as 5000 ms.
+#[case::seconds_to_ms(
+    "
 PROGRAM main
   VAR
     t : LTIME;
   END_VAR
   t := LTIME#5s;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    assert_eq!(bufs.vars[0].as_i64(), 5000);
-}
-
-#[test]
-fn end_to_end_when_ltime_addition_then_correct() {
-    let source = "
+",
+    0,
+    5000
+)]
+// Addition of two LTIME values (100ms + 200ms = 300ms).
+#[case::addition(
+    "
 PROGRAM main
   VAR
     a : LTIME;
@@ -55,17 +50,13 @@ PROGRAM main
   b := LTIME#200ms;
   c := a + b;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
-        source,
-        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
-    );
-    assert_eq!(bufs.vars[2].as_i64(), 300);
-}
-
-#[test]
-fn end_to_end_when_ltime_comparison_then_correct() {
-    let source = "
+",
+    2,
+    300
+)]
+// Comparison of two LTIME values (5s > 3s is TRUE).
+#[case::comparison(
+    "
 PROGRAM main
   VAR
     a : LTIME;
@@ -80,10 +71,14 @@ PROGRAM main
     result := 0;
   END_IF;
 END_PROGRAM
-";
-    let (_c, bufs) = parse_and_run(
+",
+    2,
+    1
+)]
+fn end_to_end_ltime(#[case] source: &str, #[case] index: usize, #[case] expected: i64) {
+    assert_run_i64_with(
         source,
         &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
+        &[(index, expected)],
     );
-    assert_eq!(bufs.vars[2].as_i64(), 1);
 }

--- a/compiler/parser/src/tests/dialect_flags.rs
+++ b/compiler/parser/src/tests/dialect_flags.rs
@@ -167,9 +167,15 @@ fn parse_with_dialect_flag_then_ok(
     assert!(result.is_ok());
 }
 
-#[test]
-fn parse_when_struct_without_trailing_semicolon_and_flag_disabled_then_err() {
-    let source = "TYPE MY_POINT :
+/// Dialect-flag rejection tests.
+///
+/// Each case: given a program that the default dialect rejects, parsing with
+/// the default (strict) options should fail because the corresponding
+/// `--allow-*` flag is not enabled; each row still runs as an
+/// individually-named test.
+#[rstest]
+#[case::struct_without_trailing_semicolon_and_flag_disabled(
+    "TYPE MY_POINT :
 STRUCT
     X : REAL;
     Y : REAL;
@@ -182,20 +188,17 @@ VAR
 END_VAR
     pt.X := 1.0;
     pt.Y := 2.0;
-END_PROGRAM";
-
-    let result = parse_program(source, &FileId::default(), &CompilerOptions::default());
-    assert!(result.is_err());
-}
-
-#[test]
-fn parse_when_empty_var_in_function_without_flag_then_error() {
-    let source = "
+END_PROGRAM"
+)]
+#[case::empty_var_in_function_without_flag(
+    "
 FUNCTION myFunc : INT
 VAR
 END_VAR
     myFunc := 1;
-END_FUNCTION";
+END_FUNCTION"
+)]
+fn parse_without_dialect_flag_then_err(#[case] source: &str) {
     let result = parse_program(source, &FileId::default(), &CompilerOptions::default());
     assert!(result.is_err());
 }

--- a/compiler/plc2plc/src/tests/reference_to.rs
+++ b/compiler/plc2plc/src/tests/reference_to.rs
@@ -1,6 +1,7 @@
 //! `REFERENCE TO` / dereference / NULL round-tripping.
 
 use super::common::*;
+use rstest::rstest;
 
 #[test]
 fn write_to_string_when_reference_to_then_round_trips() {
@@ -22,97 +23,92 @@ fn write_to_string_ref() {
     assert_eq!(rendered, expected);
 }
 
-#[test]
-fn write_to_string_when_ref_to_var_decl_then_preserves_ref_to() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
+/// Edition-3 render preserves the given reference-related fragment.
+///
+/// Each case parses a small program under the edition-3 dialect, renders it
+/// back to text, and checks the rendering contains the expected fragment.
+/// Collapses the single-`contains` reference round-trip tests into one table;
+/// each row still runs as an individually-named test.
+#[rstest]
+#[case::ref_to_var_decl(
+    "PROGRAM main
 VAR
     x : REF_TO INT;
 END_VAR
 END_PROGRAM",
-    );
-    assert!(
-        rendered.contains("REF_TO INT"),
-        "Expected REF_TO INT in output, got: {rendered}"
-    );
-}
-
-#[test]
-fn write_to_string_when_ref_to_array_var_decl_then_preserves_ref_to() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
+    "REF_TO INT"
+)]
+#[case::ref_to_array_var_decl(
+    "PROGRAM main
 VAR
     PT : REF_TO ARRAY[0..10] OF BYTE;
 END_VAR
 END_PROGRAM",
-    );
-    assert!(
-        rendered.contains("REF_TO ARRAY"),
-        "Expected REF_TO ARRAY in output, got: {rendered}"
-    );
-}
-
-#[test]
-fn write_to_string_when_ref_to_var_decl_with_null_init_then_preserves() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
+    "REF_TO ARRAY"
+)]
+#[case::ref_to_var_decl_with_null_init(
+    "PROGRAM main
 VAR
     x : REF_TO INT := NULL;
 END_VAR
 END_PROGRAM",
-    );
-    assert!(
-        rendered.contains("REF_TO INT := NULL"),
-        "Expected REF_TO INT := NULL in output, got: {rendered}"
-    );
-}
-
-#[test]
-fn write_to_string_when_ref_to_var_decl_with_ref_init_then_preserves() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
+    "REF_TO INT := NULL"
+)]
+#[case::ref_to_var_decl_with_ref_init(
+    "PROGRAM main
 VAR
     counter : INT;
     x : REF_TO INT := REF(counter);
 END_VAR
 END_PROGRAM",
-    );
-    assert!(
-        rendered.contains("REF_TO INT := REF("),
-        "Expected REF_TO INT := REF(...) in output, got: {rendered}"
-    );
-}
-
-#[test]
-fn write_to_string_when_deref_assign_then_preserves_caret() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
+    "REF_TO INT := REF("
+)]
+#[case::deref_assign(
+    "PROGRAM main
 VAR
     myRef : REF_TO INT;
 END_VAR
     myRef^ := 42;
 END_PROGRAM",
-    );
-    assert!(
-        rendered.contains("myRef^ :="),
-        "Expected myRef^ := in output, got: {rendered}"
-    );
-}
-
-#[test]
-fn write_to_string_when_deref_expression_then_preserves_caret() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
+    "myRef^ :="
+)]
+#[case::deref_expression(
+    "PROGRAM main
 VAR
     myRef : REF_TO INT;
     value : INT;
 END_VAR
     value := myRef^;
 END_PROGRAM",
-    );
+    "myRef ^"
+)]
+#[case::ref_expression(
+    "PROGRAM main
+VAR
+    counter : INT;
+    x : REF_TO INT;
+END_VAR
+    x := REF(counter);
+END_PROGRAM",
+    "REF("
+)]
+#[case::null_expression(
+    "PROGRAM main
+VAR
+    x : REF_TO INT;
+END_VAR
+    x := NULL;
+END_PROGRAM",
+    "NULL"
+)]
+fn write_to_string_when_reference_source_then_preserves(
+    #[case] source: &str,
+    #[case] needle: &str,
+) {
+    let rendered = parse_and_render_edition3(source);
     assert!(
-        rendered.contains("myRef ^"),
-        "Expected myRef ^ in output, got: {rendered}"
+        rendered.contains(needle),
+        "Expected {needle} in output, got: {rendered}"
     );
 }
 
@@ -133,39 +129,6 @@ END_FUNCTION",
     assert!(
         rendered.contains("[ 0 ]"),
         "Expected array subscript in output, got: {rendered}"
-    );
-}
-
-#[test]
-fn write_to_string_when_ref_expression_then_preserves() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
-VAR
-    counter : INT;
-    x : REF_TO INT;
-END_VAR
-    x := REF(counter);
-END_PROGRAM",
-    );
-    assert!(
-        rendered.contains("REF("),
-        "Expected REF( in output, got: {rendered}"
-    );
-}
-
-#[test]
-fn write_to_string_when_null_expression_then_preserves() {
-    let rendered = parse_and_render_edition3(
-        "PROGRAM main
-VAR
-    x : REF_TO INT;
-END_VAR
-    x := NULL;
-END_PROGRAM",
-    );
-    assert!(
-        rendered.contains("NULL"),
-        "Expected NULL in output, got: {rendered}"
     );
 }
 

--- a/compiler/vm/tests/it/execute_array_ops.rs
+++ b/compiler/vm/tests/it/execute_array_ops.rs
@@ -3,6 +3,7 @@ use ironplc_container::opcode;
 use ironplc_container::ContainerBuilder;
 use ironplc_container::VarIndex;
 use ironplc_vm::error::Trap;
+use rstest::rstest;
 
 /// Helper: builds a container with one array variable at var[0].
 ///
@@ -55,67 +56,56 @@ fn array_container(
         .build()
 }
 
-#[test]
-fn execute_when_store_array_then_load_array_roundtrips_i32() {
-    // Store 42 at index 2, then load from index 2 into var[1].
+/// Store `value` at `index`, then load it back into var[1] and confirm the
+/// value round-trips. Each case shares the same bytecode shape and differs only
+/// by array size, stored value, and index (constant[0] = value, constant[1] =
+/// index); each row still runs as an individually-named test.
+#[rstest]
+#[case::roundtrips_index_2(5, 42, 2)]
+#[case::index_0(3, 99, 0)]
+#[case::last_valid_index(5, 77, 4)]
+fn execute_when_store_array_then_load_array_roundtrips_i32(
+    #[case] total_elements: u32,
+    #[case] value: i32,
+    #[case] index: i32,
+) {
     #[rustfmt::skip]
     let bytecode: Vec<u8> = vec![
         // STORE_ARRAY: push value, push index, STORE_ARRAY var[0] desc[0]
-        opcode::LOAD_CONST_I32, 0x00, 0x00,    // push 42 (constant[0])
-        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push 2 (constant[1] = index)
-        opcode::STORE_ARRAY,    0x00, 0x00,     // var_index=0, desc_index=0
-                                0x00, 0x00,
+        opcode::LOAD_CONST_I32, 0x00, 0x00,    // push value (constant[0])
+        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push index (constant[1])
+        opcode::STORE_ARRAY,    0x00, 0x00, 0x00, 0x00,
 
         // LOAD_ARRAY: push index, LOAD_ARRAY var[0] desc[0]
-        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push 2 (index)
-        opcode::LOAD_ARRAY,     0x00, 0x00,     // var_index=0, desc_index=0
-                                0x00, 0x00,
+        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push index
+        opcode::LOAD_ARRAY,     0x00, 0x00, 0x00, 0x00,
 
         // Store result to var[1]
         opcode::STORE_VAR_I32,  0x01, 0x00,
         opcode::RET_VOID,
     ];
-    let c = array_container(&bytecode, 5, &[42, 2]);
+    let c = array_container(&bytecode, total_elements, &[value, index]);
     let mut b = VmBuffers::from_container(&c);
     let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
     vm.run_round(0).unwrap();
 
-    assert_eq!(vm.read_variable(VarIndex::new(1)).unwrap(), 42);
+    assert_eq!(vm.read_variable(VarIndex::new(1)).unwrap(), value);
 }
 
-#[test]
-fn execute_when_store_array_at_index_0_then_loads_correctly() {
-    // Store 99 at index 0, then load from index 0.
+/// Loading at an out-of-bounds index traps. Both cases share the load-only
+/// bytecode shape (constant[0] = index) against a 5-element array and differ
+/// only by the offending index.
+#[rstest]
+#[case::negative_index(-1)]
+#[case::index_equals_size(5)]
+fn execute_when_load_array_out_of_bounds_then_trap(#[case] index: i32) {
     #[rustfmt::skip]
     let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_I32, 0x00, 0x00,    // push 99
-        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push 0 (index)
-        opcode::STORE_ARRAY,    0x00, 0x00, 0x00, 0x00,
-
-        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push 0 (index)
-        opcode::LOAD_ARRAY,     0x00, 0x00, 0x00, 0x00,
-
-        opcode::STORE_VAR_I32,  0x01, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = array_container(&bytecode, 3, &[99, 0]);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    assert_eq!(vm.read_variable(VarIndex::new(1)).unwrap(), 99);
-}
-
-#[test]
-fn execute_when_load_array_negative_index_then_trap() {
-    // Push index -1, LOAD_ARRAY => should trap.
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_I32, 0x00, 0x00,    // push -1 (index)
+        opcode::LOAD_CONST_I32, 0x00, 0x00,    // push index
         opcode::LOAD_ARRAY,     0x00, 0x00, 0x00, 0x00,
         opcode::RET_VOID,
     ];
-    let c = array_container(&bytecode, 5, &[-1]);
+    let c = array_container(&bytecode, 5, &[index]);
     let mut b = VmBuffers::from_container(&c);
     let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
     let err = vm.run_round(0).unwrap_err();
@@ -124,31 +114,7 @@ fn execute_when_load_array_negative_index_then_trap() {
         err.trap,
         Trap::ArrayIndexOutOfBounds {
             var_index: ironplc_container::VarIndex::new(0),
-            index: -1,
-            total_elements: 5,
-        }
-    );
-}
-
-#[test]
-fn execute_when_load_array_index_equals_size_then_trap() {
-    // Push index 5 for an array of 5 elements => out of bounds.
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_I32, 0x00, 0x00,    // push 5 (index)
-        opcode::LOAD_ARRAY,     0x00, 0x00, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = array_container(&bytecode, 5, &[5]);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    let err = vm.run_round(0).unwrap_err();
-
-    assert_eq!(
-        err.trap,
-        Trap::ArrayIndexOutOfBounds {
-            var_index: ironplc_container::VarIndex::new(0),
-            index: 5,
+            index,
             total_elements: 5,
         }
     );
@@ -177,29 +143,6 @@ fn execute_when_store_array_negative_index_then_trap() {
             total_elements: 5,
         }
     );
-}
-
-#[test]
-fn execute_when_store_array_at_last_valid_index_then_succeeds() {
-    // Store at index 4 (last valid) for array of 5 elements.
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_I32, 0x00, 0x00,    // push 77
-        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push 4 (index)
-        opcode::STORE_ARRAY,    0x00, 0x00, 0x00, 0x00,
-
-        opcode::LOAD_CONST_I32, 0x01, 0x00,    // push 4 (index)
-        opcode::LOAD_ARRAY,     0x00, 0x00, 0x00, 0x00,
-
-        opcode::STORE_VAR_I32,  0x01, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = array_container(&bytecode, 5, &[77, 4]);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    assert_eq!(vm.read_variable(VarIndex::new(1)).unwrap(), 77);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #1325 and #1327, targeting the remaining test-code clusters that `cargo dupes` still flagged. Test-inclusive exact duplication drops **19.7% → 17.9%** (~2,760 fewer lines). Coverage is held (production `src` missed lines 4,972 → 4,973, within proptest noise; the full `just` pipeline passes the 85% floor).

Mechanism is rstest parametrization throughout — collapsing the repeated per-variant/per-scenario scaffold into `#[case]` tables, preserving every input. (Property subsumption was deliberately avoided here: the remaining conversions have no clean oracle — IEC rounding, decimal formatting, BCD, reinterpret casts.)

### Conversions
`conv_bool_to_int`, `conv_int_widening`, `conv_int_narrowing`, `conv_real_to_int`, `conv_string`, `conv_time_date`, `bcd` — the declare/assign/convert/assert boilerplate collapsed into rstest tables. Kept the float-result and roundtrip tests (distinct assertion shape) separate.

### Function-block timers/counters
Added an `FbStep` enum + `drive_fb` helper to `codegen/tests/it/common/mod.rs` that wraps the repeated multi-round VM-driving scaffold. Every TON/TOF/TP/CTU/CTD/CTUD/R_TRIG/F_TRIG/RS/SR scenario is now a `&[FbStep]` case. Also collapsed `ltime`/`ldate` into tables, and deleted 5 same-path `codegen_max_call_depth` tests — keeping the CALL and FB_CALL edge-wiring representatives, since the depth algorithm itself is exhaustively unit-tested in `codegen/src/call_graph.rs`. (codegen `it`: 1058 → 1053.)

### Non-codegen
`plc2plc` `reference_to` render tests (12 → 5 fns), `vm` `execute_array_ops` (7 → 4), `analyzer` `rule_pou_hierarchy` duplicate-name (4 → 1) and `rule_function_call_type_check` cross-family-widening flag tests (7 → 2), and the `parser` `dialect_flags` negative cases. Tests whose context or assertion shape genuinely differs (`parse_only` vs resolved semantic context, AST-inspection) were left as-is.

## Not touched
- The 178 build-enforced `#[spec_test(REQ_…)]` conformance tests.
- Codegen `compile_*.rs` bytecode-golden tests (the opcode-selection deletion lever) — intentionally kept.
- Parser literal/duration tests (parser is the oracle) and other AST-inspection tests.

## Verification
- `cd compiler && just` — compile + coverage (≥ 85%) + lint + dupes all green.
- Every parametrized cluster preserves its full set of input cases; runtime counts are unchanged except the intended `max_call_depth` deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019vU1G5crSM1YNDgbq8upHQ)_