### PR TITLE
feat(sources): Tc2_BuiltIns compatibility library with BOOL_TO_STRING, auto-activated for TwinCAT projects

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "ironplc-dsl",
  "ironplc-parser",
  "ironplc-problems",
+ "ironplc-sources",
  "ironplc-spec-requirements-gen",
  "ironplc-vm",
  "proptest",

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -20,6 +20,7 @@ ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
 [dev-dependencies]
 ironplc-analyzer = { path = "../analyzer", version = "0.234.0" }
 ironplc-parser = { path = "../parser", version = "0.234.0" }
+ironplc-sources = { path = "../sources", version = "0.234.0" }
 ironplc-vm = { path = "../vm", version = "0.234.0", features = ["test-support"] }
 spec_test_macro = { path = "../spec_test_macro" }
 proptest = "1"

--- a/compiler/codegen/tests/it/end_to_end_library_tc2_builtins.rs
+++ b/compiler/codegen/tests/it/end_to_end_library_tc2_builtins.rs
@@ -1,0 +1,83 @@
+//! End-to-end tests for the bundled `Tc2_BuiltIns` compatibility library:
+//! load the real bundled package, compile user source against it, and run the
+//! VM.
+//!
+//! `Tc2_BuiltIns` mirrors TwinCAT's *built-in* operator surface — implicit
+//! conversion operators such as `BOOL_TO_STRING` that TwinCAT always has in
+//! scope and that belong to no vendor library there. IronPLC does not add
+//! vendor names to its compiler tables (ADR-0042 rule 1), so the operator
+//! ships as a plain library ST function — no intrinsic, no func_id — compiled
+//! like user code. These tests pin the behavior from the clean-room spec in
+//! `specs/design/library-interfaces/bool-to-string.md`.
+
+use ironplc_container::STRING_HEADER_BYTES;
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_sources::libraries::{LibraryName, LibraryRegistry};
+use ironplc_vm::test_support::load_and_start;
+use ironplc_vm::VmBuffers;
+
+/// Loads the named bundled library, merges its declarations ahead of
+/// `user_source` (so a user declaration would shadow a library one), compiles,
+/// and runs one scan cycle.
+fn run_with_bundled_library(library_name: &str, user_source: &str) -> VmBuffers {
+    let options = CompilerOptions::default();
+    let registry = LibraryRegistry::bundled();
+    let loaded = registry.load(&LibraryName::from(library_name)).unwrap();
+
+    let user =
+        ironplc_parser::parse_program(user_source, &FileId::from_string("user.st"), &options)
+            .unwrap();
+    let analyze_input: Vec<&ironplc_dsl::common::Library> = [&loaded.library, &user].to_vec();
+    let (analyzed, ctx) =
+        ironplc_analyzer::stages::resolve_types(&analyze_input, &options).unwrap();
+
+    let container = ironplc_codegen::compile(
+        &analyzed,
+        &ctx,
+        &ironplc_codegen::CodegenOptions::default(),
+        &ironplc_codegen::EmptyLookup,
+    )
+    .unwrap();
+
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs).unwrap();
+        vm.run_round(0).unwrap();
+    }
+    bufs
+}
+
+/// Reads a STRING value from the data region at the given byte offset.
+fn read_string(data_region: &[u8], data_offset: usize) -> String {
+    let cur_len =
+        u16::from_le_bytes([data_region[data_offset + 2], data_region[data_offset + 3]]) as usize;
+    let data_start = data_offset + STRING_HEADER_BYTES;
+    let bytes = &data_region[data_start..data_start + cur_len];
+    bytes.iter().map(|&b| b as char).collect()
+}
+
+fn bool_to_string_result(literal: &str) -> String {
+    let source = format!(
+        "PROGRAM main
+VAR
+    s : STRING;
+END_VAR
+    s := BOOL_TO_STRING({literal});
+END_PROGRAM
+"
+    );
+    let bufs = run_with_bundled_library("Tc2_BuiltIns", &source);
+    read_string(&bufs.data_region, 0)
+}
+
+#[test]
+fn end_to_end_when_bool_to_string_true_then_exact_true_keyword() {
+    // Exactly the uppercase keyword spelling, no padding.
+    assert_eq!(bool_to_string_result("TRUE"), "TRUE");
+}
+
+#[test]
+fn end_to_end_when_bool_to_string_false_then_exact_false_keyword() {
+    assert_eq!(bool_to_string_result("FALSE"), "FALSE");
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -84,6 +84,7 @@ mod end_to_end_insert;
 mod end_to_end_ldate;
 mod end_to_end_left;
 mod end_to_end_len;
+mod end_to_end_library_tc2_builtins;
 mod end_to_end_limit;
 mod end_to_end_limit_float;
 mod end_to_end_limit_lint;

--- a/compiler/ironplc-cli/tests/cli.rs
+++ b/compiler/ironplc-cli/tests/cli.rs
@@ -345,6 +345,106 @@ fn check_when_twincat_solution_library_reference_removed_then_pi_undefined(
     Ok(())
 }
 
+/// A source using TwinCAT's built-in `BOOL_TO_STRING` conversion operator,
+/// which IronPLC serves from the bundled `Tc2_BuiltIns` library (never from
+/// the compiler tables — ADR-0042 rule 1).
+const BOOL_TO_STRING_SOURCE: &str = "PROGRAM main
+VAR
+    flag : BOOL;
+    s : STRING;
+END_VAR
+    s := BOOL_TO_STRING(flag);
+END_PROGRAM
+";
+
+/// Discovering a `.plcproj` — the project's explicit statement of the TwinCAT
+/// target — auto-activates `Tc2_BuiltIns`, even though the `.plcproj` carries
+/// no library reference at all (in TwinCAT the built-in operators belong to
+/// no library, so there is nothing to reference).
+#[test]
+fn check_when_plcproj_discovered_then_tc2_builtins_auto_activates(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    std::fs::write(dir.path().join("main.st"), BOOL_TO_STRING_SOURCE)?;
+    std::fs::write(
+        dir.path().join("project.plcproj"),
+        r#"<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="main.st" />
+  </ItemGroup>
+</Project>"#,
+    )?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("check").arg(dir.path());
+    cmd.assert().success().stdout(predicate::str::is_empty());
+
+    Ok(())
+}
+
+/// Negative control: the identical source compiled as a bare `.st` file (no
+/// `.plcproj`, no `--library`) fails — `Tc2_BuiltIns` is dormant by default,
+/// so `BOOL_TO_STRING` does not resolve. This proves the test above passes
+/// *because of* the `.plcproj` discovery, not because `BOOL_TO_STRING` is a
+/// compiler builtin.
+#[test]
+fn check_when_bare_st_file_then_bool_to_string_dormant() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let source = dir.path().join("main.st");
+    std::fs::write(&source, BOOL_TO_STRING_SOURCE)?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("check").arg(&source);
+    // P4017: FunctionCallUndeclared -- BOOL_TO_STRING is not in scope.
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("P4017"));
+
+    Ok(())
+}
+
+/// Explicit activation for source with no project context: `--library
+/// Tc2_BuiltIns` brings the operator surface into scope for `check`.
+#[test]
+fn check_when_library_flag_tc2_builtins_then_ok() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let source = dir.path().join("main.st");
+    std::fs::write(&source, BOOL_TO_STRING_SOURCE)?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("check")
+        .arg("--library")
+        .arg("Tc2_BuiltIns")
+        .arg(&source);
+    cmd.assert().success().stdout(predicate::str::is_empty());
+
+    Ok(())
+}
+
+/// Explicit activation also carries through `compile`: the library's ST body
+/// is compiled like user code into the output container.
+#[test]
+fn compile_when_library_flag_tc2_builtins_then_creates_output(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let source = dir.path().join("main.st");
+    std::fs::write(&source, BOOL_TO_STRING_SOURCE)?;
+    let output = NamedTempFile::new()?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+    cmd.arg("compile")
+        .arg("--library")
+        .arg("Tc2_BuiltIns")
+        .arg(&source)
+        .arg("--output")
+        .arg(output.path());
+    cmd.assert().success().stdout(predicate::str::is_empty());
+
+    assert!(output.path().metadata()?.len() > 0);
+
+    Ok(())
+}
+
 #[test]
 fn version_then_ok() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));

--- a/compiler/project/src/project.rs
+++ b/compiler/project/src/project.rs
@@ -499,6 +499,72 @@ mod test {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Implicit Tc2_BuiltIns activation for TwinCAT projects.
+    //
+    // TwinCAT's built-in conversion operators (e.g. BOOL_TO_STRING) are
+    // always in scope there and belong to no library, so no real .plcproj
+    // references them -- discovering the .plcproj itself (the explicit
+    // statement of the TwinCAT target) activates the bundled Tc2_BuiltIns
+    // library that mirrors them.
+    // -----------------------------------------------------------------
+
+    const BOOL_TO_STRING_PROGRAM: &str = "FUNCTION_BLOCK FB_Report VAR flag : BOOL; s : STRING; END_VAR s := BOOL_TO_STRING(flag); END_FUNCTION_BLOCK";
+
+    #[test]
+    fn semantic_when_plcproj_discovered_then_tc2_builtins_auto_activates() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("main.st"), BOOL_TO_STRING_PROGRAM).unwrap();
+        // Note: NO library reference of any kind in the .plcproj.
+        fs::write(
+            dir.path().join("proj.plcproj"),
+            r#"<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="main.st" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let mut project = FileBackedProject::default();
+        let errors = project.initialize(dir.path());
+        assert!(errors.is_empty(), "unexpected discovery errors: {errors:?}");
+
+        // The .plcproj's presence alone activated Tc2_BuiltIns, so
+        // BOOL_TO_STRING resolves.
+        let result = project.semantic();
+        assert!(
+            result.is_ok(),
+            "expected clean analysis, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn semantic_when_bare_st_directory_then_bool_to_string_dormant() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        // Negative control: the identical source without a .plcproj makes no
+        // statement of a TwinCAT target, so Tc2_BuiltIns stays dormant and
+        // BOOL_TO_STRING does not resolve.
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("main.st"), BOOL_TO_STRING_PROGRAM).unwrap();
+
+        let mut project = FileBackedProject::default();
+        let errors = project.initialize(dir.path());
+        assert!(errors.is_empty(), "unexpected discovery errors: {errors:?}");
+
+        let result = project.semantic();
+        assert!(
+            result.is_err(),
+            "BOOL_TO_STRING must not resolve without activation"
+        );
+    }
+
     #[test]
     fn semantic_when_unshipped_library_activated_then_diagnostic() {
         let mut project = MemoryBackedProject::new(library_options());

--- a/compiler/sources/resources/libs/Tc2_BuiltIns/1.0.0/Tc2_BuiltIns.st
+++ b/compiler/sources/resources/libs/Tc2_BuiltIns/1.0.0/Tc2_BuiltIns.st
@@ -1,0 +1,20 @@
+(* Tc2_BuiltIns compatibility library -- TwinCAT built-in operator surface.
+
+   This file reproduces the *interface* (names and signatures) of TwinCAT's
+   implicit built-in conversion operators for interoperability. In TwinCAT
+   these operators are always in scope and belong to no vendor library; in
+   IronPLC they ship as ordinary library ST, authored from the clean-room
+   spec at specs/design/library-interfaces/bool-to-string.md. IronPLC is an
+   independent open-source project and is not affiliated with, endorsed by,
+   or sponsored by Beckhoff Automation GmbH. See
+   specs/steering/compatibility-library-authoring.md. *)
+FUNCTION BOOL_TO_STRING : STRING
+VAR_INPUT
+    IN : BOOL;
+END_VAR
+    IF IN THEN
+        BOOL_TO_STRING := 'TRUE';
+    ELSE
+        BOOL_TO_STRING := 'FALSE';
+    END_IF;
+END_FUNCTION

--- a/compiler/sources/resources/libs/Tc2_BuiltIns/library.toml
+++ b/compiler/sources/resources/libs/Tc2_BuiltIns/library.toml
@@ -1,0 +1,18 @@
+name = "Tc2_BuiltIns"
+vendor = "Beckhoff Automation GmbH"
+default_version = "1.0.0"
+# This library mirrors TwinCAT's *built-in* operator surface: implicit
+# conversion operators such as BOOL_TO_STRING that are always in scope in a
+# TwinCAT project and belong to no vendor library there. IronPLC does not add
+# vendor names to its compiler tables (ADR-0042 rule 1), so these
+# operator-surface names ship here as ordinary library ST instead. Because the
+# operators are unconditionally available in the environment a `.plcproj`
+# targets, discovering a `.plcproj` auto-activates this library; it can also
+# be activated explicitly via `--library Tc2_BuiltIns`. The `vendor` field is
+# nominative (whose interface this mirrors), not a claim of affiliation. See
+# specs/steering/compatibility-library-authoring.md and
+# specs/design/library-interfaces/bool-to-string.md.
+references = [
+  "https://infosys.beckhoff.com/content/1033/tcplccontrol/925577611.html -- BOOL_TO conversions (result is 'TRUE' / 'FALSE')",
+  "https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529047435.html -- Boolean conversion (TwinCAT 3)",
+]

--- a/compiler/sources/src/discovery/mod.rs
+++ b/compiler/sources/src/discovery/mod.rs
@@ -41,12 +41,16 @@ pub struct DiscoveredProject {
     pub root_dir: PathBuf,
     /// The source files to load, in deterministic order
     pub files: Vec<PathBuf>,
-    /// The compatibility libraries the project declares it references, in
-    /// declaration order and deduplicated by name. Read from a `.plcproj`'s
+    /// The compatibility libraries the project references, in declaration
+    /// order and deduplicated by name. Read from a `.plcproj`'s
     /// `<PlaceholderReference>` / `<LibraryReference>` elements
     /// (`REQ-CL-sources-001`); system libraries (`<SystemLibrary>true`) are
-    /// skipped. Empty for project types that carry no library references.
-    /// Callers resolve these against the bundled registry
+    /// skipped. For a TwinCAT project this also carries the implicit
+    /// [`TWINCAT_BUILTINS_LIBRARY`] reference -- TwinCAT's built-in operator
+    /// surface belongs to no library there, so no real `.plcproj` declares
+    /// it, yet it is unconditionally available in the environment the
+    /// `.plcproj` targets. Empty for project types that carry no library
+    /// references. Callers resolve these against the bundled registry
     /// ([`crate::libraries::LibraryRegistry::resolve_references`]) to decide
     /// which libraries to activate.
     pub library_references: Vec<LibraryReference>,
@@ -60,6 +64,25 @@ pub struct DiscoveredProject {
     /// behavior of e.g. MSBuild's `CS2001`).
     pub errors: Vec<Diagnostic>,
 }
+
+/// The bundled library mirroring TwinCAT's built-in operator surface --
+/// implicit conversion operators such as `BOOL_TO_STRING` that TwinCAT's
+/// compiler always has in scope and that belong to no vendor library there.
+///
+/// IronPLC does not add vendor names to its compiler tables (ADR-0042 rule
+/// 1), so these operator-surface names ship in the `Tc2_BuiltIns`
+/// compatibility library instead. Because the operators are unconditionally
+/// available in the environment a `.plcproj` targets, discovering a
+/// `.plcproj` activates this library implicitly -- that preserves the
+/// portability promise in both directions: TwinCAT code using
+/// `BOOL_TO_STRING` compiles in IronPLC unchanged, and code that compiles in
+/// IronPLC against a TwinCAT project works in TwinCAT. This is not
+/// source-sniffing: the `.plcproj` itself is the project's explicit statement
+/// of the TwinCAT target (the "never sniff, never guess" rule in
+/// `specs/design/compatibility-libraries.md` forbids inferring a library from
+/// POU *source content*, `REQ-CL-sources-005`). Bare directories of `.st`
+/// files and Beremiz projects never get this implicit reference.
+pub const TWINCAT_BUILTINS_LIBRARY: &str = "Tc2_BuiltIns";
 
 /// Discover the project structure in a directory.
 ///
@@ -254,6 +277,23 @@ fn detect_twincat(dir: &Path) -> Option<Result<DiscoveredProject, Diagnostic>> {
             }
         }
         merged_errors.extend(project.errors);
+    }
+
+    // The `.plcproj` is the project's explicit statement of the TwinCAT
+    // target, and TwinCAT's built-in operators (e.g. BOOL_TO_STRING) are
+    // unconditionally in scope in that environment without any library
+    // reference -- so every discovered TwinCAT project implicitly references
+    // the bundled library that mirrors them (see TWINCAT_BUILTINS_LIBRARY).
+    // Guarded by the same dedup set as declared references, so a (never
+    // observed in practice) explicit reference to the same name wins.
+    let builtins = LibraryName::from(TWINCAT_BUILTINS_LIBRARY);
+    if seen_libraries.insert(builtins.clone()) {
+        merged_library_references.push(LibraryReference {
+            name: builtins,
+            version: None,
+            namespace: None,
+            declared_in: FileId::from_path(&plcproj_paths[0]),
+        });
     }
 
     Some(Ok(DiscoveredProject {
@@ -649,7 +689,9 @@ mod tests {
 
         let result = discover(dir.path()).unwrap();
 
-        assert_eq!(result.library_references.len(), 2);
+        // Declared references first (in declaration order), then the implicit
+        // built-in operator-surface reference every TwinCAT project gets.
+        assert_eq!(result.library_references.len(), 3);
         assert_eq!(result.library_references[0].name.as_str(), "Tc2_System");
         assert_eq!(result.library_references[0].version.as_deref(), Some("*"));
         assert_eq!(
@@ -660,6 +702,10 @@ mod tests {
         assert_eq!(
             result.library_references[1].version.as_deref(),
             Some("3.3.7.0")
+        );
+        assert_eq!(
+            result.library_references[2].name.as_str(),
+            TWINCAT_BUILTINS_LIBRARY
         );
     }
 
@@ -679,7 +725,18 @@ mod tests {
         .unwrap();
 
         let result = discover(dir.path()).unwrap();
-        assert!(result.library_references.is_empty());
+
+        // The skipped system library contributes nothing; only the implicit
+        // TwinCAT built-in operator-surface reference remains.
+        assert!(!result
+            .library_references
+            .iter()
+            .any(|reference| reference.name.as_str() == "VisuElems"));
+        assert_eq!(result.library_references.len(), 1);
+        assert_eq!(
+            result.library_references[0].name.as_str(),
+            TWINCAT_BUILTINS_LIBRARY
+        );
     }
 
     #[test]
@@ -719,8 +776,70 @@ mod tests {
         .unwrap();
 
         let result = discover(dir.path()).unwrap();
-        assert_eq!(result.library_references.len(), 1);
+
+        // Tc2_System deduplicated across the two sub-projects, plus the
+        // implicit TwinCAT built-in operator-surface reference.
+        assert_eq!(result.library_references.len(), 2);
         assert_eq!(result.library_references[0].name.as_str(), "Tc2_System");
+        assert_eq!(
+            result.library_references[1].name.as_str(),
+            TWINCAT_BUILTINS_LIBRARY
+        );
+    }
+
+    // -- Implicit Tc2_BuiltIns activation on .plcproj discovery --
+
+    #[test]
+    fn discover_when_plcproj_has_no_library_references_then_implicit_tc2_builtins() {
+        // No real .plcproj ever references Tc2_BuiltIns -- TwinCAT's built-in
+        // operators belong to no library there -- yet discovering the
+        // .plcproj (the explicit statement of the TwinCAT target) implies it.
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("MAIN.TcPOU"), "<TcPlcObject/>").unwrap();
+        fs::write(
+            dir.path().join("project.plcproj"),
+            r#"<Project>
+  <ItemGroup>
+    <Compile Include="MAIN.TcPOU" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        assert_eq!(result.project_type, ProjectType::TwinCat);
+        assert_eq!(result.library_references.len(), 1);
+        assert_eq!(
+            result.library_references[0].name.as_str(),
+            TWINCAT_BUILTINS_LIBRARY
+        );
+    }
+
+    #[test]
+    fn discover_when_beremiz_project_then_no_implicit_tc2_builtins() {
+        // The implicit reference is a statement about the TwinCAT
+        // environment; a Beremiz project makes no such statement.
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("plc.xml"), "<project/>").unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        assert_eq!(result.project_type, ProjectType::Beremiz);
+        assert!(result.library_references.is_empty());
+    }
+
+    #[test]
+    fn discover_when_bare_st_directory_then_no_implicit_tc2_builtins() {
+        // A bare directory of .st files has no project context at all, so
+        // nothing is activated (libraries stay dormant, REQ-CL-analyzer-001).
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("main.st"), "PROGRAM Main END_PROGRAM").unwrap();
+
+        let result = discover(dir.path()).unwrap();
+
+        assert_eq!(result.project_type, ProjectType::Unstructured);
+        assert!(result.library_references.is_empty());
     }
 
     #[test]

--- a/compiler/sources/src/libraries/mod.rs
+++ b/compiler/sources/src/libraries/mod.rs
@@ -363,11 +363,37 @@ mod tests {
         })
     }
 
+    /// Whether the library declares a FUNCTION with the given name.
+    fn library_declares_function(library: &Library, name: &str) -> bool {
+        library.elements.iter().any(|element| {
+            matches!(element, LibraryElementKind::FunctionDeclaration(function)
+                if function.name.original() == name)
+        })
+    }
+
     #[test]
     fn bundled_registry_contains_tc2_system() {
         let registry = LibraryRegistry::bundled();
         assert!(registry.contains(&LibraryName::from("Tc2_System")));
         assert!(!registry.contains(&LibraryName::from("DoesNotExist")));
+    }
+
+    #[test]
+    fn bundled_registry_contains_tc2_builtins() {
+        let registry = LibraryRegistry::bundled();
+        assert!(registry.contains(&LibraryName::from("Tc2_BuiltIns")));
+    }
+
+    #[test]
+    fn load_when_tc2_builtins_then_provides_bool_to_string() {
+        let registry = LibraryRegistry::bundled();
+        let loaded = registry.load(&LibraryName::from("Tc2_BuiltIns")).unwrap();
+        assert_eq!(loaded.manifest.name, "Tc2_BuiltIns");
+        assert_eq!(loaded.manifest.default_version, "1.0.0");
+        assert!(
+            library_declares_function(&loaded.library, "BOOL_TO_STRING"),
+            "Tc2_BuiltIns must declare the function BOOL_TO_STRING"
+        );
     }
 
     #[test]

--- a/specs/design/library-interfaces/bool-to-string.md
+++ b/specs/design/library-interfaces/bool-to-string.md
@@ -1,0 +1,78 @@
+# Library Interface Spec: `BOOL_TO_STRING`
+
+This is a **clean-room interface/behavior spec** authored from the public
+Beckhoff InfoSys documentation listed under *References*, per the
+[Compatibility Library Authoring policy](../../steering/compatibility-library-authoring.md).
+It is committed and merged as its own non-squashed git entry *before* any
+implementation, and is the sole input to the implementation (Tier A —
+the two-way mapping `TRUE ↔ 'TRUE'`, `FALSE ↔ 'FALSE'` is a fact with
+essentially one expression).
+
+IronPLC is an independent open-source project. It is not affiliated with,
+endorsed by, or sponsored by any third party.
+
+## Scope and placement
+
+In TwinCAT, `BOOL_TO_STRING` is one of the implicit `BOOL_TO_*` conversion
+operators — it belongs to the compiler surface, not to any vendor library,
+and is therefore always in scope in a TwinCAT project. IronPLC does not add
+vendor names to its compiler tables
+([ADR-0042](../../adrs/0042-library-functions-over-compiler-intrinsics.md)
+rule 1), so it ships as an ST function in the bundled **`Tc2_BuiltIns`**
+library — the library that mirrors TwinCAT's built-in operator surface.
+
+Because these operators are unconditionally available in the environment a
+`.plcproj` targets, discovering a `.plcproj` **auto-activates**
+`Tc2_BuiltIns` (no real `.plcproj` ever references it — there is nothing to
+reference; the operators belong to no library there). That preserves the
+portability promise in both directions: TwinCAT code that uses
+`BOOL_TO_STRING` compiles in IronPLC unchanged, and code that compiles in
+IronPLC against a TwinCAT project works in TwinCAT. This is not
+source-sniffing — the `.plcproj` itself is the project's explicit statement
+of the TwinCAT target (the design's "never sniff, never guess" rule forbids
+inferring a library from POU *source content*). The library can also be
+activated explicitly via `--library Tc2_BuiltIns` for source with no
+project context.
+
+## Interface
+
+```iecst
+FUNCTION BOOL_TO_STRING : STRING
+VAR_INPUT
+    IN : BOOL;
+END_VAR
+```
+
+## Behavior
+
+Converts a `BOOL` to its string representation:
+
+| Call | Result |
+|---|---|
+| `BOOL_TO_STRING(TRUE)` | `'TRUE'` |
+| `BOOL_TO_STRING(FALSE)` | `'FALSE'` |
+
+The result is exactly the uppercase keyword spelling, with no padding.
+
+**Medium:** trivially expressible, so it is an ST body in the library — no
+intrinsic, no func_id, no wire-format commitment:
+
+```iecst
+IF IN THEN
+    BOOL_TO_STRING := 'TRUE';
+ELSE
+    BOOL_TO_STRING := 'FALSE';
+END_IF;
+```
+
+## References
+
+Public Beckhoff InfoSys documentation (also recorded in the library's
+manifest `references`):
+
+- <https://infosys.beckhoff.com/content/1033/tcplccontrol/925577611.html> — `BOOL_TO` conversions (result is `'TRUE'` / `'FALSE'`)
+- <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529047435.html> — Boolean conversion (TwinCAT 3)
+
+No vendor implementation source, exported `.library` files, or encumbered
+third-party source was used as an input to this spec or to the
+implementation generated from it.


### PR DESCRIPTION
Closes #1340.

## Summary

Adds a bundled `Tc2_BuiltIns` compatibility library providing `BOOL_TO_STRING`, auto-activated when a TwinCAT `.plcproj` file is discovered — so TwinCAT sources that call `BOOL_TO_STRING` now check and execute without manual flags.

Per ADR-0042, vendor built-ins are implemented as bundled ST library functions rather than compiler intrinsics, keeping the analyzer/codegen core dialect-neutral.

## Changes

- **Plan + spec**: implementation plan in `specs/plans/`, plus a clean-room interface spec for `BOOL_TO_STRING` following the compatibility-library authoring workflow (Tier-1 interface facts only)
- **Library**: `compiler/sources/resources/libs/Tc2_BuiltIns/1.0.0/Tc2_BuiltIns.st` with `library.toml` metadata (name, version, activation trigger)
- **Activation**: `.plcproj` discovery in the project crate now activates `Tc2_BuiltIns` automatically; bare ST files do not get the library (no silent dialect widening)
- **Tests**:
  - CLI integration tests: auto-activation on `.plcproj` discovery; library stays dormant for bare ST files
  - Project-crate semantic test: `BOOL_TO_STRING` must not resolve without activation
  - End-to-end codegen/execution test for `BOOL_TO_STRING` (`TRUE` → `'TRUE'`, `FALSE` → `'FALSE'`)

## Validation

Full CI pipeline (`cd compiler && just`) passes locally: compile, coverage (≥85%), clippy, rustfmt, and duplication checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6k4CWyhhPUbbDqygfbfuG

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6k4CWyhhPUbbDqygfbfuG)_