### PR TITLE
refactor(dsl): replace hand-written Located::span impls with a derive macro

### DIFF
--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 
-use dsl_macro_derive::Recurse;
+use dsl_macro_derive::{Located, Recurse};
 
 use crate::configuration::{ConfigurationDeclaration, Direction};
 use crate::core::{Id, Located, SourceSpan};
@@ -98,19 +98,14 @@ impl fmt::Display for Boolean {
 
 /// Integer liberal. The representation is of the largest possible integer
 /// and later bound to smaller types depend on context.
-#[derive(Debug, Clone, PartialEq, Recurse)]
+#[derive(Debug, Clone, PartialEq, Recurse, Located)]
 pub struct Integer {
+    #[located(position)]
     pub span: SourceSpan,
     /// The value in the maximum possible size. An integer is inherently
     /// an unsigned value.
     #[recurse(ignore)]
     pub value: u128,
-}
-
-impl Located for Integer {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 #[derive(Debug)]
@@ -603,8 +598,9 @@ impl fmt::Display for BitStringLiteral {
 /// Types are all identifiers but we use a separate structure
 /// because it is convenient to treat types and other identifiers
 /// separately.
-#[derive(Clone, Debug, PartialEq, Recurse)]
+#[derive(Clone, Debug, PartialEq, Recurse, Located)]
 pub struct TypeName {
+    #[located(delegate)]
     pub name: Id,
 }
 
@@ -626,12 +622,6 @@ impl Eq for TypeName {}
 impl Hash for TypeName {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name.hash(state);
-    }
-}
-
-impl Located for TypeName {
-    fn span(&self) -> SourceSpan {
-        self.name.span()
     }
 }
 
@@ -1917,9 +1907,10 @@ pub fn next_block_id() -> BlockId {
 /// Variable declaration.
 ///
 /// See section 2.4.3.
-#[derive(Clone, Debug, Recurse)]
+#[derive(Clone, Debug, Recurse, Located)]
 pub struct VarDecl {
     // Not all variable types have a "name", so the name is part of the type.
+    #[located(delegate)]
     pub identifier: VariableIdentifier,
     #[recurse(ignore)]
     pub var_type: VariableType,
@@ -1942,12 +1933,6 @@ impl PartialEq for VarDecl {
             && self.var_type == other.var_type
             && self.qualifier == other.qualifier
             && self.initializer == other.initializer
-    }
-}
-
-impl Located for VarDecl {
-    fn span(&self) -> SourceSpan {
-        self.identifier.span()
     }
 }
 
@@ -2305,17 +2290,12 @@ impl Display for VariableIdentifier {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Recurse)]
+#[derive(Clone, Debug, PartialEq, Recurse, Located)]
 pub struct DirectVariableIdentifier {
     pub name: Option<Id>,
     pub address_assignment: AddressAssignment,
+    #[located(position)]
     pub span: SourceSpan,
-}
-
-impl Located for DirectVariableIdentifier {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 /// Qualifier types for definitions.
@@ -2557,7 +2537,7 @@ pub struct SimpleExprInitializer {
 /// Provides the initialization of a string variable declaration.
 ///
 /// See sections 2.4.3.1 and 2.4.3.2.
-#[derive(Clone, PartialEq, Debug, Recurse)]
+#[derive(Clone, PartialEq, Debug, Recurse, Located)]
 pub struct StringInitializer {
     /// Maximum length of the string.
     pub length: Option<IntegerRef>,
@@ -2569,13 +2549,8 @@ pub struct StringInitializer {
     #[recurse(ignore)]
     pub initial_value: Option<Vec<char>>,
 
+    #[located(position)]
     pub keyword_span: SourceSpan,
-}
-
-impl Located for StringInitializer {
-    fn span(&self) -> SourceSpan {
-        self.keyword_span.clone()
-    }
 }
 
 impl StringInitializer {
@@ -2769,12 +2744,13 @@ impl HasVariables for FunctionDeclaration {
 /// and variables retain values between invocations.
 ///
 /// See section 2.5.2.
-#[derive(Clone, Debug, PartialEq, Recurse)]
+#[derive(Clone, Debug, PartialEq, Recurse, Located)]
 pub struct FunctionBlockDeclaration {
     pub name: TypeName,
     pub variables: Vec<VarDecl>,
     pub edge_variables: Vec<EdgeVarDecl>,
     pub body: FunctionBlockBodyKind,
+    #[located(position)]
     pub span: SourceSpan,
     /// Object-oriented facet (OOP extension).
     ///
@@ -2789,12 +2765,6 @@ pub struct FunctionBlockDeclaration {
 impl HasVariables for FunctionBlockDeclaration {
     fn variables(&self) -> &Vec<VarDecl> {
         &self.variables
-    }
-}
-
-impl Located for FunctionBlockDeclaration {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
     }
 }
 

--- a/compiler/dsl/src/core.rs
+++ b/compiler/dsl/src/core.rs
@@ -8,7 +8,7 @@ use std::{hash::Hash, hash::Hasher};
 
 use crate::fold::Fold;
 use crate::visitor::Visitor;
-use dsl_macro_derive::Recurse;
+use dsl_macro_derive::{Located, Recurse};
 
 // Static singletons for common FileId values to avoid repeated allocations.
 // This is particularly beneficial for test code which frequently uses FileId::default(),
@@ -178,12 +178,13 @@ pub trait Located {
 /// and can use containers as appropriate.
 ///
 /// See section 2.1.2.
-#[derive(Recurse)]
+#[derive(Recurse, Located)]
 pub struct Id {
     #[recurse(ignore)]
     pub original: String,
     #[recurse(ignore)]
     pub lower_case: String,
+    #[located(position)]
     pub span: SourceSpan,
 }
 
@@ -243,15 +244,67 @@ impl fmt::Display for Id {
     }
 }
 
-impl Located for Id {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Uses `#[located(position)]` on a `SourceSpan` field so the derived
+    /// `span` clones that field.
+    #[derive(Located)]
+    struct PositionNode {
+        #[located(position)]
+        span: SourceSpan,
+    }
+
+    /// Uses `#[located(delegate)]` on a sub-node so the derived `span`
+    /// delegates to the sub-node's `span`.
+    #[derive(Located)]
+    struct DelegateNode {
+        #[located(delegate)]
+        inner: Id,
+    }
+
+    /// Uses the default rule: no attribute but a field named `position`.
+    #[derive(Located)]
+    struct DefaultPositionNode {
+        position: SourceSpan,
+    }
+
+    #[test]
+    fn span_when_position_attribute_then_clones_field() {
+        let node = PositionNode {
+            span: SourceSpan::range(3, 7),
+        };
+
+        let span = node.span();
+
+        assert_eq!(span.start, 3);
+        assert_eq!(span.end, 7);
+    }
+
+    #[test]
+    fn span_when_delegate_attribute_then_delegates_to_field() {
+        let node = DelegateNode {
+            inner: Id::from("example").with_position(SourceSpan::range(5, 9)),
+        };
+
+        let span = node.span();
+
+        assert_eq!(span.start, 5);
+        assert_eq!(span.end, 9);
+    }
+
+    #[test]
+    fn span_when_no_attribute_and_position_field_then_clones_position() {
+        let node = DefaultPositionNode {
+            position: SourceSpan::range(2, 4),
+        };
+
+        let span = node.span();
+
+        assert_eq!(span.start, 2);
+        assert_eq!(span.end, 4);
+    }
 
     #[test]
     fn file_id_when_clone_then_same_underlying_data() {

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -10,7 +10,7 @@ use std::fmt;
 
 use crate::fold::Fold;
 use crate::visitor::Visitor;
-use dsl_macro_derive::Recurse;
+use dsl_macro_derive::{Located, Recurse};
 
 /// A body of a function bock (one of the possible types).
 ///
@@ -131,8 +131,9 @@ impl Variable {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct NamedVariable {
+    #[located(delegate)]
     pub name: Id,
 }
 
@@ -142,15 +143,10 @@ impl fmt::Display for NamedVariable {
     }
 }
 
-impl Located for NamedVariable {
-    fn span(&self) -> SourceSpan {
-        self.name.span()
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct ArrayVariable {
     /// The variable that is being accessed by subscript (the array).
+    #[located(delegate)]
     pub subscripted_variable: Box<SymbolicVariableKind>,
     /// The ordered set of subscripts. These should be expressions that
     /// evaluate to an index.
@@ -167,12 +163,6 @@ impl fmt::Display for ArrayVariable {
             write!(f, "{subscript}")?;
         }
         write!(f, "]")
-    }
-}
-
-impl Located for ArrayVariable {
-    fn span(&self) -> SourceSpan {
-        self.subscripted_variable.as_ref().span()
     }
 }
 
@@ -283,9 +273,10 @@ impl Located for PartialAccessVariable {
 /// accessed (e.g., `PT^[0]` or `PT^.field`).
 ///
 /// See section B.1.4.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct DerefVariable {
     /// The variable being dereferenced.
+    #[located(delegate)]
     pub variable: Box<SymbolicVariableKind>,
 }
 
@@ -295,28 +286,16 @@ impl fmt::Display for DerefVariable {
     }
 }
 
-impl Located for DerefVariable {
-    fn span(&self) -> SourceSpan {
-        self.variable.span()
-    }
-}
-
 /// Function block invocation.
 ///
 /// See section 3.2.3.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct FbCall {
     /// Name of the variable that is associated with the function block
     /// call.
     pub var_name: Id,
     pub params: Vec<ParamAssignmentKind>,
     pub position: SourceSpan,
-}
-
-impl Located for FbCall {
-    fn span(&self) -> SourceSpan {
-        self.position.clone()
-    }
 }
 
 /// A binary expression that produces a Boolean result by comparing operands.
@@ -380,8 +359,9 @@ impl fmt::Display for LateBound {
 ///
 /// The `resolved_type` field is populated by a later analysis pass. During
 /// parsing and initial construction, it is always `None`.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct Expr {
+    #[located(delegate)]
     pub kind: ExprKind,
     #[recurse(ignore)]
     pub resolved_type: Option<TypeName>,
@@ -408,12 +388,6 @@ impl Expr {
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.kind)
-    }
-}
-
-impl Located for Expr {
-    fn span(&self) -> SourceSpan {
-        self.kind.span()
     }
 }
 
@@ -825,7 +799,7 @@ impl StmtKind {
 /// Assigns a variable as the evaluation of an expression.
 ///
 /// See section 3.3.2.1.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct Assignment {
     pub target: Variable,
     #[recurse(ignore)]
@@ -838,31 +812,21 @@ pub struct Assignment {
     #[recurse(ignore)]
     pub ref_bind: bool,
     pub value: Expr,
+    #[located(position)]
     pub span: SourceSpan,
-}
-
-impl Located for Assignment {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 /// If selection statement.
 ///
 /// See section 3.3.2.3.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct If {
     pub expr: Expr,
     pub body: Vec<StmtKind>,
     pub else_ifs: Vec<ElseIf>,
     pub else_body: Vec<StmtKind>,
+    #[located(position)]
     pub span: SourceSpan,
-}
-
-impl Located for If {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Recurse)]
@@ -874,19 +838,14 @@ pub struct ElseIf {
 /// Case selection statement.
 ///
 /// See section 3.3.2.3.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct Case {
     /// An expression, the result of which is used to select a particular case.
     pub selector: Expr,
     pub statement_groups: Vec<CaseStatementGroup>,
     pub else_body: Vec<StmtKind>,
+    #[located(position)]
     pub span: SourceSpan,
-}
-
-impl Located for Case {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 /// A group of statements that can be selected within a case.
@@ -915,7 +874,7 @@ pub enum CaseSelectionKind {
 /// The for loop statement.
 ///
 /// See section 3.3.2.4.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct For {
     /// The variable that is assigned and contains the value for each loop iteration.
     pub control: Id,
@@ -923,45 +882,30 @@ pub struct For {
     pub to: Expr,
     pub step: Option<Expr>,
     pub body: Vec<StmtKind>,
+    #[located(position)]
     pub span: SourceSpan,
-}
-
-impl Located for For {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 /// The while loop statement.
 ///
 /// See section 3.3.2.4.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct While {
     pub condition: Expr,
     pub body: Vec<StmtKind>,
+    #[located(position)]
     pub span: SourceSpan,
-}
-
-impl Located for While {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 /// The repeat loop statement.
 ///
 /// See section 3.3.2.4.
-#[derive(Debug, PartialEq, Clone, Recurse)]
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct Repeat {
     pub until: Expr,
     pub body: Vec<StmtKind>,
+    #[located(position)]
     pub span: SourceSpan,
-}
-
-impl Located for Repeat {
-    fn span(&self) -> SourceSpan {
-        self.span.clone()
-    }
 }
 
 #[cfg(test)]

--- a/compiler/dsl_macro_derive/src/lib.rs
+++ b/compiler/dsl_macro_derive/src/lib.rs
@@ -79,6 +79,135 @@ pub fn recurse_macro_derive(input: TokenStream) -> TokenStream {
     visit_res
 }
 
+/// Derives an implementation of the `Located` trait for a struct.
+///
+/// The generated `span` method returns a `SourceSpan` derived from one of the
+/// struct's fields. Which field (and how) is selected as follows:
+///
+/// 1. A field marked `#[located(position)]` is treated as a `SourceSpan`
+///    field, generating `self.<field>.clone()`.
+/// 2. A field marked `#[located(delegate)]` is treated as a sub-node that
+///    itself implements `Located`, generating `self.<field>.span()`.
+/// 3. With no attribute, the struct must have a field named `position`, and
+///    the body becomes `self.position.clone()`.
+///
+/// Only structs with named fields are supported. Types whose span requires
+/// real logic (combining spans, matching over variants, etc.) must implement
+/// `Located` by hand.
+#[proc_macro_derive(Located, attributes(located))]
+pub fn located_macro_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    expand_located(&ast).unwrap_or_else(|err| err.to_compile_error().into())
+}
+
+/// Selects how a field contributes to the derived `span` implementation.
+enum LocatedKind {
+    /// The field is a `SourceSpan`; clone it.
+    Position,
+    /// The field is a sub-node implementing `Located`; delegate to it.
+    Delegate,
+}
+
+/// Returns a stream of tokens that implement `Located` for the given type.
+fn expand_located(ast: &DeriveInput) -> Result<TokenStream> {
+    let name = &ast.ident;
+
+    let fields = match &ast.data {
+        syn::Data::Struct(data_struct) => match &data_struct.fields {
+            syn::Fields::Named(named_fields) => named_fields,
+            _ => {
+                return Err(Error::new(
+                    ast.span(),
+                    "#[derive(Located)] is only supported for structs with named fields",
+                ))
+            }
+        },
+        _ => {
+            return Err(Error::new(
+                ast.span(),
+                "#[derive(Located)] is only supported for structs with named fields",
+            ))
+        }
+    };
+
+    let body = located_body(fields)?;
+
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let gen = quote! {
+        impl #impl_generics crate::core::Located for #name #ty_generics #where_clause {
+            fn span(&self) -> crate::core::SourceSpan {
+                #body
+            }
+        }
+    };
+
+    Ok(gen.into())
+}
+
+/// Returns the body of the derived `span` method for the given fields.
+fn located_body(fields: &FieldsNamed) -> Result<proc_macro2::TokenStream> {
+    // Collect every field that carries a `#[located(...)]` attribute.
+    let mut annotated: Vec<(&Ident, LocatedKind)> = Vec::new();
+    for field in &fields.named {
+        if let Some(kind) = located_field_kind(field)? {
+            let ident = field
+                .ident
+                .as_ref()
+                .expect("named field always has an identifier");
+            annotated.push((ident, kind));
+        }
+    }
+
+    match annotated.as_slice() {
+        // No attribute: fall back to a field named `position`.
+        [] => {
+            let has_position = fields
+                .named
+                .iter()
+                .any(|f| f.ident.as_ref().is_some_and(|i| i == "position"));
+            if has_position {
+                Ok(quote! { self.position.clone() })
+            } else {
+                Err(Error::new(
+                    fields.span(),
+                    "#[derive(Located)] requires a field named `position` or a field annotated \
+                     with #[located(position)] or #[located(delegate)]",
+                ))
+            }
+        }
+        [(ident, kind)] => match kind {
+            LocatedKind::Position => Ok(quote! { self.#ident.clone() }),
+            LocatedKind::Delegate => Ok(quote! { self.#ident.span() }),
+        },
+        _ => Err(Error::new(
+            fields.span(),
+            "#[derive(Located)] permits at most one #[located(...)] field attribute",
+        )),
+    }
+}
+
+/// Returns the `Located` kind requested by a field's `#[located(...)]`
+/// attribute, or `None` when the field carries no such attribute.
+fn located_field_kind(field: &Field) -> Result<Option<LocatedKind>> {
+    let mut kind = None;
+    for attr in &field.attrs {
+        if attr.path().is_ident("located") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("position") {
+                    kind = Some(LocatedKind::Position);
+                    return Ok(());
+                }
+                if meta.path.is_ident("delegate") {
+                    kind = Some(LocatedKind::Delegate);
+                    return Ok(());
+                }
+                Err(meta.error("unrecognized value in located; expected `position` or `delegate`"))
+            })?;
+        }
+    }
+    Ok(kind)
+}
+
 /// Returns a stream of tokens that implement recursive visit for an enumeration.
 fn expand_enum_recurse_visit(name: &Ident, data_enum: &DataEnum) -> Result<TokenStream> {
     // Generate the matcher and dispatch for each variant


### PR DESCRIPTION
## Summary

The most-duplicated genuine-source pattern in the DSL crate was the trivial three-line `impl Located for X { fn span(&self) -> SourceSpan { ... } }` block, repeated across `core.rs`, `common.rs`, and `textual.rs` in two shapes:

- `self.<field>.clone()` where `<field>` is a `SourceSpan`
- `self.<field>.span()` delegating to a sub-node

This PR adds a `#[derive(Located)]` proc-macro to the existing `dsl_macro_derive` crate and uses it to remove those hand-written impls, leaving only the impls that contain real logic (variant matching, `SourceSpan::join`/`join2`, first/last spanning) hand-written.

## The derive

`#[derive(Located)]` supports two field attributes plus a default:

- `#[located(position)]` on a `SourceSpan` field → generates `self.<field>.clone()`
- `#[located(delegate)]` on a sub-node field → generates `self.<field>.span()` (auto-derefs through `Box`)
- No attribute → if a field named `position` exists, generates `self.position.clone()`

The generated impl references the trait/type by full path (`crate::core::Located` / `crate::core::SourceSpan`), mirroring how the sibling `Recurse` derive resolves paths, so it works from within the `dsl` crate. Misuse (non-struct, no annotation and no `position` field, more than one attribute, unknown attribute value) produces a compile error via `syn::Error`.

## Files changed

- `compiler/dsl_macro_derive/src/lib.rs` — new `Located` derive macro (`expand_located`, `located_body`, `located_field_kind`) plus doc comments.
- `compiler/dsl/src/core.rs` — derive `Located` on `Id`; three unit tests covering the `position`, `delegate`, and default-`position` shapes.
- `compiler/dsl/src/common.rs` — derive on `Integer`, `TypeName`, `VarDecl`, `DirectVariableIdentifier`, `StringInitializer`, `FunctionBlockDeclaration`.
- `compiler/dsl/src/textual.rs` — derive on `NamedVariable`, `ArrayVariable`, `DerefVariable`, `FbCall`, `Expr`, `Assignment`, `If`, `Case`, `For`, `While`, `Repeat`.

## Left hand-written (real logic, unchanged)

`ConstantKind`, `LateBoundDeclaration`, `EnumeratedValue`, `VariableIdentifier`, `EnumeratedValuesInitializer`, `InterfaceDeclaration`, `SymbolicVariableKind`, `Variable`, `StructuredVariable`, `BitAccessVariable`, `PartialAccessVariable`, `ExprKind`, `StmtKind` — these match over enum variants or combine multiple spans.

## Behavior

Behavior-preserving: every generated `span()` returns exactly what the removed impl returned.

## Duplication (`cargo dupes stats --exclude-tests`)

- Before: 13.6% exact, 3.0% near
- After: 13.4% exact, 3.0% near

## Validation

Full CI pipeline (`just`: compile, coverage ≥85%, clippy, fmt-check, dupes gate) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4gKeGoC5KyBnPSUJgxkmn

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4gKeGoC5KyBnPSUJgxkmn)_