### PR TITLE
docs(specs): design doc for ADR operator and POINTER TO type

### DIFF
--- a/compiler/analyzer/build.rs
+++ b/compiler/analyzer/build.rs
@@ -4,5 +4,8 @@ fn main() {
         // The analyzer owns the resolution/scoping requirements
         // (`REQ-CL-analyzer-*`) for activated compatibility libraries.
         "compatibility-libraries.md",
+        // The analyzer owns the explicit-dereference semantics requirements
+        // (`REQ-PTR-analyzer-*`) for POINTER TO.
+        "adr-and-pointer-to.md",
     ]);
 }

--- a/compiler/analyzer/src/lib.rs
+++ b/compiler/analyzer/src/lib.rs
@@ -103,3 +103,5 @@ mod spec_requirements {
 }
 #[cfg(test)]
 mod spec_conformance;
+#[cfg(test)]
+mod spec_conformance_pointer_to;

--- a/compiler/analyzer/src/spec_conformance_pointer_to.rs
+++ b/compiler/analyzer/src/spec_conformance_pointer_to.rs
@@ -1,0 +1,174 @@
+//! Spec conformance tests for TwinCAT/CODESYS `POINTER TO` support
+//! (analyzer-owned requirements): explicit-dereference semantics.
+//!
+//! Each test is annotated with `#[spec_test(REQ_PTR_analyzer_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test fails
+//! to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test in `spec_conformance` asserts
+//! every analyzer-owned requirement has a test.
+//!
+//! See `specs/design/adr-and-pointer-to.md`.
+
+use ironplc_dsl::common::{FunctionBlockBodyKind, Library, LibraryElementKind};
+use ironplc_dsl::core::FileId;
+use ironplc_dsl::textual::{ExprKind, StmtKind};
+use ironplc_parser::options::CompilerOptions;
+use ironplc_parser::parse_program;
+use ironplc_problems::Problem;
+use spec_test_macro::spec_test;
+
+use crate::stages::analyze;
+
+/// `allow_pointer_to` plus `allow_ref_to`, the combination the `codesys`
+/// dialect provides: `REF()`/`NULL` are the only binding forms until `ADR`
+/// lands (Phase 2).
+fn pointer_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_pointer_to: true,
+        allow_ref_to: true,
+        ..CompilerOptions::default()
+    }
+}
+
+/// Analyze a program and return the set of problem codes it produced.
+fn analyze_codes(program: &str, options: &CompilerOptions) -> Vec<String> {
+    let library = parse_program(program, &FileId::default(), options).unwrap();
+    let (_library, context) = analyze(&[&library], options).unwrap();
+    context
+        .diagnostics()
+        .iter()
+        .map(|d| d.code.clone())
+        .collect()
+}
+
+/// Returns the statements of the (single) PROGRAM in a library.
+fn program_statements(lib: &Library) -> Vec<StmtKind> {
+    for element in &lib.elements {
+        if let LibraryElementKind::ProgramDeclaration(prog) = element {
+            let FunctionBlockBodyKind::Statements(stmts) = &prog.body else {
+                panic!("program body is not a statement list");
+            };
+            return stmts.body.clone();
+        }
+    }
+    panic!("no program declaration found");
+}
+
+/// REQ-PTR-analyzer-300: Reading through an explicit dereference of a
+/// `POINTER TO` variable is accepted — the pointer resolves to the same
+/// reference intermediate type as `REF_TO`, with no P2031 diagnostic.
+#[spec_test(REQ_PTR_analyzer_300)]
+fn analyzer_spec_req_ptr_300_explicit_deref_of_pointer_is_accepted() {
+    let source = "PROGRAM Main
+VAR
+    x : INT;
+    p : POINTER TO INT;
+    y : INT;
+END_VAR
+    p := REF(x);
+    y := p^;
+    p^ := 42;
+END_PROGRAM";
+    let codes = analyze_codes(source, &pointer_options());
+    assert!(codes.is_empty(), "expected clean analysis, got {codes:?}");
+}
+
+/// REQ-PTR-analyzer-301: A bare use of a `POINTER TO` variable is not
+/// implicitly dereferenced, even when `allow_reference_to` is also enabled —
+/// the implicit-deref transform keys on `RefSyntax::ReferenceTo` and leaves
+/// `PointerTo` variables on explicit `^`.
+#[spec_test(REQ_PTR_analyzer_301)]
+fn analyzer_spec_req_ptr_301_pointer_is_not_implicitly_dereferenced() {
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        allow_reference_to: true,
+        ..CompilerOptions::default()
+    };
+    let source = "PROGRAM Main
+VAR
+    p : POINTER TO INT;
+    r : REFERENCE TO INT;
+    y : INT;
+END_VAR
+    y := p;
+    y := r;
+END_PROGRAM";
+    let library = parse_program(source, &FileId::default(), &options).unwrap();
+    let (analyzed, _context) = analyze(&[&library], &options).unwrap();
+    let statements = program_statements(&analyzed);
+    let StmtKind::Assignment(pointer_read) = &statements[0] else {
+        panic!("expected assignment");
+    };
+    assert!(
+        matches!(pointer_read.value.kind, ExprKind::Variable(_)),
+        "a bare read of a POINTER TO variable must stay un-dereferenced, got {:?}",
+        pointer_read.value.kind
+    );
+    // Control: the REFERENCE TO variable in the same program *is* wrapped.
+    let StmtKind::Assignment(reference_read) = &statements[1] else {
+        panic!("expected assignment");
+    };
+    assert!(
+        matches!(reference_read.value.kind, ExprKind::Deref(_)),
+        "a bare read of a REFERENCE TO variable must be auto-dereferenced"
+    );
+}
+
+/// REQ-PTR-analyzer-302: Binding a `POINTER TO T` variable to a reference of
+/// a different base type is rejected with P2032, reusing the `REF_TO`
+/// compatibility rule.
+#[spec_test(REQ_PTR_analyzer_302)]
+fn analyzer_spec_req_ptr_302_pointer_bind_type_mismatch_is_rejected() {
+    let source = "PROGRAM Main
+VAR
+    x : REAL;
+    p : POINTER TO INT;
+END_VAR
+    p := REF(x);
+END_PROGRAM";
+    let codes = analyze_codes(source, &pointer_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::ReferenceTypeMismatch.code()),
+        "expected P2032 (ReferenceTypeMismatch), got {codes:?}"
+    );
+}
+
+/// REQ-PTR-analyzer-303: Arithmetic on a `POINTER TO` value is rejected with
+/// P2033 unless `allow_ref_arithmetic` is set — pointer arithmetic cannot be
+/// mapped onto variable-table indices.
+#[spec_test(REQ_PTR_analyzer_303)]
+fn analyzer_spec_req_ptr_303_pointer_arithmetic_is_rejected() {
+    let source = "PROGRAM Main
+VAR
+    x : INT;
+    p : POINTER TO INT := REF(x);
+    y : INT;
+END_VAR
+    y := p + 1;
+END_PROGRAM";
+    let codes = analyze_codes(source, &pointer_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::ArithmeticOnReference.code()),
+        "expected P2033 (ArithmeticOnReference), got {codes:?}"
+    );
+}
+
+/// REQ-PTR-analyzer-304: `NULL` may be assigned to a `POINTER TO` variable
+/// (the `NULL` keyword comes from `allow_ref_to`, as in the `codesys`
+/// dialect).
+#[spec_test(REQ_PTR_analyzer_304)]
+fn analyzer_spec_req_ptr_304_null_assignment_to_pointer_is_accepted() {
+    let source = "PROGRAM Main
+VAR
+    x : INT;
+    p : POINTER TO INT := REF(x);
+END_VAR
+    p := NULL;
+END_PROGRAM";
+    let codes = analyze_codes(source, &pointer_options());
+    assert!(codes.is_empty(), "expected clean analysis, got {codes:?}");
+}

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -1351,12 +1351,13 @@ impl ReferenceTarget {
 
 /// The surface syntax that produced a reference declaration or initializer.
 ///
-/// References share a single backend (a variable-table index), but two
+/// References share a single backend (a variable-table index), but three
 /// keywords produce them: the IEC 61131-3 `REF_TO` and the Beckhoff
-/// TwinCAT / CODESYS `REFERENCE TO`. This tag records which one appeared in
-/// the source so the renderer can reproduce it and so per-declaration
-/// dereference behavior can be keyed on it. See
-/// `specs/design/reference-to-twincat.md`.
+/// TwinCAT / CODESYS `REFERENCE TO` and `POINTER TO`. This tag records which
+/// one appeared in the source so the renderer can reproduce it and so
+/// per-declaration dereference behavior can be keyed on it. See
+/// `specs/design/reference-to-twincat.md` and
+/// `specs/design/adr-and-pointer-to.md`.
 ///
 /// This is a leaf tag, always carried behind a `#[recurse(ignore)]` field, so
 /// it deliberately does not derive `Recurse`.
@@ -1366,6 +1367,10 @@ pub enum RefSyntax {
     RefTo,
     /// Beckhoff TwinCAT / CODESYS `REFERENCE TO`.
     ReferenceTo,
+    /// Beckhoff TwinCAT / CODESYS `POINTER TO`. Same backend as `REF_TO`
+    /// with explicit `^` dereference. See
+    /// `specs/design/adr-and-pointer-to.md`.
+    PointerTo,
 }
 
 /// Reference type declaration (`REF_TO` or `REFERENCE TO`).

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -117,6 +117,12 @@ struct FileArgs {
     #[arg(long)]
     allow_reference_to: bool,
 
+    /// Allow the Beckhoff TwinCAT/CODESYS `POINTER TO` pointer type with
+    /// explicit dereference (^). This is an extension; the `twincat` and
+    /// `codesys` dialects enable it.
+    #[arg(long)]
+    allow_pointer_to: bool,
+
     /// Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types.
     /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
@@ -220,6 +226,7 @@ impl FileArgs {
         options.allow_long_time_types |= self.allow_long_time_types;
         options.allow_ref_to |= self.allow_ref_to;
         options.allow_reference_to |= self.allow_reference_to;
+        options.allow_pointer_to |= self.allow_pointer_to;
         options.allow_ref_arithmetic |= self.allow_ref_arithmetic;
         options.allow_ref_stack_variables |= self.allow_ref_stack_variables;
         options.allow_ref_type_punning |= self.allow_ref_type_punning;

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -936,6 +936,8 @@ mod test {
         // TwinCAT spells references/pointers REFERENCE TO / POINTER TO, not the
         // CODESYS REF_TO / REF() / NULL, so none of the REF_TO-family flags are
         // enabled.
+        assert!(options.allow_reference_to);
+        assert!(options.allow_pointer_to);
         assert!(!options.allow_ref_to);
         assert!(!options.allow_ref_arithmetic);
         assert!(!options.allow_ref_stack_variables);
@@ -1122,6 +1124,28 @@ mod test {
 
         let options = super::extract_compiler_options(&params);
         assert!(options.allow_reference_to);
+    }
+
+    #[test]
+    fn extract_compiler_options_when_allow_pointer_to_then_enables_flag() {
+        #[allow(deprecated)]
+        let params = InitializeParams {
+            process_id: None,
+            root_path: None,
+            root_uri: None,
+            initialization_options: Some(serde_json::json!({"allowPointerTo": true})),
+            capabilities: ClientCapabilities::default(),
+            trace: None,
+            workspace_folders: None,
+            client_info: None,
+            locale: None,
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        };
+
+        let options = super::extract_compiler_options(&params);
+        assert!(options.allow_pointer_to);
     }
 
     #[test]

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -615,6 +615,7 @@ impl From<LspTokenType> for Option<SemanticToken> {
             TokenType::Ref => Some(KEYWORD_INDEX),
             TokenType::Null => Some(KEYWORD_INDEX),
             TokenType::Reference => Some(KEYWORD_INDEX),
+            TokenType::Pointer => Some(KEYWORD_INDEX),
             TokenType::Date => Some(KEYWORD_INDEX),
             TokenType::TimeOfDay => Some(KEYWORD_INDEX),
             TokenType::DateAndTime => Some(KEYWORD_INDEX),

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -120,6 +120,14 @@ const FLAG_FIXTURES: &[FlagFixture] = &[
         prereqs: &[],
         source: "PROGRAM main\nVAR\nx : REFERENCE TO INT;\nEND_VAR\nEND_PROGRAM",
     },
+    // TwinCAT/CODESYS POINTER TO: without the flag, POINTER is a demoted
+    // identifier and the declaration is a parse error; with it, the type
+    // parses.
+    FlagFixture {
+        key: "allow_pointer_to",
+        prereqs: &[],
+        source: "PROGRAM main\nVAR\np : POINTER TO INT;\nEND_VAR\nEND_PROGRAM",
+    },
     // Arithmetic on a REF_TO type (P2033). Needs REF_TO to parse at all.
     FlagFixture {
         key: "allow_ref_arithmetic",

--- a/compiler/parser/build.rs
+++ b/compiler/parser/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    ironplc_spec_requirements_gen::generate(&["reference-to-twincat.md"]);
+    ironplc_spec_requirements_gen::generate(&["reference-to-twincat.md", "adr-and-pointer-to.md"]);
 }

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -37,6 +37,8 @@ mod spec_requirements {
 }
 #[cfg(test)]
 mod spec_conformance;
+#[cfg(test)]
+mod spec_conformance_pointer_to;
 pub mod token;
 
 /// Tokenize a IEC 61131 program.

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -32,11 +32,10 @@ pub enum Dialect {
     /// extensions that TwinCAT accepts.  TwinCAT 3 is built on the CODESYS V3
     /// runtime, so this is close to [`Dialect::Codesys`], but does not enable
     /// the `REF_TO` / `REF()` / `NULL` reference extensions: TwinCAT spells
-    /// references and pointers `REFERENCE TO` / `POINTER TO` (with `ADR()`),
-    /// which IronPLC does not parse yet, so enabling the CODESYS `REF_TO`
-    /// syntax here would accept code TwinCAT itself rejects.  Like CODESYS, it
-    /// does not bind the implicit `__SYSTEM_UP_TIME` globals (an IronPLC
-    /// runtime convention).
+    /// references and pointers `REFERENCE TO` / `POINTER TO`, so enabling the
+    /// CODESYS `REF_TO` syntax here would accept code TwinCAT itself rejects.
+    /// Like CODESYS, it does not bind the implicit `__SYSTEM_UP_TIME` globals
+    /// (an IronPLC runtime convention).
     TwinCat,
 }
 
@@ -265,6 +264,11 @@ define_compiler_options! {
     [Codesys, TwinCat],
     allow_reference_to,
 
+    "Allow POINTER TO pointer types with explicit dereference (^)",
+    "--allow-pointer-to",
+    [Codesys, TwinCat],
+    allow_pointer_to,
+
     "Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types",
     "--allow-ref-arithmetic",
     [Rusty, Codesys],
@@ -480,6 +484,7 @@ mod tests {
                 "allow_long_time_types",
                 "allow_ref_to",
                 "allow_reference_to",
+                "allow_pointer_to",
                 "allow_ref_arithmetic",
                 "allow_ref_stack_variables",
                 "allow_ref_type_punning",
@@ -502,13 +507,14 @@ mod tests {
     /// The TwinCAT dialect is close to CODESYS (TwinCAT 3 runs on the CODESYS
     /// V3 runtime) but does *not* enable the `REF_TO` reference extensions.
     /// TwinCAT spells references `REFERENCE TO` (not the CODESYS `REF_TO` /
-    /// `REF()` / `NULL`), so it enables `allow_reference_to` instead, and none
-    /// of `allow_ref_to`, `allow_ref_arithmetic`, `allow_ref_stack_variables`,
-    /// or `allow_ref_type_punning` are enabled -- enabling those would accept
-    /// `REF_TO` code that TwinCAT itself rejects. (Pointer types `POINTER TO`
-    /// with `ADR()` are not parsed yet.) It does enable `allow_long_time_types`,
-    /// since TwinCAT supports the LTIME/LDATE/LTOD/LDT keywords. Listed
-    /// explicitly so an accidental divergence from the intended set is caught.
+    /// `REF()` / `NULL`), so it enables `allow_reference_to` and
+    /// `allow_pointer_to` instead, and none of `allow_ref_to`,
+    /// `allow_ref_arithmetic`, `allow_ref_stack_variables`, or
+    /// `allow_ref_type_punning` are enabled -- enabling those would accept
+    /// `REF_TO` code that TwinCAT itself rejects. It does enable
+    /// `allow_long_time_types`, since TwinCAT supports the
+    /// LTIME/LDATE/LTOD/LDT keywords. Listed explicitly so an accidental
+    /// divergence from the intended set is caught.
     #[test]
     fn twincat_dialect_enables_exactly_these_flags() {
         assert_enabled_flags(
@@ -522,6 +528,7 @@ mod tests {
                 "allow_time_as_function_name",
                 "allow_long_time_types",
                 "allow_reference_to",
+                "allow_pointer_to",
                 "allow_int_to_bool_initializer",
                 "allow_sizeof",
                 "allow_cross_family_widening",

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1035,12 +1035,14 @@ parser! {
         }
       }).collect()
     }
-    // Matches either the IEC `REF_TO` keyword or the TwinCAT/CODESYS
-    // `REFERENCE TO` keyword pair, returning which surface syntax matched.
-    // See `specs/design/reference-to-twincat.md`.
+    // Matches the IEC `REF_TO` keyword or one of the TwinCAT/CODESYS
+    // `REFERENCE TO` / `POINTER TO` keyword pairs, returning which surface
+    // syntax matched. See `specs/design/reference-to-twincat.md` and
+    // `specs/design/adr-and-pointer-to.md`.
     rule ref_to_keyword() -> RefSyntax =
       tok(TokenType::RefTo) { RefSyntax::RefTo }
       / tok(TokenType::Reference) _ tok(TokenType::To) { RefSyntax::ReferenceTo }
+      / tok(TokenType::Pointer) _ tok(TokenType::To) { RefSyntax::PointerTo }
     // Matches the TwinCAT/CODESYS `REF=` binding operator, returning the `=`
     // token (used for the assignment span). The `=` must immediately follow
     // `REF` with no intervening whitespace (no `_`), so `REF =` is not a binding

--- a/compiler/parser/src/spec_conformance_pointer_to.rs
+++ b/compiler/parser/src/spec_conformance_pointer_to.rs
@@ -1,0 +1,173 @@
+//! Spec conformance tests for TwinCAT/CODESYS `POINTER TO` support
+//! (parser-owned requirements).
+//!
+//! Each test is annotated with `#[spec_test(REQ_PTR_parser_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test fails
+//! to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test in `spec_conformance` asserts
+//! every parser-owned requirement has a test.
+//!
+//! See `specs/design/adr-and-pointer-to.md`.
+
+use dsl::common::{
+    DataTypeDeclarationKind, InitialValueAssignmentKind, Library, LibraryElementKind, RefSyntax,
+    SpecificationKind,
+};
+use dsl::core::FileId;
+use ironplc_test::cast;
+use spec_test_macro::spec_test;
+
+use crate::options::{CompilerOptions, Dialect};
+use crate::token::TokenType;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn pointer_to_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_pointer_to: true,
+        ..CompilerOptions::default()
+    }
+}
+
+fn parse(source: &str, options: &CompilerOptions) -> Library {
+    crate::parse_program(source, &FileId::default(), options).unwrap()
+}
+
+fn token_types(source: &str, options: &CompilerOptions) -> Vec<TokenType> {
+    let (tokens, _errors) = crate::tokenize_program(source, &FileId::default(), options, 0, 0);
+    tokens.iter().map(|t| t.token_type.clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Options & dialects
+// ---------------------------------------------------------------------------
+
+/// REQ-PTR-parser-001: The `codesys` dialect enables `allow_pointer_to`.
+#[spec_test(REQ_PTR_parser_001)]
+fn options_spec_req_ptr_001_codesys_enables_pointer_to() {
+    assert!(CompilerOptions::from_dialect(Dialect::Codesys).allow_pointer_to);
+}
+
+/// REQ-PTR-parser-002: The `twincat` dialect enables `allow_pointer_to`.
+#[spec_test(REQ_PTR_parser_002)]
+fn options_spec_req_ptr_002_twincat_enables_pointer_to() {
+    assert!(CompilerOptions::from_dialect(Dialect::TwinCat).allow_pointer_to);
+}
+
+/// REQ-PTR-parser-003: The `iec61131-3-ed2`, `iec61131-3-ed3`, and `rusty`
+/// dialects do not enable `allow_pointer_to`.
+#[spec_test(REQ_PTR_parser_003)]
+fn options_spec_req_ptr_003_other_dialects_do_not_enable_pointer_to() {
+    assert!(!CompilerOptions::from_dialect(Dialect::Iec61131_3Ed2).allow_pointer_to);
+    assert!(!CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3).allow_pointer_to);
+    assert!(!CompilerOptions::from_dialect(Dialect::Rusty).allow_pointer_to);
+}
+
+// ---------------------------------------------------------------------------
+// Lexer & keyword demotion
+// ---------------------------------------------------------------------------
+
+/// REQ-PTR-parser-100: `POINTER` lexes as a single `Pointer` keyword token.
+#[spec_test(REQ_PTR_parser_100)]
+fn lexer_spec_req_ptr_100_pointer_lexes_as_pointer_token() {
+    let types = token_types("POINTER", &pointer_to_options());
+    assert!(types.contains(&TokenType::Pointer));
+}
+
+/// REQ-PTR-parser-101: With the flag off, `POINTER` is demoted to
+/// `Identifier`.
+#[spec_test(REQ_PTR_parser_101)]
+fn xform_spec_req_ptr_101_pointer_demoted_when_flag_off() {
+    let types = token_types("POINTER", &CompilerOptions::default());
+    assert!(types.contains(&TokenType::Identifier));
+    assert!(!types.contains(&TokenType::Pointer));
+}
+
+/// REQ-PTR-parser-102: With the flag on, `POINTER` stays the `Pointer`
+/// keyword.
+#[spec_test(REQ_PTR_parser_102)]
+fn xform_spec_req_ptr_102_pointer_kept_when_flag_on() {
+    let types = token_types("POINTER", &pointer_to_options());
+    assert!(types.contains(&TokenType::Pointer));
+    assert!(!types.contains(&TokenType::Identifier));
+}
+
+/// REQ-PTR-parser-103: `POINTER` is a valid identifier in standard mode.
+#[spec_test(REQ_PTR_parser_103)]
+fn parser_spec_req_ptr_103_pointer_is_identifier_in_standard_mode() {
+    let source = "PROGRAM main
+VAR
+    POINTER : INT;
+END_VAR
+END_PROGRAM";
+    let lib = parse(source, &CompilerOptions::default());
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let name = prog.variables[0].identifier.symbolic_id().unwrap();
+    assert_eq!(name.to_string(), "POINTER");
+}
+
+// ---------------------------------------------------------------------------
+// Parser productions
+// ---------------------------------------------------------------------------
+
+/// REQ-PTR-parser-200: `p : POINTER TO INT;` yields an initializer tagged
+/// `RefSyntax::PointerTo`.
+#[spec_test(REQ_PTR_parser_200)]
+fn parser_spec_req_ptr_200_pointer_to_var_decl_is_tagged() {
+    let source = "PROGRAM main
+VAR
+    p : POINTER TO INT;
+END_VAR
+END_PROGRAM";
+    let lib = parse(source, &pointer_to_options());
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let init = cast!(
+        &prog.variables[0].initializer,
+        InitialValueAssignmentKind::Reference
+    );
+    assert_eq!(init.syntax, RefSyntax::PointerTo);
+}
+
+/// REQ-PTR-parser-201: `TYPE T : POINTER TO INT; END_TYPE` yields a
+/// declaration tagged `RefSyntax::PointerTo`.
+#[spec_test(REQ_PTR_parser_201)]
+fn parser_spec_req_ptr_201_pointer_to_type_decl_is_tagged() {
+    let lib = parse("TYPE T : POINTER TO INT; END_TYPE", &pointer_to_options());
+    let dt = cast!(&lib.elements[0], LibraryElementKind::DataTypeDeclaration);
+    let decl = cast!(dt, DataTypeDeclarationKind::Reference);
+    assert_eq!(decl.syntax, RefSyntax::PointerTo);
+}
+
+/// REQ-PTR-parser-210: `ARRAY [..] OF POINTER TO T` tags the element
+/// `Some(RefSyntax::PointerTo)`.
+#[spec_test(REQ_PTR_parser_210)]
+fn parser_spec_req_ptr_210_array_of_pointer_to_is_tagged() {
+    let source = "PROGRAM main
+VAR
+    a : ARRAY[0..3] OF POINTER TO INT;
+END_VAR
+END_PROGRAM";
+    let lib = parse(source, &pointer_to_options());
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let arr = cast!(
+        &prog.variables[0].initializer,
+        InitialValueAssignmentKind::Array
+    );
+    let subranges = cast!(&arr.spec, SpecificationKind::Inline);
+    assert_eq!(subranges.ref_to, Some(RefSyntax::PointerTo));
+}
+
+/// REQ-PTR-parser-211: With the flag off, `p : POINTER TO INT;` is a syntax
+/// error.
+#[spec_test(REQ_PTR_parser_211)]
+fn parser_spec_req_ptr_211_pointer_to_rejected_when_flag_off() {
+    let source = "PROGRAM main
+VAR
+    p : POINTER TO INT;
+END_VAR
+END_PROGRAM";
+    let result = crate::parse_program(source, &FileId::default(), &CompilerOptions::default());
+    assert!(result.is_err());
+}

--- a/compiler/parser/src/tests/mod.rs
+++ b/compiler/parser/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod fb_inheritance;
 mod function_calls;
 mod literals;
 mod partial_access;
+mod pointer_to;
 mod pragmas;
 mod reference_to;
 mod short_circuit;

--- a/compiler/parser/src/tests/pointer_to.rs
+++ b/compiler/parser/src/tests/pointer_to.rs
@@ -1,0 +1,162 @@
+//! `POINTER TO` pointer type declarations (`--allow-pointer-to`).
+
+use super::common::*;
+
+/// Parse with `allow_pointer_to` enabled. The default (strict IEC 61131-3)
+/// dialect rejects the syntax.
+fn parse_text_pointer_to(source: &str) -> Library {
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        ..CompilerOptions::default()
+    };
+    let result = parse_program(source, &FileId::default(), &options);
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    result.unwrap()
+}
+
+#[test]
+fn pointer_to_when_flag_enabled_then_parses() {
+    let lib = parse_text_pointer_to(
+        "PROGRAM main
+VAR
+    p : POINTER TO INT;
+END_VAR
+END_PROGRAM",
+    );
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let init = cast!(
+        &prog.variables[0].initializer,
+        InitialValueAssignmentKind::Reference
+    );
+    assert_eq!(init.syntax, dsl::common::RefSyntax::PointerTo);
+    assert_eq!(init.target.type_name().unwrap().to_string(), "INT");
+}
+
+#[test]
+fn pointer_to_when_flag_disabled_then_rejected() {
+    let source = "PROGRAM main
+VAR
+    p : POINTER TO INT;
+END_VAR
+END_PROGRAM";
+    let result = parse_program(source, &FileId::default(), &CompilerOptions::default());
+    assert!(result.is_err(), "POINTER TO must be rejected without the flag");
+}
+
+/// With the flag off, `POINTER` demotes to an identifier and remains usable
+/// as an ordinary variable name.
+#[test]
+fn pointer_to_when_flag_disabled_then_pointer_is_identifier() {
+    let source = "PROGRAM main
+VAR
+    POINTER : INT;
+END_VAR
+    POINTER := 5;
+END_PROGRAM";
+    let lib = parse_text(source);
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let name = prog.variables[0].identifier.symbolic_id().unwrap();
+    assert_eq!(name.to_string(), "POINTER");
+}
+
+#[test]
+fn pointer_to_when_type_declaration_then_tagged_pointer_to() {
+    let lib = parse_text_pointer_to("TYPE IntPtr : POINTER TO INT; END_TYPE");
+    let dt = cast!(&lib.elements[0], LibraryElementKind::DataTypeDeclaration);
+    let decl = cast!(dt, DataTypeDeclarationKind::Reference);
+    assert_eq!(decl.type_name.to_string(), "IntPtr");
+    assert_eq!(decl.syntax, dsl::common::RefSyntax::PointerTo);
+}
+
+#[test]
+fn pointer_to_when_array_element_then_tagged_pointer_to() {
+    let lib = parse_text_pointer_to(
+        "PROGRAM main
+VAR
+    a : ARRAY[0..3] OF POINTER TO INT;
+END_VAR
+END_PROGRAM",
+    );
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let arr = cast!(
+        &prog.variables[0].initializer,
+        InitialValueAssignmentKind::Array
+    );
+    let subranges = cast!(&arr.spec, SpecificationKind::Inline);
+    assert_eq!(subranges.ref_to, Some(dsl::common::RefSyntax::PointerTo));
+}
+
+#[test]
+fn pointer_to_when_pointer_to_array_then_target_is_array() {
+    let lib = parse_text_pointer_to(
+        "PROGRAM main
+VAR
+    p : POINTER TO ARRAY[1..10] OF INT;
+END_VAR
+END_PROGRAM",
+    );
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let init = cast!(
+        &prog.variables[0].initializer,
+        InitialValueAssignmentKind::Reference
+    );
+    assert!(matches!(init.target, ReferenceTarget::Array(_)));
+}
+
+/// The `^` dereference works on `POINTER TO` variables with only
+/// `allow_pointer_to` set (no `allow_ref_to` needed).
+#[test]
+fn pointer_to_when_deref_then_parses() {
+    let lib = parse_text_pointer_to(
+        "PROGRAM main
+VAR
+    p : POINTER TO INT;
+    value : INT;
+END_VAR
+    value := p^;
+    p^ := 42;
+END_PROGRAM",
+    );
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let s = cast!(&prog.body, FunctionBlockBodyKind::Statements);
+    assert_eq!(s.body.len(), 2);
+    let store = cast!(&s.body[1], StmtKind::Assignment);
+    assert!(store.deref);
+}
+
+/// `NULL` and `REF()` initializers come from the `REF_TO` family, so a
+/// pointer can be initialized when `allow_ref_to` is also on (e.g. the
+/// `codesys` dialect).
+#[test]
+fn pointer_to_when_ref_init_and_ref_to_enabled_then_parses() {
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        allow_ref_to: true,
+        ..CompilerOptions::default()
+    };
+    let source = "PROGRAM main
+VAR
+    counter : INT;
+    p : POINTER TO INT := REF(counter);
+    q : POINTER TO INT := NULL;
+END_VAR
+END_PROGRAM";
+    let lib = parse_program(source, &FileId::default(), &options).unwrap();
+    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
+    let p_init = cast!(
+        &prog.variables[1].initializer,
+        InitialValueAssignmentKind::Reference
+    );
+    assert!(matches!(
+        p_init.initial_value,
+        Some(dsl::common::ReferenceInitialValue::Ref(_))
+    ));
+    let q_init = cast!(
+        &prog.variables[2].initializer,
+        InitialValueAssignmentKind::Reference
+    );
+    assert!(matches!(
+        q_init.initial_value,
+        Some(dsl::common::ReferenceInitialValue::Null(_))
+    ));
+}

--- a/compiler/parser/src/tests/pointer_to.rs
+++ b/compiler/parser/src/tests/pointer_to.rs
@@ -40,7 +40,10 @@ VAR
 END_VAR
 END_PROGRAM";
     let result = parse_program(source, &FileId::default(), &CompilerOptions::default());
-    assert!(result.is_err(), "POINTER TO must be rejected without the flag");
+    assert!(
+        result.is_err(),
+        "POINTER TO must be rejected without the flag"
+    );
 }
 
 /// With the flag off, `POINTER` demotes to an identifier and remains usable

--- a/compiler/parser/src/token.rs
+++ b/compiler/parser/src/token.rs
@@ -360,6 +360,10 @@ pub enum TokenType {
     // (`--allow-reference-to`). Longest-match keeps this distinct from `REF`.
     #[token("REFERENCE", ignore(case))]
     Reference,
+    // Beckhoff TwinCAT / CODESYS `POINTER TO` pointer types
+    // (`--allow-pointer-to`).
+    #[token("POINTER", ignore(case))]
+    Pointer,
 
     #[token("DATE", ignore(case))]
     Date,
@@ -610,6 +614,7 @@ impl TokenType {
             TokenType::Ref => "'REF'",
             TokenType::Null => "'NULL'",
             TokenType::Reference => "'REFERENCE'",
+            TokenType::Pointer => "'POINTER'",
             TokenType::Date => "'DATE' | 'D'",
             TokenType::TimeOfDay => "'TIME_OF_DAY' | 'TOD'",
             TokenType::DateAndTime => "'DATE_AND_TIME' | 'DT'",

--- a/compiler/parser/src/xform_demote_keywords.rs
+++ b/compiler/parser/src/xform_demote_keywords.rs
@@ -32,6 +32,8 @@ use crate::{
 ///   keeping `LDT` etc. available as identifiers.
 /// * **`REFERENCE`** — demoted unless `allow_reference_to` (TwinCAT/CODESYS
 ///   `REFERENCE TO`).
+/// * **`POINTER`** — demoted unless `allow_pointer_to` (TwinCAT/CODESYS
+///   `POINTER TO`).
 /// * **OOP keywords** (`EXTENDS`, `IMPLEMENTS`, `INTERFACE`, `END_INTERFACE`,
 ///   `ABSTRACT`) — demoted unless `allow_fb_inheritance`.
 /// * **`AND_THEN`** — demoted unless `allow_short_circuit_operators`.
@@ -42,6 +44,7 @@ pub fn apply(tokens: &mut [Token], options: &CompilerOptions) {
     let demote_time_types = !options.allow_long_time_types;
     let demote_ref = !options.allow_ref_to;
     let demote_reference = !options.allow_reference_to;
+    let demote_pointer = !options.allow_pointer_to;
     let demote_oop = !options.allow_fb_inheritance;
     let demote_and_then = !options.allow_short_circuit_operators;
 
@@ -52,6 +55,7 @@ pub fn apply(tokens: &mut [Token], options: &CompilerOptions) {
             }
             TokenType::RefTo | TokenType::Ref | TokenType::Null => demote_ref,
             TokenType::Reference => demote_reference,
+            TokenType::Pointer => demote_pointer,
             TokenType::Extends
             | TokenType::Implements
             | TokenType::Interface

--- a/compiler/plc2plc/build.rs
+++ b/compiler/plc2plc/build.rs
@@ -5,5 +5,8 @@ fn main() {
         // source renders unchanged and injected library declarations are never
         // emitted.
         "compatibility-libraries.md",
+        // plc2plc owns the POINTER TO rendering requirements
+        // (`REQ-PTR-plc2plc-*`).
+        "adr-and-pointer-to.md",
     ]);
 }

--- a/compiler/plc2plc/resources/test/pointer_to_rendered.st
+++ b/compiler/plc2plc/resources/test/pointer_to_rendered.st
@@ -1,0 +1,25 @@
+TYPE
+   IntPtr : POINTER TO INT ;
+END_TYPE
+PROGRAM main
+
+VAR
+   counter : INT := 42;
+END_VAR
+
+VAR
+   p : POINTER TO INT;
+END_VAR
+
+VAR
+   ptrs : ARRAY [ 0.. 2 ] OF POINTER TO INT;
+END_VAR
+
+VAR
+   value : INT;
+END_VAR
+p := REF( counter ) ;
+value := p ^ ;
+p^ := 99 ;
+p := NULL ;
+END_PROGRAM

--- a/compiler/plc2plc/src/lib.rs
+++ b/compiler/plc2plc/src/lib.rs
@@ -17,6 +17,8 @@ mod spec_requirements {
 }
 #[cfg(test)]
 mod spec_conformance;
+#[cfg(test)]
+mod spec_conformance_pointer_to;
 
 pub fn write_to_string(lib: &Library) -> Result<String, Vec<Diagnostic>> {
     apply(lib)

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -88,12 +88,17 @@ impl LibraryRenderer {
     }
 
     /// Writes the reference-type keyword for the given surface syntax:
-    /// `REF_TO` for IEC, `REFERENCE TO` for the TwinCAT/CODESYS variant.
+    /// `REF_TO` for IEC, `REFERENCE TO` / `POINTER TO` for the
+    /// TwinCAT/CODESYS variants.
     fn write_ref_keyword(&mut self, syntax: &RefSyntax) {
         match syntax {
             RefSyntax::RefTo => self.write_ws("REF_TO"),
             RefSyntax::ReferenceTo => {
                 self.write_ws("REFERENCE");
+                self.write_ws("TO");
+            }
+            RefSyntax::PointerTo => {
+                self.write_ws("POINTER");
                 self.write_ws("TO");
             }
         }

--- a/compiler/plc2plc/src/spec_conformance_pointer_to.rs
+++ b/compiler/plc2plc/src/spec_conformance_pointer_to.rs
@@ -1,0 +1,73 @@
+//! Spec conformance tests for TwinCAT/CODESYS `POINTER TO` support
+//! (plc2plc-owned requirements): round-trip rendering of the surface syntax.
+//!
+//! Each test is annotated with `#[spec_test(REQ_PTR_plc2plc_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test fails
+//! to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test in `spec_conformance` asserts
+//! every plc2plc-owned requirement has a test.
+//!
+//! See `specs/design/adr-and-pointer-to.md`.
+
+use dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_parser::parse_program;
+use spec_test_macro::spec_test;
+
+use crate::write_to_string;
+
+fn render(source: &str, options: &CompilerOptions) -> String {
+    let library = parse_program(source, &FileId::default(), options).unwrap();
+    write_to_string(&library).unwrap()
+}
+
+/// REQ-PTR-plc2plc-600: A `PointerTo`-tagged declaration renders as
+/// `POINTER TO <target>`.
+#[spec_test(REQ_PTR_plc2plc_600)]
+fn plc2plc_spec_req_ptr_600_pointer_to_declaration_renders() {
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        ..CompilerOptions::default()
+    };
+    let rendered = render("TYPE T : POINTER TO INT; END_TYPE", &options);
+    assert!(
+        rendered.contains("POINTER TO INT"),
+        "expected `POINTER TO INT` in:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("REF_TO"),
+        "POINTER TO must not render as REF_TO:\n{rendered}"
+    );
+}
+
+/// REQ-PTR-plc2plc-601: `REF_TO`, `REFERENCE TO`, and `POINTER TO`
+/// declarations in one program each render with their own spelling preserved.
+#[spec_test(REQ_PTR_plc2plc_601)]
+fn plc2plc_spec_req_ptr_601_all_three_spellings_render_distinctly() {
+    let options = CompilerOptions {
+        allow_ref_to: true,
+        allow_reference_to: true,
+        allow_pointer_to: true,
+        ..CompilerOptions::default()
+    };
+    let source = "PROGRAM main
+VAR
+    a : REF_TO INT;
+    b : REFERENCE TO INT;
+    c : POINTER TO INT;
+END_VAR
+END_PROGRAM";
+    let rendered = render(source, &options);
+    assert!(
+        rendered.contains("a : REF_TO INT"),
+        "expected `REF_TO` spelling preserved in:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("b : REFERENCE TO INT"),
+        "expected `REFERENCE TO` spelling preserved in:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("c : POINTER TO INT"),
+        "expected `POINTER TO` spelling preserved in:\n{rendered}"
+    );
+}

--- a/compiler/plc2plc/src/tests/mod.rs
+++ b/compiler/plc2plc/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod enums;
 mod fb_inheritance;
 mod mixed_vars;
 mod partial_access;
+mod pointer_to;
 mod reference_to;
 mod short_circuit;
 mod struct_init_expressions;

--- a/compiler/plc2plc/src/tests/pointer_to.rs
+++ b/compiler/plc2plc/src/tests/pointer_to.rs
@@ -1,0 +1,20 @@
+//! `POINTER TO` declaration and dereference round-tripping.
+
+use super::common::*;
+
+/// `POINTER TO` binding uses `REF()`/`NULL` (from `allow_ref_to`) until the
+/// `ADR()` operator lands, so the fixture enables both flags — the same
+/// combination the `codesys` dialect provides.
+#[test]
+fn write_to_string_when_pointer_to_then_round_trips() {
+    let source = read_shared_resource("pointer_to.st");
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        allow_ref_to: true,
+        ..CompilerOptions::default()
+    };
+    let library = parse_program(&source, &FileId::default(), &options).unwrap();
+    let rendered = write_to_string(&library).unwrap();
+    let expected = read_resource("pointer_to_rendered.st");
+    assert_eq!(rendered, expected);
+}

--- a/compiler/resources/test/pointer_to.st
+++ b/compiler/resources/test/pointer_to.st
@@ -1,0 +1,14 @@
+TYPE IntPtr : POINTER TO INT; END_TYPE
+
+PROGRAM main
+VAR
+    counter : INT := 42;
+    p : POINTER TO INT;
+    ptrs : ARRAY[0..2] OF POINTER TO INT;
+    value : INT;
+END_VAR
+    p := REF(counter);
+    value := p^;
+    p^ := 99;
+    p := NULL;
+END_PROGRAM

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -66,7 +66,8 @@ Supported Dialects
    ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
    ``--allow-empty-var-blocks``, ``--allow-time-as-function-name``,
    ``--allow-long-time-types``,
-   ``--allow-ref-to``, ``--allow-reference-to``, ``--allow-ref-arithmetic``,
+   ``--allow-ref-to``, ``--allow-reference-to``, ``--allow-pointer-to``,
+   ``--allow-ref-arithmetic``,
    ``--allow-ref-stack-variables``, ``--allow-ref-type-punning``,
    ``--allow-int-to-bool-initializer``, ``--allow-sizeof``,
    ``--allow-cross-family-widening``, ``--allow-partial-access-syntax``,
@@ -87,9 +88,10 @@ Supported Dialects
    such as curly-brace pragmas, C-style comments, and the ``AND_THEN``
    short-circuit operator. Unlike ``codesys``, it does **not** enable the
    ``REF_TO`` / ``REF()`` / ``NULL`` reference extensions: TwinCAT spells
-   references ``REFERENCE TO`` (bound with ``REF=``), which this dialect
-   enables instead via ``--allow-reference-to``. (Pointer types —
-   ``POINTER TO`` with ``ADR()`` — are not parsed yet.) As with ``codesys``,
+   references ``REFERENCE TO`` (bound with ``REF=``) and pointers
+   ``POINTER TO``, which this dialect enables instead via
+   ``--allow-reference-to`` and ``--allow-pointer-to``. (The ``ADR()``
+   address-of operator is not supported yet.) As with ``codesys``,
    the implicit
    :doc:`__SYSTEM_UP_TIME </reference/extension-library/variables/system-uptime>`
    globals are not pre-bound, since they are an IronPLC runtime convention
@@ -99,7 +101,8 @@ Supported Dialects
    ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
    ``--allow-empty-var-blocks``, ``--allow-time-as-function-name``,
    ``--allow-long-time-types``,
-   ``--allow-reference-to``, ``--allow-int-to-bool-initializer``,
+   ``--allow-reference-to``, ``--allow-pointer-to``,
+   ``--allow-int-to-bool-initializer``,
    ``--allow-sizeof``, ``--allow-cross-family-widening``,
    ``--allow-partial-access-syntax``, ``--allow-pragmas``,
    ``--allow-short-circuit-operators``,
@@ -222,6 +225,15 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    ``--allow-ref-to``: the two describe the same underlying reference but with
    different surface syntax. The compiler does not restrict flag combinations, so
    ``--allow-ref-to`` and ``--allow-reference-to`` may be set at once. See
+   :doc:`/reference/language/data-types/derived/reference-types`.
+
+``--allow-pointer-to``
+   Allow the Beckhoff TwinCAT / CODESYS ``POINTER TO`` pointer type. A
+   ``POINTER TO`` variable behaves like a ``REF_TO`` reference: reading or
+   writing the target requires the explicit dereference operator (``^``),
+   unlike ``REFERENCE TO``, which dereferences implicitly. (The ``ADR()``
+   address-of operator is not supported yet; pointers are bound with the
+   ``REF()``/``NULL`` forms from ``--allow-ref-to``.) See
    :doc:`/reference/language/data-types/derived/reference-types`.
 
 ``--allow-ref-arithmetic``

--- a/docs/reference/compiler/ironplcc.rst
+++ b/docs/reference/compiler/ironplcc.rst
@@ -144,6 +144,10 @@ Options
    ``REF=`` binding operator — the TwinCAT/CODESYS-facing alternative to
    ``--allow-ref-to``.
 
+``--allow-pointer-to``
+   Allow the Beckhoff TwinCAT / CODESYS ``POINTER TO`` pointer type with
+   explicit dereference (``^``).
+
 ``--allow-ref-arithmetic``
    Allow arithmetic (``+``, ``-``) and ordering comparisons (``<``, ``>``,
    ``<=``, ``>=``) on ``REF_TO`` types. By default, only ``=`` and ``<>``

--- a/specs/design/adr-and-pointer-to.md
+++ b/specs/design/adr-and-pointer-to.md
@@ -1,0 +1,185 @@
+# Design: `ADR` Operator and `POINTER TO` Type
+
+## Overview
+
+This document describes support for the TwinCAT/CODESYS pointer feature
+family — the `POINTER TO T` type, the postfix `^` dereference, and the
+`ADR()` address-of operator — so that idiomatic code like this compiles and
+runs:
+
+```iecst
+FUNCTION_BLOCK FB_Point
+VAR
+   pNumber : POINTER TO INT;
+   iNumber1 : INT := 5;
+   iNumber2 : INT;
+END_VAR
+pNumber := ADR(iNumber1);
+iNumber2 := pNumber^;
+```
+
+It is the follow-on work deferred by
+[reference-to-twincat.md](reference-to-twincat.md) and supersedes the
+"out of scope" pointer notes there and the parse-only sketch in
+[beckhoff-twincat-dialect.md](beckhoff-twincat-dialect.md) §2.1
+(`TypeSpec::PointerTo`). The implementation plan is
+[2026-08-11-adr-operator-and-pointer-to.md](../plans/2026-08-11-adr-operator-and-pointer-to.md).
+
+References: [Beckhoff ADR](https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529015179.html),
+[Beckhoff POINTER](https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529453451.html),
+[CODESYS ADR](https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_adr.html).
+
+## Semantics mapping: TwinCAT memory model → IronPLC memory model
+
+TwinCAT's `ADR(x)` yields the byte address of `x` as `PVOID` (an opaque
+pointer-width integer). The result is assigned to a `POINTER TO T` variable
+and dereferenced with the postfix `^` operator.
+
+IronPLC's VM has no byte addresses for variables
+([ADR-0017](../adrs/0017-unified-data-region.md),
+[ADR-0021](../adrs/0021-flat-variable-table-for-function-calls.md)): a
+variable is a slot in a flat 64-bit slot table, indexed by `VarIndex`. The
+existing reference backend already models "the address of a variable" as the
+variable's table index stored as a `u64` (`ExprKind::Ref` pushes the
+`VarIndex`; `ExprKind::Deref` emits `LOAD_INDIRECT`; `NULL` is the sentinel
+`u64::MAX`). Consequently:
+
+1. **`ADR(x)` lowers exactly like `REF(x)`** — push the argument's variable
+   table index. No new opcodes, no VM changes, no wire-format changes.
+2. **`POINTER TO T` maps to the existing reference intermediate type** with
+   *explicit* dereference (`^` required) — the same intermediate type as
+   `REF_TO T`, under a third surface syntax (alongside `REF_TO` and
+   `REFERENCE TO`).
+3. **`PVOID` is not introduced.** In IronPLC, `ADR(x)` has the inferred type
+   `POINTER TO typeof(x)` and is type-checked against the destination
+   pointer's target type. This is strictly safer than TwinCAT and matches how
+   the existing reference types already behave.
+4. **What cannot be mapped** is diagnosed instead (see Out of scope):
+   pointer arithmetic, sub-object addresses (`ADR(arr[i])`,
+   `ADR(struct.field)`), and address-as-integer conversions.
+
+## Delivery
+
+The feature is delivered in phases, mirroring the plan:
+
+- **Phase 1 — `POINTER TO` declarations (this document's requirements
+  `0xx`–`3xx` and `6xx`).** The `allow_pointer_to` flag, the `POINTER`
+  keyword with demotion, parser productions reusing the `REF_TO` grammar and
+  AST (`RefSyntax::PointerTo` tag), explicit-`^` semantics in the analyzer,
+  and plc2plc round-tripping. In this phase a `POINTER TO` variable is bound
+  via the existing `REF()` initializer/assignment forms (available when
+  `allow_ref_to` is also on, as in the `codesys` dialect) — `ADR` itself is
+  Phase 2.
+- **Phase 2 — the `ADR()` operator and `allow_adr` flag.** An analyzer
+  rewrite of `Function("ADR", [expr])` → `ExprKind::Ref(variable)` when
+  `allow_adr` is on, with diagnostics for invalid operands. The `allow_adr`
+  flag lands together with the rewrite (not in Phase 1) because every
+  feature flag must gate real behavior the moment it is declared — the MCP
+  `feature_flag_conformance` suite has no "declared but not yet enforced"
+  escape hatch, and a flag whose behavior does not exist yet would be a dead
+  flag. Phase 2 adds its own requirement IDs (`4xx`–`5xx`) to this document
+  when it lands.
+- **Phase 3 — documentation sweep.** User docs, dialect tables, and stale
+  comments.
+
+## Gating & coexistence
+
+`POINTER TO` is gated behind `--allow-pointer-to`, following the established
+token-demotion pattern used by `REFERENCE TO`: a `POINTER` keyword token is
+demoted to `Identifier` unless the flag is set, so standard programs may use
+`POINTER` as an ordinary name. The `twincat` and `codesys` dialect presets
+enable the flag.
+
+Per [ADR-0042](../adrs/0042-library-functions-over-compiler-intrinsics.md)
+rule 4, `ADR` is a language extension on the dialect axis — a function-like
+operator requiring compile-time symbol knowledge that no library function
+could have — so it is implemented in the compiler (Phase 2) and must NOT be
+added to the bundled libraries.
+
+Per [ADR-0038](../adrs/0038-no-restrictions-on-flag-combinations.md), no
+flag combination is rejected: `REF_TO`, `REFERENCE TO`, and `POINTER TO`
+may all be enabled together. Coexistence stays well-defined because each
+declaration carries a `RefSyntax` tag; the implicit-dereference transform
+keys on `RefSyntax::ReferenceTo` only, so `POINTER TO` (like `REF_TO`)
+always keeps explicit-`^` semantics.
+
+### Options & dialects
+
+- **REQ-PTR-parser-001** The `codesys` dialect preset enables `allow_pointer_to`.
+- **REQ-PTR-parser-002** The `twincat` dialect preset enables `allow_pointer_to`.
+- **REQ-PTR-parser-003** The `iec61131-3-ed2`, `iec61131-3-ed3`, and `rusty` dialect presets do not enable `allow_pointer_to`.
+
+## Lexer & keyword demotion
+
+`POINTER` becomes a keyword token, demoted to an identifier when the flag is
+off — exactly how `REFERENCE` is handled. The `TO` keyword already exists;
+the type constructor is the two-token sequence `POINTER TO`.
+
+- **REQ-PTR-parser-100** `POINTER` lexes as a single `Pointer` keyword token (distinct from any identifier).
+- **REQ-PTR-parser-101** With `allow_pointer_to` off, `POINTER` is demoted to `Identifier`.
+- **REQ-PTR-parser-102** With `allow_pointer_to` on, `POINTER` stays the `Pointer` keyword.
+- **REQ-PTR-parser-103** `POINTER` is a valid identifier (e.g. a variable name) in standard mode.
+
+## Parser productions & AST tagging
+
+The grammar reuses the existing reference productions: the `ref_to_keyword`
+rule gains a `POINTER TO` alternative returning a new `RefSyntax::PointerTo`
+tag, which flows into the shared `ReferenceDeclaration`,
+`ReferenceInitializer`, and `ArraySubranges.ref_to` nodes. No new AST node
+shapes are introduced, so every declaration position that accepts `REF_TO`
+(variable declarations, `TYPE` declarations, array element types) accepts
+`POINTER TO` under the flag.
+
+```rust
+pub enum RefSyntax {
+    RefTo,        // IEC 61131-3 REF_TO
+    ReferenceTo,  // TwinCAT / CODESYS REFERENCE TO
+    PointerTo,    // TwinCAT / CODESYS POINTER TO
+}
+```
+
+- **REQ-PTR-parser-200** `p : POINTER TO INT;` yields a reference initializer tagged `RefSyntax::PointerTo`.
+- **REQ-PTR-parser-201** `TYPE T : POINTER TO INT; END_TYPE` yields a reference declaration tagged `RefSyntax::PointerTo`.
+- **REQ-PTR-parser-210** `ARRAY [..] OF POINTER TO T` tags the element type `Some(RefSyntax::PointerTo)`.
+- **REQ-PTR-parser-211** With `allow_pointer_to` off, `p : POINTER TO INT;` is a syntax error.
+
+## Analyzer semantics
+
+`POINTER TO T` behaves as `REF_TO T`: explicit `^` dereference, `NULL`
+comparable and assignable, and the existing reference rules apply unchanged
+(P2031 deref of non-reference, P2032 target-type mismatch, P2033
+arithmetic, P2035 ordering comparisons). The implicit-dereference transform
+(`xform_insert_implicit_deref`) keys on `RefSyntax::ReferenceTo` and must
+not treat `PointerTo` as auto-dereferencing.
+
+- **REQ-PTR-analyzer-300** Reading through an explicit dereference of a `POINTER TO` variable (`value := p^;`) is accepted.
+- **REQ-PTR-analyzer-301** A bare use of a `POINTER TO` variable is not implicitly dereferenced, even when `allow_reference_to` is also enabled.
+- **REQ-PTR-analyzer-302** Binding a `POINTER TO T` variable to a reference of a different base type is rejected (P2032) unless `allow_ref_type_punning` is set.
+- **REQ-PTR-analyzer-303** Arithmetic on a `POINTER TO` value is rejected (P2033) unless `allow_ref_arithmetic` is set.
+- **REQ-PTR-analyzer-304** `NULL` may be assigned to a `POINTER TO` variable (when the `NULL` keyword is available via `allow_ref_to`).
+
+## Rendering (plc2plc)
+
+The renderer reproduces the surface spelling from the `RefSyntax` tag, so
+source using `POINTER TO` round-trips without being normalized to `REF_TO`.
+
+- **REQ-PTR-plc2plc-600** A `PointerTo`-tagged declaration renders as `POINTER TO`.
+- **REQ-PTR-plc2plc-601** `REF_TO`, `REFERENCE TO`, and `POINTER TO` declarations in one program each render with their own spelling preserved.
+
+## Out of scope
+
+- **`PVOID` as a named type.** Not needed: `ADR` returns a typed pointer.
+  Revisit only if a compatibility-library interface requires the name.
+- **Pointer arithmetic** (`p + 2`, `p - p`) — meaningless on table indices;
+  rejected via existing P2033. TwinCAT code relying on it (byte walking,
+  `MEMCPY` patterns) cannot be mapped to this memory model.
+- **Sub-object addresses**: `ADR(arr[i])`, `ADR(struct.field)`,
+  `ADR(string[3])` — slot indices cannot express data-region byte offsets;
+  rejected via P2028/P2030. Lifting this needs a fat-pointer representation
+  (slot index + byte offset) and is its own future design.
+- **`BITADR`, `INDEXOF`, `__ADRINST`, address-to-integer conversions**
+  (`LWORD_TO_PVOID` etc.).
+- **`MEMCPY`/`MEMSET`-style Tc2_System functions** that consume `ADR`
+  results — separate compatibility-library + builtin work per ADR-0042
+  rule 3.
+- **Online-change pointer semantics** — IronPLC has no online change.

--- a/specs/plans/2026-08-11-adr-operator-and-pointer-to.md
+++ b/specs/plans/2026-08-11-adr-operator-and-pointer-to.md
@@ -74,7 +74,19 @@ Consequently:
 
 ## Status & handoff notes
 
-- Nothing is implemented yet; this plan is the first commit on the branch.
+- **Phase 1 is implemented** (flags, `POINTER TO` parsing/semantics/round-trip,
+  design doc `specs/design/adr-and-pointer-to.md`). Two deviations from the
+  original sketch below:
+  - `allow_adr` is **not** added in Phase 1. The MCP
+    `feature_flag_conformance` suite requires every declared flag to have a
+    behavioral reject→accept fixture ("no escape hatch for declared but not
+    yet enforced"), and `ADR`'s behavior only exists once the Phase 2 rewrite
+    lands — so the flag lands together with that rewrite.
+  - `POINTER` is a demoted keyword token (a `Pointer` token plus an
+    `xform_demote_keywords` arm), not an identifier-sequence match: the
+    parser has no access to `CompilerOptions`, so token demotion is the only
+    gating mechanism — the same way `REFERENCE` is actually implemented.
+    `POINTER` still remains usable as an identifier when the flag is off.
 - Line anchors below are guides that will have drifted — re-locate by
   symbol, not line number.
 - Automatically wired surfaces when a flag is added via
@@ -199,14 +211,14 @@ It supersedes the "out of scope" notes in
 ## Tasks
 
 ### Phase 1 — `POINTER TO`
-- [ ] Write `specs/design/adr-and-pointer-to.md` with REQ-PTR requirement IDs (own commit, before implementation)
-- [ ] Add `allow_pointer_to` + `allow_adr` flags; update exact-set dialect tests (`twincat_...`, `codesys_...`)
-- [ ] Wire CLI + LSP surfaces; add `feature_flag_conformance` fixtures
-- [ ] `RefSyntax::PointerTo` in dsl + parser grammar + plc2plc renderer
-- [ ] Parser tests: `pointer_to_when_flag_enabled_then_parses`, `pointer_to_when_flag_disabled_then_rejected`
-- [ ] Analyzer: explicit-deref semantics; exclude from implicit-deref xform; type-mismatch (P2032) and deref (P2031) coverage
-- [ ] plc2plc round-trip fixture + test
-- [ ] `cd compiler && just` — all checks pass
+- [x] Write `specs/design/adr-and-pointer-to.md` with REQ-PTR requirement IDs (own commit, before implementation)
+- [x] Add `allow_pointer_to` flag; update exact-set dialect tests (`twincat_...`, `codesys_...`) — `allow_adr` moved to Phase 2, see handoff notes
+- [x] Wire CLI + LSP surfaces; add `feature_flag_conformance` fixture
+- [x] `RefSyntax::PointerTo` in dsl + parser grammar + plc2plc renderer
+- [x] Parser tests: `pointer_to_when_flag_enabled_then_parses`, `pointer_to_when_flag_disabled_then_rejected`
+- [x] Analyzer: explicit-deref semantics; exclude from implicit-deref xform; type-mismatch (P2032) and deref (P2031) coverage
+- [x] plc2plc round-trip fixture + test
+- [x] `cd compiler && just` — all checks pass
 
 ### Phase 2 — `ADR`
 - [ ] Analyzer rewrite `ADR(var)` → `ExprKind::Ref` gated by `allow_adr`; arity/operand diagnostics; verify `rule_ref_to` gating admits it without `allow_ref_to`


### PR DESCRIPTION
Phase 1 of specs/plans/2026-08-11-adr-operator-and-pointer-to.md starts
with the design document. Requirement IDs cover the Phase 1 scope
(POINTER TO declarations, explicit-deref semantics, round-tripping);
ADR requirement IDs land with the Phase 2 implementation because the
feature-flag conformance suite forbids flags that gate no behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T7E1pCZQmjPdPi8zBnrgso