### PR TITLE
Implement ADR() address-of operator for POINTER TO

### DIFF
--- a/compiler/analyzer/src/lib.rs
+++ b/compiler/analyzer/src/lib.rs
@@ -68,6 +68,7 @@ mod xform_fold_initializer_expressions;
 mod xform_insert_implicit_deref;
 mod xform_int_to_bool_initializer;
 mod xform_named_to_positional_args;
+mod xform_resolve_adr;
 mod xform_resolve_constant_expressions;
 mod xform_resolve_expr_types;
 mod xform_resolve_late_bound_expr_kind;
@@ -103,5 +104,7 @@ mod spec_requirements {
 }
 #[cfg(test)]
 mod spec_conformance;
+#[cfg(test)]
+mod spec_conformance_adr;
 #[cfg(test)]
 mod spec_conformance_pointer_to;

--- a/compiler/analyzer/src/spec_conformance_adr.rs
+++ b/compiler/analyzer/src/spec_conformance_adr.rs
@@ -1,0 +1,218 @@
+//! Spec conformance tests for the TwinCAT/CODESYS `ADR()` operator
+//! (analyzer-owned requirements): the call rewrite and operand diagnostics.
+//!
+//! Each test is annotated with `#[spec_test(REQ_PTR_analyzer_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test fails
+//! to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test in `spec_conformance` asserts
+//! every analyzer-owned requirement has a test.
+//!
+//! See `specs/design/adr-and-pointer-to.md`.
+
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_parser::parse_program;
+use ironplc_problems::Problem;
+use spec_test_macro::spec_test;
+
+use crate::stages::analyze;
+
+/// The minimal flag set for `ADR`: the pointer type plus the operator, and
+/// deliberately *not* `allow_ref_to` — the `twincat` dialect has no
+/// `REF_TO`/`REF()`/`NULL` keywords, so `ADR` must work without them.
+fn adr_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_pointer_to: true,
+        allow_adr: true,
+        ..CompilerOptions::default()
+    }
+}
+
+/// Analyze a program and return the problem codes it produced.
+fn analyze_codes(program: &str, options: &CompilerOptions) -> Vec<String> {
+    let library = parse_program(program, &FileId::default(), options).unwrap();
+    let (_library, context) = analyze(&[&library], options).unwrap();
+    context
+        .diagnostics()
+        .iter()
+        .map(|d| d.code.clone())
+        .collect()
+}
+
+/// REQ-PTR-analyzer-410: With `allow_adr` on, binding a `POINTER TO T`
+/// variable via `ADR` of a `T` variable is accepted — without `allow_ref_to`.
+#[spec_test(REQ_PTR_analyzer_410)]
+fn analyzer_spec_req_ptr_410_adr_of_variable_is_accepted_without_ref_to() {
+    let source = "PROGRAM Main
+VAR
+    x : INT;
+    p : POINTER TO INT;
+    y : INT;
+END_VAR
+    p := ADR(x);
+    y := p^;
+END_PROGRAM";
+    let codes = analyze_codes(source, &adr_options());
+    assert!(codes.is_empty(), "expected clean analysis, got {codes:?}");
+}
+
+/// REQ-PTR-analyzer-411: With `allow_adr` off, `ADR(x)` is an ordinary
+/// identifier and the call is reported as an undeclared function (P4017) —
+/// the same fall-through `SIZEOF` has.
+#[spec_test(REQ_PTR_analyzer_411)]
+fn analyzer_spec_req_ptr_411_adr_is_undeclared_function_when_flag_off() {
+    let source = "PROGRAM Main
+VAR
+    x : INT;
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(x);
+END_PROGRAM";
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        ..CompilerOptions::default()
+    };
+    let codes = analyze_codes(source, &options);
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::FunctionCallUndeclared.code()),
+        "expected P4017 (FunctionCallUndeclared), got {codes:?}"
+    );
+}
+
+/// REQ-PTR-analyzer-412: An `ADR` call with a number of arguments other than
+/// one is rejected with P2028.
+#[spec_test(REQ_PTR_analyzer_412)]
+fn analyzer_spec_req_ptr_412_adr_with_wrong_arity_is_rejected() {
+    let source = "PROGRAM Main
+VAR
+    x : INT;
+    y : INT;
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(x, y);
+END_PROGRAM";
+    let codes = analyze_codes(source, &adr_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::RefOperandNotVariable.code()),
+        "expected P2028 (RefOperandNotVariable), got {codes:?}"
+    );
+}
+
+/// REQ-PTR-analyzer-413: An `ADR` operand that is not a variable — a literal
+/// or a call result — is rejected with P2028.
+#[spec_test(REQ_PTR_analyzer_413)]
+fn analyzer_spec_req_ptr_413_adr_of_non_variable_is_rejected() {
+    let literal = "PROGRAM Main
+VAR
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(5);
+END_PROGRAM";
+    let codes = analyze_codes(literal, &adr_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::RefOperandNotVariable.code()),
+        "ADR of a literal: expected P2028, got {codes:?}"
+    );
+
+    // A call result is not addressable either — including a nested ADR.
+    let call_result = "PROGRAM Main
+VAR
+    x : INT;
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(ADR(x));
+END_PROGRAM";
+    let codes = analyze_codes(call_result, &adr_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::RefOperandNotVariable.code()),
+        "ADR of a call result: expected P2028, got {codes:?}"
+    );
+}
+
+/// REQ-PTR-analyzer-414: `ADR` of an array element is rejected with P2030 and
+/// `ADR` of a structure field with P2028 — slot indices cannot name a
+/// sub-object.
+#[spec_test(REQ_PTR_analyzer_414)]
+fn analyzer_spec_req_ptr_414_adr_of_sub_object_is_rejected() {
+    let array_element = "PROGRAM Main
+VAR
+    arr : ARRAY [0..9] OF INT;
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(arr[3]);
+END_PROGRAM";
+    let codes = analyze_codes(array_element, &adr_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::RefOfArrayElement.code()),
+        "ADR of an array element: expected P2030, got {codes:?}"
+    );
+
+    let struct_field = "TYPE MyStruct : STRUCT field : INT; END_STRUCT; END_TYPE
+PROGRAM Main
+VAR
+    s : MyStruct;
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(s.field);
+END_PROGRAM";
+    let codes = analyze_codes(struct_field, &adr_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::RefOperandNotVariable.code()),
+        "ADR of a struct field: expected P2028, got {codes:?}"
+    );
+}
+
+/// REQ-PTR-analyzer-415: Binding `ADR(x)` to a pointer whose target type
+/// differs from `typeof(x)` is rejected with P2032, reusing the `REF_TO`
+/// compatibility rule.
+#[spec_test(REQ_PTR_analyzer_415)]
+fn analyzer_spec_req_ptr_415_adr_type_mismatch_is_rejected() {
+    let source = "PROGRAM Main
+VAR
+    x : REAL;
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(x);
+END_PROGRAM";
+    let codes = analyze_codes(source, &adr_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::ReferenceTypeMismatch.code()),
+        "expected P2032 (ReferenceTypeMismatch), got {codes:?}"
+    );
+}
+
+/// REQ-PTR-analyzer-416: `ADR` of a stack-allocated (`VAR_TEMP`) variable is
+/// rejected with P2029 unless `allow_ref_stack_variables` is set.
+#[spec_test(REQ_PTR_analyzer_416)]
+fn analyzer_spec_req_ptr_416_adr_of_ephemeral_variable_is_rejected() {
+    let source = "FUNCTION_BLOCK FB1
+VAR_TEMP
+    temp : INT;
+END_VAR
+VAR
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(temp);
+END_FUNCTION_BLOCK";
+    let codes = analyze_codes(source, &adr_options());
+    assert!(
+        codes
+            .iter()
+            .any(|c| c.as_str() == Problem::RefOfEphemeralVariable.code()),
+        "expected P2029 (RefOfEphemeralVariable), got {codes:?}"
+    );
+}

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -31,7 +31,7 @@ use crate::{
     type_environment::{TypeEnvironment, TypeEnvironmentBuilder},
     type_table, xform_fold_constant_expressions, xform_fold_initializer_expressions,
     xform_insert_implicit_deref, xform_int_to_bool_initializer, xform_named_to_positional_args,
-    xform_resolve_constant_expressions, xform_resolve_expr_types,
+    xform_resolve_adr, xform_resolve_constant_expressions, xform_resolve_expr_types,
     xform_resolve_late_bound_expr_kind, xform_resolve_late_bound_type_initializer,
     xform_resolve_symbol_and_function_environment, xform_resolve_type_aliases,
     xform_resolve_type_decl_environment, xform_toposort_declarations,
@@ -192,6 +192,24 @@ pub fn resolve_types(
     let fallback = library.clone();
     match xform_insert_implicit_deref::apply(library, options) {
         Ok(result) => library = result,
+        Err(errs) => {
+            diagnostics.extend(errs);
+            library = fallback;
+        }
+    }
+
+    // Rewrite the `ADR(x)` address-of operator into `ExprKind::Ref` when
+    // `allow_adr` is set. Runs after implicit-deref (so a `REFERENCE TO`
+    // operand is not mis-addressed) and before symbol/function resolution
+    // (so a recognized `ADR` is not reported as an undeclared function).
+    // Recoverable: a diagnosed call is lowered to a placeholder, so the
+    // transformed library is kept even when diagnostics are present.
+    let fallback = library.clone();
+    match xform_resolve_adr::apply(library, options) {
+        Ok((result, errs)) => {
+            library = result;
+            diagnostics.extend(errs);
+        }
         Err(errs) => {
             diagnostics.extend(errs);
             library = fallback;

--- a/compiler/analyzer/src/xform_resolve_adr.rs
+++ b/compiler/analyzer/src/xform_resolve_adr.rs
@@ -1,0 +1,107 @@
+//! Transform that rewrites the TwinCAT/CODESYS `ADR(x)` address-of operator
+//! into the reference address-of expression the backend already understands.
+//!
+//! `ADR(x)` parses as an ordinary function call (like `SIZEOF` — no keyword
+//! token). Its return type depends on its argument (`POINTER TO typeof(x)`),
+//! which a stdlib function signature cannot express, so the call is rewritten
+//! early instead: `Function("ADR", [variable])` becomes
+//! `ExprKind::Ref(variable)`, and all existing reference type inference,
+//! assignment checking (P2032), semantic rules, and codegen apply unchanged.
+//! The reference semantic rules (`rule_ref_to`) validate `ExprKind::Ref`
+//! nodes unconditionally, so the rewritten node is checked without requiring
+//! `allow_ref_to` — as in the `twincat` dialect.
+//!
+//! An `ADR` call whose operand is not a variable expression (a literal, a
+//! call result, or a wrong number of arguments) is diagnosed with P2028 and
+//! lowered to `NULL` so the recognized-but-invalid call does not cascade into
+//! a misleading "undeclared function" diagnostic. Operands that are variables
+//! but not addressable (array elements, struct fields, ephemeral variables)
+//! are rewritten and left to `rule_ref_to` to reject (P2028/P2029/P2030),
+//! reusing the `REF()` operand rules.
+//!
+//! Runs after late-bound expression resolution (so bare identifiers are
+//! already `ExprKind::Variable`) and after the implicit-dereference transform
+//! (so a `REFERENCE TO` operand is not silently mis-addressed), but before
+//! symbol/function resolution (so a recognized `ADR` is not reported as an
+//! undeclared function). With `allow_adr` off the transform is a no-op and
+//! `ADR(x)` falls through to the normal undeclared-function path (P4017).
+//!
+//! See `specs/design/adr-and-pointer-to.md`.
+
+use ironplc_dsl::common::Library;
+use ironplc_dsl::core::Located;
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
+use ironplc_dsl::fold::Fold;
+use ironplc_dsl::textual::*;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_problems::Problem;
+
+/// The address-of operator, recognized only when `allow_adr` is set.
+const ADR: &str = "ADR";
+
+pub fn apply(
+    lib: Library,
+    options: &CompilerOptions,
+) -> Result<(Library, Vec<Diagnostic>), Vec<Diagnostic>> {
+    if !options.allow_adr {
+        return Ok((lib, Vec::new()));
+    }
+    let mut resolver = ResolveAdr {
+        diagnostics: Vec::new(),
+    };
+    let result = resolver.fold_library(lib).map_err(|e| vec![e])?;
+    Ok((result, resolver.diagnostics))
+}
+
+struct ResolveAdr {
+    diagnostics: Vec<Diagnostic>,
+}
+
+/// If `func` is an `ADR(...)` call with exactly one positional input
+/// argument, returns that argument expression.
+fn adr_operand(func: &Function) -> Option<Expr> {
+    if func.param_assignment.len() != 1 {
+        return None;
+    }
+    match &func.param_assignment[0] {
+        ParamAssignmentKind::PositionalInput(pos) => Some(pos.expr.clone()),
+        _ => None,
+    }
+}
+
+impl Fold<Diagnostic> for ResolveAdr {
+    fn fold_expr_kind(&mut self, node: ExprKind) -> Result<ExprKind, Diagnostic> {
+        match node {
+            ExprKind::Function(func) if func.name.to_string().eq_ignore_ascii_case(ADR) => {
+                // Fold the arguments first so a nested `ADR` is rewritten
+                // before the outer operand is inspected.
+                let func = func.recurse_fold(self)?;
+                let span = func.name.span();
+                match adr_operand(&func) {
+                    Some(operand) => match operand.kind {
+                        // Any variable expression becomes an address-of node;
+                        // `rule_ref_to` rejects non-addressable variables
+                        // (array elements, struct fields, ephemerals) with
+                        // the same codes `REF()` uses.
+                        ExprKind::Variable(var) => Ok(ExprKind::Ref(Box::new(var))),
+                        _ => {
+                            self.diagnostics.push(Diagnostic::problem(
+                                Problem::RefOperandNotVariable,
+                                Label::span(operand.span(), "ADR() operand must be a variable"),
+                            ));
+                            Ok(ExprKind::Null(operand.span()))
+                        }
+                    },
+                    None => {
+                        self.diagnostics.push(Diagnostic::problem(
+                            Problem::RefOperandNotVariable,
+                            Label::span(span.clone(), "ADR() requires exactly one input argument"),
+                        ));
+                        Ok(ExprKind::Null(span))
+                    }
+                }
+            }
+            other => other.recurse_fold(self),
+        }
+    }
+}

--- a/compiler/codegen/build.rs
+++ b/compiler/codegen/build.rs
@@ -1,3 +1,9 @@
 fn main() {
-    ironplc_spec_requirements_gen::generate(&["enumeration-codegen.md", "reference-to-twincat.md"]);
+    ironplc_spec_requirements_gen::generate(&[
+        "enumeration-codegen.md",
+        "reference-to-twincat.md",
+        // The codegen crate owns the execution requirements
+        // (`REQ-PTR-codegen-*`) for the ADR operator and POINTER TO.
+        "adr-and-pointer-to.md",
+    ]);
 }

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -53,3 +53,5 @@ mod spec_requirements {
 }
 #[cfg(test)]
 mod spec_conformance;
+#[cfg(test)]
+mod spec_conformance_adr;

--- a/compiler/codegen/src/spec_conformance_adr.rs
+++ b/compiler/codegen/src/spec_conformance_adr.rs
@@ -1,0 +1,149 @@
+//! Spec conformance tests for the TwinCAT/CODESYS `ADR()` operator
+//! (codegen-owned requirements): end-to-end execution.
+//!
+//! `ADR` is rewritten to `ExprKind::Ref` in the analyzer, so codegen needs
+//! zero changes — these tests pin the end-to-end behavior through the shared
+//! reference backend (push the variable's table index; `^` emits
+//! `LOAD_INDIRECT`).
+//!
+//! Each test is annotated with `#[spec_test(REQ_PTR_codegen_NNN)]`, which adds
+//! `#[test]` and references a build-script-generated constant so the test
+//! fails to compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test in `spec_conformance` asserts
+//! every codegen-owned requirement has a test.
+//!
+//! See `specs/design/adr-and-pointer-to.md`.
+
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::{CompilerOptions, Dialect};
+use ironplc_vm::test_support::load_and_start;
+use ironplc_vm::VmBuffers;
+use spec_test_macro::spec_test;
+
+/// The plan's Goal example: a function-block instance binding a pointer to
+/// one of its own members and reading it back through `^`. The member value
+/// is assigned in the body rather than by a `:= 5` member initializer:
+/// declared initial values are not yet applied to user FB instance fields (a
+/// pre-existing gap unrelated to `ADR`).
+const GOAL_EXAMPLE: &str = "
+FUNCTION_BLOCK FB_Point
+VAR
+   pNumber : POINTER TO INT;
+   iNumber1 : INT;
+   iNumber2 : INT;
+END_VAR
+iNumber1 := 5;
+pNumber := ADR(iNumber1);
+iNumber2 := pNumber^;
+END_FUNCTION_BLOCK
+
+PROGRAM main
+VAR
+    point : FB_Point;
+END_VAR
+    point();
+END_PROGRAM
+";
+
+/// The minimal flag set for `ADR`: the pointer type plus the operator,
+/// without `allow_ref_to`.
+fn adr_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_pointer_to: true,
+        allow_adr: true,
+        ..CompilerOptions::default()
+    }
+}
+
+/// Parse, analyze, compile, and run one scan cycle with the given options.
+fn adr_compile_and_run(
+    source: &str,
+    options: &CompilerOptions,
+) -> (ironplc_container::Container, VmBuffers) {
+    let library = ironplc_parser::parse_program(source, &FileId::default(), options).unwrap();
+    let (analyzed, ctx) = ironplc_analyzer::stages::resolve_types(&[&library], options).unwrap();
+    let codegen_options = crate::CodegenOptions::default();
+    let container = crate::compile(&analyzed, &ctx, &codegen_options, &crate::EmptyLookup).unwrap();
+    let mut bufs = VmBuffers::from_container(&container);
+    {
+        let mut vm = load_and_start(&container, &mut bufs).unwrap();
+        vm.run_round(0).unwrap();
+    }
+    (container, bufs)
+}
+
+/// REQ-PTR-codegen-500: The Goal example executes — inside an FB instance
+/// called from a PROGRAM, `pNumber := ADR(iNumber1); iNumber2 := pNumber^;`
+/// yields the addressed member's value.
+#[spec_test(REQ_PTR_codegen_500)]
+fn codegen_spec_req_ptr_500_goal_example_deref_yields_value() {
+    let (_c, bufs) = adr_compile_and_run(GOAL_EXAMPLE, &adr_options());
+    // vars: point=0, then the FB body's slots pNumber=1, iNumber1=2,
+    // iNumber2=3.
+    assert_eq!(bufs.vars[2].as_i32(), 5);
+    assert_eq!(bufs.vars[3].as_i32(), 5);
+}
+
+/// REQ-PTR-codegen-501: Storing through an `ADR`-bound pointer (`p^ := v`)
+/// updates the addressed variable.
+#[spec_test(REQ_PTR_codegen_501)]
+fn codegen_spec_req_ptr_501_store_through_pointer_updates_target() {
+    let source = "
+PROGRAM main
+VAR
+    x : INT := 1;
+    p : POINTER TO INT;
+    v : INT := 99;
+END_VAR
+    p := ADR(x);
+    p^ := v;
+END_PROGRAM
+";
+    let (_c, bufs) = adr_compile_and_run(source, &adr_options());
+    // vars: x=0, p=1, v=2. Writing through p must update x.
+    assert_eq!(bufs.vars[0].as_i32(), 99);
+}
+
+/// REQ-PTR-codegen-502: An `ADR`-bound pointer compares non-equal to `NULL`,
+/// and an unbound pointer defaults to `NULL`. (`NULL` is the `allow_ref_to`
+/// keyword, as in the `codesys` dialect.)
+#[spec_test(REQ_PTR_codegen_502)]
+fn codegen_spec_req_ptr_502_null_guard_reflects_binding() {
+    let source = "
+PROGRAM main
+VAR
+    x : INT;
+    bound : POINTER TO INT;
+    unbound : POINTER TO INT;
+    boundValid : BOOL;
+    unboundValid : BOOL;
+END_VAR
+    bound := ADR(x);
+    boundValid := bound <> NULL;
+    unboundValid := unbound <> NULL;
+END_PROGRAM
+";
+    let options = CompilerOptions {
+        allow_ref_to: true,
+        ..adr_options()
+    };
+    let (_c, bufs) = adr_compile_and_run(source, &options);
+    // vars: x=0, bound=1, unbound=2, boundValid=3, unboundValid=4.
+    assert_eq!(bufs.vars[3].as_i32(), 1, "bound pointer is not NULL");
+    assert_eq!(bufs.vars[4].as_i32(), 0, "unbound pointer defaults to NULL");
+}
+
+/// REQ-PTR-codegen-510: The `twincat` and `codesys` dialect presets compile
+/// and run the Goal example with no explicit flags.
+#[spec_test(REQ_PTR_codegen_510)]
+fn codegen_spec_req_ptr_510_dialect_presets_run_goal_example() {
+    for dialect in [Dialect::TwinCat, Dialect::Codesys] {
+        let options = CompilerOptions::from_dialect(dialect);
+        let (_c, bufs) = adr_compile_and_run(GOAL_EXAMPLE, &options);
+        assert_eq!(
+            bufs.vars[3].as_i32(),
+            5,
+            "Goal example must run under the {dialect} dialect preset"
+        );
+    }
+}

--- a/compiler/codegen/tests/it/end_to_end_adr.rs
+++ b/compiler/codegen/tests/it/end_to_end_adr.rs
@@ -1,0 +1,205 @@
+//! End-to-end integration tests for the `ADR()` address-of operator.
+//!
+//! These tests exercise the full pipeline: parse → semantic analysis (where
+//! `ADR(x)` is rewritten to the reference address-of expression) → codegen →
+//! VM execution. `ADR` reuses the `REF_TO` backend, so no new opcodes are
+//! involved — the pointer holds the addressed variable's table index and `^`
+//! loads/stores indirectly.
+
+use ironplc_dsl::core::FileId;
+use ironplc_parser::options::{CompilerOptions, Dialect};
+use ironplc_parser::parse_program;
+use ironplc_problems::Problem;
+use ironplc_vm::error::Trap;
+
+use crate::common::{parse_and_run, parse_and_try_run};
+
+/// The minimal flag set for `ADR`: the pointer type plus the operator,
+/// deliberately without `allow_ref_to` (as in the `twincat` dialect).
+fn adr_options() -> CompilerOptions {
+    CompilerOptions {
+        allow_pointer_to: true,
+        allow_adr: true,
+        ..CompilerOptions::default()
+    }
+}
+
+/// The plan's Goal example: an FB instance binding a pointer to one of its
+/// own members and reading it back through `^`. The member value is assigned
+/// in the body because declared initial values are not yet applied to user
+/// FB instance fields (a pre-existing gap unrelated to `ADR`).
+///
+/// var layout: point=0, then the FB body's slots pNumber=1, iNumber1=2,
+/// iNumber2=3.
+const GOAL_EXAMPLE: &str = "
+FUNCTION_BLOCK FB_Point
+VAR
+   pNumber : POINTER TO INT;
+   iNumber1 : INT;
+   iNumber2 : INT;
+END_VAR
+iNumber1 := 5;
+pNumber := ADR(iNumber1);
+iNumber2 := pNumber^;
+END_FUNCTION_BLOCK
+
+PROGRAM main
+VAR
+    point : FB_Point;
+END_VAR
+    point();
+END_PROGRAM
+";
+
+#[test]
+fn end_to_end_when_adr_goal_example_then_deref_yields_value() {
+    let (_c, bufs) = parse_and_run(GOAL_EXAMPLE, &adr_options());
+    assert_eq!(bufs.vars[2].as_i32(), 5);
+    assert_eq!(bufs.vars[3].as_i32(), 5);
+}
+
+// Store-through: writing `p^ := v` updates the addressed variable.
+// var layout: x=0, p=1, v=2
+e2e_i32_with!(
+    end_to_end_when_adr_store_through_then_target_updated,
+    adr_options(),
+    "
+PROGRAM main
+VAR
+    x : INT := 1;
+    p : POINTER TO INT;
+    v : INT := 99;
+END_VAR
+    p := ADR(x);
+    p^ := v;
+END_PROGRAM
+",
+    &[(0, 99)],
+);
+
+// Two instances of one FB: ADR inside each call addresses that call's own
+// member value, so each instance's output reflects its own input.
+// var layout: inst1=0, inst2=1, r1=2, r2=3, then the FB body's slots.
+e2e_i32_with!(
+    end_to_end_when_adr_in_two_fb_instances_then_each_addresses_own_member,
+    adr_options(),
+    "
+FUNCTION_BLOCK FB_Echo
+VAR_INPUT
+    x : INT;
+END_VAR
+VAR
+    held : INT;
+    p : POINTER TO INT;
+END_VAR
+VAR_OUTPUT
+    y : INT;
+END_VAR
+held := x;
+p := ADR(held);
+y := p^;
+END_FUNCTION_BLOCK
+
+PROGRAM main
+VAR
+    inst1 : FB_Echo;
+    inst2 : FB_Echo;
+    r1 : INT;
+    r2 : INT;
+END_VAR
+    inst1(x := 7, y => r1);
+    inst2(x := 9, y => r2);
+END_PROGRAM
+",
+    &[(2, 7), (3, 9)],
+);
+
+// NULL guard: the guarded dereference only runs once the pointer is bound.
+// NULL is the allow_ref_to keyword, as in the codesys dialect.
+// var layout: x=0, p=1, y=2
+e2e_i32_with!(
+    end_to_end_when_adr_null_guard_then_deref_only_when_bound,
+    CompilerOptions {
+        allow_ref_to: true,
+        ..adr_options()
+    },
+    "
+PROGRAM main
+VAR
+    x : INT := 42;
+    p : POINTER TO INT;
+    y : INT;
+END_VAR
+    IF p <> NULL THEN
+        y := 1;
+    END_IF;
+    p := ADR(x);
+    IF p <> NULL THEN
+        y := p^;
+    END_IF;
+END_PROGRAM
+",
+    &[(2, 42)],
+);
+
+#[test]
+fn end_to_end_when_adr_unbound_pointer_deref_then_trap() {
+    // An unbound POINTER TO defaults to NULL and traps on dereference.
+    let source = "
+PROGRAM main
+VAR
+    p : POINTER TO INT;
+    y : INT;
+END_VAR
+    y := p^;
+END_PROGRAM
+";
+    let err = parse_and_try_run(source, &adr_options()).unwrap_err();
+    assert_eq!(err.trap, Trap::NullDereference);
+}
+
+#[test]
+fn end_to_end_when_adr_flag_off_then_undeclared_function() {
+    // Without allow_adr, ADR stays an ordinary identifier and the call is
+    // reported as an undeclared function (P4017), like SIZEOF.
+    let source = "
+PROGRAM main
+VAR
+    x : INT;
+    p : POINTER TO INT;
+END_VAR
+    p := ADR(x);
+END_PROGRAM
+";
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        ..CompilerOptions::default()
+    };
+    let library = parse_program(source, &FileId::default(), &options).unwrap();
+    let (_library, context) = ironplc_analyzer::stages::analyze(&[&library], &options).unwrap();
+    let codes: Vec<&str> = context
+        .diagnostics()
+        .iter()
+        .map(|d| d.code.as_str())
+        .collect();
+    assert!(
+        codes.contains(&Problem::FunctionCallUndeclared.code()),
+        "expected P4017 (FunctionCallUndeclared), got {codes:?}"
+    );
+}
+
+#[test]
+fn end_to_end_when_twincat_dialect_then_goal_example_runs() {
+    // The pure twincat preset enables the whole Goal example with no
+    // explicit flags — and without any REF_TO/REF()/NULL keywords.
+    let options = CompilerOptions::from_dialect(Dialect::TwinCat);
+    let (_c, bufs) = parse_and_run(GOAL_EXAMPLE, &options);
+    assert_eq!(bufs.vars[3].as_i32(), 5);
+}
+
+#[test]
+fn end_to_end_when_codesys_dialect_then_goal_example_runs() {
+    let options = CompilerOptions::from_dialect(Dialect::Codesys);
+    let (_c, bufs) = parse_and_run(GOAL_EXAMPLE, &options);
+    assert_eq!(bufs.vars[3].as_i32(), 5);
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -31,6 +31,7 @@ mod end_to_end_abs;
 mod end_to_end_abs_float;
 mod end_to_end_abs_lint;
 mod end_to_end_add;
+mod end_to_end_adr;
 mod end_to_end_any_int_literals;
 mod end_to_end_array;
 mod end_to_end_array_ref_to;

--- a/compiler/ironplc-cli/bin/main.rs
+++ b/compiler/ironplc-cli/bin/main.rs
@@ -123,6 +123,12 @@ struct FileArgs {
     #[arg(long)]
     allow_pointer_to: bool,
 
+    /// Allow the ADR() address-of operator, which returns a typed pointer to
+    /// a variable. This is an extension; the `twincat` and `codesys` dialects
+    /// enable it.
+    #[arg(long)]
+    allow_adr: bool,
+
     /// Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types.
     /// This is an extension not part of the IEC 61131-3 standard.
     #[arg(long)]
@@ -227,6 +233,7 @@ impl FileArgs {
         options.allow_ref_to |= self.allow_ref_to;
         options.allow_reference_to |= self.allow_reference_to;
         options.allow_pointer_to |= self.allow_pointer_to;
+        options.allow_adr |= self.allow_adr;
         options.allow_ref_arithmetic |= self.allow_ref_arithmetic;
         options.allow_ref_stack_variables |= self.allow_ref_stack_variables;
         options.allow_ref_type_punning |= self.allow_ref_type_punning;

--- a/compiler/ironplc-cli/src/lsp.rs
+++ b/compiler/ironplc-cli/src/lsp.rs
@@ -1149,6 +1149,28 @@ mod test {
     }
 
     #[test]
+    fn extract_compiler_options_when_allow_adr_then_enables_flag() {
+        #[allow(deprecated)]
+        let params = InitializeParams {
+            process_id: None,
+            root_path: None,
+            root_uri: None,
+            initialization_options: Some(serde_json::json!({"allowAdr": true})),
+            capabilities: ClientCapabilities::default(),
+            trace: None,
+            workspace_folders: None,
+            client_info: None,
+            locale: None,
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+        };
+
+        let options = super::extract_compiler_options(&params);
+        assert!(options.allow_adr);
+    }
+
+    #[test]
     fn extract_compiler_options_when_allow_fb_inheritance_then_enables_flag() {
         #[allow(deprecated)]
         let params = InitializeParams {

--- a/compiler/mcp/src/feature_flag_conformance.rs
+++ b/compiler/mcp/src/feature_flag_conformance.rs
@@ -128,6 +128,15 @@ const FLAG_FIXTURES: &[FlagFixture] = &[
         prereqs: &[],
         source: "PROGRAM main\nVAR\np : POINTER TO INT;\nEND_VAR\nEND_PROGRAM",
     },
+    // The ADR() address-of operator. With the flag off, ADR is an ordinary
+    // identifier and the call is an undeclared function (P4017); with it on,
+    // the call is rewritten to the reference address-of expression. Needs
+    // allow_pointer_to for the destination pointer declaration.
+    FlagFixture {
+        key: "allow_adr",
+        prereqs: &["allow_pointer_to"],
+        source: "PROGRAM main\nVAR\nx : INT;\np : POINTER TO INT;\nEND_VAR\np := ADR(x);\nEND_PROGRAM",
+    },
     // Arithmetic on a REF_TO type (P2033). Needs REF_TO to parse at all.
     FlagFixture {
         key: "allow_ref_arithmetic",

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -38,6 +38,8 @@ mod spec_requirements {
 #[cfg(test)]
 mod spec_conformance;
 #[cfg(test)]
+mod spec_conformance_adr;
+#[cfg(test)]
 mod spec_conformance_pointer_to;
 pub mod token;
 

--- a/compiler/parser/src/options.rs
+++ b/compiler/parser/src/options.rs
@@ -269,6 +269,11 @@ define_compiler_options! {
     [Codesys, TwinCat],
     allow_pointer_to,
 
+    "Allow the ADR() address-of operator (returns a typed pointer to a variable)",
+    "--allow-adr",
+    [Codesys, TwinCat],
+    allow_adr,
+
     "Allow arithmetic (+, -) and ordering comparisons (<, >, <=, >=) on REF_TO types",
     "--allow-ref-arithmetic",
     [Rusty, Codesys],
@@ -485,6 +490,7 @@ mod tests {
                 "allow_ref_to",
                 "allow_reference_to",
                 "allow_pointer_to",
+                "allow_adr",
                 "allow_ref_arithmetic",
                 "allow_ref_stack_variables",
                 "allow_ref_type_punning",
@@ -529,6 +535,7 @@ mod tests {
                 "allow_long_time_types",
                 "allow_reference_to",
                 "allow_pointer_to",
+                "allow_adr",
                 "allow_int_to_bool_initializer",
                 "allow_sizeof",
                 "allow_cross_family_widening",

--- a/compiler/parser/src/spec_conformance_adr.rs
+++ b/compiler/parser/src/spec_conformance_adr.rs
@@ -1,0 +1,37 @@
+//! Spec conformance tests for the TwinCAT/CODESYS `ADR()` operator
+//! (parser-owned requirements): dialect presets for the `allow_adr` flag.
+//!
+//! `ADR` itself needs no parser change — it parses as an ordinary function
+//! call — so the parser owns only the options/dialect requirements. Each test
+//! is annotated with `#[spec_test(REQ_PTR_parser_NNN)]`, which adds `#[test]`
+//! and references a build-script-generated constant so the test fails to
+//! compile if the requirement is removed from the spec. The
+//! `all_spec_requirements_have_tests` meta-test in `spec_conformance` asserts
+//! every parser-owned requirement has a test.
+//!
+//! See `specs/design/adr-and-pointer-to.md`.
+
+use spec_test_macro::spec_test;
+
+use crate::options::{CompilerOptions, Dialect};
+
+/// REQ-PTR-parser-400: The `codesys` dialect enables `allow_adr`.
+#[spec_test(REQ_PTR_parser_400)]
+fn options_spec_req_ptr_400_codesys_enables_adr() {
+    assert!(CompilerOptions::from_dialect(Dialect::Codesys).allow_adr);
+}
+
+/// REQ-PTR-parser-401: The `twincat` dialect enables `allow_adr`.
+#[spec_test(REQ_PTR_parser_401)]
+fn options_spec_req_ptr_401_twincat_enables_adr() {
+    assert!(CompilerOptions::from_dialect(Dialect::TwinCat).allow_adr);
+}
+
+/// REQ-PTR-parser-402: The `iec61131-3-ed2`, `iec61131-3-ed3`, and `rusty`
+/// dialects do not enable `allow_adr`.
+#[spec_test(REQ_PTR_parser_402)]
+fn options_spec_req_ptr_402_other_dialects_do_not_enable_adr() {
+    assert!(!CompilerOptions::from_dialect(Dialect::Iec61131_3Ed2).allow_adr);
+    assert!(!CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3).allow_adr);
+    assert!(!CompilerOptions::from_dialect(Dialect::Rusty).allow_adr);
+}

--- a/compiler/plc2plc/resources/test/adr_rendered.st
+++ b/compiler/plc2plc/resources/test/adr_rendered.st
@@ -1,0 +1,17 @@
+PROGRAM main
+
+VAR
+   counter : INT := 42;
+END_VAR
+
+VAR
+   p : POINTER TO INT;
+END_VAR
+
+VAR
+   value : INT;
+END_VAR
+p := ADR ( counter ) ;
+value := p ^ ;
+p^ := 99 ;
+END_PROGRAM

--- a/compiler/plc2plc/src/tests/adr.rs
+++ b/compiler/plc2plc/src/tests/adr.rs
@@ -1,0 +1,20 @@
+//! `ADR()` operator round-tripping.
+//!
+//! `ADR` parses as an ordinary function call (no keyword token), so the
+//! fixture needs only `allow_pointer_to` for the destination pointer
+//! declaration — the call round-trips like any other function call.
+
+use super::common::*;
+
+#[test]
+fn write_to_string_when_adr_then_round_trips() {
+    let source = read_shared_resource("adr.st");
+    let options = CompilerOptions {
+        allow_pointer_to: true,
+        ..CompilerOptions::default()
+    };
+    let library = parse_program(&source, &FileId::default(), &options).unwrap();
+    let rendered = write_to_string(&library).unwrap();
+    let expected = read_resource("adr_rendered.st");
+    assert_eq!(rendered, expected);
+}

--- a/compiler/plc2plc/src/tests/mod.rs
+++ b/compiler/plc2plc/src/tests/mod.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+mod adr;
 mod case;
 mod constant_initializers;
 mod corpus;

--- a/compiler/resources/test/adr.st
+++ b/compiler/resources/test/adr.st
@@ -1,0 +1,10 @@
+PROGRAM main
+VAR
+    counter : INT := 42;
+    p : POINTER TO INT;
+    value : INT;
+END_VAR
+    p := ADR(counter);
+    value := p^;
+    p^ := 99;
+END_PROGRAM

--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -67,6 +67,7 @@ Supported Dialects
    ``--allow-empty-var-blocks``, ``--allow-time-as-function-name``,
    ``--allow-long-time-types``,
    ``--allow-ref-to``, ``--allow-reference-to``, ``--allow-pointer-to``,
+   ``--allow-adr``,
    ``--allow-ref-arithmetic``,
    ``--allow-ref-stack-variables``, ``--allow-ref-type-punning``,
    ``--allow-int-to-bool-initializer``, ``--allow-sizeof``,
@@ -89,9 +90,9 @@ Supported Dialects
    short-circuit operator. Unlike ``codesys``, it does **not** enable the
    ``REF_TO`` / ``REF()`` / ``NULL`` reference extensions: TwinCAT spells
    references ``REFERENCE TO`` (bound with ``REF=``) and pointers
-   ``POINTER TO``, which this dialect enables instead via
-   ``--allow-reference-to`` and ``--allow-pointer-to``. (The ``ADR()``
-   address-of operator is not supported yet.) As with ``codesys``,
+   ``POINTER TO`` (bound with ``ADR()``), which this dialect enables instead
+   via ``--allow-reference-to``, ``--allow-pointer-to``, and
+   ``--allow-adr``. As with ``codesys``,
    the implicit
    :doc:`__SYSTEM_UP_TIME </reference/extension-library/variables/system-uptime>`
    globals are not pre-bound, since they are an IronPLC runtime convention
@@ -101,7 +102,7 @@ Supported Dialects
    ``--allow-top-level-var-global``, ``--allow-constant-type-params``,
    ``--allow-empty-var-blocks``, ``--allow-time-as-function-name``,
    ``--allow-long-time-types``,
-   ``--allow-reference-to``, ``--allow-pointer-to``,
+   ``--allow-reference-to``, ``--allow-pointer-to``, ``--allow-adr``,
    ``--allow-int-to-bool-initializer``,
    ``--allow-sizeof``, ``--allow-cross-family-widening``,
    ``--allow-partial-access-syntax``, ``--allow-pragmas``,
@@ -231,10 +232,19 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    Allow the Beckhoff TwinCAT / CODESYS ``POINTER TO`` pointer type. A
    ``POINTER TO`` variable behaves like a ``REF_TO`` reference: reading or
    writing the target requires the explicit dereference operator (``^``),
-   unlike ``REFERENCE TO``, which dereferences implicitly. (The ``ADR()``
-   address-of operator is not supported yet; pointers are bound with the
-   ``REF()``/``NULL`` forms from ``--allow-ref-to``.) See
+   unlike ``REFERENCE TO``, which dereferences implicitly. Pointers are
+   bound with the ``ADR()`` operator (``--allow-adr``) or the
+   ``REF()``/``NULL`` forms from ``--allow-ref-to``. See
    :doc:`/reference/language/data-types/derived/reference-types`.
+
+``--allow-adr``
+   Allow the ``ADR()`` address-of operator, which returns a typed pointer to
+   a variable for assignment to a ``POINTER TO`` variable
+   (``--allow-pointer-to``). Unlike TwinCAT's untyped ``PVOID`` result,
+   ``ADR(x)`` in IronPLC has the type ``POINTER TO`` *typeof(x)* and is
+   type-checked against the destination pointer's target type. Addresses of
+   sub-objects (array elements, structure fields) and pointer arithmetic are
+   not supported and are rejected with a diagnostic.
 
 ``--allow-ref-arithmetic``
    Allow arithmetic (``+``, ``-``) and ordering comparisons (``<``, ``>``,

--- a/docs/reference/compiler/ironplcc.rst
+++ b/docs/reference/compiler/ironplcc.rst
@@ -148,6 +148,10 @@ Options
    Allow the Beckhoff TwinCAT / CODESYS ``POINTER TO`` pointer type with
    explicit dereference (``^``).
 
+``--allow-adr``
+   Allow the ``ADR()`` address-of operator, which returns a typed pointer to
+   a variable for assignment to a ``POINTER TO`` variable.
+
 ``--allow-ref-arithmetic``
    Allow arithmetic (``+``, ``-``) and ordering comparisons (``<``, ``>``,
    ``<=``, ``>=``) on ``REF_TO`` types. By default, only ``=`` and ``<>``

--- a/specs/design/adr-and-pointer-to.md
+++ b/specs/design/adr-and-pointer-to.md
@@ -70,15 +70,14 @@ The feature is delivered in phases, mirroring the plan:
   via the existing `REF()` initializer/assignment forms (available when
   `allow_ref_to` is also on, as in the `codesys` dialect) — `ADR` itself is
   Phase 2.
-- **Phase 2 — the `ADR()` operator and `allow_adr` flag.** An analyzer
-  rewrite of `Function("ADR", [expr])` → `ExprKind::Ref(variable)` when
-  `allow_adr` is on, with diagnostics for invalid operands. The `allow_adr`
-  flag lands together with the rewrite (not in Phase 1) because every
-  feature flag must gate real behavior the moment it is declared — the MCP
-  `feature_flag_conformance` suite has no "declared but not yet enforced"
-  escape hatch, and a flag whose behavior does not exist yet would be a dead
-  flag. Phase 2 adds its own requirement IDs (`4xx`–`5xx`) to this document
-  when it lands.
+- **Phase 2 — the `ADR()` operator and `allow_adr` flag (requirements
+  `4xx`–`5xx`).** An analyzer rewrite of `Function("ADR", [expr])` →
+  `ExprKind::Ref(variable)` when `allow_adr` is on, with diagnostics for
+  invalid operands. The `allow_adr` flag lands together with the rewrite
+  (not in Phase 1) because every feature flag must gate real behavior the
+  moment it is declared — the MCP `feature_flag_conformance` suite has no
+  "declared but not yet enforced" escape hatch, and a flag whose behavior
+  does not exist yet would be a dead flag.
 - **Phase 3 — documentation sweep.** User docs, dialect tables, and stale
   comments.
 
@@ -157,6 +156,56 @@ not treat `PointerTo` as auto-dereferencing.
 - **REQ-PTR-analyzer-302** Binding a `POINTER TO T` variable to a reference of a different base type is rejected (P2032) unless `allow_ref_type_punning` is set.
 - **REQ-PTR-analyzer-303** Arithmetic on a `POINTER TO` value is rejected (P2033) unless `allow_ref_arithmetic` is set.
 - **REQ-PTR-analyzer-304** `NULL` may be assigned to a `POINTER TO` variable (when the `NULL` keyword is available via `allow_ref_to`).
+
+## The `ADR()` operator (Phase 2)
+
+`ADR` needs no parser change: `ADR(x)` parses as an ordinary function call,
+exactly like `SIZEOF` (which is not a token), and plc2plc round-trips it for
+free. `ADR`'s return type depends on its argument (`POINTER TO typeof(x)`),
+which a stdlib `FunctionSignature` cannot express, so instead of registering
+a signature the analyzer rewrites the call early: when `allow_adr` is on, a
+transform rewrites `Function("ADR", [expr])` → `ExprKind::Ref(variable)`.
+All existing reference type inference, assignment checking (P2032), and
+codegen then apply unchanged.
+
+The rewrite does not require `allow_ref_to`: the reference semantic rules
+validate `ExprKind::Ref` nodes unconditionally, so an `ADR`-produced node is
+checked (and accepted) even when the `REF_TO`/`REF()`/`NULL` keywords are
+unavailable — as in the `twincat` dialect.
+
+Invalid operands reuse the `REF()` diagnostics: P2028 (operand must be a
+simple variable — covers literals, call results, struct fields, and wrong
+arity), P2029 (ephemeral/stack variable), and P2030 (array element). With
+the flag off, `ADR` stays an ordinary identifier and the call falls through
+to the normal undeclared-function diagnostic (P4017), matching `SIZEOF`
+behavior.
+
+### Options & dialects (Phase 2)
+
+- **REQ-PTR-parser-400** The `codesys` dialect preset enables `allow_adr`.
+- **REQ-PTR-parser-401** The `twincat` dialect preset enables `allow_adr`.
+- **REQ-PTR-parser-402** The `iec61131-3-ed2`, `iec61131-3-ed3`, and `rusty` dialect presets do not enable `allow_adr`.
+
+### Analyzer rewrite & diagnostics
+
+- **REQ-PTR-analyzer-410** With `allow_adr` on, `p := ADR(x);` binding a `POINTER TO T` variable to a variable of type `T` is accepted, without requiring `allow_ref_to`.
+- **REQ-PTR-analyzer-411** With `allow_adr` off, `ADR(x)` is reported as an undeclared function (P4017).
+- **REQ-PTR-analyzer-412** An `ADR` call with a number of arguments other than one is rejected (P2028).
+- **REQ-PTR-analyzer-413** An `ADR` operand that is not a variable (a literal or a call result) is rejected (P2028).
+- **REQ-PTR-analyzer-414** `ADR` of an array element is rejected (P2030); `ADR` of a structure field is rejected (P2028) — slot indices cannot name a sub-object.
+- **REQ-PTR-analyzer-415** Binding `ADR(x)` to a pointer whose target type differs from `typeof(x)` is rejected (P2032) unless `allow_ref_type_punning` is set.
+- **REQ-PTR-analyzer-416** `ADR` of a stack-allocated variable (`VAR_TEMP`) is rejected (P2029) unless `allow_ref_stack_variables` is set.
+
+### Execution (codegen)
+
+`ADR` lowers exactly like `REF()` — the rewrite happens before codegen, so
+codegen needs zero changes and these requirements pin the end-to-end
+behavior.
+
+- **REQ-PTR-codegen-500** The Goal example executes: inside a function-block instance called from a `PROGRAM`, `pNumber := ADR(iNumber1); iNumber2 := pNumber^;` yields the addressed member's value.
+- **REQ-PTR-codegen-501** Storing through an `ADR`-bound pointer (`p^ := v`) updates the addressed variable.
+- **REQ-PTR-codegen-502** An `ADR`-bound pointer compares non-equal to `NULL`, and an unbound pointer defaults to `NULL` (dereferencing it traps).
+- **REQ-PTR-codegen-510** The `twincat` and `codesys` dialect presets compile and run the Goal example with no explicit flags.
 
 ## Rendering (plc2plc)
 

--- a/specs/plans/2026-08-11-adr-operator-and-pointer-to.md
+++ b/specs/plans/2026-08-11-adr-operator-and-pointer-to.md
@@ -221,11 +221,11 @@ It supersedes the "out of scope" notes in
 - [x] `cd compiler && just` — all checks pass
 
 ### Phase 2 — `ADR`
-- [ ] Analyzer rewrite `ADR(var)` → `ExprKind::Ref` gated by `allow_adr`; arity/operand diagnostics; verify `rule_ref_to` gating admits it without `allow_ref_to`
-- [ ] Negative tests: `ADR` of array element / struct field / literal / call result → P2028/P2030; flag off → P4017
-- [ ] End-to-end tests in `end_to_end_adr.rs`: Goal example runs (deref yields 5); `p^ := v` store-through; FB instance address; `NULL` compare
-- [ ] Dialect test: TwinCAT + CODESYS presets compile the Goal example with no explicit flags
-- [ ] `cd compiler && just` — all checks pass
+- [x] Analyzer rewrite `ADR(var)` → `ExprKind::Ref` gated by `allow_adr` (new `xform_resolve_adr`); arity/operand diagnostics; `rule_ref_to` runs unconditionally so the rewritten node is validated without `allow_ref_to`
+- [x] Negative tests: `ADR` of array element / struct field / literal / call result → P2028/P2030; flag off → P4017 (`analyzer/src/spec_conformance_adr.rs`)
+- [x] End-to-end tests in `end_to_end_adr.rs`: Goal example runs (deref yields 5 — assigned in the body, since FB member initial values are not yet applied to instances); `p^ := v` store-through; per-instance FB member addressing; `NULL` compare
+- [x] Dialect test: TwinCAT + CODESYS presets compile the Goal example with no explicit flags
+- [x] `cd compiler && just` — all checks pass
 
 ### Phase 3 — docs
 - [ ] Docs + stale-comment sweep per Phase 3 file map


### PR DESCRIPTION
## Summary

Implements the `ADR()` address-of operator (Phase 2 of the pointer-to feature), enabling typed pointer binding without requiring the `REF_TO`/`REF()`/`NULL` keywords. The operator is gated by the `allow_adr` flag and enabled in the `twincat` and `codesys` dialects.

## Key Changes

### Analyzer
- **New transform `xform_resolve_adr`**: Rewrites `ADR(x)` function calls to `ExprKind::Ref` when `allow_adr` is enabled, enabling the call to reuse existing reference type inference and validation without requiring `allow_ref_to`
- Operand validation: rejects non-variables (literals, call results), wrong arity, array elements, struct fields, and ephemeral variables with appropriate diagnostics (P2028/P2029/P2030)
- Invalid operands are lowered to `NULL` to prevent cascading "undeclared function" errors
- Transform runs after implicit-deref and before symbol/function resolution

### Parser & Options
- Added `allow_adr` compiler option to `CompilerOptions`
- Enabled in `twincat` and `codesys` dialect presets
- Disabled in `iec61131-3-ed2`, `iec61131-3-ed3`, and `rusty` presets
- CLI flag `--allow-adr` and LSP initialization option support

### Testing
- **Spec conformance tests** (analyzer, codegen, parser): 16 tests covering requirements REQ-PTR-parser-400 through REQ-PTR-codegen-510
  - Analyzer: operand validation, type checking, ephemeral variable rejection
  - Codegen: end-to-end execution, pointer dereferencing, NULL guards, dialect presets
  - Parser: dialect preset verification
- **End-to-end tests**: Goal example (FB instance binding pointer to member), store-through, multiple instances, NULL guards, unbound pointer traps
- **plc2plc round-trip tests**: Verify `ADR()` parses and renders correctly as an ordinary function call
- **Feature flag conformance**: Verify flag behavior (off → P4017, on → rewrite)

### Documentation
- Updated `specs/design/adr-and-pointer-to.md` with Phase 2 requirements (400–510)
- Updated dialect documentation to reflect `ADR()` support in `twincat` and `codesys`
- Added CLI reference documentation for `--allow-adr`

## Implementation Details

- **No parser changes needed**: `ADR(x)` parses as an ordinary function call (like `SIZEOF`), so plc2plc round-trips it unchanged
- **Reuses reference backend**: The rewritten `ExprKind::Ref` node uses existing reference type inference, assignment checking (P2032), and codegen — no new opcodes required
- **Works without `allow_ref_to`**: Reference semantic rules validate `ExprKind::Ref` unconditionally, so `ADR`-produced nodes are accepted even when `REF_TO`/`REF()`/`NULL` keywords are unavailable
- **Graceful fallback**: With `allow_adr` off, `ADR` remains an ordinary identifier and the call is reported as an undeclared function (P4017), matching `SIZEOF` behavior

https://claude.ai/code/session_01UostSaNZ6S5kmVU9iWTtKA