### PR TITLE
docs: ADR-0042 (library functions over intrinsics) + plan for compatibility-library bindings

### DIFF
--- a/specs/adrs/0042-library-functions-over-compiler-intrinsics.md
+++ b/specs/adrs/0042-library-functions-over-compiler-intrinsics.md
@@ -1,0 +1,181 @@
+# Library Functions Over Compiler Intrinsics
+
+status: proposed
+date: 2026-08-08
+
+## Context and Problem Statement
+
+IronPLC now has two ways to make a callable function name resolve:
+
+1. **Compiler-provided (intrinsic).** The compiler seeds the name into the
+   function environment (`analyzer/src/intermediates/stdlib_function.rs`) and
+   codegen lowers calls to a `BUILTIN func_id` executed natively by the VM
+   ([ADR-0008](0008-unified-builtin-opcode.md)). The name exists in every
+   compilation (or behind an `--allow-*` flag), with no on-disk artifact.
+2. **Library-provided.** A [compatibility library](../design/compatibility-libraries.md)
+   — on-disk data (manifest + `.st` declarations) — declares the name under its
+   exact vendor spelling. The name resolves only when the library is activated
+   (project reference or `--library`), and the body is ordinary IEC 61131-3
+   source compiled like user code.
+
+Recent contributions added vendor functions (Beckhoff `Tc2_Math`'s `LTRUNC`,
+`LMOD`, `MODABS`; `BOOL_TO_STRING`; `Tc2_Utilities`' `LREAL_TO_FMTSTR`) as
+compiler intrinsics behind new per-family `--allow-*` flags. Review rejected
+that shape, but the criteria were implicit. When someone proposes a new
+function, which mechanism must it use?
+
+## Decision Drivers
+
+* **No IronPLC dialect** ([ADR-0036](0036-no-ironplc-dialect.md)) — an
+  always-on vendor name would create a configuration no real toolchain accepts
+* **Scalability** — vendor runtimes define hundreds of functions; per-function
+  compiler tables and flags do not scale, libraries-as-data do
+* **Auditability and provenance** — library content carries manifest
+  `references` and the clean-room authoring record
+  ([authoring policy](../steering/compatibility-library-authoring.md));
+  compiler tables carry neither
+* **Wire-format stability** — every `BUILTIN` func_id is a permanent
+  compiler/VM ABI commitment pinned by wire-format tests; ST bodies are not
+* **Behavioral fidelity** — some semantics (hardware access, IEEE-754
+  operations like floating truncation/modulo) cannot be expressed in IEC
+  61131-3 source and require a native implementation
+* **Simplicity of contribution** — adding an ST function to a library touches
+  no Rust; adding an intrinsic touches the analyzer, codegen, VM,
+  disassembler, and wire-format tests
+
+## Considered Options
+
+* Compiler intrinsics for any function a target dialect provides, gated by
+  `--allow-*` flags per function family
+* Library functions for everything, including the IEC 61131-3 standard surface
+* Compiler intrinsics only for the IEC 61131-3 standard surface and for
+  behavior that cannot be a function; libraries for everything else
+
+## Decision Outcome
+
+Chosen option: "Compiler intrinsics only for the IEC 61131-3 standard surface
+and for behavior that cannot be a function; libraries for everything else."
+
+The rule, in order of application to a proposed function name:
+
+1. **Vendor-defined names are always library functions.** If the name comes
+   from a vendor runtime rather than IEC 61131-3, it ships in a compatibility
+   library — never in the compiler's tables, never behind an `--allow-*` flag.
+   (`--allow-*` flags gate *syntax*, not callable names — see the
+   [glossary](../steering/glossary.md) dialect/vendor distinction.)
+2. **Expressible bodies are ST bodies.** A library function whose semantics
+   can be written in IEC 61131-3 source gets an ST body in the library. This
+   is the default and preferred implementation medium (it is also the
+   preferred clean-room medium per the authoring policy).
+3. **Native implementations require inexpressibility.** Only when the
+   semantics cannot be expressed in IEC 61131-3 source — IEEE-754 operations
+   with no source-level equivalent, hardware access, compile-time knowledge —
+   may the implementation be native. For a *vendor* name, the native
+   implementation is an **unnamed VM builtin** reached exclusively through the
+   library's manifest binding (see
+   [Compatibility Library Format](../design/compatibility-library-format.md));
+   the builtin adds no name to any scope, so the library remains the only way
+   to call it. For a *standard* name, the compiler seeds the name and lowers
+   to the builtin directly — this is the only case that adds to the compiler's
+   function tables.
+4. **Function-like operators are the dialect axis, not functions.** Constructs
+   that parse as calls but require compiler cooperation no function could have
+   (`SIZEOF`'s compile-time type knowledge, `ADR`'s address-of) are syntax
+   extensions: gated by `--allow-*` flags per the
+   [syntax support guide](../steering/syntax-support-guide.md), implemented in
+   the compiler because they *cannot* be library functions.
+
+Existing compiler-seeded standard functions are conformant (they are IEC
+61131-3 surface) and are not migrated. The rule governs additions.
+
+### Consequences
+
+* Good, because the compiler's out-of-the-box surface stays exactly the IEC
+  61131-3 standard plus flag-gated syntax — no de-facto IronPLC dialect
+* Good, because vendor function proposals become library PRs (data + ST +
+  provenance), reviewable without compiler expertise and scalable to hundreds
+  of functions
+* Good, because a function like `BOOL_TO_STRING` — trivially expressible as
+  `IF IN THEN BOOL_TO_STRING := 'TRUE'; ...` — costs no func_id, no VM arm,
+  no wire-format entry, and no permanent ABI commitment
+* Good, because the scarce resources ([ADR-0033](0033-opcode-encoding-by-class-and-type.md)
+  op-class slots, func_id space, compiler table entries) are spent only where
+  inexpressibility forces it
+* Bad, because a library ST body is interpreted bytecode, slower than a native
+  builtin — acceptable until profiling shows otherwise, and revisable per
+  function by adding a binding without changing the library's interface
+* Bad, because "cannot be expressed in IEC 61131-3 source" requires judgment;
+  the review checklist below is the tiebreaker
+
+### Confirmation
+
+For each new callable name in a PR, review confirms:
+
+1. Vendor name → it appears only under `compiler/sources/resources/libs/`,
+   with manifest `references`; no new entry in `stdlib_function.rs`, no new
+   `--allow-*` flag.
+2. ST-expressible → the body is ST; no new func_id exists for it.
+3. Native → the PR demonstrates inexpressibility (what IEC 61131-3 construct
+   is missing), and for vendor names the func_id is reachable only via a
+   manifest binding (no compiler-seeded name resolves to it).
+
+## Pros and Cons of the Options
+
+### Compiler intrinsics per target dialect, gated by `--allow-*` flags
+
+Each vendor function family gets a flag (e.g. `--allow-extended-math-functions`)
+and entries in the compiler's function tables.
+
+* Good, because it reuses the existing `SIZEOF` conditional-seeding pattern
+  with no new mechanism
+* Bad, because flags gate syntax, not runtime surface — a flag per function
+  family conflates the dialect and vendor axes the glossary separates
+* Bad, because it does not scale: hundreds of vendor functions means hundreds
+  of table entries, func_ids, and VM arms, all permanent ABI
+* Bad, because activation would not match how real projects work — a TwinCAT
+  project states its libraries in `.plcproj`; it does not pass compiler flags
+* Bad, because compiler tables carry no provenance record, weakening the
+  clean-room story
+
+### Library functions for everything, including the standard surface
+
+Ship the IEC 61131-3 standard functions themselves as a bundled library.
+
+* Good, because one mechanism serves everything
+* Bad, because the standard surface is the compiler's contract
+  ([ADR-0036](0036-no-ironplc-dialect.md)): it must exist in every
+  compilation with no activation step, which is precisely what libraries
+  are designed not to do
+* Bad, because many standard functions are generic over `ANY_*` categories,
+  which IEC 61131-3 source cannot declare — they would need bindings for
+  nearly every entry, gaining nothing over compiler tables
+* Bad, because it would churn the entire existing, tested stdlib for no
+  behavioral gain
+
+### Intrinsics only for the standard surface and the inexpressible (chosen)
+
+* Good, for the reasons in the decision outcome
+* Neutral, because the boundary case — a standard-defined function that is
+  also trivially expressible — defaults to the cheaper medium (ST in a
+  library, or an ST-bodied addition later if the standard surface demands
+  unconditional availability); the review checklist decides
+* Bad, because two mechanisms coexist and contributors must pick — mitigated
+  by the four-step rule being mechanical for the common cases
+
+## More Information
+
+* [ADR-0003](0003-plc-standard-function-blocks-as-intrinsics.md) — the same
+  principle for function blocks: intrinsics are a VM dispatch detail behind
+  exact type IDs, never an instruction-set or language-surface feature
+* [ADR-0008](0008-unified-builtin-opcode.md) — `BUILTIN func_id` is the single
+  lowering target for native functions; new functions never add opcodes
+* [Compatibility Libraries](../design/compatibility-libraries.md) — the
+  library mechanism, its portability promise, and the bindings future goal
+  this ADR's rule 3 relies on
+* Worked examples under this rule: `LTRUNC`/`LMOD` (vendor, IEEE-754
+  truncation/modulo inexpressible in ST → library POUs bound to unnamed VM
+  builtins); `MODABS` (vendor, math-dictated from `LMOD` → library ST body);
+  `BOOL_TO_STRING` (expressible → library ST body); `LREAL_TO_FMTSTR`
+  (vendor, native formatting not yet built → library declare-only, calls
+  fail compile); `ADR`/`SIZEOF` (function-like operators → dialect axis,
+  `--allow-*` flags)

--- a/specs/adrs/0042-library-functions-over-compiler-intrinsics.md
+++ b/specs/adrs/0042-library-functions-over-compiler-intrinsics.md
@@ -26,8 +26,20 @@ function, which mechanism must it use?
 
 ## Decision Drivers
 
-* **No IronPLC dialect** ([ADR-0036](0036-no-ironplc-dialect.md)) — an
-  always-on vendor name would create a configuration no real toolchain accepts
+* **Compatibility** — the library mechanism's promise is that a name is in
+  scope exactly when the corresponding real-world library is activated, so
+  code that compiles in IronPLC also compiles in the environment it targets.
+  An always-on vendor name in the compiler breaks that promise in both
+  directions. (Dialect — syntax, [ADR-0036](0036-no-ironplc-dialect.md) — is
+  a separate axis: IronPLC has no dialect of its own, but it may well ship
+  its own libraries; the manifest format already admits `vendor = "IronPLC"`.
+  What is decided is that such names arrive *as libraries*, with the same
+  activation model, never as unconditional compiler names.)
+* **Per-vendor behavior divergence** — different vendors give the same
+  function name different signatures or behavior (TwinCAT's `FLOOR` takes
+  `LREAL`, unlike base IEC; rounding and edge-case conventions differ). A
+  library captures each vendor's behavior in that vendor's package; a single
+  compiler intrinsic would have to pick one vendor's behavior for everyone
 * **Scalability** — vendor runtimes define hundreds of functions; per-function
   compiler tables and flags do not scale, libraries-as-data do
 * **Auditability and provenance** — library content carries manifest
@@ -36,12 +48,16 @@ function, which mechanism must it use?
   compiler tables carry neither
 * **Wire-format stability** — every `BUILTIN` func_id is a permanent
   compiler/VM ABI commitment pinned by wire-format tests; ST bodies are not
-* **Behavioral fidelity** — some semantics (hardware access, IEEE-754
-  operations like floating truncation/modulo) cannot be expressed in IEC
-  61131-3 source and require a native implementation
+* **Behavioral fidelity** — some semantics cannot be expressed in IEC 61131-3
+  source at all and require a native implementation; the inexpressible set is
+  small and enumerable (see *What IEC 61131-3 source cannot express* below)
 * **Simplicity of contribution** — adding an ST function to a library touches
   no Rust; adding an intrinsic touches the analyzer, codegen, VM,
   disassembler, and wire-format tests
+* **Testability** — the trade-off runs the other way: an intrinsic is
+  directly unit-testable in Rust, while a library ST body is testable only
+  end-to-end (activate → compile → run in the VM). Choosing libraries
+  obligates the project to keep that end-to-end harness cheap to use
 
 ## Considered Options
 
@@ -104,8 +120,14 @@ Existing compiler-seeded standard functions are conformant (they are IEC
 * Bad, because a library ST body is interpreted bytecode, slower than a native
   builtin — acceptable until profiling shows otherwise, and revisable per
   function by adding a binding without changing the library's interface
+* Bad, because library functions are harder to test than intrinsics: an
+  intrinsic gets a direct Rust unit test, while a library body is exercised
+  only through the full activate → compile → VM-run path — mitigated by the
+  existing end-to-end test harness (`codegen/tests/it/`) and conformance
+  tests that load every bundled library
 * Bad, because "cannot be expressed in IEC 61131-3 source" requires judgment;
-  the review checklist below is the tiebreaker
+  *What IEC 61131-3 source cannot express* below bounds the categories, and
+  the review checklist is the tiebreaker
 
 ### Confirmation
 
@@ -163,6 +185,43 @@ Ship the IEC 61131-3 standard functions themselves as a bundled library.
   by the four-step rule being mechanical for the common cases
 
 ## More Information
+
+### What IEC 61131-3 source cannot express
+
+The set of behaviors that genuinely cannot be written as an ST function body
+is small and falls into four categories. Anything outside them is expressible
+— "laborious to write in ST" is not inexpressible, and defaults to an ST body.
+
+1. **Arithmetic primitives absent from the operator/stdlib surface.**
+   LREAL-preserving truncation (`TRUNC` clamps to `ANY_INT`, so the fractional
+   cut cannot be taken without leaving `LREAL`'s range guarantees) and
+   floating modulo (`MOD` is integer-only). These two are the motivating
+   builtins here (`trunc_lreal`, `fmod_lreal`) — and once they exist, the
+   category is essentially closed: `MODABS`, `FRAC`, `CEIL`, `FLOOR`, and
+   round-half-away variants are all math-dictated compositions of them.
+2. **Bit-level reinterpretation across type families.** Reading an `LREAL`'s
+   bits as a `LWORD` (or back) without numeric conversion has no ST
+   construct. Needed by checksum, serialization, and float-inspection
+   functions some vendor libraries provide.
+3. **Compile-time knowledge.** `SIZEOF`, `ADR`/`BITADR`/`INDEXOF`, and any
+   type/layout introspection require the compiler's symbol and layout tables.
+   These are not functions at all — they are function-like operators on the
+   dialect axis (rule 4).
+4. **Runtime-service access.** Wall-clock and system time, hardware I/O,
+   file/persistence access, task control — anything that reaches outside the
+   program's own data (e.g. `Tc2_System`'s file and event functions). These
+   need VM or runtime services: FB-shaped ones follow
+   [ADR-0003](0003-plc-standard-function-blocks-as-intrinsics.md) intrinsics;
+   function-shaped ones need bindings.
+
+Borderline case worth recording: numeric-to-string *formatting* with runtime
+precision (`LREAL_TO_FMTSTR`) is expressible in principle (integer math plus
+the string stdlib) but numerically-faithful float formatting is subtle enough
+that neither medium is chosen yet — the plan lands it declare-only, and the
+follow-up decides ST versus a formatting builtin on fidelity grounds, not
+convenience.
+
+### Related decisions
 
 * [ADR-0003](0003-plc-standard-function-blocks-as-intrinsics.md) — the same
   principle for function blocks: intrinsics are a VM dispatch detail behind

--- a/specs/plans/2026-08-08-compatibility-library-bindings.md
+++ b/specs/plans/2026-08-08-compatibility-library-bindings.md
@@ -6,7 +6,7 @@ Deliver the support primitives that let the stalled vendor-function PRs
 ([#1217](https://github.com/ironplc/ironplc/pull/1217) `LTRUNC`/`LMOD`,
 [#1218](https://github.com/ironplc/ironplc/pull/1218) `MODABS`,
 [#1246](https://github.com/ironplc/ironplc/pull/1246)
-`BOOL_TO_STRING`/`LREAL_TO_FMTSTR`/`ADR`) be resolved the way review asked:
+`BOOL_TO_STRING`/`LREAL_TO_FMTSTR`) be resolved the way review asked:
 vendor functions **externalized as compatibility libraries**, with native code
 in the compiler only where IEC 61131-3 source cannot express the semantics.
 
@@ -51,7 +51,6 @@ Under the ADR-0042 rule each function lands as:
 | `FRAC(IN: LREAL): LREAL` | `Tc2_Math` POU with a math-dictated **ST body**: `FRAC := IN - LTRUNC(IN);` — no builtin (reviewer-requested addition; not in the original PRs) |
 | `BOOL_TO_STRING(IN: BOOL): STRING` | library **ST body** (`IF IN THEN BOOL_TO_STRING := 'TRUE'; ELSE ... 'FALSE'`) — trivially expressible, so no intrinsic and no func_id |
 | `LREAL_TO_FMTSTR(in: LREAL, iPrecision: INT, bRound: BOOL): STRING(255)` | `Tc2_Utilities` POU, **declare-only** — surface lands now, calls fail compile with the new code; native formatting is a follow-up plan |
-| `ADR` | **non-goal** — a function-like operator on the dialect axis, deferred to the future `POINTER TO` family work (interacts with ADR-0017/ADR-0021; a declared signature today would have to lie about its return type) |
 
 The mechanism is not TwinCAT-specific: bindings, declare-only, and the new
 problem code are generic library-format capabilities. The Tc2 libraries are
@@ -59,8 +58,6 @@ the first consumers because TwinCAT is a target.
 
 ## Non-goals
 
-- The `ADR` address operator and the `POINTER TO` family (dialect axis; its
-  own future design).
 - A native `LREAL_TO_FMTSTR` implementation (declare-only now; follow-up
   plan adds a formatting builtin and flips the binding).
 - Collision/precedence between libraries or vs. the base stdlib (design
@@ -228,5 +225,5 @@ declare-only compatibility library function", naming the library and POU.
   so it becomes a Phase 2 general capability (benefits every future library),
   and `BOOL_TO_STRING` ships declare-only until it lands — never a builtin.
 - Once the phases land, PRs #1217/#1218/#1246 are superseded: same names,
-  same behavior, delivered per ADR-0042 (`ADR` deferred to the `POINTER TO`
-  work; native `LREAL_TO_FMTSTR` as a follow-up plan).
+  same behavior, delivered per ADR-0042 (native `LREAL_TO_FMTSTR` as a
+  follow-up plan).

--- a/specs/plans/2026-08-08-compatibility-library-bindings.md
+++ b/specs/plans/2026-08-08-compatibility-library-bindings.md
@@ -24,7 +24,7 @@ The primitives, from the deferred *Future Goals* of the
 
    ```toml
    ["1.0.0".bindings]
-   LTRUNC = { intrinsic = "trunc_lreal" }
+   LTRUNC = { intrinsic = "trunc_f64" }
    ```
 
    or **declare-only** (`POU = "declare-only"`): the signature exists so the
@@ -45,8 +45,8 @@ Under the ADR-0042 rule each function lands as:
 
 | Function | Mechanism |
 |---|---|
-| `LTRUNC(IN: LREAL): LREAL` | `Tc2_Math` POU bound to new `trunc_lreal` VM builtin — `TRUNC` clamps to `ANY_INT`, so LREAL-preserving truncation is inexpressible in ST |
-| `LMOD(IN1: LREAL, IN2: LREAL): LREAL` | `Tc2_Math` POU bound to new `fmod_lreal` VM builtin — no floating modulo exists in ST (`MOD` is integer) |
+| `LTRUNC(IN: LREAL): LREAL` | `Tc2_Math` POU bound to new `trunc_f64` VM builtin — `TRUNC` clamps to `ANY_INT`, so LREAL-preserving truncation is inexpressible in ST |
+| `LMOD(IN1: LREAL, IN2: LREAL): LREAL` | `Tc2_Math` POU bound to new `mod_f64` VM builtin — no floating modulo exists in ST (`MOD` is integer) |
 | `MODABS(IN: LREAL, IM: LREAL): LREAL` | `Tc2_Math` POU with a math-dictated **ST body** calling `LMOD` — no builtin |
 | `FRAC(IN: LREAL): LREAL` | `Tc2_Math` POU with a math-dictated **ST body**: `FRAC := IN - LTRUNC(IN);` — no builtin (reviewer-requested addition; not in the original PRs) |
 | `BOOL_TO_STRING(IN: BOOL): STRING` | library **ST body** (`IF IN THEN BOOL_TO_STRING := 'TRUE'; ELSE ... 'FALSE'`) — trivially expressible, so no intrinsic and no func_id |
@@ -62,9 +62,17 @@ the first consumers because TwinCAT is a target.
   plan adds a formatting builtin and flips the binding).
 - Collision/precedence between libraries or vs. the base stdlib (design
   *Future Goals*; none of these names collide).
-- F32/REAL variants of the new builtins — Beckhoff signatures are LREAL-only
-  ([ADR-0022](../adrs/0022-exact-type-matching-for-function-arguments.md)
-  exact matching); ADR-0004 permits adding F32 func_ids later.
+- F32/REAL variants of the new builtins, and `ANY_REAL` signatures for the
+  library functions. `ANY_REAL` is a generic category that exists only in the
+  compiler-seeded stdlib tables — a library `.st` declaration must use
+  concrete types, so a generic `FRAC` would have to move back into the
+  compiler, against ADR-0042. It would also diverge from Beckhoff, whose
+  `Tc2_Math` signatures are LREAL-only: TwinCAT accepts `FRAC(someReal)` by
+  implicitly widening the *argument* REAL→LREAL (result stays LREAL), not by
+  a generic signature (which would make the result REAL). That call-site
+  widening is its own planned work
+  ([2026-07-27-twincat-real-to-lreal-widening.md](2026-07-27-twincat-real-to-lreal-widening.md))
+  and serves every LREAL-taking function uniformly.
 - Migrating any existing compiler-seeded standard function to a library
   (ADR-0042 governs additions only).
 
@@ -85,8 +93,8 @@ is three nested TOML tables and is rejected by shape validation):
 
 ```toml
 ["1.0.0".bindings]
-LTRUNC = { intrinsic = "trunc_lreal" }
-LMOD   = { intrinsic = "fmod_lreal" }
+LTRUNC = { intrinsic = "trunc_f64" }
+LMOD   = { intrinsic = "mod_f64" }
 ```
 
 or `POU = "declare-only"`. A bound or declare-only POU still appears in the
@@ -120,7 +128,7 @@ with P6010 anchored on the manifest file.
 
 **New VM builtins** (next free func_ids; pure-stack, so they go in
 `vm/src/builtin.rs::dispatch`, not the inline string region):
-`TRUNC_F64 = 0x03A3` (`f64::trunc`) and `FMOD_F64 = 0x03A4` (Rust `%`,
+`TRUNC_F64 = 0x03A3` (`f64::trunc`) and `MOD_F64 = 0x03A4` (Rust `%`,
 IEEE-754 sign-of-dividend; `x % 0.0` is NaN, not a trap — pinned in the
 clean-room spec). Plus `arg_count` arms, disassembler arms, and wire-format
 pins.
@@ -183,7 +191,7 @@ declare-only compatibility library function", naming the library and POU.
 - [ ] Promote §Bindings in both design docs; add `REQ-LF-sources-005..007`, `REQ-CL-codegen-001/002`, `REQ-CL-analyzer-007`
 
 ### Phase 2 — Container + VM primitives
-- [ ] `TRUNC_F64`/`FMOD_F64` func_ids, `arg_count`, `intrinsic_func_id` table
+- [ ] `TRUNC_F64`/`MOD_F64` func_ids, `arg_count`, `intrinsic_func_id` table
 - [ ] `vm/builtin.rs` arms; disassembler arms; wire-format pins; VM unit tests
 - [ ] Verify STRING return from user-defined functions (needed by `BOOL_TO_STRING`'s ST body); implement as a general codegen capability if missing
 - [ ] `cd compiler && just` green
@@ -220,7 +228,7 @@ declare-only compatibility library function", naming the library and POU.
   never silently wrong.
 - Risk: `MODABS`-via-ST assumes function-name return assignment works in
   library bodies (believed supported by `compile_user_function`); verify at
-  the start of Phase 5 — fallback is a `modabs_lreal` builtin at `0x03A5`.
+  the start of Phase 5 — fallback is a `modabs_f64` builtin at `0x03A5`.
 - Risk: STRING-returning user functions may be unimplemented in codegen; if
   so it becomes a Phase 2 general capability (benefits every future library),
   and `BOOL_TO_STRING` ships declare-only until it lands — never a builtin.

--- a/specs/plans/2026-08-08-compatibility-library-bindings.md
+++ b/specs/plans/2026-08-08-compatibility-library-bindings.md
@@ -1,0 +1,214 @@
+# Plan: Compatibility-Library Bindings and TwinCAT Math/Utility Functions
+
+## Goal
+
+Deliver the support primitives that let the stalled vendor-function PRs
+([#1217](https://github.com/ironplc/ironplc/pull/1217) `LTRUNC`/`LMOD`,
+[#1218](https://github.com/ironplc/ironplc/pull/1218) `MODABS`,
+[#1246](https://github.com/ironplc/ironplc/pull/1246)
+`BOOL_TO_STRING`/`LREAL_TO_FMTSTR`/`ADR`) be resolved the way review asked:
+vendor functions **externalized as compatibility libraries**, with native code
+in the compiler only where IEC 61131-3 source cannot express the semantics.
+
+The primitives, from the deferred *Future Goals* of the
+[Compatibility Libraries design](../design/compatibility-libraries.md):
+
+1. **Bindings** — a per-version `library.toml` table mapping a library POU to
+   a **VM builtin** or to **declare-only**.
+2. **Fail-if-unimplemented** — a call to a declare-only POU is a dedicated
+   compile error (new problem code), never silently-wrong codegen and never a
+   runtime trap. `check` still passes (the declaration resolves), matching the
+   corpus-check motivation of the original PRs.
+3. **Two new BUILTIN func_ids** for semantics inexpressible in ST: LREAL
+   truncation and LREAL modulo.
+4. **[ADR-0042](../adrs/0042-library-functions-over-compiler-intrinsics.md)**
+   codifying when a function may be compiler-provided versus must be a library
+   function (this plan's companion; reviewed in the same PR).
+
+Under the ADR-0042 rule each function lands as:
+
+| Function | Mechanism |
+|---|---|
+| `LTRUNC(IN: LREAL): LREAL` | `Tc2_Math` POU bound to new `trunc_lreal` VM builtin — `TRUNC` clamps to `ANY_INT`, so LREAL-preserving truncation is inexpressible in ST |
+| `LMOD(IN1: LREAL, IN2: LREAL): LREAL` | `Tc2_Math` POU bound to new `fmod_lreal` VM builtin — no floating modulo exists in ST (`MOD` is integer) |
+| `MODABS(IN: LREAL, IM: LREAL): LREAL` | `Tc2_Math` POU with a math-dictated **ST body** calling `LMOD` — no builtin |
+| `BOOL_TO_STRING(IN: BOOL): STRING` | library **ST body** (`IF IN THEN BOOL_TO_STRING := 'TRUE'; ELSE ... 'FALSE'`) — trivially expressible, so no intrinsic and no func_id |
+| `LREAL_TO_FMTSTR(in: LREAL, iPrecision: INT, bRound: BOOL): STRING(255)` | `Tc2_Utilities` POU, **declare-only** — surface lands now, calls fail compile with the new code; native formatting is a follow-up plan |
+| `ADR` | **non-goal** — a function-like operator on the dialect axis, deferred to the future `POINTER TO` family work (interacts with ADR-0017/ADR-0021; a declared signature today would have to lie about its return type) |
+
+The mechanism is not TwinCAT-specific: bindings, declare-only, and the new
+problem code are generic library-format capabilities. The Tc2 libraries are
+the first consumers because TwinCAT is a target.
+
+## Non-goals
+
+- The `ADR` address operator and the `POINTER TO` family (dialect axis; its
+  own future design).
+- A native `LREAL_TO_FMTSTR` implementation (declare-only now; follow-up
+  plan adds a formatting builtin and flips the binding).
+- Collision/precedence between libraries or vs. the base stdlib (design
+  *Future Goals*; none of these names collide).
+- F32/REAL variants of the new builtins — Beckhoff signatures are LREAL-only
+  ([ADR-0022](../adrs/0022-exact-type-matching-for-function-arguments.md)
+  exact matching); ADR-0004 permits adding F32 func_ids later.
+- Migrating any existing compiler-seeded standard function to a library
+  (ADR-0042 governs additions only).
+
+## Design doc reference
+
+[compatibility-libraries.md](../design/compatibility-libraries.md)
+(`REQ-CL-*`) and
+[compatibility-library-format.md](../design/compatibility-library-format.md)
+(`REQ-LF-*`) — Phase 1 promotes *Bindings* out of both docs' future sections
+and adds the new requirement markers listed there. Owning crate slugs:
+`sources`, `codegen`, `analyzer`.
+
+## Architecture
+
+**Bindings are manifest data.** A per-version table in `library.toml` (the
+version key must be quoted — `["1.0.0".bindings]`; unquoted `[1.0.0.bindings]`
+is three nested TOML tables and is rejected by shape validation):
+
+```toml
+["1.0.0".bindings]
+LTRUNC = { intrinsic = "trunc_lreal" }
+LMOD   = { intrinsic = "fmod_lreal" }
+```
+
+or `POU = "declare-only"`. A bound or declare-only POU still appears in the
+version's `.st` with its full interface and a body of exactly `;` (parses to
+an empty statement list today — verified against `parser.rs`
+`statements_or_empty()`); that body is never compiled.
+
+**Binding info travels out of band.** The analyze merge erases which POUs came
+from a library, and ADR-0040 rule 4 forbids provenance markers in the AST. So
+bindings ride a side-table: new `ironplc_dsl::bindings` module with
+`PouBinding::{Intrinsic { name }, DeclareOnly}` and `LibraryBindings`
+(uppercased-POU-name map + the set of library-source `FileId`s), produced by
+the `sources` loader (`CompatLibrary` gains a `bindings` field), threaded by
+the CLI into a new `CodegenOptions::library_bindings` (`Default` = empty, so
+untouched consumers — playground, benchmarks, MCP — compile unchanged and
+fail closed to P9999 rather than ever lowering wrongly). The analyzer never
+sees bindings — that is exactly what makes a declare-only call pass `check`.
+
+**Codegen consumes bindings at two points.** (1) Body compilation: skip any
+`FunctionDeclaration` whose name is bound *and* whose `FileId` is a library
+file — the `FileId` check preserves user shadowing (REQ-CL-analyzer-004): a
+user-defined `LMOD` still compiles as a user function. (2) Call lowering, in
+`compile_function_call`'s fallthrough *after* the existing `user_functions`
+check: `Intrinsic` compiles each argument at the parameter's op type and emits
+`BUILTIN func_id` (per ADR-0008); `DeclareOnly` returns the new diagnostic at
+the call site. Intrinsic names resolve via a single name→func_id table beside
+the func_id constants (`container::opcode::builtin::intrinsic_func_id`), so
+`sources` needs no new dependency for validation; unresolvable names in a
+bundled manifest are caught by a conformance test, and defensively at codegen
+with P6010 anchored on the manifest file.
+
+**New VM builtins** (next free func_ids; pure-stack, so they go in
+`vm/src/builtin.rs::dispatch`, not the inline string region):
+`TRUNC_F64 = 0x03A3` (`f64::trunc`) and `FMOD_F64 = 0x03A4` (Rust `%`,
+IEEE-754 sign-of-dividend; `x % 0.0` is NaN, not a trap — pinned in the
+clean-room spec). Plus `arg_count` arms, disassembler arms, and wire-format
+pins.
+
+**New problem code** `P4046 LibraryFunctionNotImplemented` — "call to a
+declare-only compatibility library function", naming the library and POU.
+
+## File map
+
+**New**
+- `specs/adrs/0042-library-functions-over-compiler-intrinsics.md` — the intrinsic-vs-library rule (this PR).
+- `specs/design/library-interfaces/tc2-math.md`, `tc2-utilities.md`, `bool-to-string.md` — clean-room interface specs from public Beckhoff InfoSys docs, each merged as its own non-squashed commit *before* implementation (authoring policy).
+- `compiler/dsl/src/bindings.rs` — `PouBinding`, `LibraryBindings` (+ `lib.rs` export).
+- `compiler/codegen/src/compile_library.rs` — bound-function pre-resolution and lowering helpers (`compile_call.rs` is at the 1000-line cap).
+- `compiler/sources/resources/libs/Tc2_Math/{library.toml, 1.0.0/Tc2_Math.st}` — LTRUNC/LMOD (bound, `;` bodies), MODABS (ST body).
+- `compiler/sources/resources/libs/Tc2_Utilities/{library.toml, 1.0.0/Tc2_Utilities.st}` — LREAL_TO_FMTSTR (declare-only).
+- `docs/reference/compiler/problems/P4046.rst` (+ index entry).
+
+**Modified**
+- `specs/design/compatibility-library-format.md` — §Bindings specified (quoted-version-key shape, value forms, `;`-body rule, P6010 on malformed); new `REQ-LF-sources-005..007`.
+- `specs/design/compatibility-libraries.md` — fail-if-unimplemented specified; new `REQ-CL-codegen-001` (intrinsic-bound call lowers to BUILTIN), `REQ-CL-codegen-002` (declare-only call fails compile with P4046), `REQ-CL-analyzer-007` (declare-only call passes check).
+- `compiler/container/src/opcode.rs` — func_ids, `arg_count`, `intrinsic_func_id`.
+- `compiler/vm/src/builtin.rs`, `compiler/project/src/disassemble.rs`, `compiler/codegen/tests/it/wire_format.rs`.
+- `compiler/sources/src/libraries/manifest.rs` — bindings table parse + shape validation of *all* version tables (catches the unquoted-key trap); `mod.rs` — `CompatLibrary.bindings`, library `FileId` set.
+- `compiler/sources/src/project.rs` — `load_activated_libraries` carries `CompatLibrary`s; adapt callers in `compiler/project/src/project.rs`, `compiler/ironplc-cli/src/cli.rs`.
+- `compiler/codegen/src/compile.rs` (skip-body filter, `CodegenOptions.library_bindings`), `compile_call.rs` (fallthrough hook).
+- `compiler/problems/resources/problem-codes.csv` — P4046.
+- `compiler/playground/src/lib.rs` + `playground/` frontend — payload `{manifest, files[]}` (old raw-string form still accepted), bindings threading.
+- `compiler/{sources,codegen,analyzer}/src/spec_conformance.rs` + `codegen/build.rs` — new `#[spec_test]`s.
+
+## Testing strategy
+
+- Each new `REQ-*` marker gets a `#[spec_test]` per the reconcile-spec
+  convention; `#[ignore]` for markers landing in a later phase.
+- Manifest: bindings happy path; each malformed shape → P6010 (including the
+  unquoted version key); non-default-version tables validated but inert.
+- Parser regression pinning the `;`-body idiom.
+- Codegen (temp registry root, no bundled dependency): intrinsic call emits
+  the exact func_id; declare-only call → P4046 on compile and clean on check
+  (CLI-level split test); user function shadowing a bound name compiles the
+  user body; bound `;` bodies never compiled.
+- VM: `f64::trunc` ±, fmod negatives, fmod-by-zero → NaN not trap.
+- End-to-end (`codegen/tests/it/`, VM-run, epsilon asserts):
+  `LMOD(400.56, 360.0) ≈ 40.56`, `MODABS(-400.56, 360.0) ≈ 319.44`,
+  `LTRUNC(3.7) = 3.0`, `LTRUNC(-3.7) = -3.0`, `BOOL_TO_STRING(TRUE) = 'TRUE'`;
+  a `.plcproj`-driven activation test (the exact contributor scenario);
+  `plc2plc` round-trip of a file calling `LTRUNC` is byte-identical.
+- Conformance: every bundled intrinsic binding resolves via
+  `intrinsic_func_id`; provenance test already covers the new manifests.
+- `cd compiler && just` green per phase.
+
+## Tasks
+
+### Phase 0 — ADR + this plan (docs-only PR, for review)
+- [ ] ADR-0042 and this plan committed and PR opened
+
+### Phase 1 — Clean-room interface specs + design-doc promotion (docs)
+- [ ] `library-interfaces/` specs from public Beckhoff references, each its own non-squashed commit (LMOD pinned to fmod sign-of-dividend; `LMOD(x, 0.0)` → NaN; `MODABS(-400.56, 360) = 319.44`; `BOOL_TO_STRING` → `'TRUE'`/`'FALSE'`)
+- [ ] Promote §Bindings in both design docs; add `REQ-LF-sources-005..007`, `REQ-CL-codegen-001/002`, `REQ-CL-analyzer-007`
+
+### Phase 2 — Container + VM primitives
+- [ ] `TRUNC_F64`/`FMOD_F64` func_ids, `arg_count`, `intrinsic_func_id` table
+- [ ] `vm/builtin.rs` arms; disassembler arms; wire-format pins; VM unit tests
+- [ ] Verify STRING return from user-defined functions (needed by `BOOL_TO_STRING`'s ST body); implement as a general codegen capability if missing
+- [ ] `cd compiler && just` green
+
+### Phase 3 — Bindings model: dsl type, manifest parse, loader threading
+- [ ] `dsl/src/bindings.rs`; manifest bindings parse + shape validation → P6010 — **REQ-LF-sources-005/006/007**
+- [ ] `CompatLibrary.bindings` + library `FileId` set; thread through `load_activated_libraries` callers
+- [ ] Parser `;`-body regression test; spec tests
+- [ ] `cd compiler && just` green
+
+### Phase 4 — Codegen: builtin lowering, declare-only P4046, skip-body
+- [ ] P4046 CSV row + `P4046.rst`
+- [ ] `CodegenOptions.library_bindings`; `compile_library.rs` pre-resolution; skip-body filter; fallthrough hook — **REQ-CL-codegen-001/002**, **REQ-CL-analyzer-007**
+- [ ] CLI threads bindings; check/compile split test; shadowing test; bundled-bindings-resolve conformance test
+- [ ] `cd compiler && just` green
+
+### Phase 5 — Ship `Tc2_Math` + `Tc2_Utilities`; `BOOL_TO_STRING`; end-to-end
+- [ ] `Tc2_Math` package (manifest references per function; MODABS ST body `MODABS := LMOD(IN, IM); IF MODABS < 0.0 THEN MODABS := MODABS + ABS(IM); END_IF;`)
+- [ ] `Tc2_Utilities` package (LREAL_TO_FMTSTR declare-only)
+- [ ] `BOOL_TO_STRING` ST function — **placement to confirm in review**: recommend the bundled `Tc2_System` library (TwinCAT treats it as a compiler operator, so no vendor library is its true home; `Tc2_System` is referenced by real projects by default, so it lights up on the paved path)
+- [ ] End-to-end VM-run tests; `.plcproj` activation test; plc2plc round-trip
+- [ ] `cd compiler && just` green
+
+### Phase 6 — Playground bindings threading
+- [ ] Serve `{manifest, files[]}`; build `LibraryBindings` in `playground/src/lib.rs`; thread through `CodegenOptions`
+- [ ] `cd compiler && just` green
+
+## Implementation notes
+
+- Order matters in `compile_function_call`: `ctx.user_functions` first, then
+  bindings — user shadowing stays intact with zero new mechanism.
+- Interim playground behavior (before Phase 6) is safe: an intrinsic-bound
+  call falls through to `compile_generic_builtin` → P9999 — fails closed,
+  never silently wrong.
+- Risk: `MODABS`-via-ST assumes function-name return assignment works in
+  library bodies (believed supported by `compile_user_function`); verify at
+  the start of Phase 5 — fallback is a `modabs_lreal` builtin at `0x03A5`.
+- Risk: STRING-returning user functions may be unimplemented in codegen; if
+  so it becomes a Phase 2 general capability (benefits every future library),
+  and `BOOL_TO_STRING` ships declare-only until it lands — never a builtin.
+- Once the phases land, PRs #1217/#1218/#1246 are superseded: same names,
+  same behavior, delivered per ADR-0042 (`ADR` deferred to the `POINTER TO`
+  work; native `LREAL_TO_FMTSTR` as a follow-up plan).

--- a/specs/plans/2026-08-08-compatibility-library-bindings.md
+++ b/specs/plans/2026-08-08-compatibility-library-bindings.md
@@ -13,8 +13,24 @@ in the compiler only where IEC 61131-3 source cannot express the semantics.
 The primitives, from the deferred *Future Goals* of the
 [Compatibility Libraries design](../design/compatibility-libraries.md):
 
-1. **Bindings** — a per-version `library.toml` table mapping a library POU to
-   a **VM builtin** or to **declare-only**.
+1. **Bindings** — a way for a library to declare a POU whose implementation
+   is *not* an ordinary ST body. Today the loader can only compile
+   fully-defined ST, so a function like `LTRUNC` — whose semantics cannot be
+   written in ST — cannot ship in a library at all. A binding is an entry in
+   the library's `library.toml`, per version, that marks such a POU as either
+   **backed by a native VM builtin** (the `.st` file still declares the full
+   signature, so `check` and type-checking work unchanged; codegen lowers
+   calls to the named builtin instead of a `CALL`):
+
+   ```toml
+   ["1.0.0".bindings]
+   LTRUNC = { intrinsic = "trunc_lreal" }
+   ```
+
+   or **declare-only** (`POU = "declare-only"`): the signature exists so the
+   library's surface can land ahead of its implementation, and *calling* it
+   is a compile error. This is the mechanism the compatibility-libraries
+   design defers under *Future Goals* ("bindings"); this plan builds it.
 2. **Fail-if-unimplemented** — a call to a declare-only POU is a dedicated
    compile error (new problem code), never silently-wrong codegen and never a
    runtime trap. `check` still passes (the declaration resolves), matching the

--- a/specs/plans/2026-08-08-compatibility-library-bindings.md
+++ b/specs/plans/2026-08-08-compatibility-library-bindings.md
@@ -48,6 +48,7 @@ Under the ADR-0042 rule each function lands as:
 | `LTRUNC(IN: LREAL): LREAL` | `Tc2_Math` POU bound to new `trunc_lreal` VM builtin — `TRUNC` clamps to `ANY_INT`, so LREAL-preserving truncation is inexpressible in ST |
 | `LMOD(IN1: LREAL, IN2: LREAL): LREAL` | `Tc2_Math` POU bound to new `fmod_lreal` VM builtin — no floating modulo exists in ST (`MOD` is integer) |
 | `MODABS(IN: LREAL, IM: LREAL): LREAL` | `Tc2_Math` POU with a math-dictated **ST body** calling `LMOD` — no builtin |
+| `FRAC(IN: LREAL): LREAL` | `Tc2_Math` POU with a math-dictated **ST body**: `FRAC := IN - LTRUNC(IN);` — no builtin (reviewer-requested addition; not in the original PRs) |
 | `BOOL_TO_STRING(IN: BOOL): STRING` | library **ST body** (`IF IN THEN BOOL_TO_STRING := 'TRUE'; ELSE ... 'FALSE'`) — trivially expressible, so no intrinsic and no func_id |
 | `LREAL_TO_FMTSTR(in: LREAL, iPrecision: INT, bRound: BOOL): STRING(255)` | `Tc2_Utilities` POU, **declare-only** — surface lands now, calls fail compile with the new code; native formatting is a follow-up plan |
 | `ADR` | **non-goal** — a function-like operator on the dialect axis, deferred to the future `POINTER TO` family work (interacts with ADR-0017/ADR-0021; a declared signature today would have to lie about its return type) |
@@ -137,7 +138,7 @@ declare-only compatibility library function", naming the library and POU.
 - `specs/design/library-interfaces/tc2-math.md`, `tc2-utilities.md`, `bool-to-string.md` — clean-room interface specs from public Beckhoff InfoSys docs, each merged as its own non-squashed commit *before* implementation (authoring policy).
 - `compiler/dsl/src/bindings.rs` — `PouBinding`, `LibraryBindings` (+ `lib.rs` export).
 - `compiler/codegen/src/compile_library.rs` — bound-function pre-resolution and lowering helpers (`compile_call.rs` is at the 1000-line cap).
-- `compiler/sources/resources/libs/Tc2_Math/{library.toml, 1.0.0/Tc2_Math.st}` — LTRUNC/LMOD (bound, `;` bodies), MODABS (ST body).
+- `compiler/sources/resources/libs/Tc2_Math/{library.toml, 1.0.0/Tc2_Math.st}` — LTRUNC/LMOD (bound, `;` bodies), MODABS and FRAC (ST bodies).
 - `compiler/sources/resources/libs/Tc2_Utilities/{library.toml, 1.0.0/Tc2_Utilities.st}` — LREAL_TO_FMTSTR (declare-only).
 - `docs/reference/compiler/problems/P4046.rst` (+ index entry).
 
@@ -167,6 +168,7 @@ declare-only compatibility library function", naming the library and POU.
 - VM: `f64::trunc` ±, fmod negatives, fmod-by-zero → NaN not trap.
 - End-to-end (`codegen/tests/it/`, VM-run, epsilon asserts):
   `LMOD(400.56, 360.0) ≈ 40.56`, `MODABS(-400.56, 360.0) ≈ 319.44`,
+  `FRAC(3.7) ≈ 0.7`, `FRAC(-3.7) ≈ -0.7`,
   `LTRUNC(3.7) = 3.0`, `LTRUNC(-3.7) = -3.0`, `BOOL_TO_STRING(TRUE) = 'TRUE'`;
   a `.plcproj`-driven activation test (the exact contributor scenario);
   `plc2plc` round-trip of a file calling `LTRUNC` is byte-identical.
@@ -180,7 +182,7 @@ declare-only compatibility library function", naming the library and POU.
 - [ ] ADR-0042 and this plan committed and PR opened
 
 ### Phase 1 — Clean-room interface specs + design-doc promotion (docs)
-- [ ] `library-interfaces/` specs from public Beckhoff references, each its own non-squashed commit (LMOD pinned to fmod sign-of-dividend; `LMOD(x, 0.0)` → NaN; `MODABS(-400.56, 360) = 319.44`; `BOOL_TO_STRING` → `'TRUE'`/`'FALSE'`)
+- [ ] `library-interfaces/` specs from public Beckhoff references, each its own non-squashed commit (LMOD pinned to fmod sign-of-dividend; `LMOD(x, 0.0)` → NaN; `MODABS(-400.56, 360) = 319.44`; `FRAC` keeps the sign of its input, `FRAC(-3.7) = -0.7`; `BOOL_TO_STRING` → `'TRUE'`/`'FALSE'`)
 - [ ] Promote §Bindings in both design docs; add `REQ-LF-sources-005..007`, `REQ-CL-codegen-001/002`, `REQ-CL-analyzer-007`
 
 ### Phase 2 — Container + VM primitives
@@ -202,7 +204,7 @@ declare-only compatibility library function", naming the library and POU.
 - [ ] `cd compiler && just` green
 
 ### Phase 5 — Ship `Tc2_Math` + `Tc2_Utilities`; `BOOL_TO_STRING`; end-to-end
-- [ ] `Tc2_Math` package (manifest references per function; MODABS ST body `MODABS := LMOD(IN, IM); IF MODABS < 0.0 THEN MODABS := MODABS + ABS(IM); END_IF;`)
+- [ ] `Tc2_Math` package (manifest references per function; MODABS ST body `MODABS := LMOD(IN, IM); IF MODABS < 0.0 THEN MODABS := MODABS + ABS(IM); END_IF;`; FRAC ST body `FRAC := IN - LTRUNC(IN);`)
 - [ ] `Tc2_Utilities` package (LREAL_TO_FMTSTR declare-only)
 - [ ] `BOOL_TO_STRING` ST function — **placement to confirm in review**: recommend the bundled `Tc2_System` library (TwinCAT treats it as a compiler operator, so no vendor library is its true home; `Tc2_System` is referenced by real projects by default, so it lights up on the paved path)
 - [ ] End-to-end VM-run tests; `.plcproj` activation test; plc2plc round-trip


### PR DESCRIPTION
## Summary

Docs-only PR: the decision rule and implementation plan for the support primitives needed to resolve #1217 (`LTRUNC`/`LMOD`), #1218 (`MODABS`), and #1246 (`BOOL_TO_STRING`/`LREAL_TO_FMTSTR`/`ADR`) per review — vendor functions externalized as compatibility libraries, native code in the compiler only where ST cannot express the semantics.

**ADR-0042 — Library Functions Over Compiler Intrinsics.** Compiler-provided names are limited to the IEC 61131-3 standard surface, and native implementations to behavior that cannot be a function. Every vendor-defined name ships as a compatibility library function: ST body when expressible; when not, the library's manifest binds the POU to an *unnamed* VM builtin (new func_ids are fine per ADR-0008, but they add no name to any scope — the library is the only way to reach them). Function-like operators that require compiler cooperation (`SIZEOF`, `ADR`) remain the dialect axis behind `--allow-*` flags.

**Plan — compatibility-library bindings.** Builds the deferred pieces of the compatibility-libraries design: the `["1.0.0".bindings]` manifest table (`intrinsic` / `declare-only`), the fail-if-unimplemented compile error (new P4046; declare-only calls still pass `check`, matching the corpus-check motivation of the original PRs), two new LREAL builtins (`trunc_lreal` 0x03A3, `fmod_lreal` 0x03A4), and the `Tc2_Math`/`Tc2_Utilities` libraries. Under the rule:

| Function | Mechanism |
|---|---|
| `LTRUNC`, `LMOD` | `Tc2_Math` POUs bound to the two new builtins (LREAL-preserving trunc / float modulo are inexpressible in ST) |
| `MODABS` | `Tc2_Math` ST body calling `LMOD` — no builtin |
| `BOOL_TO_STRING` | plain library ST function — trivially expressible, so no intrinsic and no func_id |
| `LREAL_TO_FMTSTR` | `Tc2_Utilities`, declare-only — surface lands, calls fail compile with P4046; native formatting is a follow-up |
| `ADR` | non-goal — dialect axis, deferred to the `POINTER TO` family work |

Open item flagged for review in the plan: where `BOOL_TO_STRING` lives (recommend bundled `Tc2_System`, since TwinCAT treats it as a compiler operator and real projects reference `Tc2_System` by default).

## Test plan
- [x] Docs only — no code changes
- [x] Full CI (`cd compiler && just`): compile, coverage ≥85%, clippy, fmt, dupes — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GECQRVfdE7uzpe5VaxzLx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GECQRVfdE7uzpe5VaxzLx5)_