### PR TITLE
Tc2_Utilities LREAL_TO_FMTSTR implementation

### DIFF
--- a/compiler/codegen/tests/it/end_to_end_tc2_utilities.rs
+++ b/compiler/codegen/tests/it/end_to_end_tc2_utilities.rs
@@ -1,0 +1,272 @@
+//! End-to-end tests for the `Tc2_Utilities` compatibility library.
+//!
+//! Pins every test vector from the clean-room behavior specification
+//! (`specs/design/library-interfaces/tc2-utilities.md`): the bundled library
+//! is activated through the real registry, merged ahead of user source,
+//! analyzed, compiled, and run on the VM. Every row asserts exact string
+//! equality — the spec's fixed-point formatting is deterministic, digit for
+//! digit.
+
+use ironplc_analyzer::stages::analyze;
+use ironplc_codegen::compile;
+use ironplc_container::STRING_HEADER_BYTES;
+use ironplc_dsl::common::Library;
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_parser::parse_program;
+use ironplc_sources::libraries::{remove_shadowed_functions, LibraryName, LibraryRegistry};
+use ironplc_vm::test_support::load_and_start;
+use ironplc_vm::VmBuffers;
+
+/// Activates the bundled `Tc2_Utilities`, analyzes it merged ahead of
+/// `source`, compiles, and runs one scan cycle. The full activate → analyze →
+/// codegen → VM-run path the acceptance criteria require.
+fn run_with_tc2_utilities(source: &str) -> VmBuffers {
+    let options = CompilerOptions::default();
+    let compat = LibraryRegistry::bundled()
+        .load(&LibraryName::from("Tc2_Utilities"))
+        .expect("bundled Tc2_Utilities must load")
+        .library;
+    let user = parse_program(source, &FileId::default(), &options).unwrap();
+    // The same user-shadowing filter the project pipeline applies.
+    let compat = remove_shadowed_functions(vec![compat], &[&user]);
+    let analyze_input: Vec<&Library> = compat.iter().chain(std::iter::once(&user)).collect();
+    let (analyzed, context) = analyze(&analyze_input, &options).unwrap();
+    assert!(
+        !context.has_diagnostics(),
+        "unexpected diagnostics: {:?}",
+        context.diagnostics()
+    );
+
+    let codegen_options = ironplc_codegen::CodegenOptions {
+        system_uptime_global: false,
+    };
+    let container = compile(
+        &analyzed,
+        &context,
+        &codegen_options,
+        &ironplc_codegen::EmptyLookup,
+    )
+    .unwrap();
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs).expect("VM load must not trap");
+        vm.run_round(0).expect("VM run must not trap");
+    }
+    bufs
+}
+
+/// Reads a STRING value from the data region at the given byte offset.
+fn read_string(data_region: &[u8], data_offset: usize) -> String {
+    let cur_len =
+        u16::from_le_bytes([data_region[data_offset + 2], data_region[data_offset + 3]]) as usize;
+    let data_start = data_offset + STRING_HEADER_BYTES;
+    let bytes = &data_region[data_start..data_start + cur_len];
+    bytes.iter().map(|&b| b as char).collect()
+}
+
+/// Formats one call `LREAL_TO_FMTSTR(x, <precision>, <round>)` where `x` is
+/// an LREAL assigned from `value_expr`, and returns the resulting string
+/// (`s`, the first and only STRING variable, at data offset 0). Routing the
+/// input through an LREAL variable keeps the value in binary64 — a bare real
+/// literal in argument position would resolve as REAL (binary32) — and lets
+/// a vector construct its input arithmetically (infinity, NaN).
+fn fmt(value_expr: &str, precision: i32, round: bool) -> String {
+    let round = if round { "TRUE" } else { "FALSE" };
+    let source = format!(
+        "PROGRAM main
+VAR
+    s : STRING;
+    x : LREAL;
+END_VAR
+    x := {value_expr};
+    s := LREAL_TO_FMTSTR(x, {precision}, {round});
+END_PROGRAM
+"
+    );
+    let bufs = run_with_tc2_utilities(&source);
+    read_string(&bufs.data_region, 0)
+}
+
+// ---------------------------------------------------------------------------
+// Sign, rounding mode, and truncation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn end_to_end_when_round_then_rounds_at_last_place() {
+    assert_eq!(fmt("123.456", 2, true), "123.46");
+}
+
+#[test]
+fn end_to_end_when_truncate_then_drops_beyond_last_place() {
+    assert_eq!(fmt("123.456", 2, false), "123.45");
+}
+
+#[test]
+fn end_to_end_when_negative_then_signed() {
+    assert_eq!(fmt("-123.456", 2, true), "-123.46");
+}
+
+#[test]
+fn end_to_end_when_half_then_rounds_away_from_zero_not_bankers() {
+    assert_eq!(fmt("2.5", 0, true), "3");
+    assert_eq!(fmt("-2.5", 0, true), "-3");
+}
+
+#[test]
+fn end_to_end_when_half_truncated_then_drops_fraction() {
+    assert_eq!(fmt("2.5", 0, false), "2");
+}
+
+#[test]
+fn end_to_end_when_negative_truncated_then_toward_zero() {
+    assert_eq!(fmt("-2.8", 0, false), "-2");
+}
+
+// ---------------------------------------------------------------------------
+// Carry, padding, and zero.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn end_to_end_when_fraction_rounds_all_the_way_up_then_carries_into_integer() {
+    assert_eq!(fmt("0.996", 2, true), "1.00");
+}
+
+#[test]
+fn end_to_end_when_negative_truncated_fraction_then_no_carry() {
+    assert_eq!(fmt("-0.996", 2, false), "-0.99");
+}
+
+#[test]
+fn end_to_end_when_fraction_has_leading_zero_then_left_padded() {
+    assert_eq!(fmt("1.05", 2, true), "1.05");
+}
+
+#[test]
+fn end_to_end_when_fraction_shorter_than_precision_then_zero_filled() {
+    assert_eq!(fmt("1.5", 3, false), "1.500");
+}
+
+#[test]
+fn end_to_end_when_zero_then_zero_digits() {
+    assert_eq!(fmt("0.0", 2, true), "0.00");
+}
+
+#[test]
+fn end_to_end_when_negative_zero_then_unsigned() {
+    // -0.0 < 0.0 is FALSE, so negative zero renders without a sign. The
+    // input is negated from a variable so no constant folding can drop the
+    // sign of zero before the call.
+    let source = "PROGRAM main
+VAR
+    s : STRING;
+    zero : LREAL;
+END_VAR
+    zero := 0.0;
+    s := LREAL_TO_FMTSTR(-zero, 2, TRUE);
+END_PROGRAM
+";
+    let bufs = run_with_tc2_utilities(source);
+    assert_eq!(read_string(&bufs.data_region, 0), "0.00");
+}
+
+// ---------------------------------------------------------------------------
+// Precision clamping.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn end_to_end_when_negative_precision_then_clamped_to_zero() {
+    assert_eq!(fmt("1.5", -3, true), "2");
+}
+
+#[test]
+fn end_to_end_when_precision_above_fifteen_then_clamped_to_fifteen() {
+    assert_eq!(fmt("1.5", 100, false), "1.500000000000000");
+}
+
+// ---------------------------------------------------------------------------
+// Domain boundaries.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn end_to_end_when_literal_not_representable_then_stored_value_renders() {
+    // The literal is not representable in binary64; the stored value — 2^53 —
+    // renders exactly.
+    assert_eq!(fmt("9007199254740993.0", 0, true), "9007199254740992");
+}
+
+#[test]
+fn end_to_end_when_large_integral_value_then_exact_digits() {
+    // In domain; binary64 values >= 2^52 are integral, so the fraction digits
+    // are genuinely zero.
+    assert_eq!(fmt("9.0E18", 0, true), "9000000000000000000");
+}
+
+#[test]
+fn end_to_end_when_at_or_beyond_two_pow_63_then_empty() {
+    assert_eq!(fmt("1.0E19", 0, true), "");
+    assert_eq!(fmt("-1.0E19", 2, true), "");
+}
+
+#[test]
+fn end_to_end_when_infinite_then_empty() {
+    // Constructed arithmetically: 1.0E308 * 10.0 overflows to +infinity.
+    assert_eq!(fmt("1.0E308 * 10.0", 2, true), "");
+    assert_eq!(fmt("-1.0E308 * 10.0", 2, true), "");
+}
+
+#[test]
+fn end_to_end_when_nan_then_empty() {
+    // Constructed arithmetically: __MOD(1.5, 0.0) is NaN. NaN fails every
+    // comparison, so this exercises the deliberate `in = in` domain test.
+    assert_eq!(fmt("__MOD(1.5, 0.0)", 2, true), "");
+    assert_eq!(fmt("__MOD(1.5, 0.0)", 0, false), "");
+}
+
+// ---------------------------------------------------------------------------
+// Formal (named) argument passing — the vendor's documented parameter names.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn end_to_end_when_formal_arguments_then_vendor_names_resolve() {
+    let source = "PROGRAM main
+VAR
+    s : STRING;
+    x : LREAL;
+END_VAR
+    x := 123.456;
+    s := LREAL_TO_FMTSTR(in := x, iPrecision := 2, bRound := TRUE);
+END_PROGRAM
+";
+    let bufs = run_with_tc2_utilities(source);
+    assert_eq!(read_string(&bufs.data_region, 0), "123.46");
+}
+
+// ---------------------------------------------------------------------------
+// Shadowing — a user-defined LREAL_TO_FMTSTR takes precedence.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn end_to_end_when_user_function_shadows_lreal_to_fmtstr_then_user_body_runs() {
+    let bufs = run_with_tc2_utilities(
+        "FUNCTION LREAL_TO_FMTSTR : STRING
+VAR_INPUT
+    in : LREAL;
+    iPrecision : INT;
+    bRound : BOOL;
+END_VAR
+    LREAL_TO_FMTSTR := 'shadowed';
+END_FUNCTION
+PROGRAM main
+VAR
+    s : STRING;
+    x : LREAL;
+END_VAR
+    x := 123.456;
+    s := LREAL_TO_FMTSTR(x, 2, TRUE);
+END_PROGRAM
+",
+    );
+    // The user's body (the constant), not the library's formatter.
+    assert_eq!(read_string(&bufs.data_region, 0), "shadowed");
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -132,6 +132,7 @@ mod end_to_end_sub;
 mod end_to_end_subrange;
 mod end_to_end_system_uptime;
 mod end_to_end_tc2_math;
+mod end_to_end_tc2_utilities;
 mod end_to_end_time_function;
 mod end_to_end_time_functions;
 mod end_to_end_trig;

--- a/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution.sln
+++ b/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution.sln
@@ -1,0 +1,17 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{B1E792BE-AA5F-4E3C-8C82-674BF9C0715B}") = "FormatSolution", "FormatSolution\FormatSolution.tsproj", "{7E15A2C4-9B38-4D61-A5F0-2C86D4B9E713}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Release|TwinCAT RT (x64) = Release|TwinCAT RT (x64)
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7E15A2C4-9B38-4D61-A5F0-2C86D4B9E713}.Release|TwinCAT RT (x64).ActiveCfg = Release|TwinCAT RT (x64)
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution/FormatSolution.tsproj
+++ b/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution/FormatSolution.tsproj
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" TcSmVersion="1.0" TcVersion="3.1.4024.0">
+	<Project ProjectGUID="{7E15A2C4-9B38-4D61-A5F0-2C86D4B9E713}" ShowHideConfigurations="#x106">
+		<Plc>
+			<Project GUID="{F2A84D06-1C57-4B92-8E3D-A9605B7F1E48}" Name="PlcFormat" PrjFilePath="PlcFormat\PlcFormat.plcproj" TmcFilePath="" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true"/>
+		</Plc>
+	</Project>
+</TcSmProject>

--- a/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution/PlcFormat/POUs/MAIN.TcPOU
+++ b/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution/PlcFormat/POUs/MAIN.TcPOU
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.0">
+  <POU Name="MAIN" Id="{c53d0a86-4e17-4b29-9f80-72b1e6d40a35}" SpecialFunc="None">
+    <Declaration><![CDATA[PROGRAM MAIN
+VAR
+    measured : LREAL;
+    display : STRING;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[measured := measured + 0.125;
+display := LREAL_TO_FMTSTR(measured, 2, TRUE);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution/PlcFormat/PlcFormat.plcproj
+++ b/compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/FormatSolution/PlcFormat/PlcFormat.plcproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <FileVersion>1.0.0.0</FileVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{f2a84d06-1c57-4b92-8e3d-a9605b7f1e48}</ProjectGuid>
+    <SubObjectsSortedByName>True</SubObjectsSortedByName>
+    <DownloadApplicationInfo>true</DownloadApplicationInfo>
+    <DefaultNamespace>PlcFormat</DefaultNamespace>
+    <Name>PlcFormat</Name>
+    <ProgramVersion>3.1.4024.0</ProgramVersion>
+    <Application>{6D24E8B1-4A70-4F35-92C8-0B57E3D9A162}</Application>
+    <TypeSystem>{B8F05C27-3E91-4D68-A74B-1F82C6E05D93}</TypeSystem>
+    <Implicit_Task_Info>{4C71D9E5-08B2-4F63-95A7-2E80B5C1F374}</Implicit_Task_Info>
+    <Implicit_KindOfTask>{9A35E7C0-6D14-4B82-B1E9-5C08F27A3D61}</Implicit_KindOfTask>
+    <Implicit_Jitter_Distribution>{2F80C4B6-7A53-4E29-8D07-C41B96E5F038}</Implicit_Jitter_Distribution>
+    <LibraryReferences>{5E29B7D4-91C6-4A38-BE02-83F7D0A64C15}</LibraryReferences>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="POUs\MAIN.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PlaceholderReference Include="Tc2_Utilities">
+      <DefaultResolution>Tc2_Utilities, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc2_Utilities</Namespace>
+    </PlaceholderReference>
+  </ItemGroup>
+  <ProjectExtensions>
+    <PlcProjectOptions>
+      <XmlArchive>
+        <Data/>
+        <TypeList/>
+      </XmlArchive>
+    </PlcProjectOptions>
+  </ProjectExtensions>
+</Project>

--- a/compiler/ironplc-cli/tests/cli.rs
+++ b/compiler/ironplc-cli/tests/cli.rs
@@ -456,6 +456,68 @@ fn check_when_twincat_solution_tc2_math_reference_removed_then_undefined(
     Ok(())
 }
 
+/// `Tc2_Utilities` activation from the project file alone: a realistic
+/// TwinCAT solution whose `.plcproj` declares a `<PlaceholderReference>` to
+/// `Tc2_Utilities`, whose `MAIN` calls `LREAL_TO_FMTSTR`. The check passes
+/// with no `--library` flag — activation comes from the reference, matching
+/// how real TwinCAT projects state their `Tc2_Utilities` dependency.
+#[test]
+fn check_when_twincat_solution_references_tc2_utilities_then_ok(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+
+    cmd.arg("check")
+        .arg("--dialect")
+        .arg("twincat")
+        .arg(path_to_test_resource("twincat_tc2_utilities_solution"));
+    cmd.assert().success().stdout(predicate::str::is_empty());
+
+    Ok(())
+}
+
+/// Negative control for the test above: the identical solution with the
+/// `<PlaceholderReference>` removed must fail — `Tc2_Utilities` is
+/// reference-activated only (dormant by default, never implicit), so
+/// `LREAL_TO_FMTSTR` no longer resolves.
+#[test]
+fn check_when_twincat_solution_tc2_utilities_reference_removed_then_undefined(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    copy_dir_recursive(
+        &path_to_test_resource("twincat_tc2_utilities_solution"),
+        temp.path(),
+    )?;
+
+    let plcproj = temp
+        .path()
+        .join("FormatSolution")
+        .join("PlcFormat")
+        .join("PlcFormat.plcproj");
+    let content = std::fs::read_to_string(&plcproj)?;
+    let start = content
+        .find("<PlaceholderReference")
+        .expect("fixture .plcproj must contain a PlaceholderReference element");
+    let end_tag = "</PlaceholderReference>";
+    let end = content
+        .find(end_tag)
+        .expect("fixture .plcproj must close the PlaceholderReference element")
+        + end_tag.len();
+    std::fs::write(
+        &plcproj,
+        format!("{}{}", &content[..start], &content[end..]),
+    )?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));
+
+    cmd.arg("check")
+        .arg("--dialect")
+        .arg("twincat")
+        .arg(temp.path());
+    cmd.assert().failure();
+
+    Ok(())
+}
+
 #[test]
 fn version_then_ok() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(cargo::cargo_bin!("ironplcc"));

--- a/compiler/plc2plc/src/tests/mod.rs
+++ b/compiler/plc2plc/src/tests/mod.rs
@@ -17,4 +17,5 @@ mod reference_to;
 mod short_circuit;
 mod struct_init_expressions;
 mod tc2_math_calls;
+mod tc2_utilities_calls;
 mod time_and_sizeof;

--- a/compiler/plc2plc/src/tests/tc2_utilities_calls.rs
+++ b/compiler/plc2plc/src/tests/tc2_utilities_calls.rs
@@ -1,0 +1,43 @@
+//! Round-tripping of user source that calls the `Tc2_Utilities` library
+//! function.
+//!
+//! The compatibility-library mechanism must leave user source untouched
+//! (`REQ-CL-plc2plc-001`): calls to `LREAL_TO_FMTSTR` render back under the
+//! exact vendor name — including formal (named) argument passing with the
+//! vendor's documented parameter names — and no library declaration is ever
+//! emitted as user source. See
+//! specs/design/library-interfaces/tc2-utilities.md.
+
+use super::common::*;
+
+#[test]
+fn write_to_string_when_source_calls_lreal_to_fmtstr_then_round_trips() {
+    let source = "
+PROGRAM main
+VAR
+    measured : LREAL;
+    display : STRING;
+END_VAR
+display := LREAL_TO_FMTSTR(measured, 2, TRUE);
+display := LREAL_TO_FMTSTR(in := measured, iPrecision := 3, bRound := FALSE);
+END_PROGRAM
+";
+    let options = CompilerOptions::default();
+    let library_original = parse_program(source, &FileId::default(), &options).unwrap();
+    let rendered = write_to_string(&library_original).unwrap();
+
+    // The calls come through unchanged, under the exact vendor name and the
+    // vendor's formal parameter names.
+    for name in ["LREAL_TO_FMTSTR", "iPrecision", "bRound"] {
+        assert!(
+            rendered.contains(name),
+            "rendered source must keep {name}:\n{rendered}"
+        );
+    }
+    // Nothing of the library implementation leaks into rendered user source.
+    assert!(!rendered.contains("__TRUNC"));
+    assert!(!rendered.contains("0123456789"));
+
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
+    assert_eq!(library_original, library_rendered);
+}

--- a/compiler/sources/resources/libs/Tc2_Utilities/1.0.0/Tc2_Utilities.st
+++ b/compiler/sources/resources/libs/Tc2_Utilities/1.0.0/Tc2_Utilities.st
@@ -1,0 +1,259 @@
+(* Tc2_Utilities compatibility library -- formatting functions.
+
+   This file reproduces the *interface* (name and signature) of the
+   LREAL_TO_FMTSTR function from Beckhoff's TwinCAT 3 Tc2_Utilities PLC
+   library for interoperability. The body is IronPLC-authored ST implementing
+   the normative definition in the clean-room spec at
+   specs/design/library-interfaces/tc2-utilities.md (the sole input to this
+   implementation): fixed-point decimal formatting with precision clamped to
+   0..15, round-half-away-from-zero or truncate-toward-zero, exact digit
+   rendering for |in| < 2^63, and the empty string outside that domain.
+   Formal parameter names are the vendor's documented names (in, iPrecision,
+   bRound) -- not IronPLC's IN/IN1/IN2 convention -- so vendor source using
+   formal (named) argument passing resolves unchanged.
+   IronPLC is an independent open-source project and is not affiliated with,
+   endorsed by, or sponsored by Beckhoff Automation GmbH. See
+   specs/steering/compatibility-library-authoring.md. *)
+
+(* Fixed-point decimal rendering of in with exactly LIMIT(0, iPrecision, 15)
+   digits after the decimal point; bRound TRUE rounds half away from zero at
+   the last place, FALSE truncates toward zero. NaN, +/-infinity, and
+   |in| >= 2^63 are out of domain and return ''.
+
+   The digit rendering is deliberately unrolled -- one block per decimal
+   weight, highest first -- rather than looped: the VM sizes its temporary
+   string-buffer pool by counting string-operation call sites statically and
+   releases the buffers only on function return, so a string operation inside
+   a loop would exhaust the pool. Unrolled, every call site executes at most
+   once per call, which is exactly the model the pool is sized for. *)
+FUNCTION LREAL_TO_FMTSTR : STRING
+VAR_INPUT
+    in         : LREAL;   (* value to format *)
+    iPrecision : INT;     (* number of decimal places *)
+    bRound     : BOOL;    (* TRUE: round at the last place; FALSE: truncate *)
+END_VAR
+VAR
+    p : INT;              (* precision clamped to 0..15 *)
+    i : INT;
+    v : LREAL;            (* ABS(in) *)
+    intPart : LREAL;      (* integer part of v, exact in binary64 *)
+    scale : LREAL;        (* 10^p, exactly representable for p <= 15 *)
+    scaled : LREAL;       (* fraction scaled by 10^p *)
+    intVal : LINT;        (* integer part as a 64-bit integer *)
+    n : LINT;             (* fraction digits as a 64-bit integer *)
+    digit : LINT;
+    bStarted : BOOL;      (* an integer digit has been emitted *)
+    result : STRING;
+END_VAR
+(* NaN fails every comparison, so it must be tested deliberately: in = in is
+   FALSE only for NaN. 9.223372036854775808E18 is 2^63; the >= also catches
+   +/-infinity. *)
+IF NOT (in = in) OR ABS(in) >= 9.223372036854775808E18 THEN
+    LREAL_TO_FMTSTR := '';
+    RETURN;
+END_IF;
+
+p := LIMIT(0, iPrecision, 15);
+
+(* Both the truncation and the fraction subtraction below are exact in
+   binary64. *)
+v := ABS(in);
+intPart := __TRUNC(v);
+
+scale := 1.0;
+FOR i := 1 TO p DO
+    scale := scale * 10.0;
+END_FOR;
+(* The one binary64 rounding in the whole computation. *)
+scaled := (v - intPart) * scale;
+
+(* scaled < 10^15 < 2^52, so adding 0.5 is exact; LREAL_TO_LINT truncates
+   toward zero. Working on |in| makes bRound round half away from zero
+   symmetrically for negative inputs. *)
+IF bRound THEN
+    n := LREAL_TO_LINT(scaled + 0.5);
+ELSE
+    n := LREAL_TO_LINT(scaled);
+END_IF;
+
+intVal := LREAL_TO_LINT(intPart);
+(* The fraction rounded all the way up to 10^p: carry into the integer part.
+   Only reachable for v < 2^52 (larger binary64 values are integral), so the
+   increment cannot overflow. *)
+IF n = LREAL_TO_LINT(scale) THEN
+    intVal := intVal + 1;
+    n := 0;
+END_IF;
+
+(* -0.0 < 0.0 is FALSE, so negative zero renders unsigned. *)
+IF in < 0.0 THEN
+    result := '-';
+ELSE
+    result := '';
+END_IF;
+
+(* Integer digits by exact 64-bit arithmetic, highest weight (10^18, the
+   19th digit -- intVal < 2^63 < 10^19) first, leading zeros suppressed. *)
+digit := (intVal / LINT#1000000000000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#100000000000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#10000000000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#1000000000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#100000000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#10000000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#1000000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#100000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#10000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#1000000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#100000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#10000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#1000000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#100000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#10000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#1000) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#100) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+digit := (intVal / LINT#10) MOD 10;
+IF bStarted OR digit <> 0 THEN
+    bStarted := TRUE;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+(* The ones digit always renders: a zero integer part renders '0'. *)
+digit := intVal MOD 10;
+result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+
+(* Fraction: exactly p digits of n, highest weight first -- the block at
+   weight 10^k renders only when k < p, which left-pads with zeros to
+   exactly p digits. No decimal point when p = 0. *)
+IF p > 0 THEN
+    result := CONCAT(result, '.');
+END_IF;
+IF p > 14 THEN
+    digit := (n / LINT#100000000000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 13 THEN
+    digit := (n / LINT#10000000000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 12 THEN
+    digit := (n / LINT#1000000000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 11 THEN
+    digit := (n / LINT#100000000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 10 THEN
+    digit := (n / LINT#10000000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 9 THEN
+    digit := (n / LINT#1000000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 8 THEN
+    digit := (n / LINT#100000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 7 THEN
+    digit := (n / LINT#10000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 6 THEN
+    digit := (n / LINT#1000000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 5 THEN
+    digit := (n / LINT#100000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 4 THEN
+    digit := (n / LINT#10000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 3 THEN
+    digit := (n / LINT#1000) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 2 THEN
+    digit := (n / LINT#100) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 1 THEN
+    digit := (n / LINT#10) MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+IF p > 0 THEN
+    digit := n MOD 10;
+    result := CONCAT(result, MID('0123456789', 1, LINT_TO_INT(digit) + 1));
+END_IF;
+
+LREAL_TO_FMTSTR := result;
+END_FUNCTION

--- a/compiler/sources/resources/libs/Tc2_Utilities/library.toml
+++ b/compiler/sources/resources/libs/Tc2_Utilities/library.toml
@@ -1,0 +1,15 @@
+name = "Tc2_Utilities"
+vendor = "Beckhoff Automation GmbH"
+default_version = "1.0.0"
+# One function mirroring the TwinCAT Tc2_Utilities PLC library interface:
+# LREAL_TO_FMTSTR, fixed-point decimal formatting with clamped precision
+# 0..15 and a round-or-truncate switch. The body is IronPLC-authored ST
+# authored per specs/steering/compatibility-library-authoring.md from the
+# clean-room spec at specs/design/library-interfaces/tc2-utilities.md,
+# which is the sole input to this implementation. Reference-activated only
+# (a .plcproj reference or --library Tc2_Utilities), matching how real
+# TwinCAT projects declare their Tc2_Utilities dependency. No bindings
+# table.
+references = [
+  "https://infosys.beckhoff.com/ -- TwinCAT Tc2_Utilities PLC library: LREAL_TO_FMTSTR function page (section TwinCAT 3 -> PLC libraries -> Tc2_Utilities -> Functions -> Formatting)",
+]

--- a/compiler/sources/src/libraries/mod.rs
+++ b/compiler/sources/src/libraries/mod.rs
@@ -422,6 +422,12 @@ mod tests {
         assert!(registry.contains(&LibraryName::from("Tc2_Math")));
     }
 
+    #[test]
+    fn bundled_registry_contains_tc2_utilities() {
+        let registry = LibraryRegistry::bundled();
+        assert!(registry.contains(&LibraryName::from("Tc2_Utilities")));
+    }
+
     /// The names of the `FUNCTION` declarations in a library, as written.
     fn function_names(library: &Library) -> Vec<String> {
         library
@@ -446,6 +452,15 @@ mod tests {
             function_names(&loaded.library),
             ["LTRUNC", "LMOD", "MODABS", "FRAC"]
         );
+    }
+
+    #[test]
+    fn load_when_tc2_utilities_then_provides_lreal_to_fmtstr() {
+        let registry = LibraryRegistry::bundled();
+        let loaded = registry.load(&LibraryName::from("Tc2_Utilities")).unwrap();
+        assert_eq!(loaded.manifest.name, "Tc2_Utilities");
+        assert_eq!(loaded.manifest.default_version, "1.0.0");
+        assert_eq!(function_names(&loaded.library), ["LREAL_TO_FMTSTR"]);
     }
 
     #[test]

--- a/specs/plans/2026-08-11-tc2-utilities-lreal-to-fmtstr.md
+++ b/specs/plans/2026-08-11-tc2-utilities-lreal-to-fmtstr.md
@@ -1,0 +1,83 @@
+# Implementation Plan: `Tc2_Utilities` Compatibility Library (`LREAL_TO_FMTSTR`)
+
+## Goal
+
+Implement the `Tc2_Utilities` compatibility library — one function,
+`LREAL_TO_FMTSTR` — exactly as specified by the clean-room behavior
+specification at
+[specs/design/library-interfaces/tc2-utilities.md](../design/library-interfaces/tc2-utilities.md),
+which is the **sole input** to this implementation per the
+[Compatibility Library Authoring policy](../steering/compatibility-library-authoring.md).
+
+## Design doc reference
+
+- [specs/design/library-interfaces/tc2-utilities.md](../design/library-interfaces/tc2-utilities.md)
+  — the behavior spec (signature, normative fixed-point formatting semantics,
+  domain, test vectors, package contents, acceptance criteria)
+- [specs/design/compatibility-libraries.md](../design/compatibility-libraries.md)
+  — the library mechanism (`REQ-CL-*`), including `REQ-CL-analyzer-004`
+  (user declaration shadows an activated library declaration)
+
+## Architecture
+
+- **Library package as data.** A new bundled package
+  `compiler/sources/resources/libs/Tc2_Utilities/` (manifest + one `.st`
+  file), following the existing `Tc2_Math` layout. `LREAL_TO_FMTSTR` is a
+  fully-defined ST body — no VM builtin, no manifest bindings table. Per the
+  spec's *Implementation medium*, the body uses the `__TRUNC` compiler
+  intrinsic, the standard string functions (`CONCAT`, `MID`), `LIMIT`, `ABS`,
+  and `LREAL_TO_LINT` (which truncates toward zero); all digit production is
+  exact 64-bit `LINT` arithmetic.
+- **Formal parameter names.** The vendor's documented names (`in`,
+  `iPrecision`, `bRound`) are kept verbatim so vendor source using formal
+  (named) argument passing resolves unchanged. `in` is not a reserved word in
+  the IronPLC lexer, so no parser change is needed.
+- **Reference-activated only.** No discovery-module implicit list entry — the
+  existing activation channels (`.plcproj` reference resolution and
+  `--library`) already cover `Tc2_Utilities` by name with zero new code.
+- **No new mechanism.** The shadowed-function filter, registry loader,
+  `.plcproj` reference resolution, and end-to-end harness all exist from the
+  `Tc2_Math` increment; this change is a new data package plus tests.
+
+## ST body shape (from the spec's normative steps)
+
+1. Domain check: `NOT (in = in)` (NaN) `OR ABS(in) >= 9.223372036854775808E18`
+   (the binary64 value 2^63; also catches ±∞) → return `''`.
+2. `p := LIMIT(0, iPrecision, 15)`.
+3. Split on `ABS(in)`: integer part via `__TRUNC`, fraction by exact
+   subtraction.
+4. Scale by `10^p` (computed by a `FOR` loop of exact multiplications),
+   round (`+ 0.5` then `LREAL_TO_LINT`) or truncate (`LREAL_TO_LINT`).
+5. Carry: fraction `n = 10^p` increments the integer part and zeroes `n`.
+6. Render: sign (`in < 0.0`; negative zero renders unsigned), integer digits
+   by repeated `MOD 10` / `/ 10` with `MID('0123456789', 1, digit + 1)`
+   character lookup, then `'.'` plus the fraction left-padded to exactly `p`
+   digits (a `FOR i := 1 TO p` render of `n` naturally zero-pads).
+
+## File map
+
+| File | Change |
+|---|---|
+| `compiler/sources/resources/libs/Tc2_Utilities/library.toml` | New — manifest (`name`, `vendor`, `default_version`, `references`; no bindings) |
+| `compiler/sources/resources/libs/Tc2_Utilities/1.0.0/Tc2_Utilities.st` | New — the `LREAL_TO_FMTSTR` ST body |
+| `compiler/sources/src/libraries/mod.rs` | Loader unit tests: registry contains/loads `Tc2_Utilities` |
+| `compiler/codegen/tests/it/end_to_end_tc2_utilities.rs` | New — every spec test vector end-to-end (exact string equality), shadowing end-to-end, formal-argument call |
+| `compiler/codegen/tests/it/main.rs` | Register the new test module |
+| `compiler/ironplc-cli/resources/test/twincat_tc2_utilities_solution/…` | New fixture — solution referencing `Tc2_Utilities` |
+| `compiler/ironplc-cli/tests/cli.rs` | `.plcproj` activation test + dormant-by-default negative test |
+| `compiler/plc2plc/src/tests/tc2_utilities_calls.rs` | Round-trip test for source calling `LREAL_TO_FMTSTR` |
+| `compiler/plc2plc/src/tests/mod.rs` | Register the new test module |
+
+## Tasks
+
+- [ ] Commit this plan
+- [ ] Author `library.toml` and `Tc2_Utilities.st` from the spec
+- [ ] Loader tests: bundled registry contains and loads `Tc2_Utilities`
+      (criterion 1)
+- [ ] End-to-end vector tests (criterion 2): every vector, exact string
+      equality; NaN/∞ constructed arithmetically per the spec
+- [ ] Shadowing end-to-end test (criterion 4)
+- [ ] `.plcproj` activation fixture + positive/negative CLI tests
+      (criterion 3)
+- [ ] `plc2plc` round-trip test (criterion 5)
+- [ ] Full CI green (`cd compiler && just`) (criterion 6)

--- a/specs/plans/2026-08-11-tc2-utilities-lreal-to-fmtstr.md
+++ b/specs/plans/2026-08-11-tc2-utilities-lreal-to-fmtstr.md
@@ -50,9 +50,19 @@ which is the **sole input** to this implementation per the
    round (`+ 0.5` then `LREAL_TO_LINT`) or truncate (`LREAL_TO_LINT`).
 5. Carry: fraction `n = 10^p` increments the integer part and zeroes `n`.
 6. Render: sign (`in < 0.0`; negative zero renders unsigned), integer digits
-   by repeated `MOD 10` / `/ 10` with `MID('0123456789', 1, digit + 1)`
-   character lookup, then `'.'` plus the fraction left-padded to exactly `p`
-   digits (a `FOR i := 1 TO p` render of `n` naturally zero-pads).
+   by exact 64-bit `/ 10^k` / `MOD 10` arithmetic with
+   `MID('0123456789', 1, digit + 1)` character lookup, then `'.'` plus the
+   fraction rendered to exactly `p` digits (rendering `n` at fixed weights
+   `10^(p-1) … 10^0` left-pads with zeros).
+
+**Digit rendering is unrolled, not looped.** The VM sizes its temporary
+string-buffer pool by statically counting string-operation call sites and
+releases buffers only on function return, so a `CONCAT`/`MID` inside a loop
+allocates per iteration and exhausts the pool (`TempBufferExhausted` trap).
+Unrolled — one block per decimal weight, 19 for the integer part (intVal <
+2^63 < 10^19) and 15 for the fraction, each guarded so it executes at most
+once per call — the runtime allocation count is bounded by the static site
+count, which is exactly the model the pool is sized for.
 
 ## File map
 
@@ -70,14 +80,14 @@ which is the **sole input** to this implementation per the
 
 ## Tasks
 
-- [ ] Commit this plan
-- [ ] Author `library.toml` and `Tc2_Utilities.st` from the spec
-- [ ] Loader tests: bundled registry contains and loads `Tc2_Utilities`
+- [x] Commit this plan
+- [x] Author `library.toml` and `Tc2_Utilities.st` from the spec
+- [x] Loader tests: bundled registry contains and loads `Tc2_Utilities`
       (criterion 1)
-- [ ] End-to-end vector tests (criterion 2): every vector, exact string
+- [x] End-to-end vector tests (criterion 2): every vector, exact string
       equality; NaN/∞ constructed arithmetically per the spec
-- [ ] Shadowing end-to-end test (criterion 4)
-- [ ] `.plcproj` activation fixture + positive/negative CLI tests
+- [x] Shadowing end-to-end test (criterion 4)
+- [x] `.plcproj` activation fixture + positive/negative CLI tests
       (criterion 3)
-- [ ] `plc2plc` round-trip test (criterion 5)
-- [ ] Full CI green (`cd compiler && just`) (criterion 6)
+- [x] `plc2plc` round-trip test (criterion 5)
+- [x] Full CI green (`cd compiler && just`) (criterion 6)


### PR DESCRIPTION
Implementation plan for the Tc2_Utilities compatibility library's
LREAL_TO_FMTSTR function, implemented solely from the clean-room
behavior spec at specs/design/library-interfaces/tc2-utilities.md.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YUgREhqVu6S8QALksxJnkL