### PR TITLE
feat: __TRUNC/__MOD ANY_REAL compiler intrinsics

### DIFF
--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -1024,7 +1024,49 @@ pub fn get_all_stdlib_functions() -> Vec<FunctionSignature> {
     // Time functions (IEC 61131-3 Section 2.5.1.5.8, Table 35)
     functions.extend(get_time_functions());
 
+    // Compiler intrinsics (reserved `__` namespace)
+    functions.extend(get_compiler_intrinsic_functions());
+
     functions
+}
+
+// =============================================================================
+// Compiler intrinsics (reserved `__` namespace)
+// =============================================================================
+
+/// Returns the `__`-prefixed compiler intrinsic function definitions.
+///
+/// The `__` prefix is the established compiler-provided namespace (like
+/// `__SYSTEM_UP_TIME`): names only the compiler can provide, visibly
+/// non-portable, and colliding with no IEC 61131-3 or vendor name. These
+/// exist for behavior IEC 61131-3 source cannot express, and their intended
+/// callers are bundled compatibility-library bodies (e.g. `Tc2_Math`'s
+/// `LTRUNC := __TRUNC(IN);`). They are seeded unconditionally because
+/// library bodies are analyzed under the *user's* options, so a flag gate
+/// would break every library that uses them.
+///
+/// - `__TRUNC(IN: ANY_REAL): ANY_REAL` — truncation toward zero that stays
+///   in the input's real type (unlike `TRUNC`, whose `ANY_INT` result clamps
+///   values beyond the integer range).
+/// - `__MOD(IN1, IN2: ANY_REAL): ANY_REAL` — IEEE-754 floating remainder
+///   with the sign of the dividend (unlike `MOD`, which is integer-only);
+///   `__MOD(x, 0.0)` is NaN, never a runtime error.
+pub fn get_compiler_intrinsic_functions() -> Vec<FunctionSignature> {
+    vec![
+        FunctionSignature::stdlib(
+            "__TRUNC",
+            TypeName::from("ANY_REAL"),
+            vec![input_param("IN", "ANY_REAL")],
+        ),
+        FunctionSignature::stdlib(
+            "__MOD",
+            TypeName::from("ANY_REAL"),
+            vec![
+                input_param("IN1", "ANY_REAL"),
+                input_param("IN2", "ANY_REAL"),
+            ],
+        ),
+    ]
 }
 
 // =============================================================================
@@ -1453,5 +1495,42 @@ mod tests {
                 func.name.original()
             );
         }
+    }
+
+    #[test]
+    fn get_compiler_intrinsic_functions_when_called_then_any_real_signatures() {
+        let functions = get_compiler_intrinsic_functions();
+
+        let trunc = functions
+            .iter()
+            .find(|f| f.name.original() == "__TRUNC")
+            .unwrap();
+        assert!(trunc.is_stdlib());
+        assert_eq!(trunc.input_parameter_count(), 1);
+        assert_eq!(trunc.parameters[0].param_type, TypeName::from("ANY_REAL"));
+        assert_eq!(
+            trunc.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("ANY_REAL")))
+        );
+
+        let fmod = functions
+            .iter()
+            .find(|f| f.name.original() == "__MOD")
+            .unwrap();
+        assert!(fmod.is_stdlib());
+        assert_eq!(fmod.input_parameter_count(), 2);
+        assert_eq!(fmod.parameters[0].param_type, TypeName::from("ANY_REAL"));
+        assert_eq!(fmod.parameters[1].param_type, TypeName::from("ANY_REAL"));
+        assert_eq!(
+            fmod.return_type,
+            Some(FunctionReturnType::Named(TypeName::from("ANY_REAL")))
+        );
+    }
+
+    #[test]
+    fn get_all_stdlib_functions_when_called_then_includes_compiler_intrinsics() {
+        let functions = get_all_stdlib_functions();
+        assert!(functions.iter().any(|f| f.name.original() == "__TRUNC"));
+        assert!(functions.iter().any(|f| f.name.original() == "__MOD"));
     }
 }

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -153,6 +153,11 @@ pub(crate) fn lookup_builtin(name: &str, op_width: OpWidth, signedness: Signedne
         "ACOS" => float_builtin!(op_width, builtin::ACOS_F32, builtin::ACOS_F64),
         "ATAN" => float_builtin!(op_width, builtin::ATAN_F32, builtin::ATAN_F64),
         "ATAN2" => float_builtin!(op_width, builtin::ATAN2_F32, builtin::ATAN2_F64),
+        // Compiler intrinsics (reserved `__` namespace): real-preserving
+        // truncation and floating modulo, ANY_REAL with the width selecting
+        // the F32/F64 builtin variant.
+        "__TRUNC" => float_builtin!(op_width, builtin::TRUNC_F32, builtin::TRUNC_F64),
+        "__MOD" => float_builtin!(op_width, builtin::MOD_F32, builtin::MOD_F64),
         _ => None,
     }
 }

--- a/compiler/codegen/tests/it/end_to_end_compiler_intrinsics.rs
+++ b/compiler/codegen/tests/it/end_to_end_compiler_intrinsics.rs
@@ -1,0 +1,100 @@
+//! End-to-end tests for the `__TRUNC`/`__MOD` compiler intrinsics.
+//!
+//! These are the `__`-namespace intrinsics for real-number semantics IEC
+//! 61131-3 source cannot express: truncation that stays in the real type,
+//! and floating modulo (fmod, sign of the dividend). `ANY_REAL` genericity
+//! is exercised at both widths — the op width selects the F32/F64 builtin
+//! variant.
+
+use ironplc_parser::options::CompilerOptions;
+
+use crate::common::parse_and_run;
+
+/// Compiles a one-expression LREAL program and returns `result` (var 2).
+///
+/// Operands render via `{:?}` (uppercased), so values like `1.5e300` become
+/// the ST exponent literal `1.5E300` instead of 300 digits of integer text.
+fn eval_lreal(a: f64, b: f64, expression: &str) -> f64 {
+    let source = format!(
+        "PROGRAM main
+VAR
+    a : LREAL;
+    b : LREAL;
+    result : LREAL;
+END_VAR
+    a := {a};
+    b := {b};
+    result := {expression};
+END_PROGRAM
+",
+        a = format!("{a:?}").to_uppercase(),
+        b = format!("{b:?}").to_uppercase(),
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    bufs.vars[2].as_f64()
+}
+
+/// Compiles a one-expression REAL program and returns `result` (var 2).
+fn eval_real(a: f32, b: f32, expression: &str) -> f32 {
+    let source = format!(
+        "PROGRAM main
+VAR
+    a : REAL;
+    b : REAL;
+    result : REAL;
+END_VAR
+    a := {a};
+    b := {b};
+    result := {expression};
+END_PROGRAM
+"
+    );
+    let (_c, bufs) = parse_and_run(&source, &CompilerOptions::default());
+    bufs.vars[2].as_f32()
+}
+
+#[test]
+fn end_to_end_when_trunc_intrinsic_lreal_then_truncates_toward_zero() {
+    assert!((eval_lreal(3.7, 0.0, "__TRUNC(a)") - 3.0).abs() < 1e-9);
+    assert!((eval_lreal(-3.7, 0.0, "__TRUNC(a)") + 3.0).abs() < 1e-9);
+}
+
+#[test]
+fn end_to_end_when_trunc_intrinsic_lreal_beyond_integer_range_then_exact() {
+    // The reason __TRUNC exists: unlike TRUNC (ANY_INT result), values
+    // beyond any integer type's range truncate without clamping.
+    let big = 1.5e300_f64;
+    assert_eq!(eval_lreal(big, 0.0, "__TRUNC(a)"), big.trunc());
+}
+
+#[test]
+fn end_to_end_when_trunc_intrinsic_real_then_truncates_toward_zero() {
+    assert_eq!(eval_real(3.7, 0.0, "__TRUNC(a)"), 3.0);
+    assert_eq!(eval_real(-3.7, 0.0, "__TRUNC(a)"), -3.0);
+}
+
+#[test]
+fn end_to_end_when_mod_intrinsic_lreal_then_sign_of_dividend() {
+    assert!((eval_lreal(400.56, 360.0, "__MOD(a, b)") - 40.56).abs() < 1e-9);
+    assert!((eval_lreal(-400.56, 360.0, "__MOD(a, b)") + 40.56).abs() < 1e-9);
+}
+
+#[test]
+fn end_to_end_when_mod_intrinsic_real_then_sign_of_dividend() {
+    let r = eval_real(400.5, 360.0, "__MOD(a, b)");
+    assert!((r - 40.5).abs() < 1e-4, "expected 40.5, got {r}");
+    let r = eval_real(-400.5, 360.0, "__MOD(a, b)");
+    assert!((r + 40.5).abs() < 1e-4, "expected -40.5, got {r}");
+}
+
+#[test]
+fn end_to_end_when_mod_intrinsic_by_zero_then_nan_not_trap() {
+    // Division by zero yields NaN — it must never trap the VM.
+    assert!(eval_lreal(1.5, 0.0, "__MOD(a, b)").is_nan());
+}
+
+#[test]
+fn end_to_end_when_intrinsics_composed_then_frac_shape_works() {
+    // The composition Tc2_Math's FRAC will use: IN - __TRUNC(IN).
+    assert!((eval_lreal(-3.7, 0.0, "a - __TRUNC(a)") + 0.7).abs() < 1e-9);
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -43,6 +43,7 @@ mod end_to_end_bitstring;
 mod end_to_end_bool;
 mod end_to_end_case;
 mod end_to_end_cmp;
+mod end_to_end_compiler_intrinsics;
 mod end_to_end_concat;
 mod end_to_end_constant_initializer_expressions;
 mod end_to_end_conv_bool_to_int;

--- a/compiler/codegen/tests/it/wire_format.rs
+++ b/compiler/codegen/tests/it/wire_format.rs
@@ -216,11 +216,13 @@ fn opcode_constants_when_builtin_then_pinned_byte() {
 
 #[test]
 fn builtin_func_ids_when_unnamed_arithmetic_builtins_then_pinned_values() {
-    // Unnamed LREAL builtins are permanent compiler/VM ABI: containers
-    // encode these func_ids directly, so the values are wire-format
-    // commitments and must never change.
+    // The __TRUNC/__MOD lowering targets are permanent compiler/VM ABI:
+    // containers encode these func_ids directly, so the values are
+    // wire-format commitments and must never change.
     assert_eq!(opcode::builtin::TRUNC_F64, 0x03A3);
     assert_eq!(opcode::builtin::MOD_F64, 0x03A4);
+    assert_eq!(opcode::builtin::TRUNC_F32, 0x03A5);
+    assert_eq!(opcode::builtin::MOD_F32, 0x03A6);
 }
 
 #[test]

--- a/compiler/container/src/opcode.rs
+++ b/compiler/container/src/opcode.rs
@@ -1212,11 +1212,12 @@ pub mod builtin {
     pub const CMP_STR: u16 = 0x03A2;
 
     // =========================================================================
-    // Unnamed arithmetic builtins
+    // Real truncation / floating-modulo builtins
     //
-    // These func_ids have no compiler-seeded name: they implement LREAL
-    // semantics that IEC 61131-3 source cannot express (ADR-0042) and are
-    // intended to be reached only through compatibility-library bindings.
+    // These implement real-number semantics that IEC 61131-3 source cannot
+    // express (ADR-0042): truncation that stays in the real type, and a
+    // floating modulo. They are the lowering targets of the `__TRUNC` /
+    // `__MOD` compiler intrinsics (ANY_REAL, width selects the variant).
     // =========================================================================
 
     /// LREAL-preserving truncation toward zero (`f64::trunc`): pops one f64,
@@ -1228,6 +1229,14 @@ pub mod builtin {
     /// i.e. fmod; `x % 0.0` is NaN, not a trap): pops divisor then dividend,
     /// pushes the remainder.
     pub const MOD_F64: u16 = 0x03A4;
+
+    /// REAL-preserving truncation toward zero (`f32::trunc`): the f32 variant
+    /// of [`TRUNC_F64`].
+    pub const TRUNC_F32: u16 = 0x03A5;
+
+    /// Floating-point modulo with the sign of the dividend on f32: the f32
+    /// variant of [`MOD_F64`] (`x % 0.0` is NaN, not a trap).
+    pub const MOD_F32: u16 = 0x03A6;
 
     // =========================================================================
     // MUX (multiplexer) range-based opcodes
@@ -1292,11 +1301,12 @@ pub mod builtin {
             | BCD_TO_INT_16 | BCD_TO_INT_32 | BCD_TO_INT_64 | INT_TO_BCD_8 | INT_TO_BCD_16
             | INT_TO_BCD_32 | INT_TO_BCD_64 | CONV_I32_TO_BOOL | CONV_I64_TO_BOOL
             | CONV_I32_TO_STR | CONV_U32_TO_STR | CONV_STR_TO_I32 | CONV_F32_TO_STR
-            | CONV_STR_TO_F32 | TRUNC_F64 => 1,
+            | CONV_STR_TO_F32 | TRUNC_F64 | TRUNC_F32 => 1,
             EXPT_I32 | EXPT_F32 | EXPT_F64 | EXPT_I64 | MIN_I32 | MIN_F32 | MIN_F64 | MIN_I64
             | MIN_U32 | MIN_U64 | MAX_I32 | MAX_F32 | MAX_F64 | MAX_I64 | MAX_U32 | MAX_U64
             | SHL_I32 | SHL_I64 | SHR_I32 | SHR_I64 | ROL_I32 | ROL_I64 | ROR_I32 | ROR_I64
-            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 | ATAN2_F32 | ATAN2_F64 | CMP_STR | MOD_F64 => 2,
+            | ROL_U8 | ROL_U16 | ROR_U8 | ROR_U16 | ATAN2_F32 | ATAN2_F64 | CMP_STR | MOD_F64
+            | MOD_F32 => 2,
             LIMIT_I32 | LIMIT_F32 | LIMIT_F64 | LIMIT_I64 | LIMIT_U32 | LIMIT_U64 | SEL_I32
             | SEL_F32 | SEL_F64 | SEL_I64 => 3,
             id if is_mux(id) => {
@@ -1376,5 +1386,7 @@ mod tests {
     fn arg_count_when_unnamed_arithmetic_builtins_then_counts_match_dispatch() {
         assert_eq!(builtin::arg_count(builtin::TRUNC_F64), 1);
         assert_eq!(builtin::arg_count(builtin::MOD_F64), 2);
+        assert_eq!(builtin::arg_count(builtin::TRUNC_F32), 1);
+        assert_eq!(builtin::arg_count(builtin::MOD_F32), 2);
     }
 }

--- a/compiler/project/src/disassemble.rs
+++ b/compiler/project/src/disassemble.rs
@@ -512,6 +512,8 @@ fn decode_instructions(bytecode: &[u8], container: &Container) -> Vec<Value> {
                     }
                     opcode::builtin::TRUNC_F64 => format!("TRUNC_F64 (0x{:04X})", func_id),
                     opcode::builtin::MOD_F64 => format!("MOD_F64 (0x{:04X})", func_id),
+                    opcode::builtin::TRUNC_F32 => format!("TRUNC_F32 (0x{:04X})", func_id),
+                    opcode::builtin::MOD_F32 => format!("MOD_F32 (0x{:04X})", func_id),
                     id if opcode::builtin::is_mux(id) => {
                         let n = opcode::builtin::mux_info(id).unwrap();
                         let width = if id >= opcode::builtin::MUX_F64_BASE {

--- a/compiler/vm/src/builtin.rs
+++ b/compiler/vm/src/builtin.rs
@@ -329,6 +329,19 @@ pub fn dispatch(func_id: u16, stack: &mut OperandStack) -> Result<(), Trap> {
             stack.push(Slot::from_f64(a % b))?;
             Ok(())
         }
+        opcode::builtin::TRUNC_F32 => {
+            let a = stack.pop()?.as_f32();
+            stack.push(Slot::from_f32(a.trunc()))?;
+            Ok(())
+        }
+        opcode::builtin::MOD_F32 => {
+            // IEEE-754 remainder with the sign of the dividend (fmod).
+            // a % 0.0 is NaN, not a trap.
+            let b = stack.pop()?.as_f32();
+            let a = stack.pop()?.as_f32();
+            stack.push(Slot::from_f32(a % b))?;
+            Ok(())
+        }
         opcode::builtin::EXPT_I64 => {
             let b = stack.pop()?.as_i64();
             let a = stack.pop()?.as_i64();

--- a/compiler/vm/tests/it/execute_builtin_trunc_mod_f32.rs
+++ b/compiler/vm/tests/it/execute_builtin_trunc_mod_f32.rs
@@ -1,0 +1,68 @@
+//! VM tests for the TRUNC_F32 and MOD_F32 builtins — the f32 variants of
+//! the `__TRUNC`/`__MOD` lowering targets (see
+//! execute_builtin_trunc_mod_f64.rs for the f64 variants and the full
+//! semantics: truncation toward zero, and fmod with the sign of the
+//! dividend where division by zero yields NaN rather than a trap).
+
+/// Bytecode: load pool[0], BUILTIN TRUNC_F32, store var[0].
+fn trunc_bytecode() -> Vec<u8> {
+    #[rustfmt::skip]
+    let bytecode = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]
+        0x94, 0xA5, 0x03,  // BUILTIN TRUNC_F32 (0x03A5)
+        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0x8C,              // RET_VOID
+    ];
+    bytecode
+}
+
+/// Bytecode: load pool[0] (dividend), load pool[1] (divisor),
+/// BUILTIN MOD_F32, store var[0].
+fn fmod_bytecode() -> Vec<u8> {
+    #[rustfmt::skip]
+    let bytecode = vec![
+        0x02, 0x00, 0x00,  // LOAD_CONST_F32 pool[0]
+        0x02, 0x01, 0x00,  // LOAD_CONST_F32 pool[1]
+        0x94, 0xA6, 0x03,  // BUILTIN MOD_F32 (0x03A6)
+        0x12, 0x00, 0x00,  // STORE_VAR_F32 var[0]
+        0x8C,              // RET_VOID
+    ];
+    bytecode
+}
+
+#[test]
+fn execute_when_trunc_f32_positive_then_truncates_toward_zero() {
+    assert_eq!(
+        crate::common::run_and_read_f32(&trunc_bytecode(), 1, &[3.7]),
+        3.0
+    );
+}
+
+#[test]
+fn execute_when_trunc_f32_negative_then_truncates_toward_zero() {
+    assert_eq!(
+        crate::common::run_and_read_f32(&trunc_bytecode(), 1, &[-3.7]),
+        -3.0
+    );
+}
+
+#[test]
+fn execute_when_mod_f32_positive_then_fractional_remainder() {
+    let r = crate::common::run_and_read_f32(&fmod_bytecode(), 1, &[400.5, 360.0]);
+    assert!((r - 40.5).abs() < 1e-4, "__MOD(400.5, 360) = 40.5, got {r}");
+}
+
+#[test]
+fn execute_when_mod_f32_negative_dividend_then_sign_of_dividend() {
+    let r = crate::common::run_and_read_f32(&fmod_bytecode(), 1, &[-400.5, 360.0]);
+    assert!(
+        (r + 40.5).abs() < 1e-4,
+        "__MOD(-400.5, 360) = -40.5, got {r}"
+    );
+}
+
+#[test]
+fn execute_when_mod_f32_by_zero_then_nan_not_trap() {
+    let r = crate::common::run_and_read_f32(&fmod_bytecode(), 1, &[1.5, 0.0]);
+    assert!(r.is_nan(), "fmod by zero must be NaN, got {r}");
+}

--- a/compiler/vm/tests/it/main.rs
+++ b/compiler/vm/tests/it/main.rs
@@ -43,6 +43,7 @@ mod execute_bool_literal;
 mod execute_builtin_abs_i32;
 mod execute_builtin_abs_i64;
 mod execute_builtin_expt_i32;
+mod execute_builtin_trunc_mod_f32;
 mod execute_builtin_trunc_mod_f64;
 mod execute_call_ret;
 mod execute_cmp_i32;

--- a/specs/plans/2026-08-11-compiler-intrinsic-trunc-mod.md
+++ b/specs/plans/2026-08-11-compiler-intrinsic-trunc-mod.md
@@ -1,0 +1,81 @@
+# Plan: `__TRUNC` / `__MOD` Compiler Intrinsics
+
+## Goal
+
+Expose the LREAL-preserving truncation and floating-modulo VM builtins
+(`TRUNC_F64`/`MOD_F64`, merged in
+[#1345](https://github.com/ironplc/ironplc/pull/1345)) as two callable
+**compiler intrinsics** in the reserved `__` namespace:
+
+- `__TRUNC(IN: ANY_REAL): ANY_REAL` — truncation toward zero; the result
+  stays in the input's real type, so values beyond any integer type's range
+  do not clamp.
+- `__MOD(IN1: ANY_REAL, IN2: ANY_REAL): ANY_REAL` — IEEE-754 floating
+  remainder with the sign of the dividend (fmod); `__MOD(x, 0.0)` is NaN,
+  never a trap.
+
+`ANY_REAL` genericity requires the REAL (f32) builtin variants, which this
+plan adds (`TRUNC_F32`, `MOD_F32`).
+
+## Why intrinsics instead of manifest bindings
+
+The compatibility-library bindings design originally mapped library POUs to
+these builtins through a manifest table
+(`LTRUNC = { intrinsic = "..." }`). Review rejected that shape on security
+grounds: it makes an on-disk data file an input to code *emission*, and
+nothing structurally guarantees the library's declared signature matches the
+builtin's stack behavior — a mismatched binding would corrupt the operand
+stack. With `__TRUNC`/`__MOD` as ordinary typed intrinsics:
+
+- Every `BUILTIN` emission originates from compiler-owned tables; manifests
+  return to being pure metadata.
+- The signature is type-checked by the analyzer like any stdlib function —
+  the mismatch class cannot exist.
+- Library functions like `Tc2_Math`'s `LTRUNC` become plain ST bodies
+  (`LTRUNC := __TRUNC(IN);`), needing no mechanism at all.
+
+The `__` prefix is the established compiler-provided namespace
+(`__SYSTEM_UP_TIME`, `__ISVALIDREF`): names only the compiler can provide,
+visibly non-portable, colliding with no IEC or vendor name. The intrinsics
+are seeded unconditionally: their intended callers are bundled library
+bodies, which are analyzed under the *user's* options, so gating them behind
+a flag would break libraries for every user who did not pass it.
+
+## Design
+
+| Piece | Change |
+|---|---|
+| `container/src/opcode.rs` | `TRUNC_F32 = 0x03A5`, `MOD_F32 = 0x03A6`; `arg_count` arms |
+| `vm/src/builtin.rs` | dispatch arms (`f32::trunc`, `%` on f32) |
+| `project/src/disassemble.rs` | operand-name arms |
+| `analyzer/.../stdlib_function.rs` | `get_compiler_intrinsic_functions()` seeding `__TRUNC`/`__MOD`, aggregated unconditionally |
+| `codegen/src/compile_call.rs` | `lookup_builtin` arms via `float_builtin!` (width selects F32/F64) |
+| `codegen/tests/it/wire_format.rs` | pin the two new func_ids |
+
+## Non-goals
+
+- No manifest `intrinsic` binding form (superseded; the bindings PR is
+  reduced to declare-only).
+- No vendor names (`LTRUNC` etc.) — those arrive as pure-ST library
+  functions in a follow-up PR.
+- No integer variants: `__TRUNC`/`__MOD` are `ANY_REAL`; the integer cases
+  are already served by `TRUNC` and `MOD`.
+
+## Testing strategy
+
+- Analyzer: the signatures exist with `ANY_REAL` parameter/return types.
+- VM: f32 truncation direction, fmod sign-of-dividend, fmod-by-zero → NaN
+  (mirrors the existing f64 tests).
+- End-to-end (parse → analyze → codegen → VM): `__TRUNC`/`__MOD` for both
+  REAL and LREAL operands, negative values, epsilon asserts; proves the
+  lexer accepts the `__` call spelling and width dispatch picks the right
+  func_id.
+- Wire-format pins for 0x03A5/0x03A6.
+- `cd compiler && just` green.
+
+## Tasks
+
+- [ ] Plan (this document)
+- [ ] F32 builtins: container + VM + disassembler + wire pins + VM tests
+- [ ] Analyzer seeding + codegen lowering + e2e tests
+- [ ] Full CI green; PR


### PR DESCRIPTION
## Summary

Exposes the real-truncation and floating-modulo builtins (merged in #1345) as two callable **compiler intrinsics** in the reserved `__` namespace, following the `__SYSTEM_UP_TIME` convention:

- `__TRUNC(IN: ANY_REAL): ANY_REAL` — truncation toward zero that stays in the input's real type, so values beyond any integer type's range do not clamp (unlike `TRUNC`, whose result is `ANY_INT`).
- `__MOD(IN1, IN2: ANY_REAL): ANY_REAL` — IEEE-754 floating remainder with the sign of the dividend (fmod); `__MOD(x, 0.0)` is NaN, never a trap (unlike `MOD`, which is integer-only).

`ANY_REAL` genericity required the f32 builtin variants, added here: `TRUNC_F32` (0x03A5) and `MOD_F32` (0x03A6), with VM dispatch, disassembler arms, wire-format pins, and VM tests. The operand width selects the F32/F64 variant through the existing `lookup_builtin` dispatch.

**Why intrinsics instead of manifest bindings** (per review of the earlier design): mapping library POUs to builtins through `library.toml` made an on-disk data file an input to code *emission*, with no structural guarantee that a library's declared signature matched the builtin's stack behavior. As typed intrinsics, every `BUILTIN` emission originates from compiler-owned tables and the signatures are analyzer-checked, so that mismatch class cannot exist. Rationale is recorded in `specs/plans/2026-08-11-compiler-intrinsic-trunc-mod.md`.

The intrinsics are seeded unconditionally: their intended callers are bundled compatibility-library bodies (e.g. the upcoming `Tc2_Math`'s `LTRUNC := __TRUNC(IN);`), which are analyzed under the *user's* options — a flag gate would break every library using them. The `__` prefix marks them as compiler-provided and visibly non-portable; they collide with no IEC 61131-3 or vendor name.

## Test plan
- [x] Analyzer: `ANY_REAL` signatures present in the stdlib environment
- [x] VM: f32 truncation direction, fmod sign-of-dividend, fmod-by-zero → NaN (mirrors f64 tests)
- [x] End-to-end (parse → analyze → codegen → VM): both widths, `__TRUNC(1.5E300)` exact beyond integer range, NaN on zero divisor, and the `a - __TRUNC(a)` FRAC composition shape
- [x] Wire-format pins for 0x03A5/0x03A6
- [x] Full CI (`cd compiler && just`): compile, coverage ≥85%, clippy, fmt, duplication — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6k4CWyhhPUbbDqygfbfuG

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6k4CWyhhPUbbDqygfbfuG)_