### PR TITLE
docs(specs): clean-room interface spec for Tc2_Math (LTRUNC, LMOD, MODABS, FRAC)

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "ironplc-dsl",
  "ironplc-parser",
  "ironplc-problems",
+ "ironplc-sources",
  "ironplc-spec-requirements-gen",
  "ironplc-vm",
  "proptest",

--- a/compiler/analyzer/src/spec_conformance.rs
+++ b/compiler/analyzer/src/spec_conformance.rs
@@ -369,3 +369,45 @@ fn analyzer_spec_req_cl_006_dialect_does_not_activate_library() {
         "selecting a dialect must not activate the library"
     );
 }
+
+/// REQ-CL-analyzer-007: A program that *calls* a declare-only library POU
+/// still passes `check` cleanly — the analyzer never sees bindings, so the
+/// declaration resolves and type-checks like any other function. (Rejecting
+/// the call is codegen's job: P4046, REQ-CL-codegen-002.)
+#[spec_test(REQ_CL_analyzer_007)]
+fn analyzer_spec_req_cl_007_declare_only_call_passes_check() {
+    let options = CompilerOptions::default();
+    // The library declaration as it appears in a version's `.st`: the full
+    // interface with a body of exactly `;`. The binding itself rides a
+    // side-table to codegen and is invisible here.
+    let library = parse_program(
+        "FUNCTION LREAL_TO_FMTSTR : STRING[255]
+VAR_INPUT
+    in         : LREAL;
+    iPrecision : INT;
+    bRound     : BOOL;
+END_VAR
+;
+END_FUNCTION",
+        &FileId::from_string("lib.st"),
+        &options,
+    )
+    .unwrap();
+    let user = parse_program(
+        "PROGRAM main
+VAR
+    s : STRING[255];
+END_VAR
+    s := LREAL_TO_FMTSTR(in := 1.5, iPrecision := 2, bRound := TRUE);
+END_PROGRAM",
+        &FileId::from_string("user.st"),
+        &options,
+    )
+    .unwrap();
+    let (_lib, ctx) = analyze(&[&library, &user], &options).unwrap();
+    assert!(
+        !ctx.has_diagnostics(),
+        "a declare-only call must pass check: {:?}",
+        ctx.diagnostics()
+    );
+}

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -20,6 +20,7 @@ ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
 [dev-dependencies]
 ironplc-analyzer = { path = "../analyzer", version = "0.234.0" }
 ironplc-parser = { path = "../parser", version = "0.234.0" }
+ironplc-sources = { path = "../sources", version = "0.234.0" }
 ironplc-vm = { path = "../vm", version = "0.234.0", features = ["test-support"] }
 spec_test_macro = { path = "../spec_test_macro" }
 proptest = "1"

--- a/compiler/codegen/build.rs
+++ b/compiler/codegen/build.rs
@@ -1,3 +1,10 @@
 fn main() {
-    ironplc_spec_requirements_gen::generate(&["enumeration-codegen.md", "reference-to-twincat.md"]);
+    ironplc_spec_requirements_gen::generate(&[
+        "enumeration-codegen.md",
+        "reference-to-twincat.md",
+        // Codegen owns the compatibility-library binding requirements
+        // (`REQ-CL-codegen-*`): intrinsic-bound call lowering and the
+        // declare-only fail-if-unimplemented rule.
+        "compatibility-libraries.md",
+    ]);
 }

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -209,6 +209,12 @@ pub struct CodegenOptions {
     /// When `true`, inject `__SYSTEM_UP_TIME` (TIME) and `__SYSTEM_UP_LTIME`
     /// (LTIME) as implicit globals at the start of the variable table.
     pub system_uptime_global: bool,
+    /// Bindings of the activated compatibility libraries (see
+    /// `ironplc_dsl::bindings`). The default is empty, so consumers that
+    /// never activate a library are unaffected — and an intrinsic-bound call
+    /// reaching codegen without its bindings fails closed (generic-builtin
+    /// lookup fails) rather than ever lowering wrongly.
+    pub library_bindings: ironplc_dsl::bindings::LibraryBindings,
 }
 
 pub fn compile(
@@ -243,14 +249,28 @@ pub fn compile(
 
     let reachable = context.reachable();
 
-    // Collect user-defined function declarations from the library,
-    // filtering to only reachable functions.
+    // Pre-resolve the activated libraries' bindings (intrinsic names →
+    // func_ids, parameter op types from the library declarations) for call
+    // lowering; an unresolvable intrinsic name is a packaging error (P6010).
+    let resolved_bindings =
+        crate::compile_library::resolve_bindings(library, &options.library_bindings)?;
+
+    // Collect user-defined function declarations from the library, filtering
+    // to only reachable functions and skipping bound library POUs — their `;`
+    // bodies are never compiled; calls lower through the binding instead. The
+    // FileId check inside `is_bound_library_function` preserves user
+    // shadowing: a user function with a bound name still compiles.
     let func_decls: Vec<&FunctionDeclaration> = library
         .elements
         .iter()
         .filter_map(|e| {
             if let LibraryElementKind::FunctionDeclaration(f) = e {
-                reachable.contains(&f.name).then_some(f)
+                (reachable.contains(&f.name)
+                    && !crate::compile_library::is_bound_library_function(
+                        f,
+                        &options.library_bindings,
+                    ))
+                .then_some(f)
             } else {
                 None
             }
@@ -284,6 +304,7 @@ pub fn compile(
         context.types(),
         enum_map,
         sources,
+        resolved_bindings,
     )?;
 
     if options.system_uptime_global {
@@ -431,6 +452,7 @@ fn compile_program_with_functions(
     types: &TypeEnvironment,
     enum_map: crate::compile_enum::EnumOrdinalMap,
     sources: &dyn crate::source_lookup::SourceLookup,
+    library_bindings: crate::compile_library::ResolvedBindings,
 ) -> Result<Container, Diagnostic> {
     let ProgramInputs {
         program,
@@ -440,6 +462,7 @@ fn compile_program_with_functions(
     } = inputs;
     let mut ctx = CompileContext::new();
     ctx.enum_map = enum_map;
+    ctx.library_bindings = library_bindings;
     let mut builder = ContainerBuilder::new();
 
     // Register every top-level POU's source file with the debug
@@ -882,6 +905,10 @@ pub(crate) struct CompileContext {
     pub(crate) debug_source_files: crate::source_lookup::SourceFileRegistry,
     /// Maps user-defined function name (lowercase) to compilation metadata.
     pub(crate) user_functions: HashMap<String, UserFunctionInfo>,
+    /// Pre-resolved compatibility-library bindings for call lowering.
+    /// Checked after `user_functions` in `compile_function_call`, so user
+    /// shadowing needs no extra mechanism.
+    pub(crate) library_bindings: crate::compile_library::ResolvedBindings,
     /// Maps user-defined FB type name (uppercase) to compilation metadata.
     pub(crate) user_fb_types: HashMap<String, UserFbTypeInfo>,
     /// Next available type ID for user-defined function blocks.
@@ -940,6 +967,7 @@ impl CompileContext {
             debug_string_layouts: Vec::new(),
             debug_source_files: crate::source_lookup::SourceFileRegistry::new(),
             user_functions: HashMap::new(),
+            library_bindings: crate::compile_library::ResolvedBindings::default(),
             user_fb_types: HashMap::new(),
             next_user_fb_type_id: 0x1000,
             enum_map: crate::compile_enum::EnumOrdinalMap::default(),

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -237,9 +237,17 @@ pub(crate) fn compile_function_call(
         "mul_time" => compile_mul_div_time(emitter, ctx, func, true),
         "div_time" => compile_mul_div_time(emitter, ctx, func, false),
         _ => {
-            // Check user-defined functions first.
+            // Check user-defined functions first — a user function shadowing
+            // a bound library name compiles as the user's function with no
+            // extra mechanism (`REQ-CL-analyzer-004`). Library bindings come
+            // next: intrinsic-bound calls lower to BUILTIN, declare-only
+            // calls fail with P4046.
             if let Some(func_info) = ctx.user_functions.get(name.as_str()).cloned() {
                 compile_user_function_call(emitter, ctx, func, &func_info)
+            } else if let Some(result) =
+                crate::compile_library::compile_bound_call(emitter, ctx, func)
+            {
+                result
             } else if let Some(conv) = parse_string_conversion(name) {
                 compile_string_conversion(emitter, ctx, func, conv)
             } else if let Some((source, target)) = parse_type_conversion(name) {

--- a/compiler/codegen/src/compile_library.rs
+++ b/compiler/codegen/src/compile_library.rs
@@ -1,0 +1,211 @@
+//! Compatibility-library binding support for code generation.
+//!
+//! Codegen consumes the bindings side-table (`ironplc_dsl::bindings`,
+//! produced by the `sources` loader and threaded in via
+//! [`CodegenOptions::library_bindings`](crate::CodegenOptions)) at two
+//! points:
+//!
+//! 1. **Body compilation** — a bound library POU's `;` body is never
+//!    compiled ([`is_bound_library_function`]); the `FileId` check preserves
+//!    user shadowing, so a user-defined POU with the same name still
+//!    compiles as the user's function (`REQ-CL-analyzer-004`).
+//! 2. **Call lowering** — after the `user_functions` check in
+//!    `compile_function_call`, a call to an intrinsic-bound POU compiles its
+//!    arguments at the declared parameter types and emits `BUILTIN func_id`
+//!    per ADR-0008 (`REQ-CL-codegen-001`); a call to a declare-only POU is
+//!    the dedicated compile error P4046, never silently-wrong codegen and
+//!    never a runtime trap (`REQ-CL-codegen-002`).
+
+use std::collections::HashMap;
+
+use ironplc_container::opcode;
+use ironplc_dsl::bindings::{LibraryBindings, PouBinding};
+use ironplc_dsl::common::{
+    FunctionDeclaration, InitialValueAssignmentKind, Library, LibraryElementKind, VariableType,
+};
+use ironplc_dsl::core::Located;
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
+use ironplc_dsl::textual::{Expr, Function, ParamAssignmentKind};
+use ironplc_problems::Problem;
+
+use crate::compile::{CompileContext, OpType, DEFAULT_OP_TYPE};
+use crate::compile_expr::compile_expr;
+use crate::compile_setup::resolve_type_name;
+use crate::emit::Emitter;
+
+/// A binding resolved against the merged library's declarations, ready for
+/// call lowering.
+#[derive(Clone)]
+pub(crate) enum ResolvedBinding {
+    /// Calls lower to `BUILTIN func_id`, compiling each argument at the
+    /// declared parameter's op type.
+    Intrinsic {
+        func_id: u16,
+        param_op_types: Vec<OpType>,
+    },
+    /// Calls fail compilation with P4046, naming the declaring library.
+    DeclareOnly { library: String },
+}
+
+/// Bindings pre-resolved for codegen, keyed by uppercased POU name.
+///
+/// `Default` is empty: consumers that never thread bindings (benchmarks,
+/// direct `compile()` callers, the playground before its threading phase)
+/// see no bound names, so an intrinsic-bound call falls through to the
+/// generic-builtin path and fails closed rather than lowering wrongly.
+#[derive(Clone, Default)]
+pub(crate) struct ResolvedBindings {
+    map: HashMap<String, ResolvedBinding>,
+}
+
+impl ResolvedBindings {
+    /// Looks up the resolved binding for a POU name (case-insensitive).
+    pub(crate) fn get(&self, pou_name: &str) -> Option<&ResolvedBinding> {
+        self.map.get(&pou_name.to_uppercase())
+    }
+}
+
+/// True when this function declaration is a bound library POU whose body must
+/// not be compiled: its name carries a binding *and* it was declared in a
+/// library source file. A user-defined function that shadows a bound name
+/// fails the `FileId` check and compiles normally.
+pub(crate) fn is_bound_library_function(
+    decl: &FunctionDeclaration,
+    bindings: &LibraryBindings,
+) -> bool {
+    bindings.get(decl.name.original()).is_some()
+        && bindings.is_library_file(&decl.name.span.file_id)
+}
+
+/// Resolves every binding that has a matching library declaration.
+///
+/// Intrinsic names resolve through the single name→func_id table beside the
+/// func_id constants (`opcode::builtin::intrinsic_func_id`). A name that does
+/// not resolve is a packaging error in the library — bundled manifests are
+/// guarded by a conformance test, and this is the defensive backstop — and
+/// fails with P6010 anchored on the library's manifest file. Parameter op
+/// types come from the library's own `.st` declaration, which is what makes
+/// argument compilation match the signature `check` validated against.
+pub(crate) fn resolve_bindings(
+    library: &Library,
+    bindings: &LibraryBindings,
+) -> Result<ResolvedBindings, Diagnostic> {
+    let mut map = HashMap::new();
+    for element in &library.elements {
+        let LibraryElementKind::FunctionDeclaration(decl) = element else {
+            continue;
+        };
+        if !is_bound_library_function(decl, bindings) {
+            continue;
+        }
+        // Present by the `is_bound_library_function` check above.
+        let bound = bindings.get(decl.name.original()).unwrap();
+        let resolved = match &bound.binding {
+            PouBinding::Intrinsic { name } => {
+                let func_id = opcode::builtin::intrinsic_func_id(name).ok_or_else(|| {
+                    Diagnostic::problem(
+                        Problem::LibraryManifestInvalid,
+                        Label::file(
+                            bound.manifest_file.clone(),
+                            format!(
+                                "library `{}` binds `{}` to unknown intrinsic `{name}`",
+                                bound.library,
+                                decl.name.original()
+                            ),
+                        ),
+                    )
+                })?;
+                ResolvedBinding::Intrinsic {
+                    func_id,
+                    param_op_types: input_param_op_types(decl),
+                }
+            }
+            PouBinding::DeclareOnly => ResolvedBinding::DeclareOnly {
+                library: bound.library.clone(),
+            },
+        };
+        map.insert(decl.name.original().to_uppercase(), resolved);
+    }
+    Ok(ResolvedBindings { map })
+}
+
+/// The op type of each `VAR_INPUT` parameter, in declaration order.
+fn input_param_op_types(decl: &FunctionDeclaration) -> Vec<OpType> {
+    decl.variables
+        .iter()
+        .filter(|v| v.var_type == VariableType::Input)
+        .map(|v| match &v.initializer {
+            InitialValueAssignmentKind::Simple(simple) => resolve_type_name(&simple.type_name.name)
+                .map(|info| (info.op_width, info.signedness))
+                .unwrap_or(DEFAULT_OP_TYPE),
+            _ => DEFAULT_OP_TYPE,
+        })
+        .collect()
+}
+
+/// Compiles a call to a bound library POU, if the name is bound.
+///
+/// Returns `None` when the name carries no binding, so the caller can fall
+/// through to the remaining call-lowering paths.
+pub(crate) fn compile_bound_call(
+    emitter: &mut Emitter,
+    ctx: &mut CompileContext,
+    func: &Function,
+) -> Option<Result<(), Diagnostic>> {
+    let resolved = ctx.library_bindings.get(func.name.original())?.clone();
+    Some(match resolved {
+        ResolvedBinding::Intrinsic {
+            func_id,
+            param_op_types,
+        } => compile_intrinsic_call(emitter, ctx, func, func_id, &param_op_types),
+        ResolvedBinding::DeclareOnly { library } => Err(Diagnostic::problem(
+            Problem::LibraryFunctionNotImplemented,
+            Label::span(
+                func.name.span(),
+                format!(
+                    "`{}` is declared by compatibility library `{library}` as \
+                     declare-only: its implementation has not been built, so a \
+                     call to it cannot be compiled",
+                    func.name.original()
+                ),
+            ),
+        )),
+    })
+}
+
+/// Lowers an intrinsic-bound call: each argument compiles at the declared
+/// parameter's op type, then `BUILTIN func_id` (`REQ-CL-codegen-001`).
+fn compile_intrinsic_call(
+    emitter: &mut Emitter,
+    ctx: &mut CompileContext,
+    func: &Function,
+    func_id: u16,
+    param_op_types: &[OpType],
+) -> Result<(), Diagnostic> {
+    // Named arguments are already rewritten to positional by the analyzer
+    // (xform_named_to_positional_args), matching the user-function path.
+    let args: Vec<&Expr> = func
+        .param_assignment
+        .iter()
+        .filter_map(|p| match p {
+            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
+            _ => None,
+        })
+        .collect();
+
+    // The analyzer type-checked the call against the library's declaration,
+    // which is the same declaration the parameter types came from.
+    if args.len() != param_op_types.len() {
+        return Err(Diagnostic::todo_with_span(
+            func.name.span(),
+            file!(),
+            line!(),
+        ));
+    }
+
+    for (arg, param_op_type) in args.iter().zip(param_op_types) {
+        compile_expr(emitter, ctx, arg, *param_op_type)?;
+    }
+    emitter.emit_builtin(func_id);
+    Ok(())
+}

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -35,6 +35,7 @@ mod compile_call;
 mod compile_enum;
 mod compile_expr;
 mod compile_fn;
+mod compile_library;
 mod compile_setup;
 mod compile_stmt;
 mod compile_string;

--- a/compiler/codegen/src/spec_conformance.rs
+++ b/compiler/codegen/src/spec_conformance.rs
@@ -993,8 +993,7 @@ fn codegen_spec_req_cl_001_intrinsic_bound_call_lowers_to_builtin() {
         .windows(3)
         .position(|w| {
             w[0] == ironplc_container::opcode::BUILTIN
-                && u16::from_le_bytes([w[1], w[2]])
-                    == ironplc_container::opcode::builtin::TRUNC_F64
+                && u16::from_le_bytes([w[1], w[2]]) == ironplc_container::opcode::builtin::TRUNC_F64
         })
         .expect("scan bytecode must contain BUILTIN TRUNC_F64");
     assert!(builtin_pos > 0);
@@ -1045,19 +1044,15 @@ END_PROGRAM
 ";
     // No library declaration merged at all: everything is user source.
     let options = CompilerOptions::default();
-    let user = ironplc_parser::parse_program(
-        user_source,
-        &FileId::from_string("user.st"),
-        &options,
-    )
-    .unwrap();
+    let user =
+        ironplc_parser::parse_program(user_source, &FileId::from_string("user.st"), &options)
+            .unwrap();
     let (analyzed, ctx) = ironplc_analyzer::stages::resolve_types(&[&user], &options).unwrap();
     let codegen_options = crate::CodegenOptions {
         library_bindings: bindings,
         ..Default::default()
     };
-    let container =
-        crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
+    let container = crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
 
     // The user body compiled (init + scan + the user function) and the call
     // lowered to CALL, not to the bound builtin.
@@ -1070,8 +1065,7 @@ END_PROGRAM
     assert!(
         !scan.windows(3).any(|w| {
             w[0] == ironplc_container::opcode::BUILTIN
-                && u16::from_le_bytes([w[1], w[2]])
-                    == ironplc_container::opcode::builtin::TRUNC_F64
+                && u16::from_le_bytes([w[1], w[2]]) == ironplc_container::opcode::builtin::TRUNC_F64
         }),
         "a shadowing user function must not lower to the bound builtin"
     );

--- a/compiler/codegen/src/spec_conformance.rs
+++ b/compiler/codegen/src/spec_conformance.rs
@@ -903,3 +903,176 @@ END_PROGRAM
     // vars: x=0, r=1, y=2. `r + 2` must use r's dereferenced value (40 + 2).
     assert_eq!(bufs.vars[2].as_i32(), 42);
 }
+
+// ---------------------------------------------------------------------------
+// Compatibility-library bindings (REQ-CL-codegen-*)
+// See specs/design/compatibility-libraries.md §Bodies and bindings and
+// specs/plans/2026-08-08-compatibility-library-bindings.md.
+// ---------------------------------------------------------------------------
+
+/// A `LibraryBindings` fixture: `pou` bound as `binding`, declared in the
+/// library file `lib.st`.
+fn library_bindings_fixture(
+    pou: &str,
+    binding: ironplc_dsl::bindings::PouBinding,
+) -> ironplc_dsl::bindings::LibraryBindings {
+    let mut bindings = ironplc_dsl::bindings::LibraryBindings::new();
+    bindings.insert(
+        pou,
+        ironplc_dsl::bindings::BoundPou {
+            library: "Tc2_Math".to_string(),
+            manifest_file: FileId::from_string("library.toml"),
+            binding,
+        },
+    );
+    bindings.add_library_file(FileId::from_string("lib.st"));
+    bindings
+}
+
+/// Parses `library_source` as a library file (`lib.st`) and `user_source` as
+/// user source, analyzes them merged, and compiles with `bindings` threaded.
+fn compile_with_bindings(
+    library_source: &str,
+    user_source: &str,
+    bindings: ironplc_dsl::bindings::LibraryBindings,
+) -> Result<ironplc_container::Container, ironplc_dsl::diagnostic::Diagnostic> {
+    let options = CompilerOptions::default();
+    let lib =
+        ironplc_parser::parse_program(library_source, &FileId::from_string("lib.st"), &options)
+            .unwrap();
+    let user =
+        ironplc_parser::parse_program(user_source, &FileId::from_string("user.st"), &options)
+            .unwrap();
+    let (analyzed, ctx) =
+        ironplc_analyzer::stages::resolve_types(&[&lib, &user], &options).unwrap();
+    let codegen_options = crate::CodegenOptions {
+        library_bindings: bindings,
+        ..Default::default()
+    };
+    crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup)
+}
+
+const LTRUNC_DECLARATION: &str = "FUNCTION LTRUNC : LREAL
+VAR_INPUT
+    IN : LREAL;
+END_VAR
+;
+END_FUNCTION
+";
+
+const LTRUNC_CALLER: &str = "PROGRAM main
+VAR
+    x : LREAL;
+END_VAR
+    x := LTRUNC(3.7);
+END_PROGRAM
+";
+
+/// REQ-CL-codegen-001: A call to a library POU bound to an intrinsic compiles
+/// to `BUILTIN func_id` — not to a CALL of the POU's (empty) ST body, which is
+/// never compiled.
+#[spec_test(REQ_CL_codegen_001)]
+fn codegen_spec_req_cl_001_intrinsic_bound_call_lowers_to_builtin() {
+    let bindings = library_bindings_fixture(
+        "LTRUNC",
+        ironplc_dsl::bindings::PouBinding::Intrinsic {
+            name: "trunc_lreal".to_string(),
+        },
+    );
+    let container = compile_with_bindings(LTRUNC_DECLARATION, LTRUNC_CALLER, bindings).unwrap();
+
+    // The bound `;` body was never compiled: only init (0) and scan (1).
+    assert_eq!(container.code.functions.len(), 2);
+
+    // The call site lowered to BUILTIN TRUNC_F64 and no CALL was emitted.
+    let scan = container
+        .code
+        .get_function_bytecode(ironplc_container::FunctionId::new(1))
+        .unwrap();
+    let builtin_pos = scan
+        .windows(3)
+        .position(|w| {
+            w[0] == ironplc_container::opcode::BUILTIN
+                && u16::from_le_bytes([w[1], w[2]])
+                    == ironplc_container::opcode::builtin::TRUNC_F64
+        })
+        .expect("scan bytecode must contain BUILTIN TRUNC_F64");
+    assert!(builtin_pos > 0);
+    assert!(
+        !scan.contains(&ironplc_container::opcode::CALL),
+        "an intrinsic-bound call must not emit CALL"
+    );
+}
+
+/// REQ-CL-codegen-002: A call to a declare-only library POU fails compilation
+/// with the dedicated diagnostic P4046, naming the library and POU.
+#[spec_test(REQ_CL_codegen_002)]
+fn codegen_spec_req_cl_002_declare_only_call_fails_with_p4046() {
+    let bindings =
+        library_bindings_fixture("LTRUNC", ironplc_dsl::bindings::PouBinding::DeclareOnly);
+    let err = compile_with_bindings(LTRUNC_DECLARATION, LTRUNC_CALLER, bindings).unwrap_err();
+    assert_eq!(err.code, "P4046");
+    assert!(err.primary.message.contains("Tc2_Math"));
+    assert!(err.primary.message.contains("LTRUNC"));
+}
+
+/// User shadowing (REQ-CL-analyzer-004 at the codegen layer): a user-defined
+/// function with the same name as a bound library POU compiles as the user's
+/// function — binding lowering applies only to the library's declaration.
+#[test]
+fn codegen_when_user_function_shadows_bound_name_then_user_body_compiles() {
+    let bindings = library_bindings_fixture(
+        "LTRUNC",
+        ironplc_dsl::bindings::PouBinding::Intrinsic {
+            name: "trunc_lreal".to_string(),
+        },
+    );
+    // The user declares their own LTRUNC (in user.st, not a library file)
+    // with a real body.
+    let user_source = "FUNCTION LTRUNC : LREAL
+VAR_INPUT
+    IN : LREAL;
+END_VAR
+    LTRUNC := IN;
+END_FUNCTION
+
+PROGRAM main
+VAR
+    x : LREAL;
+END_VAR
+    x := LTRUNC(3.7);
+END_PROGRAM
+";
+    // No library declaration merged at all: everything is user source.
+    let options = CompilerOptions::default();
+    let user = ironplc_parser::parse_program(
+        user_source,
+        &FileId::from_string("user.st"),
+        &options,
+    )
+    .unwrap();
+    let (analyzed, ctx) = ironplc_analyzer::stages::resolve_types(&[&user], &options).unwrap();
+    let codegen_options = crate::CodegenOptions {
+        library_bindings: bindings,
+        ..Default::default()
+    };
+    let container =
+        crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
+
+    // The user body compiled (init + scan + the user function) and the call
+    // lowered to CALL, not to the bound builtin.
+    assert_eq!(container.code.functions.len(), 3);
+    let scan = container
+        .code
+        .get_function_bytecode(ironplc_container::FunctionId::new(1))
+        .unwrap();
+    assert!(scan.contains(&ironplc_container::opcode::CALL));
+    assert!(
+        !scan.windows(3).any(|w| {
+            w[0] == ironplc_container::opcode::BUILTIN
+                && u16::from_le_bytes([w[1], w[2]])
+                    == ironplc_container::opcode::builtin::TRUNC_F64
+        }),
+        "a shadowing user function must not lower to the bound builtin"
+    );
+}

--- a/compiler/codegen/tests/it/common/mod.rs
+++ b/compiler/codegen/tests/it/common/mod.rs
@@ -587,6 +587,7 @@ pub fn try_parse_and_compile(
     let (library, context) = parse(source, options);
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
+        ..Default::default()
     };
     compile(
         &library,
@@ -612,6 +613,7 @@ pub fn parse_and_try_run(
     let (library, context) = parse(source, options);
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
+        ..Default::default()
     };
     let container = compile(
         &library,
@@ -640,6 +642,7 @@ pub fn parse_and_run_rounds(
     let (library, context) = parse(source, options);
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
+        ..Default::default()
     };
     let container = compile(
         &library,

--- a/compiler/codegen/tests/it/end_to_end_library_bindings.rs
+++ b/compiler/codegen/tests/it/end_to_end_library_bindings.rs
@@ -1,0 +1,190 @@
+//! End-to-end tests for the bundled `Tc2_Math`/`Tc2_System` compatibility
+//! libraries: activate the real bundled package, compile against it with its
+//! bindings threaded, and run the VM.
+//!
+//! This is the full paved-path pipeline (load library → analyze merged →
+//! codegen with bindings → VM), pinning the behaviors from the clean-room
+//! specs in `specs/design/library-interfaces/`.
+
+use ironplc_container::{Container, STRING_HEADER_BYTES};
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_sources::libraries::{LibraryName, LibraryRegistry};
+use ironplc_vm::test_support::load_and_start;
+use ironplc_vm::VmBuffers;
+
+/// Loads the named bundled libraries, merges them ahead of `user_source`,
+/// and compiles with the libraries' bindings threaded into codegen.
+fn compile_with_bundled_libraries(
+    library_names: &[&str],
+    user_source: &str,
+) -> Result<Container, ironplc_dsl::diagnostic::Diagnostic> {
+    let options = CompilerOptions::default();
+    let registry = LibraryRegistry::bundled();
+
+    let mut bindings = ironplc_dsl::bindings::LibraryBindings::new();
+    let mut compat_libraries = Vec::new();
+    for name in library_names {
+        let loaded = registry.load(&LibraryName::from(*name)).unwrap();
+        bindings.merge(loaded.bindings.clone());
+        compat_libraries.push(loaded.library);
+    }
+
+    let user =
+        ironplc_parser::parse_program(user_source, &FileId::from_string("user.st"), &options)
+            .unwrap();
+    let analyze_input: Vec<&ironplc_dsl::common::Library> =
+        compat_libraries.iter().chain(std::iter::once(&user)).collect();
+    let (analyzed, ctx) =
+        ironplc_analyzer::stages::resolve_types(&analyze_input, &options).unwrap();
+
+    let codegen_options = ironplc_codegen::CodegenOptions {
+        library_bindings: bindings,
+        ..Default::default()
+    };
+    ironplc_codegen::compile(&analyzed, &ctx, &codegen_options, &ironplc_codegen::EmptyLookup)
+}
+
+/// Compiles with the bundled libraries and runs one scan cycle.
+fn run_with_bundled_libraries(library_names: &[&str], user_source: &str) -> VmBuffers {
+    let container = compile_with_bundled_libraries(library_names, user_source).unwrap();
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs).unwrap();
+        vm.run_round(0).unwrap();
+    }
+    bufs
+}
+
+/// Compiles a one-expression `LREAL` program against `Tc2_Math` and returns
+/// `result`.
+///
+/// The operands are `LREAL` variables (`a`, `b`), not literals: an untyped
+/// real literal is typed `REAL` and narrows through f32 on the user-function
+/// call path, which would blur the 1e-9 pins here. Call-site REAL→LREAL
+/// widening is separately planned work
+/// (specs/plans/2026-07-27-twincat-real-to-lreal-widening.md).
+fn eval_tc2_math(a: f64, b: f64, expression: &str) -> f64 {
+    let source = format!(
+        "PROGRAM main
+VAR
+    a : LREAL;
+    b : LREAL;
+    result : LREAL;
+END_VAR
+    a := {a};
+    b := {b};
+    result := {expression};
+END_PROGRAM
+"
+    );
+    let bufs = run_with_bundled_libraries(&["Tc2_Math"], &source);
+    bufs.vars[2].as_f64()
+}
+
+fn assert_near(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1e-9,
+        "expected ≈ {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn end_to_end_when_ltrunc_then_truncates_toward_zero() {
+    assert_near(eval_tc2_math(3.7, 0.0, "LTRUNC(a)"), 3.0);
+    assert_near(eval_tc2_math(-3.7, 0.0, "LTRUNC(a)"), -3.0);
+}
+
+#[test]
+fn end_to_end_when_lmod_then_signed_fractional_remainder() {
+    assert_near(eval_tc2_math(400.56, 360.0, "LMOD(a, b)"), 40.56);
+    assert_near(eval_tc2_math(-400.56, 360.0, "LMOD(a, b)"), -40.56);
+}
+
+#[test]
+fn end_to_end_when_modabs_then_unsigned_within_modulo_range() {
+    assert_near(eval_tc2_math(400.56, 360.0, "MODABS(a, b)"), 40.56);
+    assert_near(eval_tc2_math(-400.56, 360.0, "MODABS(a, b)"), 319.44);
+}
+
+#[test]
+fn end_to_end_when_frac_then_keeps_sign_of_input() {
+    assert_near(eval_tc2_math(3.7, 0.0, "FRAC(a)"), 0.7);
+    assert_near(eval_tc2_math(-3.7, 0.0, "FRAC(a)"), -0.7);
+}
+
+/// Reads a STRING value from the data region at the given byte offset.
+fn read_string(data_region: &[u8], data_offset: usize) -> String {
+    let cur_len =
+        u16::from_le_bytes([data_region[data_offset + 2], data_region[data_offset + 3]]) as usize;
+    let data_start = data_offset + STRING_HEADER_BYTES;
+    let bytes = &data_region[data_start..data_start + cur_len];
+    bytes.iter().map(|&b| b as char).collect()
+}
+
+#[test]
+fn end_to_end_when_bool_to_string_then_true_false_keywords() {
+    // BOOL_TO_STRING is a plain library ST function in Tc2_System — no
+    // intrinsic, no func_id (ADR-0042 rule 2).
+    let source = "PROGRAM main
+VAR
+    s : STRING;
+END_VAR
+    s := BOOL_TO_STRING(TRUE);
+END_PROGRAM
+";
+    let bufs = run_with_bundled_libraries(&["Tc2_System"], source);
+    assert_eq!(read_string(&bufs.data_region, 0), "TRUE");
+
+    let source = "PROGRAM main
+VAR
+    s : STRING;
+END_VAR
+    s := BOOL_TO_STRING(FALSE);
+END_PROGRAM
+";
+    let bufs = run_with_bundled_libraries(&["Tc2_System"], source);
+    assert_eq!(read_string(&bufs.data_region, 0), "FALSE");
+}
+
+#[test]
+fn end_to_end_when_lreal_to_fmtstr_called_then_p4046_at_compile() {
+    // Declare-only: the surface exists (check passes — covered by the
+    // analyzer's REQ-CL-analyzer-007 test and the CLI split test), but
+    // compiling a call is the dedicated error, never wrong codegen.
+    let source = "PROGRAM main
+VAR
+    s : STRING[255];
+END_VAR
+    s := LREAL_TO_FMTSTR(1.5, 2, TRUE);
+END_PROGRAM
+";
+    let err = compile_with_bundled_libraries(&["Tc2_Utilities"], source).unwrap_err();
+    assert_eq!(err.code, "P4046");
+    assert!(err.primary.message.contains("Tc2_Utilities"));
+    assert!(err.primary.message.contains("LREAL_TO_FMTSTR"));
+}
+
+/// Every bundled library's intrinsic bindings resolve via
+/// `intrinsic_func_id` — the packaging conformance guard for the defensive
+/// P6010 in codegen.
+#[test]
+fn bundled_libraries_when_intrinsic_bindings_then_all_resolve() {
+    let registry = LibraryRegistry::bundled();
+    let names = registry.library_names();
+    assert!(!names.is_empty(), "bundled registry must not be empty");
+    for name in names {
+        let loaded = registry.load(&name).unwrap();
+        for (pou, bound) in loaded.bindings.iter() {
+            if let ironplc_dsl::bindings::PouBinding::Intrinsic { name: intrinsic } =
+                &bound.binding
+            {
+                assert!(
+                    ironplc_container::opcode::builtin::intrinsic_func_id(intrinsic).is_some(),
+                    "library `{}` binds `{pou}` to unknown intrinsic `{intrinsic}`",
+                    bound.library
+                );
+            }
+        }
+    }
+}

--- a/compiler/codegen/tests/it/end_to_end_library_bindings.rs
+++ b/compiler/codegen/tests/it/end_to_end_library_bindings.rs
@@ -15,10 +15,12 @@ use ironplc_vm::VmBuffers;
 
 /// Loads the named bundled libraries, merges them ahead of `user_source`,
 /// and compiles with the libraries' bindings threaded into codegen.
+///
+/// The boxed `Err` keeps the return slim (clippy::result_large_err).
 fn compile_with_bundled_libraries(
     library_names: &[&str],
     user_source: &str,
-) -> Result<Container, ironplc_dsl::diagnostic::Diagnostic> {
+) -> Result<Container, Box<ironplc_dsl::diagnostic::Diagnostic>> {
     let options = CompilerOptions::default();
     let registry = LibraryRegistry::bundled();
 
@@ -33,8 +35,10 @@ fn compile_with_bundled_libraries(
     let user =
         ironplc_parser::parse_program(user_source, &FileId::from_string("user.st"), &options)
             .unwrap();
-    let analyze_input: Vec<&ironplc_dsl::common::Library> =
-        compat_libraries.iter().chain(std::iter::once(&user)).collect();
+    let analyze_input: Vec<&ironplc_dsl::common::Library> = compat_libraries
+        .iter()
+        .chain(std::iter::once(&user))
+        .collect();
     let (analyzed, ctx) =
         ironplc_analyzer::stages::resolve_types(&analyze_input, &options).unwrap();
 
@@ -42,7 +46,13 @@ fn compile_with_bundled_libraries(
         library_bindings: bindings,
         ..Default::default()
     };
-    ironplc_codegen::compile(&analyzed, &ctx, &codegen_options, &ironplc_codegen::EmptyLookup)
+    ironplc_codegen::compile(
+        &analyzed,
+        &ctx,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
+    .map_err(Box::new)
 }
 
 /// Compiles with the bundled libraries and runs one scan cycle.
@@ -176,8 +186,7 @@ fn bundled_libraries_when_intrinsic_bindings_then_all_resolve() {
     for name in names {
         let loaded = registry.load(&name).unwrap();
         for (pou, bound) in loaded.bindings.iter() {
-            if let ironplc_dsl::bindings::PouBinding::Intrinsic { name: intrinsic } =
-                &bound.binding
+            if let ironplc_dsl::bindings::PouBinding::Intrinsic { name: intrinsic } = &bound.binding
             {
                 assert!(
                     ironplc_container::opcode::builtin::intrinsic_func_id(intrinsic).is_some(),

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -84,6 +84,7 @@ mod end_to_end_insert;
 mod end_to_end_ldate;
 mod end_to_end_left;
 mod end_to_end_len;
+mod end_to_end_library_bindings;
 mod end_to_end_limit;
 mod end_to_end_limit_float;
 mod end_to_end_limit_lint;

--- a/compiler/codegen/tests/it/wire_format.rs
+++ b/compiler/codegen/tests/it/wire_format.rs
@@ -215,6 +215,23 @@ fn opcode_constants_when_builtin_then_pinned_byte() {
 }
 
 #[test]
+fn builtin_func_ids_when_library_bound_builtins_then_pinned_values() {
+    // Library-bound (unnamed) builtins are permanent compiler/VM ABI:
+    // manifests reach them via `intrinsic_func_id`, so both the id values
+    // and the binding names are wire-format commitments.
+    assert_eq!(opcode::builtin::TRUNC_F64, 0x03A3);
+    assert_eq!(opcode::builtin::MOD_F64, 0x03A4);
+    assert_eq!(
+        opcode::builtin::intrinsic_func_id("trunc_lreal"),
+        Some(0x03A3)
+    );
+    assert_eq!(
+        opcode::builtin::intrinsic_func_id("fmod_lreal"),
+        Some(0x03A4)
+    );
+}
+
+#[test]
 fn opcode_constants_when_fb_family_then_pinned_bytes() {
     assert_eq!(opcode::FB_LOAD_INSTANCE, 0x98);
     assert_eq!(opcode::FB_STORE_PARAM, 0x9C);

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -1212,6 +1212,37 @@ pub mod builtin {
     pub const CMP_STR: u16 = 0x03A2;
 
     // =========================================================================
+    // Unnamed library-bound builtins
+    //
+    // These func_ids have no compiler-seeded name: they are reachable only
+    // through a compatibility library's manifest binding (ADR-0042 rule 3).
+    // Manifests refer to them via the names in `intrinsic_func_id`.
+    // =========================================================================
+
+    /// LREAL-preserving truncation toward zero (`f64::trunc`): pops one f64,
+    /// pushes its integer part as f64. Bound as `trunc_lreal`.
+    pub const TRUNC_F64: u16 = 0x03A3;
+
+    /// Floating-point modulo with the sign of the dividend (Rust `%` on f64,
+    /// i.e. fmod; `x % 0.0` is NaN, not a trap): pops divisor then dividend,
+    /// pushes the remainder. Bound as `fmod_lreal`.
+    pub const MOD_F64: u16 = 0x03A4;
+
+    /// Resolves a manifest `intrinsic` binding name to its func_id.
+    ///
+    /// This is the single name→func_id table for library-bound builtins:
+    /// `sources` validates manifest names against it and codegen lowers
+    /// bound calls through it. Returns `None` for unknown names, which a
+    /// bundled-library conformance test treats as a packaging error.
+    pub fn intrinsic_func_id(name: &str) -> Option<u16> {
+        match name {
+            "trunc_lreal" => Some(TRUNC_F64),
+            "fmod_lreal" => Some(MOD_F64),
+            _ => None,
+        }
+    }
+
+    // =========================================================================
     // MUX (multiplexer) range-based opcodes
     //
     // MUX is extensible: the number of IN arguments varies per call site.
@@ -1274,11 +1305,12 @@ pub mod builtin {
             | BCD_TO_INT_16 | BCD_TO_INT_32 | BCD_TO_INT_64 | INT_TO_BCD_8 | INT_TO_BCD_16
             | INT_TO_BCD_32 | INT_TO_BCD_64 | CONV_I32_TO_BOOL | CONV_I64_TO_BOOL
             | CONV_I32_TO_STR | CONV_U32_TO_STR | CONV_STR_TO_I32 | CONV_F32_TO_STR
-            | CONV_STR_TO_F32 => 1,
+            | CONV_STR_TO_F32 | TRUNC_F64 => 1,
             EXPT_I32 | EXPT_F32 | EXPT_F64 | EXPT_I64 | MIN_I32 | MIN_F32 | MIN_F64 | MIN_I64
             | MIN_U32 | MIN_U64 | MAX_I32 | MAX_F32 | MAX_F64 | MAX_I64 | MAX_U32 | MAX_U64
             | SHL_I32 | SHL_I64 | SHR_I32 | SHR_I64 | ROL_I32 | ROL_I64 | ROR_I32 | ROR_I64
-            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 | ATAN2_F32 | ATAN2_F64 | CMP_STR => 2,
+            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 | ATAN2_F32 | ATAN2_F64 | CMP_STR
+            | MOD_F64 => 2,
             LIMIT_I32 | LIMIT_F32 | LIMIT_F64 | LIMIT_I64 | LIMIT_U32 | LIMIT_U64 | SEL_I32
             | SEL_F32 | SEL_F64 | SEL_I64 => 3,
             id if is_mux(id) => {
@@ -1352,5 +1384,30 @@ mod tests {
     #[should_panic(expected = "unknown builtin function ID")]
     fn arg_count_when_unknown_function_id_then_panics() {
         let _ = builtin::arg_count(0xFFFF);
+    }
+
+    #[test]
+    fn intrinsic_func_id_when_known_name_then_resolves() {
+        assert_eq!(
+            builtin::intrinsic_func_id("trunc_lreal"),
+            Some(builtin::TRUNC_F64)
+        );
+        assert_eq!(
+            builtin::intrinsic_func_id("fmod_lreal"),
+            Some(builtin::MOD_F64)
+        );
+    }
+
+    #[test]
+    fn intrinsic_func_id_when_unknown_name_then_none() {
+        assert_eq!(builtin::intrinsic_func_id("no_such_builtin"), None);
+        // Uppercase POU names are not intrinsic names.
+        assert_eq!(builtin::intrinsic_func_id("LTRUNC"), None);
+    }
+
+    #[test]
+    fn arg_count_when_library_bound_builtins_then_counts_match_dispatch() {
+        assert_eq!(builtin::arg_count(builtin::TRUNC_F64), 1);
+        assert_eq!(builtin::arg_count(builtin::MOD_F64), 2);
     }
 }

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -1309,8 +1309,7 @@ pub mod builtin {
             EXPT_I32 | EXPT_F32 | EXPT_F64 | EXPT_I64 | MIN_I32 | MIN_F32 | MIN_F64 | MIN_I64
             | MIN_U32 | MIN_U64 | MAX_I32 | MAX_F32 | MAX_F64 | MAX_I64 | MAX_U32 | MAX_U64
             | SHL_I32 | SHL_I64 | SHR_I32 | SHR_I64 | ROL_I32 | ROL_I64 | ROR_I32 | ROR_I64
-            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 | ATAN2_F32 | ATAN2_F64 | CMP_STR
-            | MOD_F64 => 2,
+            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 | ATAN2_F32 | ATAN2_F64 | CMP_STR | MOD_F64 => 2,
             LIMIT_I32 | LIMIT_F32 | LIMIT_F64 | LIMIT_I64 | LIMIT_U32 | LIMIT_U64 | SEL_I32
             | SEL_F32 | SEL_F64 | SEL_I64 => 3,
             id if is_mux(id) => {

--- a/compiler/dsl/src/bindings.rs
+++ b/compiler/dsl/src/bindings.rs
@@ -1,0 +1,174 @@
+//! Compatibility-library POU bindings.
+//!
+//! A binding maps a library POU to a non-default implementation: a native VM
+//! builtin (reached exclusively through the library's manifest — the builtin
+//! adds no name to any scope) or the declare-only state (the signature exists,
+//! calling it is a compile error). See
+//! `specs/design/compatibility-library-format.md` §Bindings and ADR-0042.
+//!
+//! Binding information travels *out of band*: the analyze merge erases which
+//! POUs came from a library, and provenance markers in the AST are forbidden,
+//! so the loader produces this side-table and the driver threads it into
+//! codegen. The analyzer never sees bindings — which is exactly what makes a
+//! declare-only call pass `check`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::core::FileId;
+
+/// How a bound library POU is implemented, from the manifest's per-version
+/// bindings table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PouBinding {
+    /// Calls lower to the named native VM builtin (an internal compiler/VM
+    /// identifier such as `trunc_lreal`, resolved to a func_id at codegen —
+    /// never a callable name in any scope).
+    Intrinsic {
+        /// The manifest's intrinsic name.
+        name: String,
+    },
+    /// The POU's signature exists so the library surface can land ahead of
+    /// its implementation; a *call* is a compile error (P4046).
+    DeclareOnly,
+}
+
+/// A binding plus the context needed to act on it at codegen: which library
+/// declared it (named by the P4046 diagnostic) and the manifest file to
+/// anchor packaging errors on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundPou {
+    /// The declaring library's name (e.g. `Tc2_Math`).
+    pub library: String,
+    /// The library's manifest file, anchoring diagnostics about the binding
+    /// itself (e.g. an unresolvable intrinsic name).
+    pub manifest_file: FileId,
+    /// The binding.
+    pub binding: PouBinding,
+}
+
+/// The bindings of every activated library, keyed by uppercased POU name,
+/// plus the set of library source files.
+///
+/// The file set is what preserves user shadowing: codegen skips a bound
+/// `FunctionDeclaration` only when its `FileId` is a library file, so a
+/// user-defined POU with the same name still compiles as the user's function.
+///
+/// `Default` is the empty set, so codegen consumers that never activate a
+/// library (benchmarks, direct `compile()` callers) are unaffected and an
+/// intrinsic-bound call in an unthreaded consumer fails closed rather than
+/// lowering wrongly.
+#[derive(Debug, Clone, Default)]
+pub struct LibraryBindings {
+    /// Uppercased POU name → binding.
+    bindings: HashMap<String, BoundPou>,
+    /// Every `.st` file of every activated library (bound or not).
+    library_files: HashSet<FileId>,
+}
+
+impl LibraryBindings {
+    /// An empty bindings set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// True when no library declared any binding and no library file is
+    /// registered.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty() && self.library_files.is_empty()
+    }
+
+    /// Registers a binding for a POU name (matched case-insensitively via
+    /// uppercasing, like the function environment).
+    pub fn insert(&mut self, pou_name: &str, bound: BoundPou) {
+        self.bindings.insert(pou_name.to_uppercase(), bound);
+    }
+
+    /// Looks up the binding for a POU name (case-insensitive).
+    pub fn get(&self, pou_name: &str) -> Option<&BoundPou> {
+        self.bindings.get(&pou_name.to_uppercase())
+    }
+
+    /// Registers a library source file.
+    pub fn add_library_file(&mut self, file_id: FileId) {
+        self.library_files.insert(file_id);
+    }
+
+    /// True when the file is a registered library source file.
+    pub fn is_library_file(&self, file_id: &FileId) -> bool {
+        self.library_files.contains(file_id)
+    }
+
+    /// Merges another activated library's bindings into this set.
+    pub fn merge(&mut self, other: LibraryBindings) {
+        self.bindings.extend(other.bindings);
+        self.library_files.extend(other.library_files);
+    }
+
+    /// Iterates over every registered `(uppercased POU name, binding)` pair.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &BoundPou)> {
+        self.bindings.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bound(library: &str, binding: PouBinding) -> BoundPou {
+        BoundPou {
+            library: library.to_string(),
+            manifest_file: FileId::from_string("library.toml"),
+            binding,
+        }
+    }
+
+    #[test]
+    fn get_when_case_differs_then_resolves() {
+        let mut bindings = LibraryBindings::new();
+        bindings.insert(
+            "LTRUNC",
+            bound(
+                "Tc2_Math",
+                PouBinding::Intrinsic {
+                    name: "trunc_lreal".to_string(),
+                },
+            ),
+        );
+        assert!(bindings.get("ltrunc").is_some());
+        assert!(bindings.get("LTRUNC").is_some());
+        assert!(bindings.get("LMOD").is_none());
+    }
+
+    #[test]
+    fn is_library_file_when_registered_then_true() {
+        let mut bindings = LibraryBindings::new();
+        let file = FileId::from_string("Tc2_Math.st");
+        bindings.add_library_file(file.clone());
+        assert!(bindings.is_library_file(&file));
+        assert!(!bindings.is_library_file(&FileId::from_string("user.st")));
+    }
+
+    #[test]
+    fn merge_when_two_libraries_then_union() {
+        let mut a = LibraryBindings::new();
+        a.insert("LTRUNC", bound("Tc2_Math", PouBinding::DeclareOnly));
+        a.add_library_file(FileId::from_string("a.st"));
+
+        let mut b = LibraryBindings::new();
+        b.insert("LREAL_TO_FMTSTR", bound("Tc2_Utilities", PouBinding::DeclareOnly));
+        b.add_library_file(FileId::from_string("b.st"));
+
+        a.merge(b);
+        assert!(a.get("LTRUNC").is_some());
+        assert!(a.get("LREAL_TO_FMTSTR").is_some());
+        assert!(a.is_library_file(&FileId::from_string("a.st")));
+        assert!(a.is_library_file(&FileId::from_string("b.st")));
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let bindings = LibraryBindings::default();
+        assert!(bindings.is_empty());
+        assert_eq!(bindings.iter().count(), 0);
+    }
+}

--- a/compiler/dsl/src/bindings.rs
+++ b/compiler/dsl/src/bindings.rs
@@ -155,7 +155,10 @@ mod tests {
         a.add_library_file(FileId::from_string("a.st"));
 
         let mut b = LibraryBindings::new();
-        b.insert("LREAL_TO_FMTSTR", bound("Tc2_Utilities", PouBinding::DeclareOnly));
+        b.insert(
+            "LREAL_TO_FMTSTR",
+            bound("Tc2_Utilities", PouBinding::DeclareOnly),
+        );
         b.add_library_file(FileId::from_string("b.st"));
 
         a.merge(b);

--- a/compiler/dsl/src/lib.rs
+++ b/compiler/dsl/src/lib.rs
@@ -1,6 +1,7 @@
 //! Provides definitions of objects from the IEC 61131-3 language elements
 //! and base implementations of common patterns for working with libraries.
 
+pub mod bindings;
 pub mod common;
 pub mod configuration;
 pub mod core;

--- a/compiler/ironplc-cli/src/cli.rs
+++ b/compiler/ironplc-cli/src/cli.rs
@@ -181,9 +181,16 @@ pub fn compile(
     }
 
     // Generate bytecode, skipping user-defined functions not reachable from
-    // the PROGRAM root to reduce container size.
+    // the PROGRAM root to reduce container size. The activated libraries'
+    // bindings ride along so codegen can lower intrinsic-bound calls and
+    // reject declare-only calls (the analyzer never saw the bindings).
+    let mut library_bindings = ironplc_dsl::bindings::LibraryBindings::new();
+    for compat in &compat_libraries {
+        library_bindings.merge(compat.bindings.clone());
+    }
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: compiler_options.allow_system_uptime_global,
+        library_bindings,
     };
     // Build a SourceLookup that hands codegen the exact bytes the
     // parser saw for each FileId. The container's debug section

--- a/compiler/ironplc-cli/src/cli.rs
+++ b/compiler/ironplc-cli/src/cli.rs
@@ -159,6 +159,7 @@ pub fn compile(
     }
     let analyze_input: Vec<&Library> = compat_libraries
         .iter()
+        .map(|compat| &compat.library)
         .chain(std::iter::once(&combined))
         .collect();
 

--- a/compiler/ironplc-cli/src/lsp_runner.rs
+++ b/compiler/ironplc-cli/src/lsp_runner.rs
@@ -249,6 +249,7 @@ fn compile_to_bytes(source: &str, options: &CompilerOptions) -> Result<Vec<u8>, 
 
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
+        ..Default::default()
     };
     let container = codegen_compile(
         &library,

--- a/compiler/ironplc-cli/tests/cli.rs
+++ b/compiler/ironplc-cli/tests/cli.rs
@@ -345,6 +345,101 @@ fn check_when_twincat_solution_library_reference_removed_then_pi_undefined(
     Ok(())
 }
 
+/// The contributor scenario behind the `Tc2_Math` library: a real TwinCAT
+/// project layout whose `.plcproj` references `Tc2_Math`, with source calling
+/// `LTRUNC`/`LMOD`/`MODABS`/`FRAC`. Activation comes from the project file
+/// alone (`REQ-CL-sources-001`) — no `--library` flag — and both `check` and
+/// `compile` succeed, so the intrinsic-bound functions work on the paved path.
+#[test]
+fn compile_when_plcproj_references_tc2_math_then_ok() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    std::fs::write(
+        temp.path().join("MAIN.st"),
+        "PROGRAM MAIN
+VAR
+    angle : LREAL := 400.56;
+    wrapped : LREAL;
+    truncated : LREAL;
+    fraction : LREAL;
+END_VAR
+    wrapped := MODABS(angle, 360.0);
+    truncated := LTRUNC(angle);
+    fraction := FRAC(angle);
+END_PROGRAM
+",
+    )?;
+    std::fs::write(
+        temp.path().join("project.plcproj"),
+        r#"<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="MAIN.st" />
+    <PlaceholderReference Include="Tc2_Math">
+      <DefaultResolution>Tc2_Math, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc2_Math</Namespace>
+    </PlaceholderReference>
+  </ItemGroup>
+</Project>"#,
+    )?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("check").arg(temp.path());
+    cmd.assert().success();
+
+    let output = NamedTempFile::with_suffix(".iplc")?;
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("compile")
+        .arg(temp.path())
+        .arg("--output")
+        .arg(output.path());
+    cmd.assert().success();
+    assert!(output.path().metadata()?.len() > 0);
+
+    Ok(())
+}
+
+/// The check/compile split for a declare-only library function
+/// (`REQ-CL-analyzer-007` vs `REQ-CL-codegen-002` at the CLI level):
+/// `Tc2_Utilities`' `LREAL_TO_FMTSTR` is declared but unimplemented, so
+/// `check` passes — the corpus-check use case — while `compile` of a call
+/// fails with P4046 rather than generating wrong code.
+#[test]
+fn check_passes_but_compile_fails_p4046_when_declare_only_function_called(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut source = NamedTempFile::with_suffix(".st")?;
+    use std::io::Write;
+    write!(
+        source,
+        "PROGRAM main
+VAR
+    s : STRING[255];
+END_VAR
+    s := LREAL_TO_FMTSTR(1.5, 2, TRUE);
+END_PROGRAM
+"
+    )?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("check")
+        .arg("--library")
+        .arg("Tc2_Utilities")
+        .arg(source.path());
+    cmd.assert().success();
+
+    let output = NamedTempFile::with_suffix(".iplc")?;
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("compile")
+        .arg("--library")
+        .arg("Tc2_Utilities")
+        .arg(source.path())
+        .arg("--output")
+        .arg(output.path());
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("P4046").and(predicate::str::contains("LREAL_TO_FMTSTR")));
+
+    Ok(())
+}
+
 #[test]
 fn version_then_ok() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));

--- a/compiler/mcp/src/tools/compile.rs
+++ b/compiler/mcp/src/tools/compile.rs
@@ -135,6 +135,7 @@ pub fn build_response(
     // Run codegen
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: compiler_options.allow_system_uptime_global,
+        ..Default::default()
     };
     let container = match ironplc_codegen::compile(
         library,

--- a/compiler/parser/src/tests/types_and_returns.rs
+++ b/compiler/parser/src/tests/types_and_returns.rs
@@ -45,6 +45,27 @@ fn parse_when_function_with_any_num_return_type_then_parses() {
 }
 
 #[test]
+fn parse_when_function_body_is_lone_semicolon_then_empty_statement_list() {
+    // The compatibility-library bindings format relies on this idiom: a
+    // bound or declare-only POU declares its full interface with a body of
+    // exactly `;`, which must parse to an *empty* statement list (see
+    // specs/design/compatibility-library-format.md §Bindings).
+    let lib = parse_text(
+        "FUNCTION LTRUNC : LREAL
+            VAR_INPUT
+                IN : LREAL;
+            END_VAR
+            ;
+            END_FUNCTION",
+    );
+
+    assert_eq!(lib.elements.len(), 1);
+    let func = cast!(&lib.elements[0], LibraryElementKind::FunctionDeclaration);
+    assert_eq!(func.variables.len(), 1);
+    assert!(func.body.is_empty());
+}
+
+#[test]
 fn parse_when_variable_with_any_int_type_then_parses() {
     let lib = parse_text(
         "FUNCTION TEST : INT

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -588,7 +588,10 @@ pub fn compile(source: &str, dialect: &str, allows: &str, libraries: &str) -> St
 #[derive(serde::Deserialize)]
 #[serde(untagged)]
 enum LibraryPayload {
-    Package { manifest: String, files: Vec<String> },
+    Package {
+        manifest: String,
+        files: Vec<String>,
+    },
     Source(String),
 }
 
@@ -628,19 +631,17 @@ fn parse_activated_libraries(
             }
             LibraryPayload::Package { manifest, files } => {
                 let manifest_file = FileId::from_string("library.toml");
-                let manifest =
-                    ironplc_sources::libraries::manifest::LibraryManifest::from_toml(
-                        manifest,
-                        &manifest_file,
-                    )
-                    .map_err(|diag| CompileResult {
-                        ok: false,
-                        bytecode: None,
-                        diagnostics: vec![diagnostic_info(&diag, "")],
-                    })?;
+                let manifest = ironplc_sources::libraries::manifest::LibraryManifest::from_toml(
+                    manifest,
+                    &manifest_file,
+                )
+                .map_err(|diag| CompileResult {
+                    ok: false,
+                    bytecode: None,
+                    diagnostics: vec![diagnostic_info(&diag, "")],
+                })?;
 
-                if let Some(version_bindings) = manifest.bindings.get(&manifest.default_version)
-                {
+                if let Some(version_bindings) = manifest.bindings.get(&manifest.default_version) {
                     for (pou_name, binding) in version_bindings {
                         bindings.insert(
                             pou_name,
@@ -694,11 +695,11 @@ fn compile_inner(source: &str, dialect: &str, allows: &str, libraries: &str) -> 
     // files. They are injected ahead of user source (base stdlib -> library ->
     // user), so a user declaration shadows a library declaration of the same
     // name (`REQ-CL-playground-001`).
-    let (compat_libraries, library_bindings) =
-        match parse_activated_libraries(libraries, &options) {
-            Ok(libs) => libs,
-            Err(result) => return result,
-        };
+    let (compat_libraries, library_bindings) = match parse_activated_libraries(libraries, &options)
+    {
+        Ok(libs) => libs,
+        Err(result) => return result,
+    };
 
     let library = match parse_source(file_type, source, &FileId::default(), &options) {
         Ok(lib) => lib,

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -683,6 +683,7 @@ fn compile_inner(source: &str, dialect: &str, allows: &str, libraries: &str) -> 
 
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
+        ..Default::default()
     };
     let container = match codegen_compile(
         &library,

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -581,45 +581,109 @@ pub fn compile(source: &str, dialect: &str, allows: &str, libraries: &str) -> St
     })
 }
 
+/// One activated library in the `libraries` payload: either the full package
+/// (`{ "manifest": "<library.toml text>", "files": ["<st text>", …] }`) or —
+/// the older form, still accepted — a bare `.st` source string, which carries
+/// no manifest and therefore no bindings.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum LibraryPayload {
+    Package { manifest: String, files: Vec<String> },
+    Source(String),
+}
+
 /// Parse the activated compatibility libraries from their served plain-text
-/// sources (`REQ-CL-playground-001`).
+/// files (`REQ-CL-playground-001`).
 ///
-/// `libraries` is a JSON array of ST source strings — the plain-text library
-/// files the browser fetched from the app's served assets. Each is parsed into
-/// a [`Library`] to be injected ahead of user source in analysis, so its
-/// symbols (e.g. `Tc2_System`'s `PI`) resolve under their exact vendor names.
-/// An empty or blank string activates no library.
+/// `libraries` is a JSON array of [`LibraryPayload`] entries the browser
+/// fetched from the app's served assets. Each entry's `.st` files are parsed
+/// into a [`Library`] to be injected ahead of user source in analysis, so its
+/// symbols (e.g. `Tc2_System`'s `PI`) resolve under their exact vendor names;
+/// a package entry's manifest additionally contributes its bindings so
+/// codegen can lower intrinsic-bound calls (e.g. `Tc2_Math`'s `LTRUNC`) and
+/// reject declare-only calls. An empty or blank string activates no library.
 fn parse_activated_libraries(
     libraries: &str,
     options: &CompilerOptions,
-) -> Result<Vec<Library>, CompileResult> {
+) -> Result<(Vec<Library>, ironplc_dsl::bindings::LibraryBindings), CompileResult> {
+    let mut bindings = ironplc_dsl::bindings::LibraryBindings::new();
     if libraries.trim().is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), bindings));
     }
 
-    let sources: Vec<String> = serde_json::from_str(libraries).map_err(|e| CompileResult {
-        ok: false,
-        bytecode: None,
-        diagnostics: vec![internal_diagnostic(format!(
-            "Failed to parse library sources: {e}"
-        ))],
-    })?;
+    let payloads: Vec<LibraryPayload> =
+        serde_json::from_str(libraries).map_err(|e| CompileResult {
+            ok: false,
+            bytecode: None,
+            diagnostics: vec![internal_diagnostic(format!(
+                "Failed to parse library sources: {e}"
+            ))],
+        })?;
 
-    let mut parsed = Vec::with_capacity(sources.len());
-    for source in &sources {
-        let file_type = FileType::from_content(source);
-        match parse_source(file_type, source, &FileId::default(), options) {
-            Ok(lib) => parsed.push(lib),
-            Err(diag) => {
-                return Err(CompileResult {
-                    ok: false,
-                    bytecode: None,
-                    diagnostics: vec![diagnostic_info(&diag, source)],
-                });
+    let mut parsed = Vec::with_capacity(payloads.len());
+    for (library_index, payload) in payloads.iter().enumerate() {
+        match payload {
+            LibraryPayload::Source(source) => {
+                parsed.push(parse_library_file(source, FileId::default(), options)?);
+            }
+            LibraryPayload::Package { manifest, files } => {
+                let manifest_file = FileId::from_string("library.toml");
+                let manifest =
+                    ironplc_sources::libraries::manifest::LibraryManifest::from_toml(
+                        manifest,
+                        &manifest_file,
+                    )
+                    .map_err(|diag| CompileResult {
+                        ok: false,
+                        bytecode: None,
+                        diagnostics: vec![diagnostic_info(&diag, "")],
+                    })?;
+
+                if let Some(version_bindings) = manifest.bindings.get(&manifest.default_version)
+                {
+                    for (pou_name, binding) in version_bindings {
+                        bindings.insert(
+                            pou_name,
+                            ironplc_dsl::bindings::BoundPou {
+                                library: manifest.name.clone(),
+                                manifest_file: manifest_file.clone(),
+                                binding: binding.clone(),
+                            },
+                        );
+                    }
+                }
+
+                for (file_index, source) in files.iter().enumerate() {
+                    // A distinct FileId per library file is what lets codegen
+                    // tell library declarations from user source (which
+                    // parses as `FileId::default()`), preserving user
+                    // shadowing of bound names.
+                    let file_id = FileId::from_string(&format!(
+                        "library:{}:{library_index}:{file_index}",
+                        manifest.name
+                    ));
+                    bindings.add_library_file(file_id.clone());
+                    parsed.push(parse_library_file(source, file_id, options)?);
+                }
             }
         }
     }
-    Ok(parsed)
+    Ok((parsed, bindings))
+}
+
+/// Parses one library source file, mapping a parse failure to the error
+/// payload shape.
+fn parse_library_file(
+    source: &str,
+    file_id: FileId,
+    options: &CompilerOptions,
+) -> Result<Library, CompileResult> {
+    let file_type = FileType::from_content(source);
+    parse_source(file_type, source, &file_id, options).map_err(|diag| CompileResult {
+        ok: false,
+        bytecode: None,
+        diagnostics: vec![diagnostic_info(&diag, source)],
+    })
 }
 
 fn compile_inner(source: &str, dialect: &str, allows: &str, libraries: &str) -> CompileResult {
@@ -630,10 +694,11 @@ fn compile_inner(source: &str, dialect: &str, allows: &str, libraries: &str) -> 
     // files. They are injected ahead of user source (base stdlib -> library ->
     // user), so a user declaration shadows a library declaration of the same
     // name (`REQ-CL-playground-001`).
-    let compat_libraries = match parse_activated_libraries(libraries, &options) {
-        Ok(libs) => libs,
-        Err(result) => return result,
-    };
+    let (compat_libraries, library_bindings) =
+        match parse_activated_libraries(libraries, &options) {
+            Ok(libs) => libs,
+            Err(result) => return result,
+        };
 
     let library = match parse_source(file_type, source, &FileId::default(), &options) {
         Ok(lib) => lib,
@@ -683,7 +748,7 @@ fn compile_inner(source: &str, dialect: &str, allows: &str, libraries: &str) -> 
 
     let codegen_options = ironplc_codegen::CodegenOptions {
         system_uptime_global: options.allow_system_uptime_global,
-        ..Default::default()
+        library_bindings,
     };
     let container = match codegen_compile(
         &library,

--- a/compiler/playground/src/spec_conformance.rs
+++ b/compiler/playground/src/spec_conformance.rs
@@ -56,3 +56,53 @@ fn playground_spec_req_cl_001_activates_library_from_served_files() {
         "loading the served library file must make PI resolve"
     );
 }
+
+/// The `Tc2_Math`-shaped package payload: manifest with an intrinsic binding
+/// plus the version's `.st` declaration, as `app.ts` now sends them
+/// (`{ manifest, files }`).
+#[test]
+fn compile_when_package_payload_with_intrinsic_binding_then_bound_call_compiles() {
+    let manifest = "name = \"Tc2_Math\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com\"]\n[\"1.0.0\".bindings]\nLTRUNC = { intrinsic = \"trunc_lreal\" }\n";
+    let declaration =
+        "FUNCTION LTRUNC : LREAL\nVAR_INPUT\n    IN : LREAL;\nEND_VAR\n;\nEND_FUNCTION\n";
+    let libraries = serde_json::json!([{ "manifest": manifest, "files": [declaration] }]);
+    let program = "PROGRAM main
+VAR
+    x : LREAL;
+END_VAR
+    x := LTRUNC(3.7);
+END_PROGRAM";
+
+    assert!(
+        compile_ok(program, &libraries.to_string()),
+        "an intrinsic-bound call must compile when the package payload carries the manifest"
+    );
+    // Without the library, the same call must not compile.
+    assert!(!compile_ok(program, ""));
+}
+
+/// A declare-only binding in the package payload fails compilation of a call
+/// with P4046 (never wrong codegen), matching the CLI behavior.
+#[test]
+fn compile_when_package_payload_with_declare_only_then_call_fails_p4046() {
+    let manifest = "name = \"Tc2_Utilities\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com\"]\n[\"1.0.0\".bindings]\nLREAL_TO_FMTSTR = \"declare-only\"\n";
+    let declaration = "FUNCTION LREAL_TO_FMTSTR : STRING[255]\nVAR_INPUT\n    in : LREAL;\n    iPrecision : INT;\n    bRound : BOOL;\nEND_VAR\n;\nEND_FUNCTION\n";
+    let libraries = serde_json::json!([{ "manifest": manifest, "files": [declaration] }]);
+    let program = "PROGRAM main
+VAR
+    s : STRING[255];
+END_VAR
+    s := LREAL_TO_FMTSTR(1.5, 2, TRUE);
+END_PROGRAM";
+
+    let json = crate::compile(program, "", "", &libraries.to_string());
+    let value: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(value["ok"], Value::Bool(false));
+    let codes: Vec<&str> = value["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|d| d["code"].as_str())
+        .collect();
+    assert_eq!(codes, ["P4046"]);
+}

--- a/compiler/plc2plc/src/tests/library_function_calls.rs
+++ b/compiler/plc2plc/src/tests/library_function_calls.rs
@@ -1,0 +1,33 @@
+//! Round-tripping of user source that calls compatibility-library functions.
+//!
+//! A call to a library function (e.g. `Tc2_Math`'s `LTRUNC`) is ordinary
+//! call syntax in the user's source — activation is out of band, so the
+//! renderer must emit the source unchanged with nothing injected
+//! (`REQ-CL-plc2plc-001` covers the never-render-library-declarations side).
+
+use super::common::*;
+
+#[test]
+fn write_to_string_when_calls_ltrunc_then_round_trips_byte_identical() {
+    let source = "
+PROGRAM main
+VAR
+    x : LREAL;
+    result : LREAL;
+END_VAR
+result := LTRUNC(x);
+END_PROGRAM
+";
+    let options = CompilerOptions::default();
+    let library_original = parse_program(source, &FileId::default(), &options).unwrap();
+    let first = write_to_string(&library_original).unwrap();
+
+    // The rendered text parses back to the identical AST and re-renders
+    // byte-identically — the library-bound call is plain call syntax with
+    // no marker, qualifier, or rewrite.
+    assert!(first.contains("LTRUNC ( x )"));
+    let library_rendered = parse_program(&first, &FileId::default(), &options).unwrap();
+    assert_eq!(library_original, library_rendered);
+    let second = write_to_string(&library_rendered).unwrap();
+    assert_eq!(first, second);
+}

--- a/compiler/plc2plc/src/tests/mod.rs
+++ b/compiler/plc2plc/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod corpus;
 mod declarations;
 mod enums;
 mod fb_inheritance;
+mod library_function_calls;
 mod mixed_vars;
 mod partial_access;
 mod reference_to;

--- a/compiler/problems/resources/problem-codes.csv
+++ b/compiler/problems/resources/problem-codes.csv
@@ -90,6 +90,7 @@ P4042,ParenStringLengthNotAllowed,STRING(n)/WSTRING(n) parenthesis length delimi
 P4043,StructInitializerExpressionNotAllowed,General expression as a struct/FB-instance initializer value requires --allow-struct-initializer-expressions flag
 P4044,ExtendsFieldNameDuplicated,Function block field name is already declared in a base function block via EXTENDS
 P4045,AbstractFunctionBlockInstantiated,Function block is ABSTRACT and cannot be instantiated
+P4046,LibraryFunctionNotImplemented,Call to a declare-only compatibility library function that has no implementation
 P6001,CannotCanonicalizePath,Unable to canonicalize the path
 P6002,CannotReadMetadata,Unable to read metadata for the path
 P6003,CannotReadDirectory,Unable to read directory

--- a/compiler/project/src/disassemble.rs
+++ b/compiler/project/src/disassemble.rs
@@ -510,6 +510,8 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                     opcode::builtin::INT_TO_BCD_64 => {
                         format!("INT_TO_BCD_64 (0x{:04X})", func_id)
                     }
+                    opcode::builtin::TRUNC_F64 => format!("TRUNC_F64 (0x{:04X})", func_id),
+                    opcode::builtin::MOD_F64 => format!("MOD_F64 (0x{:04X})", func_id),
                     id if opcode::builtin::is_mux(id) => {
                         let n = opcode::builtin::mux_info(id).unwrap();
                         let width = if id >= opcode::builtin::MUX_F64_BASE {

--- a/compiler/project/src/project.rs
+++ b/compiler/project/src/project.rs
@@ -13,7 +13,7 @@ use ironplc_dsl::{
 };
 use ironplc_parser::{options::CompilerOptions, token::Token, tokenize_program};
 use ironplc_problems::Problem;
-use ironplc_sources::{LibraryName, Source, SourceProject};
+use ironplc_sources::{CompatLibrary, LibraryName, Source, SourceProject};
 use log::{debug, trace};
 
 /// Runs semantic analysis on the given source project and compiler options.
@@ -72,9 +72,12 @@ fn run_semantic_analysis(
     }
 
     // Activation order: the compatibility libraries precede user source in the
-    // merge (the base stdlib is seeded inside `analyze`).
+    // merge (the base stdlib is seeded inside `analyze`). Only the parsed
+    // declarations participate in analysis; the bindings side-table is for
+    // codegen and the analyzer never sees it.
     let analyze_input: Vec<&Library> = compat_libraries
         .iter()
+        .map(|compat| &compat.library)
         .chain(all_libraries.iter().copied())
         .collect();
 
@@ -219,9 +222,10 @@ impl FileBackedProject {
 
     /// Load the activated compatibility libraries from the bundled registry.
     ///
-    /// Returns the parsed declarations to inject ahead of user source, plus one
-    /// diagnostic per library that could not be loaded.
-    pub fn load_activated_libraries(&self) -> (Vec<Library>, Vec<Diagnostic>) {
+    /// Returns the loaded libraries — parsed declarations plus the bindings
+    /// side-table — to inject ahead of user source, plus one diagnostic per
+    /// library that could not be loaded.
+    pub fn load_activated_libraries(&self) -> (Vec<CompatLibrary>, Vec<Diagnostic>) {
         self.source_project.load_activated_libraries()
     }
 }

--- a/compiler/sources/resources/libs/Tc2_Math/1.0.0/Tc2_Math.st
+++ b/compiler/sources/resources/libs/Tc2_Math/1.0.0/Tc2_Math.st
@@ -1,0 +1,61 @@
+(* Tc2_Math compatibility library -- extended math functions.
+
+   This file reproduces the *interface* (names and LREAL-only signatures) of
+   Beckhoff's TwinCAT Tc2_Math library for interoperability. IronPLC is an
+   independent open-source project and is not affiliated with, endorsed by, or
+   sponsored by Beckhoff Automation GmbH. Authored from the clean-room spec at
+   specs/design/library-interfaces/tc2-math.md; see
+   specs/steering/compatibility-library-authoring.md.
+
+   LTRUNC and LMOD are bound to native VM builtins in library.toml (their
+   semantics cannot be written in IEC 61131-3 source), so their bodies here
+   are exactly `;` and are never compiled. MODABS and FRAC are math-dictated
+   ST compositions of them. *)
+
+(* Integer part of a floating-point number, truncated toward zero. Unlike
+   TRUNC, the result stays LREAL and is not limited to an integer type's
+   value range. LTRUNC(2.8) = 2.0, LTRUNC(-2.8) = -2.0. *)
+FUNCTION LTRUNC : LREAL
+VAR_INPUT
+    IN : LREAL;
+END_VAR
+;
+END_FUNCTION
+
+(* Floating-point modulo division returning the signed remainder (the sign
+   of the dividend). Unlike MOD, operates on floating-point values and
+   returns non-integer remainders. LMOD(400.56, 360.0) = 40.56,
+   LMOD(-400.56, 360.0) = -40.56; LMOD(x, 0.0) is NaN. *)
+FUNCTION LMOD : LREAL
+VAR_INPUT
+    IN1 : LREAL;
+    IN2 : LREAL;
+END_VAR
+;
+END_FUNCTION
+
+(* Modulo division returning the unsigned modulo value within the modulo
+   range [0, |IM|). MODABS(-400.56, 360.0) = 319.44. *)
+FUNCTION MODABS : LREAL
+VAR_INPUT
+    IN : LREAL;
+    IM : LREAL;
+END_VAR
+VAR
+    remainder : LREAL;
+END_VAR
+    remainder := LMOD(IN, IM);
+    IF remainder < 0.0 THEN
+        remainder := remainder + ABS(IM);
+    END_IF;
+    MODABS := remainder;
+END_FUNCTION
+
+(* Fractional (decimal) component of a floating-point number; keeps the sign
+   of the input. FRAC(2.8) = 0.8, FRAC(-2.8) = -0.8. *)
+FUNCTION FRAC : LREAL
+VAR_INPUT
+    IN : LREAL;
+END_VAR
+    FRAC := IN - LTRUNC(IN);
+END_FUNCTION

--- a/compiler/sources/resources/libs/Tc2_Math/library.toml
+++ b/compiler/sources/resources/libs/Tc2_Math/library.toml
@@ -1,0 +1,20 @@
+name = "Tc2_Math"
+vendor = "Beckhoff Automation GmbH"
+default_version = "1.0.0"
+# These functions mirror the *interface* of Beckhoff's TwinCAT Tc2_Math
+# library, authored from the public documentation below per the clean-room
+# spec at specs/design/library-interfaces/tc2-math.md. LTRUNC and LMOD have
+# semantics IEC 61131-3 source cannot express (LREAL-preserving truncation,
+# floating modulo), so they bind to unnamed VM builtins; MODABS and FRAC are
+# Tier A math-dictated ST compositions of them. See the authoring policy at
+# specs/steering/compatibility-library-authoring.md.
+references = [
+  "https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68446347.html -- TwinCAT Tc2_Math PLC library: LTRUNC",
+  "https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68444811.html -- TwinCAT Tc2_Math PLC library: LMOD",
+  "https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68447883.html -- TwinCAT Tc2_Math PLC library: MODABS",
+  "https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68443275.html -- TwinCAT Tc2_Math PLC library: FRAC",
+]
+
+["1.0.0".bindings]
+LTRUNC = { intrinsic = "trunc_lreal" }
+LMOD = { intrinsic = "fmod_lreal" }

--- a/compiler/sources/resources/libs/Tc2_System/1.0.0/Tc2_System.st
+++ b/compiler/sources/resources/libs/Tc2_System/1.0.0/Tc2_System.st
@@ -8,3 +8,19 @@
 VAR_GLOBAL CONSTANT
     PI : LREAL := 3.1415926535897932384626433832795;
 END_VAR
+
+(* Converts a BOOL to its string representation: 'TRUE' or 'FALSE'. In
+   TwinCAT this is an implicit BOOL_TO_* conversion operator; IronPLC adds
+   no vendor names to its compiler tables (ADR-0042), so it ships here --
+   the library real TwinCAT projects reference by default. Authored from the
+   clean-room spec at specs/design/library-interfaces/bool-to-string.md. *)
+FUNCTION BOOL_TO_STRING : STRING
+VAR_INPUT
+    IN : BOOL;
+END_VAR
+    IF IN THEN
+        BOOL_TO_STRING := 'TRUE';
+    ELSE
+        BOOL_TO_STRING := 'FALSE';
+    END_IF;
+END_FUNCTION

--- a/compiler/sources/resources/libs/Tc2_System/library.toml
+++ b/compiler/sources/resources/libs/Tc2_System/library.toml
@@ -3,8 +3,14 @@ vendor = "Beckhoff Automation GmbH"
 default_version = "1.0.0"
 # `PI` mirrors the TwinCAT Tc2_System global constant of the same name. Its
 # value is the mathematical constant pi -- a Tier A, math-dictated fact rather
-# than a copied expression -- authored to LREAL precision. See the authoring
+# than a copied expression -- authored to LREAL precision. `BOOL_TO_STRING`
+# mirrors TwinCAT's implicit BOOL-to-STRING conversion operator ('TRUE' /
+# 'FALSE'); it lives here because ADR-0042 keeps vendor names out of the
+# compiler tables and Tc2_System is the library real TwinCAT projects
+# reference by default (clean-room spec:
+# specs/design/library-interfaces/bool-to-string.md). See the authoring
 # policy at specs/steering/compatibility-library-authoring.md.
 references = [
   "https://infosys.beckhoff.com/english.php?content=../content/1033/tcplclib_tc2_system/31084171.html&id= -- TwinCAT Tc2_System PLC library: PI global constant",
+  "https://infosys.beckhoff.com/content/1033/tcplccontrol/925577611.html -- TwinCAT BOOL_TO conversions: result is 'TRUE' / 'FALSE'",
 ]

--- a/compiler/sources/resources/libs/Tc2_Utilities/1.0.0/Tc2_Utilities.st
+++ b/compiler/sources/resources/libs/Tc2_Utilities/1.0.0/Tc2_Utilities.st
@@ -1,0 +1,25 @@
+(* Tc2_Utilities compatibility library -- utility functions.
+
+   This file reproduces the *interface* of Beckhoff's TwinCAT Tc2_Utilities
+   library for interoperability. IronPLC is an independent open-source project
+   and is not affiliated with, endorsed by, or sponsored by Beckhoff
+   Automation GmbH. Authored from the clean-room spec at
+   specs/design/library-interfaces/tc2-utilities.md; see
+   specs/steering/compatibility-library-authoring.md.
+
+   LREAL_TO_FMTSTR is declare-only (library.toml): the signature resolves
+   during check, and a call is compile error P4046 until the formatting
+   implementation lands. The `;` body is never compiled. The vendor return
+   type STRING(255) is spelled with the standard bracket form STRING[255],
+   which declares the identical 255-character capacity. *)
+
+(* Converts an LREAL to a formatted string: iPrecision decimal places,
+   rounded when bRound is TRUE, truncated when FALSE. *)
+FUNCTION LREAL_TO_FMTSTR : STRING[255]
+VAR_INPUT
+    in         : LREAL;
+    iPrecision : INT;
+    bRound     : BOOL;
+END_VAR
+;
+END_FUNCTION

--- a/compiler/sources/resources/libs/Tc2_Utilities/library.toml
+++ b/compiler/sources/resources/libs/Tc2_Utilities/library.toml
@@ -1,0 +1,16 @@
+name = "Tc2_Utilities"
+vendor = "Beckhoff Automation GmbH"
+default_version = "1.0.0"
+# LREAL_TO_FMTSTR mirrors the *interface* of Beckhoff's TwinCAT Tc2_Utilities
+# function of the same name, authored from the public documentation below per
+# the clean-room spec at specs/design/library-interfaces/tc2-utilities.md. It
+# is declare-only: the surface lands so real projects check cleanly, and a
+# call fails compilation with P4046 until the native formatting
+# implementation arrives. See the authoring policy at
+# specs/steering/compatibility-library-authoring.md.
+references = [
+  "https://infosys.beckhoff.com/content/1033/tcplclib_tc2_utilities/35143691.html -- TwinCAT Tc2_Utilities PLC library: LREAL_TO_FMTSTR",
+]
+
+["1.0.0".bindings]
+LREAL_TO_FMTSTR = "declare-only"

--- a/compiler/sources/src/lib.rs
+++ b/compiler/sources/src/lib.rs
@@ -58,7 +58,7 @@ pub mod xml;
 
 // Re-export main types for convenience
 pub use file_type::FileType;
-pub use libraries::LibraryName;
+pub use libraries::{CompatLibrary, LibraryName};
 pub use parsers::parse_source;
 pub use project::SourceProject;
 pub use source::Source;

--- a/compiler/sources/src/libraries/manifest.rs
+++ b/compiler/sources/src/libraries/manifest.rs
@@ -6,15 +6,18 @@
 //! behavioral requirements the loader enforces are in
 //! `specs/design/compatibility-libraries.md` (`REQ-CL-sources-002`).
 
+use std::collections::HashMap;
+
+use ironplc_dsl::bindings::PouBinding;
 use ironplc_dsl::core::FileId;
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_problems::Problem;
 
 /// A parsed and validated `library.toml` manifest.
 ///
-/// Every field is required. `vendor` is nominative — it records whose
-/// interface the library mirrors, not a claim of endorsement (see the format
-/// design's *Non-affiliation* section).
+/// Every field is required except the per-version bindings tables. `vendor`
+/// is nominative — it records whose interface the library mirrors, not a
+/// claim of endorsement (see the format design's *Non-affiliation* section).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LibraryManifest {
     /// Library identity; equals the directory name and the vendor library name.
@@ -26,6 +29,9 @@ pub struct LibraryManifest {
     pub default_version: String,
     /// The public references the library was authored from. Non-empty.
     pub references: Vec<String>,
+    /// Per-version bindings: version → uppercased POU name → binding
+    /// (`REQ-LF-sources-005`). Versions without a bindings table are absent.
+    pub bindings: HashMap<String, HashMap<String, PouBinding>>,
 }
 
 impl LibraryManifest {
@@ -72,12 +78,120 @@ impl LibraryManifest {
             references.push(reference.to_string());
         }
 
+        let bindings = Self::parse_version_bindings(&table, file_id)?;
+
         Ok(LibraryManifest {
             name,
             vendor,
             default_version,
             references,
+            bindings,
         })
+    }
+
+    /// Parse and shape-validate every per-version bindings table
+    /// (`REQ-LF-sources-005`, `REQ-LF-sources-006`).
+    ///
+    /// A version table is any top-level key whose value is a table (the
+    /// scalar identity/reference fields are handled above). Validation covers
+    /// *every* version table, not only the `default_version`, so a malformed
+    /// table cannot hide in an inactive version. The unquoted-key trap —
+    /// `[1.0.0.bindings]` parses as three nested tables `1 → 0 → 0` — is
+    /// caught because the nested tables carry keys other than `bindings`.
+    fn parse_version_bindings(
+        table: &toml::Table,
+        file_id: &FileId,
+    ) -> Result<HashMap<String, HashMap<String, PouBinding>>, Diagnostic> {
+        const SCALAR_FIELDS: [&str; 4] = ["name", "vendor", "default_version", "references"];
+
+        let mut all_bindings = HashMap::new();
+        for (key, value) in table {
+            if SCALAR_FIELDS.contains(&key.as_str()) {
+                continue;
+            }
+            let version_table = value.as_table().ok_or_else(|| {
+                Self::invalid(
+                    file_id,
+                    format!("manifest key `{key}` must be a version table"),
+                )
+            })?;
+            for nested_key in version_table.keys() {
+                if nested_key != "bindings" {
+                    return Err(Self::invalid(
+                        file_id,
+                        format!(
+                            "version table `{key}` contains unknown key `{nested_key}`; \
+                             only `bindings` is allowed (a dotted version key must be \
+                             quoted: `[\"1.0.0\".bindings]`, not `[1.0.0.bindings]`)"
+                        ),
+                    ));
+                }
+            }
+            let Some(bindings_value) = version_table.get("bindings") else {
+                continue;
+            };
+            let bindings_table = bindings_value.as_table().ok_or_else(|| {
+                Self::invalid(
+                    file_id,
+                    format!("`bindings` of version `{key}` must be a table"),
+                )
+            })?;
+
+            let mut version_bindings = HashMap::new();
+            for (pou, binding_value) in bindings_table {
+                let binding = Self::parse_binding(key, pou, binding_value, file_id)?;
+                version_bindings.insert(pou.to_uppercase(), binding);
+            }
+            all_bindings.insert(key.clone(), version_bindings);
+        }
+        Ok(all_bindings)
+    }
+
+    /// Parse one binding value: `"declare-only"` or `{ intrinsic = "<name>" }`.
+    fn parse_binding(
+        version: &str,
+        pou: &str,
+        value: &toml::Value,
+        file_id: &FileId,
+    ) -> Result<PouBinding, Diagnostic> {
+        match value {
+            toml::Value::String(text) if text == "declare-only" => Ok(PouBinding::DeclareOnly),
+            toml::Value::Table(binding_table) => {
+                let keys: Vec<&String> = binding_table.keys().collect();
+                if keys.len() != 1 || keys[0] != "intrinsic" {
+                    return Err(Self::invalid(
+                        file_id,
+                        format!(
+                            "binding for `{pou}` in version `{version}` must be \
+                             `{{ intrinsic = \"<name>\" }}` or `\"declare-only\"`"
+                        ),
+                    ));
+                }
+                let name = binding_table
+                    .get("intrinsic")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| {
+                        Self::invalid(
+                            file_id,
+                            format!(
+                                "binding for `{pou}` in version `{version}`: `intrinsic` \
+                                 must be a non-empty string"
+                            ),
+                        )
+                    })?;
+                Ok(PouBinding::Intrinsic {
+                    name: name.to_string(),
+                })
+            }
+            _ => Err(Self::invalid(
+                file_id,
+                format!(
+                    "binding for `{pou}` in version `{version}` must be \
+                     `{{ intrinsic = \"<name>\" }}` or `\"declare-only\"`"
+                ),
+            )),
+        }
     }
 
     /// Read a required, non-empty string field from the manifest table.
@@ -225,6 +339,109 @@ references = [ 1, 2, 3 ]
         let content = "this is not = valid toml {{{";
         let err = LibraryManifest::from_toml(content, &file_id()).unwrap_err();
         assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    // -----------------------------------------------------------------
+    // Per-version bindings tables.
+    // See specs/design/compatibility-library-format.md §Bindings and
+    // specs/plans/2026-08-08-compatibility-library-bindings.md.
+    // -----------------------------------------------------------------
+
+    const IDENTITY: &str = "name = \"Tc2_Math\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com\"]\n";
+
+    #[test]
+    fn from_toml_when_no_bindings_then_empty_map() {
+        let manifest = LibraryManifest::from_toml(IDENTITY, &file_id()).unwrap();
+        assert!(manifest.bindings.is_empty());
+    }
+
+    #[test]
+    fn from_toml_when_bindings_table_then_parses_both_forms() {
+        let content = format!(
+            "{IDENTITY}\n[\"1.0.0\".bindings]\nLTRUNC = {{ intrinsic = \"trunc_lreal\" }}\nLREAL_TO_FMTSTR = \"declare-only\"\n"
+        );
+        let manifest = LibraryManifest::from_toml(&content, &file_id()).unwrap();
+        let bindings = manifest.bindings.get("1.0.0").unwrap();
+        assert_eq!(
+            bindings.get("LTRUNC"),
+            Some(&PouBinding::Intrinsic {
+                name: "trunc_lreal".to_string()
+            })
+        );
+        assert_eq!(
+            bindings.get("LREAL_TO_FMTSTR"),
+            Some(&PouBinding::DeclareOnly)
+        );
+    }
+
+    #[test]
+    fn from_toml_when_binding_pou_lowercase_then_key_uppercased() {
+        let content = format!("{IDENTITY}\n[\"1.0.0\".bindings]\nltrunc = \"declare-only\"\n");
+        let manifest = LibraryManifest::from_toml(&content, &file_id()).unwrap();
+        assert!(manifest.bindings["1.0.0"].contains_key("LTRUNC"));
+    }
+
+    #[test]
+    fn from_toml_when_unquoted_version_key_then_error() {
+        // `[1.0.0.bindings]` is three nested TOML tables, not a version
+        // table -- the nested key `0` is not `bindings`, so shape
+        // validation rejects it.
+        let content = format!("{IDENTITY}\n[1.0.0.bindings]\nLTRUNC = \"declare-only\"\n");
+        let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
+        assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    #[test]
+    fn from_toml_when_unknown_key_in_version_table_then_error() {
+        let content = format!("{IDENTITY}\n[\"1.0.0\"]\nnot_bindings = 1\n");
+        let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
+        assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    #[test]
+    fn from_toml_when_binding_value_unknown_string_then_error() {
+        let content = format!("{IDENTITY}\n[\"1.0.0\".bindings]\nLTRUNC = \"native\"\n");
+        let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
+        assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    #[test]
+    fn from_toml_when_binding_table_has_unknown_key_then_error() {
+        let content =
+            format!("{IDENTITY}\n[\"1.0.0\".bindings]\nLTRUNC = {{ builtin = \"trunc_lreal\" }}\n");
+        let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
+        assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    #[test]
+    fn from_toml_when_intrinsic_name_empty_then_error() {
+        let content = format!("{IDENTITY}\n[\"1.0.0\".bindings]\nLTRUNC = {{ intrinsic = \"\" }}\n");
+        let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
+        assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    #[test]
+    fn from_toml_when_binding_value_wrong_type_then_error() {
+        let content = format!("{IDENTITY}\n[\"1.0.0\".bindings]\nLTRUNC = 42\n");
+        let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
+        assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    #[test]
+    fn from_toml_when_non_default_version_malformed_then_error() {
+        // Shape validation covers every version table, not only the
+        // default version.
+        let content = format!("{IDENTITY}\n[\"2.0.0\".bindings]\nLTRUNC = \"nope\"\n");
+        let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
+        assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+    }
+
+    #[test]
+    fn from_toml_when_non_default_version_valid_then_inert_but_parsed() {
+        let content = format!("{IDENTITY}\n[\"2.0.0\".bindings]\nLTRUNC = \"declare-only\"\n");
+        let manifest = LibraryManifest::from_toml(&content, &file_id()).unwrap();
+        assert!(manifest.bindings.contains_key("2.0.0"));
+        assert!(!manifest.bindings.contains_key("1.0.0"));
     }
 
     #[test]

--- a/compiler/sources/src/libraries/manifest.rs
+++ b/compiler/sources/src/libraries/manifest.rs
@@ -415,7 +415,8 @@ references = [ 1, 2, 3 ]
 
     #[test]
     fn from_toml_when_intrinsic_name_empty_then_error() {
-        let content = format!("{IDENTITY}\n[\"1.0.0\".bindings]\nLTRUNC = {{ intrinsic = \"\" }}\n");
+        let content =
+            format!("{IDENTITY}\n[\"1.0.0\".bindings]\nLTRUNC = {{ intrinsic = \"\" }}\n");
         let err = LibraryManifest::from_toml(&content, &file_id()).unwrap_err();
         assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
     }

--- a/compiler/sources/src/libraries/mod.rs
+++ b/compiler/sources/src/libraries/mod.rs
@@ -16,6 +16,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use ironplc_dsl::bindings::{BoundPou, LibraryBindings};
 use ironplc_dsl::common::Library;
 use ironplc_dsl::core::FileId;
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
@@ -107,6 +108,11 @@ pub struct CompatLibrary {
     pub manifest: LibraryManifest,
     /// The merged declarations parsed from the selected version's `.st` files.
     pub library: Library,
+    /// The selected version's POU bindings plus this library's source
+    /// `FileId`s, for codegen (the analyzer never sees bindings). Empty when
+    /// the version declares no bindings — the file set is still populated so
+    /// codegen can tell library declarations from user declarations.
+    pub bindings: LibraryBindings,
 }
 
 /// A registry of compatibility libraries rooted at a directory.
@@ -229,9 +235,33 @@ impl LibraryRegistry {
             .root
             .join(name.as_str())
             .join(&manifest.default_version);
-        let library = load_version_library(&version_dir, &manifest_file_id)?;
+        let (library, library_files) = load_version_library(&version_dir, &manifest_file_id)?;
 
-        Ok(CompatLibrary { manifest, library })
+        // Assemble the side-table codegen consumes: the selected (default)
+        // version's bindings, each carrying the library name and manifest file
+        // for diagnostics, plus every library source `FileId`.
+        let mut bindings = LibraryBindings::new();
+        if let Some(version_bindings) = manifest.bindings.get(&manifest.default_version) {
+            for (pou_name, binding) in version_bindings {
+                bindings.insert(
+                    pou_name,
+                    BoundPou {
+                        library: manifest.name.clone(),
+                        manifest_file: manifest_file_id.clone(),
+                        binding: binding.clone(),
+                    },
+                );
+            }
+        }
+        for file_id in library_files {
+            bindings.add_library_file(file_id);
+        }
+
+        Ok(CompatLibrary {
+            manifest,
+            library,
+            bindings,
+        })
     }
 
     /// Resolve project-declared library references to the set of bundled library
@@ -294,7 +324,10 @@ fn installed_libraries_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/libs")
 }
 
-/// Parse and merge every `.st` file in a version subdirectory into one Library.
+/// Parse and merge every `.st` file in a version subdirectory into one
+/// Library, returning the merged declarations plus the `FileId` of each
+/// parsed file (the library-source set that preserves user shadowing at
+/// codegen).
 ///
 /// Files are parsed with permissive options so a bundled library's declarations
 /// always produce an AST; policy rules (e.g. the top-level `VAR_GLOBAL` gate)
@@ -302,7 +335,7 @@ fn installed_libraries_root() -> PathBuf {
 fn load_version_library(
     version_dir: &Path,
     manifest_file_id: &FileId,
-) -> Result<Library, Diagnostic> {
+) -> Result<(Library, Vec<FileId>), Diagnostic> {
     let read_dir = fs::read_dir(version_dir).map_err(|e| {
         Diagnostic::problem(
             Problem::LibraryManifestInvalid,
@@ -321,6 +354,7 @@ fn load_version_library(
 
     let options = CompilerOptions::default();
     let mut library = Library::new();
+    let mut file_ids = Vec::new();
     for path in paths {
         let is_st = path
             .extension()
@@ -337,8 +371,9 @@ fn load_version_library(
         })?;
         let parsed = parse_program(&content, &file_id, &options)?;
         library = library.extend(parsed);
+        file_ids.push(file_id);
     }
-    Ok(library)
+    Ok((library, file_ids))
 }
 
 #[cfg(test)]

--- a/compiler/sources/src/project.rs
+++ b/compiler/sources/src/project.rs
@@ -2,11 +2,11 @@
 
 use std::{collections::HashMap, path::Path};
 
-use ironplc_dsl::{common::Library, core::FileId, diagnostic::Diagnostic};
+use ironplc_dsl::{core::FileId, diagnostic::Diagnostic};
 use ironplc_parser::options::CompilerOptions;
 use log::{debug, info, trace};
 
-use crate::libraries::{LibraryName, LibraryRegistry};
+use crate::libraries::{CompatLibrary, LibraryName, LibraryRegistry};
 use crate::source::Source;
 
 /// A project consisting of one or more source files
@@ -64,18 +64,19 @@ impl SourceProject {
 
     /// Load the activated compatibility libraries from the bundled registry.
     ///
-    /// Returns the parsed [`Library`] for each activated library that resolves,
-    /// plus one diagnostic per library that could not be loaded (unshipped name
+    /// Returns the loaded [`CompatLibrary`] — parsed declarations plus the
+    /// bindings side-table — for each activated library that resolves, plus
+    /// one diagnostic per library that could not be loaded (unshipped name
     /// or malformed manifest). The libraries are returned in activation order,
     /// which callers inject ahead of user source so a user declaration shadows
     /// a library declaration of the same name.
-    pub fn load_activated_libraries(&self) -> (Vec<Library>, Vec<Diagnostic>) {
+    pub fn load_activated_libraries(&self) -> (Vec<CompatLibrary>, Vec<Diagnostic>) {
         let registry = LibraryRegistry::bundled();
         let mut libraries = Vec::new();
         let mut diagnostics = Vec::new();
         for name in &self.activated_libraries {
             match registry.load(name) {
-                Ok(loaded) => libraries.push(loaded.library),
+                Ok(loaded) => libraries.push(loaded),
                 Err(diagnostic) => diagnostics.push(diagnostic),
             }
         }

--- a/compiler/sources/src/spec_conformance.rs
+++ b/compiler/sources/src/spec_conformance.rs
@@ -15,6 +15,7 @@
 
 use std::fs;
 
+use ironplc_dsl::bindings::PouBinding;
 use ironplc_dsl::common::{Library, LibraryElementKind};
 use ironplc_dsl::core::FileId;
 use ironplc_problems::Problem;
@@ -124,6 +125,119 @@ fn sources_spec_req_lf_004_manifest_records_references() {
     assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
 }
 
+/// REQ-LF-sources-005: A manifest may carry a per-version bindings table
+/// (quoted version key) mapping a POU name to `{ intrinsic = "<name>" }` or
+/// `"declare-only"`.
+#[spec_test(REQ_LF_sources_005)]
+fn sources_spec_req_lf_005_bindings_table_parses_both_value_forms() {
+    let file_id = FileId::from_string("library.toml");
+    let manifest = LibraryManifest::from_toml(
+        "name = \"Tc2_Math\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com\"]\n\
+         [\"1.0.0\".bindings]\nLTRUNC = { intrinsic = \"trunc_lreal\" }\nLREAL_TO_FMTSTR = \"declare-only\"\n",
+        &file_id,
+    )
+    .unwrap();
+    let bindings = manifest.bindings.get("1.0.0").unwrap();
+    assert_eq!(
+        bindings.get("LTRUNC"),
+        Some(&PouBinding::Intrinsic {
+            name: "trunc_lreal".to_string()
+        })
+    );
+    assert_eq!(
+        bindings.get("LREAL_TO_FMTSTR"),
+        Some(&PouBinding::DeclareOnly)
+    );
+}
+
+/// REQ-LF-sources-006: A malformed bindings entry — including the unquoted
+/// dotted version key, which parses as nested tables — is rejected with
+/// P6010, and validation covers every version table, not only the default
+/// version.
+#[spec_test(REQ_LF_sources_006)]
+fn sources_spec_req_lf_006_malformed_bindings_rejected_in_any_version() {
+    let file_id = FileId::from_string("library.toml");
+    let identity = "name = \"Tc2_Math\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com\"]\n";
+
+    // The unquoted-key trap: `[1.0.0.bindings]` is three nested tables.
+    let err = LibraryManifest::from_toml(
+        &format!("{identity}[1.0.0.bindings]\nLTRUNC = \"declare-only\"\n"),
+        &file_id,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+
+    // An unknown binding value form is rejected.
+    let err = LibraryManifest::from_toml(
+        &format!("{identity}[\"1.0.0\".bindings]\nLTRUNC = \"native\"\n"),
+        &file_id,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+
+    // A malformed table for a *non-default* version is still rejected.
+    let err = LibraryManifest::from_toml(
+        &format!("{identity}[\"2.0.0\".bindings]\nLTRUNC = 42\n"),
+        &file_id,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, Problem::LibraryManifestInvalid.code());
+}
+
+/// REQ-LF-sources-007: A bound or declare-only POU still appears in its
+/// version's `.st` files with its full interface and a body of exactly `;`;
+/// the loader exposes the declaration for analysis and the binding in the
+/// side-table.
+#[spec_test(REQ_LF_sources_007)]
+fn sources_spec_req_lf_007_bound_pou_declared_with_empty_body() {
+    let dir = TempDir::new().unwrap();
+    let version_dir = dir.path().join("Fixture").join("1.0.0");
+    fs::create_dir_all(&version_dir).unwrap();
+    fs::write(
+        dir.path().join("Fixture").join("library.toml"),
+        "name = \"Fixture\"\nvendor = \"ACME\"\ndefault_version = \"1.0.0\"\nreferences = [\"https://example.com\"]\n\
+         [\"1.0.0\".bindings]\nLTRUNC = { intrinsic = \"trunc_lreal\" }\n",
+    )
+    .unwrap();
+    fs::write(
+        version_dir.join("Fixture.st"),
+        "FUNCTION LTRUNC : LREAL\nVAR_INPUT\n    IN : LREAL;\nEND_VAR\n;\nEND_FUNCTION\n",
+    )
+    .unwrap();
+
+    let registry = LibraryRegistry::with_root(dir.path());
+    let loaded = registry.load(&LibraryName::from("Fixture")).unwrap();
+
+    // The full interface is declared (so `check` and type resolution work
+    // unchanged) with an empty statement list for the `;` body.
+    let function = loaded
+        .library
+        .elements
+        .iter()
+        .find_map(|element| match element {
+            LibraryElementKind::FunctionDeclaration(f) if f.name.original() == "LTRUNC" => Some(f),
+            _ => None,
+        })
+        .expect("bound POU must be declared in the version's .st");
+    assert_eq!(function.variables.len(), 1);
+    assert!(
+        function.body.is_empty(),
+        "the `;` body parses to an empty statement list and is never the implementation"
+    );
+
+    // The binding rides the side-table, along with the library file set.
+    let bound = loaded.bindings.get("LTRUNC").expect("binding recorded");
+    assert_eq!(bound.library, "Fixture");
+    assert_eq!(
+        bound.binding,
+        PouBinding::Intrinsic {
+            name: "trunc_lreal".to_string()
+        }
+    );
+    let library_file = FileId::from_path(&version_dir.join("Fixture.st"));
+    assert!(loaded.bindings.is_library_file(&library_file));
+}
+
 // ---------------------------------------------------------------------------
 // Loader / activation behavior (REQ-CL-sources-*)
 // ---------------------------------------------------------------------------
@@ -187,7 +301,7 @@ fn sources_spec_req_cl_006_explicit_activation_activates_library() {
     );
     assert_eq!(libraries.len(), 1);
     assert!(
-        declares_pi(&libraries[0]),
+        declares_pi(&libraries[0].library),
         "activated Tc2_System must provide the global constant PI"
     );
 }

--- a/compiler/vm/src/builtin.rs
+++ b/compiler/vm/src/builtin.rs
@@ -316,6 +316,19 @@ pub fn dispatch(func_id: u16, stack: &mut OperandStack) -> Result<(), Trap> {
             stack.push(Slot::from_f64(a.atan2(b)))?;
             Ok(())
         }
+        opcode::builtin::TRUNC_F64 => {
+            let a = stack.pop()?.as_f64();
+            stack.push(Slot::from_f64(a.trunc()))?;
+            Ok(())
+        }
+        opcode::builtin::MOD_F64 => {
+            // IEEE-754 remainder with the sign of the dividend (fmod).
+            // a % 0.0 is NaN, not a trap.
+            let b = stack.pop()?.as_f64();
+            let a = stack.pop()?.as_f64();
+            stack.push(Slot::from_f64(a % b))?;
+            Ok(())
+        }
         opcode::builtin::EXPT_I64 => {
             let b = stack.pop()?.as_i64();
             let a = stack.pop()?.as_i64();

--- a/compiler/vm/tests/it/execute_builtin_trunc_mod_f64.rs
+++ b/compiler/vm/tests/it/execute_builtin_trunc_mod_f64.rs
@@ -34,7 +34,10 @@ fn fmod_bytecode() -> Vec<u8> {
 
 #[test]
 fn execute_when_trunc_f64_positive_then_truncates_toward_zero() {
-    assert_eq!(crate::common::run_and_read_f64(&trunc_bytecode(), 1, &[3.7]), 3.0);
+    assert_eq!(
+        crate::common::run_and_read_f64(&trunc_bytecode(), 1, &[3.7]),
+        3.0
+    );
 }
 
 #[test]
@@ -59,7 +62,10 @@ fn execute_when_trunc_f64_beyond_i64_range_then_stays_lreal() {
 #[test]
 fn execute_when_mod_f64_positive_then_fractional_remainder() {
     let r = crate::common::run_and_read_f64(&fmod_bytecode(), 1, &[400.56, 360.0]);
-    assert!((r - 40.56).abs() < 1e-9, "LMOD(400.56, 360) = 40.56, got {r}");
+    assert!(
+        (r - 40.56).abs() < 1e-9,
+        "LMOD(400.56, 360) = 40.56, got {r}"
+    );
 }
 
 #[test]

--- a/compiler/vm/tests/it/execute_builtin_trunc_mod_f64.rs
+++ b/compiler/vm/tests/it/execute_builtin_trunc_mod_f64.rs
@@ -1,0 +1,88 @@
+//! VM tests for the library-bound TRUNC_F64 and MOD_F64 builtins.
+//!
+//! These func_ids have no compiler-seeded name — they are reachable only
+//! through a compatibility library's manifest binding (`trunc_lreal`,
+//! `fmod_lreal`), so their semantics are pinned here at the VM level:
+//! truncation toward zero, and fmod with the sign of the dividend where
+//! division by zero yields NaN rather than a trap.
+
+/// Bytecode: load pool[0], BUILTIN TRUNC_F64, store var[0].
+fn trunc_bytecode() -> Vec<u8> {
+    #[rustfmt::skip]
+    let bytecode = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]
+        0x94, 0xA3, 0x03,  // BUILTIN TRUNC_F64 (0x03A3)
+        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0x8C,              // RET_VOID
+    ];
+    bytecode
+}
+
+/// Bytecode: load pool[0] (dividend), load pool[1] (divisor),
+/// BUILTIN MOD_F64, store var[0].
+fn fmod_bytecode() -> Vec<u8> {
+    #[rustfmt::skip]
+    let bytecode = vec![
+        0x03, 0x00, 0x00,  // LOAD_CONST_F64 pool[0]
+        0x03, 0x01, 0x00,  // LOAD_CONST_F64 pool[1]
+        0x94, 0xA4, 0x03,  // BUILTIN MOD_F64 (0x03A4)
+        0x13, 0x00, 0x00,  // STORE_VAR_F64 var[0]
+        0x8C,              // RET_VOID
+    ];
+    bytecode
+}
+
+#[test]
+fn execute_when_trunc_f64_positive_then_truncates_toward_zero() {
+    assert_eq!(crate::common::run_and_read_f64(&trunc_bytecode(), 1, &[3.7]), 3.0);
+}
+
+#[test]
+fn execute_when_trunc_f64_negative_then_truncates_toward_zero() {
+    assert_eq!(
+        crate::common::run_and_read_f64(&trunc_bytecode(), 1, &[-3.7]),
+        -3.0
+    );
+}
+
+#[test]
+fn execute_when_trunc_f64_beyond_i64_range_then_stays_lreal() {
+    // The reason this builtin exists: values outside any integer type's
+    // range truncate without clamping.
+    let big = 1.5e300_f64;
+    assert_eq!(
+        crate::common::run_and_read_f64(&trunc_bytecode(), 1, &[big]),
+        big.trunc()
+    );
+}
+
+#[test]
+fn execute_when_mod_f64_positive_then_fractional_remainder() {
+    let r = crate::common::run_and_read_f64(&fmod_bytecode(), 1, &[400.56, 360.0]);
+    assert!((r - 40.56).abs() < 1e-9, "LMOD(400.56, 360) = 40.56, got {r}");
+}
+
+#[test]
+fn execute_when_mod_f64_negative_dividend_then_sign_of_dividend() {
+    let r = crate::common::run_and_read_f64(&fmod_bytecode(), 1, &[-400.56, 360.0]);
+    assert!(
+        (r + 40.56).abs() < 1e-9,
+        "LMOD(-400.56, 360) = -40.56, got {r}"
+    );
+}
+
+#[test]
+fn execute_when_mod_f64_negative_divisor_then_sign_of_dividend() {
+    let r = crate::common::run_and_read_f64(&fmod_bytecode(), 1, &[400.56, -360.0]);
+    assert!(
+        (r - 40.56).abs() < 1e-9,
+        "fmod keeps the dividend's sign, got {r}"
+    );
+}
+
+#[test]
+fn execute_when_mod_f64_by_zero_then_nan_not_trap() {
+    // Division by zero must produce NaN, never a trap.
+    let r = crate::common::run_and_read_f64(&fmod_bytecode(), 1, &[1.5, 0.0]);
+    assert!(r.is_nan(), "fmod by zero must be NaN, got {r}");
+}

--- a/compiler/vm/tests/it/main.rs
+++ b/compiler/vm/tests/it/main.rs
@@ -43,6 +43,7 @@ mod execute_bool_literal;
 mod execute_builtin_abs_i32;
 mod execute_builtin_abs_i64;
 mod execute_builtin_expt_i32;
+mod execute_builtin_trunc_mod_f64;
 mod execute_call_ret;
 mod execute_cmp_i32;
 mod execute_data_region_oob;

--- a/docs/reference/compiler/problems/P4046.rst
+++ b/docs/reference/compiler/problems/P4046.rst
@@ -1,0 +1,37 @@
+=====
+P4046
+=====
+
+.. problem-summary:: P4046
+
+This error occurs when a program *calls* a compatibility library
+function that the library declares as ``declare-only`` — the function's
+signature exists so the library's surface is complete, but its
+implementation has not been built yet. Rather than generating code whose
+behavior IronPLC cannot reproduce (or trapping at runtime), the compiler
+refuses to compile the call.
+
+Note that ``check`` (semantic analysis) still passes for the same
+source: the declaration resolves and type-checks like any other
+function. Only bytecode compilation of an actual call site fails.
+
+Example
+-------
+
+With the ``Tc2_Utilities`` library activated, the following code checks
+cleanly but generates error P4046 when compiled, because
+``LREAL_TO_FMTSTR`` is declare-only:
+
+.. code-block::
+
+   PROGRAM main
+   VAR
+       s : STRING[255];
+   END_VAR
+       s := LREAL_TO_FMTSTR(in := 1.5, iPrecision := 2, bRound := TRUE);
+   END_PROGRAM
+
+To fix this error, remove or replace the call to the unimplemented
+function. If you need the function, check for a newer IronPLC release
+where the library binds it to an implementation, or file a feature
+request naming the function.

--- a/playground/scripts/gen-libs-index.mjs
+++ b/playground/scripts/gen-libs-index.mjs
@@ -35,17 +35,23 @@ function stFiles(dir) {
   return out;
 }
 
-// name -> [ "libs/<Name>/<version>/<file>.st", ... ], paths relative to the
-// served app root so the browser can fetch them directly.
+// name -> { manifest: "libs/<Name>/library.toml",
+//           files: [ "libs/<Name>/<version>/<file>.st", ... ] },
+// paths relative to the served app root so the browser can fetch them
+// directly. The manifest rides along because its bindings tell the compiler
+// how intrinsic-bound and declare-only POUs compile.
 const index = {};
 for (const name of readdirSync(libsDir)) {
   const full = join(libsDir, name);
   if (!statSync(full).isDirectory()) {
     continue;
   }
-  index[name] = stFiles(full)
-    .map((path) => relative(root, path))
-    .sort();
+  index[name] = {
+    manifest: relative(root, join(full, "library.toml")),
+    files: stFiles(full)
+      .map((path) => relative(root, path))
+      .sort(),
+  };
 }
 
 writeFileSync(join(libsDir, "index.json"), `${JSON.stringify(index, null, 2)}\n`);

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -404,16 +404,20 @@ const librariesParam = (params.get("libraries") || "")
   .map((s) => s.trim())
   .filter((s) => s.length > 0);
 
-// The served library sources, once fetched: a JSON array of `.st` file
-// contents ready to hand to the WASM compile path. Empty until fetched (and
-// when no library is activated), which the compiler treats as "no library".
-let activatedLibrarySources: string[] = [];
+// One activated library package as the WASM compile path expects it: the
+// manifest text (whose bindings tell codegen how intrinsic-bound and
+// declare-only POUs compile) plus the version's `.st` file contents.
+type LibraryPackage = { manifest: string; files: string[] };
+
+// The served library packages, once fetched. Empty until fetched (and when no
+// library is activated), which the compiler treats as "no library".
+let activatedLibraryPackages: LibraryPackage[] = [];
 
 // Index of the served compatibility libraries, generated at build time and
-// served at `libs/index.json`: library name -> the paths of its `.st` files
-// (relative to the app root). A static index avoids relying on directory
-// listing, which static hosts do not provide.
-type LibraryIndex = Record<string, string[]>;
+// served at `libs/index.json`: library name -> its `library.toml` path and
+// the paths of its `.st` files (relative to the app root). A static index
+// avoids relying on directory listing, which static hosts do not provide.
+type LibraryIndex = Record<string, { manifest: string; files: string[] }>;
 
 // Fetch and load the activated libraries' plain-text files. Best-effort: a
 // missing index or file leaves the affected library inactive (its symbols stay
@@ -433,31 +437,45 @@ async function loadActivatedLibraries(): Promise<void> {
     return;
   }
 
-  const sources: string[] = [];
+  const packages: LibraryPackage[] = [];
   for (const name of librariesParam) {
-    const files = index[name];
-    if (!files) {
+    const entry = index[name];
+    if (!entry) {
       continue;
     }
-    for (const path of files) {
+    let manifest: string;
+    try {
+      const response = await fetch(entry.manifest);
+      if (!response.ok) {
+        // Without the manifest the library's bindings are unknown, so leave
+        // the whole library inactive rather than activating it half-wired.
+        continue;
+      }
+      manifest = await response.text();
+    } catch {
+      continue;
+    }
+    const files: string[] = [];
+    for (const path of entry.files) {
       try {
         const response = await fetch(path);
         if (response.ok) {
-          sources.push(await response.text());
+          files.push(await response.text());
         }
       } catch {
         // Skip a file that fails to load; its symbols stay undefined.
       }
     }
+    packages.push({ manifest, files });
   }
-  activatedLibrarySources = sources;
+  activatedLibraryPackages = packages;
 }
 
-// The activated library sources as the WASM compile path expects them: a JSON
-// array of `.st` file contents, or "" when none are active.
+// The activated library packages as the WASM compile path expects them: a
+// JSON array of `{ manifest, files }` objects, or "" when none are active.
 function getLibraries(): string {
-  return activatedLibrarySources.length > 0
-    ? JSON.stringify(activatedLibrarySources)
+  return activatedLibraryPackages.length > 0
+    ? JSON.stringify(activatedLibraryPackages)
     : "";
 }
 

--- a/specs/design/compatibility-libraries.md
+++ b/specs/design/compatibility-libraries.md
@@ -77,10 +77,9 @@ reproduce. This is a safety requirement, not a convenience one. Concretely:
   into something with undefined behavior; the failure mode is fixed — "does not
   compile," never "compiles and misbehaves."
 
-The first increment ships only constants (`Tc2_System`'s `PI`), so there are no
-callable library POUs that could be unimplemented. The concrete enforcement — a
-call to a declare-only POU is a compile error — arrives with *bindings* (see
-*Future Goals*).
+The concrete enforcement is the **fail-if-unimplemented rule**: a call to a
+declare-only library POU is a dedicated compile error (`P4046`), never
+silently-wrong codegen and never a runtime trap (see *Bodies and bindings*).
 
 ## Goals
 
@@ -118,9 +117,6 @@ call to a declare-only POU is a compile error — arrives with *bindings* (see
   authoring*).
 - Collision resolution between simultaneously-active libraries — deferred (see
   *Future Goals*).
-- Bindings, non-ST implementations (VM intrinsics), and the declare-only state —
-  deferred with the bindings mechanism (see *Future Goals*). The first increment
-  ships only fully-defined ST.
 
 ## Current State
 
@@ -281,20 +277,45 @@ records its references — is a conformance test; whether the references are hon
 and complete is confirmed at review. The test checks the record's *shape*; the
 reviewer checks its *truth*.
 
-### Bodies (first increment) and the future bindings mechanism
+### Bodies and bindings
 
-The first increment ships only fully-defined ST — for `Tc2_System`, `PI` as a
-`VAR_GLOBAL CONSTANT`. There is no partial/declare-only state and no non-ST
+The default implementation medium is fully-defined ST — for `Tc2_System`,
+`PI` as a `VAR_GLOBAL CONSTANT`; for a function like `BOOL_TO_STRING`, an
+ordinary ST body compiled like user code. Per
+[ADR-0042](../adrs/0042-library-functions-over-compiler-intrinsics.md), ST
+is also the preferred medium: a library function gets a non-ST
+implementation only when its semantics cannot be expressed in IEC 61131-3
+source.
+
+For those cases the manifest carries **bindings** (a per-version table; the
+on-disk shape and its `REQ-LF-sources-005..007` requirements are specified
+in [Compatibility Library Format §Bindings](compatibility-library-format.md)).
+A binding maps a POU to a **VM intrinsic** — an *unnamed* native builtin
+reached exclusively through the binding, adding no name to any scope — or
+marks it **declare-only** so a library's surface can land ahead of its
 implementation.
 
-A later increment adds **bindings** (a per-version manifest table; see
-[Compatibility Library Format §Future](compatibility-library-format.md)) so a POU
-can map to a **VM intrinsic** — for native functions like `Tc2_Math` numerics,
-where we *desire* the same numeric behavior as the vendor (feasibility TBD) — or
-be **declare-only**. Per *Safety first*, once that exists a *call* to a
-declare-only POU is a **compile error** (a dedicated problem code, not a runtime
-trap), so a large library's surface can land ahead of its bodies without letting
-an unimplemented function reach execution.
+The analyzer never sees bindings: a bound or declare-only POU's `.st`
+declaration carries its full interface, so `check` and type resolution work
+unchanged. Codegen consumes them:
+
+- **REQ-CL-codegen-001** A call to a library POU bound to an intrinsic
+  compiles to the bound native builtin invocation (`BUILTIN func_id` per
+  [ADR-0008](../adrs/0008-unified-builtin-opcode.md)), not to a call of the
+  POU's (empty) ST body; the empty body of a bound library POU is never
+  compiled.
+- **REQ-CL-codegen-002** Per *Safety first*, a *call* to a declare-only
+  library POU fails compilation with the dedicated diagnostic `P4046`
+  (`LibraryFunctionNotImplemented`), naming the library and POU — never
+  silently-wrong codegen, never a runtime trap.
+- **REQ-CL-analyzer-007** A program that *calls* a declare-only library POU
+  still passes `check` (semantic analysis) cleanly: the declaration
+  resolves and type-checks like any other, so the surface of a partially
+  implemented library is usable for corpus checking ahead of its bodies.
+
+User shadowing is preserved (**REQ-CL-analyzer-004**): a user-defined POU
+with the same name as a bound library POU compiles as the user's function —
+binding lowering applies only to the library's own declaration.
 
 ### Referenced-but-unshipped libraries
 
@@ -378,11 +399,6 @@ distribution mechanism, out of scope here.
   diagnostic on genuine ambiguity), faithfully reproducing the host's behavior.
   The `FLOOR`-override case above depends on this.
 - **Cross-library / cross-vendor mixing** as a supported configuration.
-- **Bindings** — a per-version manifest table (see
-  [Compatibility Library Format §Future](compatibility-library-format.md)) mapping
-  a POU to a **VM intrinsic** or **declare-only**, plus the fail-if-unimplemented
-  rule (a call to a declare-only POU is a compile error). Omitted from the first
-  increment, which ships only fully-defined ST.
 - **Accept source-written namespace qualifiers** (`Tc2_Standard.TON`), mapping the
   qualifier to its library. Needed only if some library requires the qualified
   form; no known Tier A/B library does.
@@ -412,7 +428,7 @@ Prior open questions are now decided:
 
 - **Manifest format** and installation — specified in
   [Compatibility Library Format](compatibility-library-format.md). The
-  **fail-if-unimplemented rule** — *Bodies and the fail-if-unimplemented rule*.
+  **fail-if-unimplemented rule** — *Bodies and bindings*.
 - **Provenance** — the manifest records the public references used; the reviewer
   and clean-room spec are recorded by git history, not manifest fields
   (*Licensing, provenance, and clean-room authoring*).

--- a/specs/design/compatibility-library-format.md
+++ b/specs/design/compatibility-library-format.md
@@ -69,8 +69,57 @@ references = [
 ## Declarations
 
 Declarations are IEC 61131-3 Structured Text in the `.st` files under a version's
-subdirectory. In the first increment every declaration is fully defined ST — for
-`Tc2_System`, `PI` is a `VAR_GLOBAL CONSTANT`.
+subdirectory. By default every declaration is fully defined ST — for
+`Tc2_System`, `PI` is a `VAR_GLOBAL CONSTANT` — and a POU's ST body is its
+implementation. A POU whose implementation is *not* an ordinary ST body is
+declared the same way but marked in the manifest's *Bindings* table (below).
+
+## Bindings
+
+A **binding** maps a POU in a specific version to a non-default
+implementation. Bindings exist for the two cases
+[ADR-0042](../adrs/0042-library-functions-over-compiler-intrinsics.md)
+carves out of the ST-body default: semantics that cannot be expressed in IEC
+61131-3 source (backed by an *unnamed* native VM builtin), and declarations
+whose implementation has not landed yet (*declare-only*).
+
+**REQ-LF-sources-005** A manifest may carry a per-version bindings table,
+keyed by the version, mapping a POU name to a binding. The version key must
+be quoted — `["1.0.0".bindings]`; the unquoted form `[1.0.0.bindings]` is
+three nested TOML tables and is rejected. A binding value is one of exactly
+two forms:
+
+- `{ intrinsic = "<name>" }` — calls to the POU lower to the named native VM
+  builtin. The name is an internal compiler/VM identifier, not a callable
+  name: the builtin adds no name to any scope, and the library is the only
+  way to reach it (ADR-0042 rule 3).
+- `"declare-only"` — the POU's declared signature exists so the library's
+  surface can land ahead of its implementation; *calling* the POU is a
+  compile error (see
+  [Compatibility Libraries](compatibility-libraries.md) *fail-if-unimplemented*).
+
+```toml
+["1.0.0".bindings]
+LTRUNC = { intrinsic = "trunc_lreal" }
+LMOD   = { intrinsic = "fmod_lreal" }
+```
+
+**REQ-LF-sources-006** A malformed bindings entry — a version key whose
+value is not a table, a `bindings` value that is not a table, a binding
+value that is neither the `intrinsic` inline-table form nor the string
+`"declare-only"`, or an unquoted dotted version key producing nested tables
+— is rejected with `P6010` anchored on the manifest file. Shape validation
+covers **every** version table in the manifest, not only the
+`default_version`, so the unquoted-key mistake cannot hide in an inactive
+version.
+
+**REQ-LF-sources-007** A bound or declare-only POU still appears in its
+version's `.st` files with its full interface (name, parameters, return
+type) and a body of exactly `;` (an empty statement). The declaration is
+what makes `check` and type resolution work unchanged; the `;` body is
+never the implementation — codegen either lowers calls to the bound builtin
+or rejects calls to a declare-only POU (see
+[Compatibility Libraries](compatibility-libraries.md)).
 
 ## Versioning
 
@@ -97,14 +146,6 @@ symlinks the executables onto the `PATH` (`current_exe()` resolves the symlink
 back to `libexec`, so the loader finds the libraries beside the real binary).
 The discovery/search mechanism beyond this fixed location is **not part of this
 format** and is defined separately when needed.
-
-## Future
-
-- **Bindings.** A per-version table keyed by the version — e.g.
-  `[1.0.0.bindings]` — mapping a POU to a non-default implementation (a VM
-  intrinsic, or declare-only). The fail-if-unimplemented rule (a call to a
-  declare-only POU is a compile error) arrives with bindings; see
-  [Compatibility Libraries](compatibility-libraries.md).
 
 ## References
 

--- a/specs/design/library-interfaces/bool-to-string.md
+++ b/specs/design/library-interfaces/bool-to-string.md
@@ -1,0 +1,68 @@
+# Library Interface Spec: `BOOL_TO_STRING`
+
+This is a **clean-room interface/behavior spec** authored from the public
+Beckhoff InfoSys documentation listed under *References*, per the
+[Compatibility Library Authoring policy](../../steering/compatibility-library-authoring.md).
+It is committed and merged as its own non-squashed git entry *before* any
+implementation, and is the sole input to the implementation (Tier A —
+the two-way mapping `TRUE ↔ 'TRUE'`, `FALSE ↔ 'FALSE'` is a fact with
+essentially one expression).
+
+IronPLC is an independent open-source project. It is not affiliated with,
+endorsed by, or sponsored by any third party.
+
+## Scope and placement
+
+In TwinCAT, `BOOL_TO_STRING` is one of the implicit `BOOL_TO_*` conversion
+operators — it belongs to the compiler surface, not to any vendor library.
+IronPLC does not add vendor names to its compiler tables
+([ADR-0042](../../adrs/0042-library-functions-over-compiler-intrinsics.md)
+rule 1), so per the
+[implementation plan](../../plans/2026-08-08-compatibility-library-bindings.md)
+it ships as an ST function in the bundled **`Tc2_System`** library — the
+library real TwinCAT projects reference by default — so it is in scope on
+the paved path (compiling a real `.plcproj` project) without widening the
+out-of-the-box compiler surface.
+
+## Interface
+
+```iecst
+FUNCTION BOOL_TO_STRING : STRING
+VAR_INPUT
+    IN : BOOL;
+END_VAR
+```
+
+## Behavior
+
+Converts a `BOOL` to its string representation:
+
+| Call | Result |
+|---|---|
+| `BOOL_TO_STRING(TRUE)` | `'TRUE'` |
+| `BOOL_TO_STRING(FALSE)` | `'FALSE'` |
+
+The result is exactly the uppercase keyword spelling, with no padding.
+
+**Medium:** trivially expressible, so it is an ST body in the library — no
+intrinsic, no func_id, no wire-format commitment:
+
+```iecst
+IF IN THEN
+    BOOL_TO_STRING := 'TRUE';
+ELSE
+    BOOL_TO_STRING := 'FALSE';
+END_IF;
+```
+
+## References
+
+Public Beckhoff InfoSys documentation (also recorded in the library's
+manifest `references`):
+
+- <https://infosys.beckhoff.com/content/1033/tcplccontrol/925577611.html> — `BOOL_TO` conversions (result is `'TRUE'` / `'FALSE'`)
+- <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529047435.html> — Boolean conversion (TwinCAT 3)
+
+No vendor implementation source, exported `.library` files, or encumbered
+third-party source was used as an input to this spec or to the
+implementation generated from it.

--- a/specs/design/library-interfaces/tc2-math.md
+++ b/specs/design/library-interfaces/tc2-math.md
@@ -1,0 +1,172 @@
+# Library Interface Spec: `Tc2_Math` (LTRUNC, LMOD, MODABS, FRAC)
+
+This is a **clean-room interface/behavior spec** authored from the public
+Beckhoff InfoSys documentation listed under *References*, per the
+[Compatibility Library Authoring policy](../../steering/compatibility-library-authoring.md).
+It is committed and merged as its own non-squashed git entry *before* any
+implementation, and is the sole input to the implementation of the
+`Tc2_Math` compatibility library (Tier B — clean-room interface shim; the
+`MODABS`/`FRAC` bodies are Tier A math-dictated compositions).
+
+IronPLC is an independent open-source project. It is not affiliated with,
+endorsed by, or sponsored by any third party. The `Tc2_Math` name is used
+nominatively: it records whose interface this library mirrors.
+
+## Scope
+
+Four functions from Beckhoff's TwinCAT 3 `Tc2_Math` PLC library. Beckhoff's
+signatures are `LREAL`-only (not generic over `ANY_REAL`); this library
+matches that exactly. Per the project convention established in review of
+the original contributions, formal parameter names are normalized to the
+IronPLC stdlib `IN`/`IN1`/`IN2` convention — real call sites use positional
+arguments for these functions, and IronPLC's stdlib does not preserve vendor
+formal names for any other function either. (For the record, Beckhoff's
+documented formal names are `lr_in` for `LTRUNC`/`FRAC` and
+`lr_Value`/`lr_Arg` for `LMOD`.)
+
+## Interface
+
+```iecst
+FUNCTION LTRUNC : LREAL
+VAR_INPUT
+    IN : LREAL;
+END_VAR
+
+FUNCTION LMOD : LREAL
+VAR_INPUT
+    IN1 : LREAL;  (* value *)
+    IN2 : LREAL;  (* modulo range *)
+END_VAR
+
+FUNCTION MODABS : LREAL
+VAR_INPUT
+    IN : LREAL;  (* value *)
+    IM : LREAL;  (* modulo range *)
+END_VAR
+
+FUNCTION FRAC : LREAL
+VAR_INPUT
+    IN : LREAL;
+END_VAR
+```
+
+## Behavior
+
+### `LTRUNC` — LREAL-preserving truncation
+
+Determines the integer part of a floating-point number. Unlike the IEC
+61131-3 `TRUNC` (whose result is `ANY_INT` and therefore clamped to an
+integer type's value range), the result is of type `LREAL` and is not
+limited to the integer range. For positive inputs the result is less than
+or equal to the input; for negative inputs it is greater than or equal
+(truncation toward zero, IEEE-754 `trunc`).
+
+Pinned examples:
+
+| Call | Result |
+|---|---|
+| `LTRUNC(2.8)` | `2.0` |
+| `LTRUNC(-2.8)` | `-2.0` |
+| `LTRUNC(3.7)` | `3.0` |
+| `LTRUNC(-3.7)` | `-3.0` |
+
+**Inexpressibility note (drives the implementation medium):** ST cannot
+express this — the only truncation primitive, `TRUNC`, leaves the `LREAL`
+domain and clamps to an integer range. `LTRUNC` is therefore bound to a
+native VM builtin (`trunc_lreal`), reached only via the library's manifest
+binding per [ADR-0042](../../adrs/0042-library-functions-over-compiler-intrinsics.md).
+
+### `LMOD` — floating-point modulo, signed remainder
+
+Carries out a modulo division and returns the **signed** remainder. Unlike
+the integer-only IEC `MOD`, `LMOD` operates on floating-point values and
+returns non-integer remainders.
+
+Pinned semantics: IEEE-754 floating remainder with the **sign of the
+dividend** (C `fmod`; Rust `%` on `f64`):
+
+- `LMOD(IN1, IN2) = IN1 - LTRUNC(IN1 / IN2) * IN2` for finite nonzero `IN2`.
+- The result has the sign of `IN1` (or is `0.0`).
+- `LMOD(x, 0.0)` is **NaN** — not a runtime trap.
+
+Pinned examples:
+
+| Call | Result |
+|---|---|
+| `LMOD(400.56, 360.0)` | `≈ 40.56` |
+| `LMOD(-400.56, 360.0)` | `≈ -40.56` |
+| `LMOD(x, 0.0)` | `NaN` |
+
+**Inexpressibility note:** no floating modulo exists in ST (`MOD` is
+integer). `LMOD` is bound to a native VM builtin (`fmod_lreal`) via the
+manifest binding.
+
+### `MODABS` — modulo, unsigned result within the modulo range
+
+Performs a modulo division and determines the **unsigned** modulo value
+within the modulo range `[0, |IM|)` — the wrap-around behavior used for
+positioning (e.g. normalizing an angle to `[0, 360)`).
+
+Math-dictated definition in terms of `LMOD`:
+
+```iecst
+MODABS := LMOD(IN, IM);
+IF MODABS < 0.0 THEN
+    MODABS := MODABS + ABS(IM);
+END_IF;
+```
+
+Pinned examples:
+
+| Call | Result |
+|---|---|
+| `MODABS(400.56, 360.0)` | `≈ 40.56` |
+| `MODABS(-400.56, 360.0)` | `≈ 319.44` |
+| `MODABS(x, 0.0)` | `NaN` (propagated from `LMOD`) |
+
+**Medium:** ST body in the library (expressible; no builtin, no func_id).
+
+### `FRAC` — fractional part
+
+Determines the decimal (fractional) component of a floating-point number.
+The result keeps the **sign of the input**.
+
+Math-dictated definition in terms of `LTRUNC`:
+
+```iecst
+FRAC := IN - LTRUNC(IN);
+```
+
+Pinned examples:
+
+| Call | Result |
+|---|---|
+| `FRAC(2.8)` | `≈ 0.8` |
+| `FRAC(-2.8)` | `≈ -0.8` |
+| `FRAC(3.7)` | `≈ 0.7` |
+| `FRAC(-3.7)` | `≈ -0.7` |
+
+**Medium:** ST body in the library (expressible; no builtin, no func_id).
+
+## Non-goals
+
+- `REAL` (F32) variants or `ANY_REAL` generic signatures — Beckhoff's
+  `Tc2_Math` signatures are `LREAL`-only; REAL arguments are served by the
+  separately-planned call-site REAL→LREAL widening.
+- Other `Tc2_Math` functions (`FLOOR`, `CEIL`, …) — added when needed,
+  each via this same clean-room process.
+
+## References
+
+Public Beckhoff InfoSys documentation (also recorded in the library's
+manifest `references`):
+
+- <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68446347.html> — `LTRUNC`
+- <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68444811.html> — `LMOD`
+- <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68447883.html> — `MODABS`
+- <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68443275.html> — `FRAC`
+- <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68440331.html> — `Tc2_Math` functions overview
+
+No vendor implementation source, exported `.library` files, or encumbered
+third-party source was used as an input to this spec or to the
+implementation generated from it.

--- a/specs/design/library-interfaces/tc2-utilities.md
+++ b/specs/design/library-interfaces/tc2-utilities.md
@@ -1,0 +1,69 @@
+# Library Interface Spec: `Tc2_Utilities` (LREAL_TO_FMTSTR)
+
+This is a **clean-room interface/behavior spec** authored from the public
+Beckhoff InfoSys documentation listed under *References*, per the
+[Compatibility Library Authoring policy](../../steering/compatibility-library-authoring.md).
+It is committed and merged as its own non-squashed git entry *before* any
+implementation, and is the sole input to the implementation of the
+`Tc2_Utilities` compatibility library (Tier B — clean-room interface shim).
+
+IronPLC is an independent open-source project. It is not affiliated with,
+endorsed by, or sponsored by any third party. The `Tc2_Utilities` name is
+used nominatively: it records whose interface this library mirrors.
+
+## Scope
+
+One function from Beckhoff's TwinCAT 3 `Tc2_Utilities` PLC library. This
+spec pins the **interface only**: per the
+[implementation plan](../../plans/2026-08-08-compatibility-library-bindings.md),
+`LREAL_TO_FMTSTR` lands **declare-only** — the signature resolves during
+`check`, and a *call* to it is a compile error (`P4046`) until the
+native formatting implementation arrives in a follow-up. Beckhoff's exact
+formal parameter names are kept (unlike the `Tc2_Math` normalization),
+because mixed-case named-argument calls appear in real TwinCAT code for
+this function.
+
+## Interface
+
+```iecst
+FUNCTION LREAL_TO_FMTSTR : STRING(255)
+VAR_INPUT
+    in         : LREAL;
+    iPrecision : INT;
+    bRound     : BOOL;
+END_VAR
+```
+
+## Behavior (pinned for the follow-up implementation)
+
+Converts an `LREAL` value to a formatted string:
+
+- `iPrecision` is the number of decimal places in the output.
+- `bRound = TRUE` rounds the value to the requested precision;
+  `bRound = FALSE` truncates (cuts) the remaining decimal places.
+- The result is a `STRING(255)` decimal representation (no exponent
+  notation for values in ordinary range).
+
+Illustrative shape (behavioral pinning of exact digits, rounding ties, and
+extreme-value handling is deferred to the follow-up plan that implements
+the formatting): `LREAL_TO_FMTSTR(in := 1.23456, iPrecision := 3,
+bRound := TRUE)` yields `'1.235'`, while `bRound := FALSE` yields `'1.234'`.
+
+**Medium note (drives declare-only):** numerically-faithful float
+formatting is expressible in principle but subtle; per
+[ADR-0042](../../adrs/0042-library-functions-over-compiler-intrinsics.md)'s
+recorded borderline case, neither ST nor a builtin is chosen yet. The
+declaration ships now so the library surface exists and `check` passes on
+real code; calls fail compile with `P4046` rather than ever producing
+unfaithful output.
+
+## References
+
+Public Beckhoff InfoSys documentation (also recorded in the library's
+manifest `references`):
+
+- <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_utilities/35143691.html> — `LREAL_TO_FMTSTR`
+- <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_utilities/34605835.html> — `Tc2_Utilities` overview
+
+No vendor implementation source, exported `.library` files, or encumbered
+third-party source was used as an input to this spec.


### PR DESCRIPTION
Authored from public Beckhoff InfoSys documentation only, per the
compatibility-library authoring policy: committed as its own non-squashed
entry before any implementation. Pins LREAL-only signatures, fmod
sign-of-dividend semantics for LMOD (LMOD(x, 0.0) is NaN, never a trap),
the unsigned MODABS wrap into [0, |IM|), and sign-preserving FRAC, plus
the implementation medium each function requires under ADR-0042.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V6k4CWyhhPUbbDqygfbfuG