### PR TITLE
Add TwinCAT how-to guides and compatibility library reference

### DIFF
--- a/.kiro/steering/coming-from-guide-authoring.md
+++ b/.kiro/steering/coming-from-guide-authoring.md
@@ -1,0 +1,10 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "docs/how-to-guides/**"
+---
+
+# "Coming from X" Guide Authoring
+
+See [specs/steering/coming-from-guide-authoring.md](../../specs/steering/coming-from-guide-authoring.md) for the full authoring guide.
+
+This file governs how the documentation website's "Coming from X" how-to sections are written — the standard page set and slugs, the URL-stability policy (published URLs are never deleted or renamed), page templates, and the rule that every documented command is verified against a checked-in fixture — so the sections stay parallel across all source products.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Before making changes, read the relevant steering files in `specs/steering/`:
 - **[PLCopen XML Module](specs/steering/plcopen-xml-module.md)** - Architecture and patterns for the PLCopen XML parsing module (especially relevant for `compiler/sources/src/xml/` files)
 - **[Syntax Support Guide](specs/steering/syntax-support-guide.md)** - Checklist and patterns for adding new syntax support, including `--allow-x` flags, plc2plc round-trip tests, and end-to-end execution tests (especially relevant for `**/parser/**`, `**/codegen/**`, `**/plc2plc/**` files)
 - **[Compatibility Library Authoring](specs/steering/compatibility-library-authoring.md)** - Licensing risk tiers, allowed/forbidden inputs, and the clean-room-with-AI workflow for authoring bundled compatibility libraries (especially relevant for `compiler/sources/resources/compat-libraries/` files)
+- **[Coming-from Guide Authoring](specs/steering/coming-from-guide-authoring.md)** - Standard page set, slugs, URL-stability policy, and content rules for the "Coming from X" how-to sections of the docs website (especially relevant for `docs/how-to-guides/**` files)
 
 ## Skills (Slash Commands)
 

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -15,6 +15,7 @@ Before making changes, read the relevant steering files in `specs/steering/`:
 - **[Problem Code Management](specs/steering/problem-code-management.md)** - Problem codes, diagnostics, and `compiler/problems/` workflows
 - **[Extension Testing Requirements](specs/steering/extension-testing-requirements.md)** - VS Code extension CI gates and invariants (especially relevant for `integrations/vscode/**`)
 - **[Steering File Guidelines](specs/steering/steering-file-guidelines.md)** - How IronPLC maintains steering docs and the pointer pattern
+- **[Coming-from Guide Authoring](specs/steering/coming-from-guide-authoring.md)** - Standard page set, slugs, URL-stability policy, and content rules for the "Coming from X" how-to sections of the docs website (especially relevant for `docs/how-to-guides/**` files)
 
 ## Skills (Slash Commands) — Claude Code
 

--- a/docs/how-to-guides/twincat/check-twincat-projects.rst
+++ b/docs/how-to-guides/twincat/check-twincat-projects.rst
@@ -3,35 +3,71 @@ Check TwinCAT 3 Projects
 ============================
 
 This guide shows how to use IronPLC to check a Beckhoff TwinCAT 3 project
-for correctness.
+for correctness — without changing the project.
 
 .. include:: ../../includes/requires-compiler.rst
+
+-------------------------------------------
+Check a Solution from the Command Line
+-------------------------------------------
+
+Point IronPLC at your solution directory and select the ``twincat``
+dialect:
+
+.. code-block:: shell
+
+   ironplcc check --dialect twincat path/to/my-solution
+
+IronPLC walks the solution layout the same way TwinCAT XAE does: past the
+:file:`.sln` and :file:`.tsproj` files, into each :file:`.plcproj` PLC
+project, which it reads to discover the :file:`.TcPOU`, :file:`.TcGVL`,
+:file:`.TcDUT`, and :file:`.TcIO` files to analyze. A solution that
+contains more than one PLC project is checked as a whole, so code in one
+project can use types and functions declared in another.
+
+On success, the command produces no output. If there are problems, IronPLC
+prints diagnostics with the file name, line number, and a description of
+each problem.
+
+The ``--dialect twincat`` option matters: it tells IronPLC to accept the
+language extensions that TwinCAT accepts, so TwinCAT-specific syntax works
+by default and you do not need to enable individual features. See
+:doc:`/explanation/enabling-dialects-and-features` for how dialects work.
+
+If your project references Beckhoff libraries such as ``Tc2_System``,
+IronPLC activates its bundled compatibility libraries automatically — see
+:doc:`use-beckhoff-libraries`.
+
+-------------------------------------------
+Check a Single File
+-------------------------------------------
+
+You can also check individual TwinCAT files:
+
+.. code-block:: shell
+
+   ironplcc check --dialect twincat MyProgram.TcPOU
+
+Checking a single file is useful for a quick look, but prefer checking the
+solution directory: only there can IronPLC resolve names declared in other
+files and read the project's library references.
 
 -----------------------------------
 Check with the VS Code Extension
 -----------------------------------
 
-1. Open your TwinCAT project folder in VS Code.
-2. Open any TwinCAT source file.
-3. The extension highlights errors and warnings in the editor as you type.
+1. Open your TwinCAT solution folder in VS Code.
+2. In the settings (:menuselection:`File --> Preferences --> Settings`),
+   set :guilabel:`Ironplc: Dialect` to ``twincat``.
+3. Open any TwinCAT source file. The extension highlights errors and
+   warnings in the editor as you type.
 
 -------------------------------------------
-Check with the Command Line
+See Also
 -------------------------------------------
 
-You can check individual TwinCAT files:
-
-.. code-block:: shell
-
-   ironplcc check MyProgram.TcPOU
-
-Or check an entire TwinCAT project by pointing to the directory containing
-the :file:`.plcproj` file. IronPLC reads the project file to discover which
-source files to analyze:
-
-.. code-block:: shell
-
-   ironplcc check path/to/my-twincat-project
-
-See :doc:`/reference/compiler/source-formats/twincat` for supported file types and
-format details.
+- :doc:`/reference/compiler/source-formats/twincat` — supported file types
+  and how project discovery works
+- :doc:`/explanation/enabling-dialects-and-features` — what the ``twincat``
+  dialect enables
+- :doc:`run-twincat-projects` — the next step: execute the project

--- a/docs/how-to-guides/twincat/index.rst
+++ b/docs/how-to-guides/twincat/index.rst
@@ -5,11 +5,33 @@ Coming from TwinCAT
 These guides are for engineers who already use Beckhoff TwinCAT 3 and want
 to use IronPLC alongside it.
 
-IronPLC can read TwinCAT project files (:file:`.plcproj`, :file:`.TcPOU`,
-:file:`.TcGVL`) directly, so you can get a second opinion on your code
-without changing your workflow.
+IronPLC reads your TwinCAT solution as-is — the :file:`.sln`,
+:file:`.tsproj`, and :file:`.plcproj` project files and the
+:file:`.TcPOU`, :file:`.TcGVL`, :file:`.TcDUT`, and :file:`.TcIO` source
+files that TwinCAT XAE created. Without changing your project or your
+workflow, you can:
+
+- **check** your project for problems and get a second opinion on your code,
+- **run** your control logic on any computer — no TwinCAT runtime, license,
+  or PLC hardware required, and
+- keep using the **Beckhoff libraries** your project references, backed by
+  IronPLC's bundled compatibility libraries.
 
 .. toctree::
    :maxdepth: 1
 
    Check TwinCAT 3 Projects <check-twincat-projects>
+   Run TwinCAT 3 Projects Without a PLC <run-twincat-projects>
+   Use Beckhoff Libraries <use-beckhoff-libraries>
+
+------------------------------------
+What Works Today
+------------------------------------
+
+IronPLC checks and executes Structured Text (the language behind most
+TwinCAT PLC code); graphical languages are not supported. Library support
+is early: IronPLC bundles compatibility implementations for a growing set
+of the most common ``Tc2_*`` libraries. See
+:doc:`/reference/compiler/source-formats/twincat` for the supported file
+formats and :doc:`/reference/compatibility-libraries/index` for exactly
+which library functions are available.

--- a/docs/how-to-guides/twincat/run-twincat-projects.rst
+++ b/docs/how-to-guides/twincat/run-twincat-projects.rst
@@ -13,9 +13,9 @@ testing control logic on a laptop or in a CI/CD pipeline.
 Compile the Solution
 -------------------------------------------
 
-Compile your solution into a bytecode container. The command takes the
-same input as ``check`` — point it at the solution directory and select
-the ``twincat`` dialect:
+Compile your solution into a bytecode container: point
+:program:`ironplcc` at the solution directory and select the ``twincat``
+dialect:
 
 .. code-block:: shell
 

--- a/docs/how-to-guides/twincat/run-twincat-projects.rst
+++ b/docs/how-to-guides/twincat/run-twincat-projects.rst
@@ -1,0 +1,78 @@
+=====================================
+Run TwinCAT 3 Projects Without a PLC
+=====================================
+
+This guide shows how to compile a Beckhoff TwinCAT 3 project and execute
+its logic in the IronPLC virtual machine — on any computer, with no
+TwinCAT runtime, no license, and no PLC hardware. This is useful for
+testing control logic on a laptop or in a CI/CD pipeline.
+
+.. include:: ../../includes/requires-compiler.rst
+
+-------------------------------------------
+Compile the Solution
+-------------------------------------------
+
+Compile your solution into a bytecode container. The command takes the
+same input as ``check`` — point it at the solution directory and select
+the ``twincat`` dialect:
+
+.. code-block:: shell
+
+   ironplcc compile --dialect twincat path/to/my-solution --output main.iplc
+
+IronPLC discovers the sources through the :file:`.plcproj` project files,
+activates any referenced Beckhoff libraries (see
+:doc:`use-beckhoff-libraries`), and on success creates :file:`main.iplc` —
+the compiled bytecode that the IronPLC virtual machine executes.
+
+-------------------------------------------
+Run the Compiled Program
+-------------------------------------------
+
+Run the container in the IronPLC virtual machine:
+
+.. code-block:: shell
+
+   ironplcvm run main.iplc --scans 1 --dump-vars
+
+The ``--scans 1`` flag runs one scan cycle, and ``--dump-vars`` prints the
+value of every variable after execution. For a program that converts a
+commanded speed from degrees to radians, the output looks like:
+
+.. code-block:: text
+
+   commandedDegPerSec: 15
+   commandedRadPerSec: 0.2617993877991494
+
+Your ``MAIN`` program runs exactly as it would in each PLC cycle. To
+observe state that evolves over time — timers, counters, edge triggers —
+increase ``--scans``.
+
+-------------------------------------------
+Run in a CI/CD Pipeline
+-------------------------------------------
+
+Both tools return a non-zero exit code on failure, so the same commands
+work as a pipeline gate:
+
+.. code-block:: shell
+
+   ironplcc check --dialect twincat . || exit 1
+   ironplcc compile --dialect twincat . --output main.iplc || exit 1
+   ironplcvm run main.iplc --scans 10 || exit 1
+
+This catches problems on every commit — before the code ever reaches a
+test rig.
+
+-------------------------------------------
+See Also
+-------------------------------------------
+
+- :doc:`/how-to-guides/getting-started/check-compile-run-from-cli` — the
+  same workflow explained for plain IEC 61131-3 files
+- :doc:`/reference/compiler/ironplcc` — full :program:`ironplcc` command
+  reference
+- :doc:`/reference/runtime/ironplcvm` — full :program:`ironplcvm` command
+  reference
+- :doc:`/explanation/execution-cycle` — how scan cycles work

--- a/docs/how-to-guides/twincat/use-beckhoff-libraries.rst
+++ b/docs/how-to-guides/twincat/use-beckhoff-libraries.rst
@@ -1,0 +1,113 @@
+========================
+Use Beckhoff Libraries
+========================
+
+This guide shows how IronPLC handles the Beckhoff libraries a TwinCAT 3
+project references — and how to structure your own libraries so IronPLC
+compiles them together with your application.
+
+.. include:: ../../includes/requires-compiler.rst
+
+-------------------------------------------
+Referenced Libraries Work Automatically
+-------------------------------------------
+
+When your :file:`.plcproj` references a Beckhoff library — for example
+``Tc2_System`` — IronPLC reads the reference from the project file and
+activates its own bundled *compatibility library*: an independently
+authored implementation of the same functions and constants, under their
+exact names. You change nothing; code like this checks, compiles, and
+runs as-is:
+
+.. code-block::
+
+   FUNCTION F_DegreesToRadians : LREAL
+   VAR_INPUT
+       degrees : LREAL;
+   END_VAR
+   F_DegreesToRadians := degrees * PI / 180.0;
+   END_FUNCTION
+
+Here ``PI`` comes from the ``Tc2_System`` reference in the project file.
+A library is only activated when your project references it, matching
+TwinCAT's own behavior.
+
+The built-in conversion operators that TwinCAT provides to every project
+without any reference — for example ``BOOL_TO_STRING`` — are always
+available in TwinCAT projects through the implicit ``Tc2_BuiltIns``
+compatibility library.
+
+-------------------------------------------
+Which Libraries Are Bundled
+-------------------------------------------
+
+Library support is early, and coverage grows release by release. IronPLC
+currently bundles compatibility libraries for ``Tc2_System``,
+``Tc2_Math``, ``Tc2_Utilities``, and the implicit ``Tc2_BuiltIns``. See
+:doc:`/reference/compatibility-libraries/index` for exactly which
+functions and constants each one provides.
+
+If your project references a library that IronPLC does not bundle, the
+check stops with problem
+:doc:`P6011 </reference/compiler/problems/P6011>` naming the library, so
+you know immediately which dependency is missing rather than getting a
+cascade of undefined-symbol errors.
+
+-------------------------------------------
+Activate a Library for Loose Files
+-------------------------------------------
+
+When you check files without a :file:`.plcproj` — a single POU, or plain
+Structured Text — there is no project file to read references from. Use
+the ``--library`` option to activate a library explicitly:
+
+.. code-block:: shell
+
+   ironplcc check --dialect twincat --library Tc2_System MyFunction.TcPOU
+
+The option is repeatable: pass ``--library`` once per library.
+
+-------------------------------------------
+Use Your Own Libraries
+-------------------------------------------
+
+If you factor shared code into your own PLC library project, keep the
+library's *source* project inside the solution (or workspace) you give
+IronPLC. IronPLC merges every :file:`.plcproj` it discovers into one
+compilation unit, so your application resolves the library's functions,
+function blocks, and types directly from their source:
+
+.. code-block:: text
+
+   MySolution/
+   ├── MySolution.sln
+   ├── App/
+   │   ├── App.plcproj
+   │   └── POUs/MAIN.TcPOU          (calls F_Scale)
+   └── MyLib/
+       ├── MyLib.plcproj
+       └── POUs/F_Scale.TcPOU
+
+IronPLC does not read precompiled or managed library files
+(:file:`.library` / :file:`.compiled-library`), so a library that exists
+only in TwinCAT's library repository is not visible to IronPLC — the
+library's source must be present in the directory you check.
+
+-------------------------------------------
+About the Compatibility Libraries
+-------------------------------------------
+
+IronPLC is an independent open-source project and is not affiliated with,
+endorsed by, or sponsored by Beckhoff Automation. The bundled
+compatibility libraries are authored independently to reproduce the
+documented interfaces of the corresponding Beckhoff libraries so that
+your code works in both environments; they contain no Beckhoff code.
+
+-------------------------------------------
+See Also
+-------------------------------------------
+
+- :doc:`/reference/compatibility-libraries/index` — bundled libraries and
+  the symbols each provides
+- :doc:`check-twincat-projects` — checking the solution that references
+  the libraries

--- a/docs/how-to-guides/twincat/use-beckhoff-libraries.rst
+++ b/docs/how-to-guides/twincat/use-beckhoff-libraries.rst
@@ -97,11 +97,7 @@ library's source must be present in the directory you check.
 About the Compatibility Libraries
 -------------------------------------------
 
-IronPLC is an independent open-source project and is not affiliated with,
-endorsed by, or sponsored by Beckhoff Automation. The bundled
-compatibility libraries are authored independently to reproduce the
-documented interfaces of the corresponding Beckhoff libraries so that
-your code works in both environments; they contain no Beckhoff code.
+.. include:: ../../includes/compat-library-independence.rst
 
 -------------------------------------------
 See Also

--- a/docs/includes/compat-library-independence.rst
+++ b/docs/includes/compat-library-independence.rst
@@ -1,0 +1,5 @@
+IronPLC is an independent open-source project and is not affiliated with,
+endorsed by, or sponsored by the vendors whose library interfaces the
+compatibility libraries reproduce. Each compatibility library is authored
+independently from the vendor's public documentation and contains no
+vendor code. See :doc:`/trademarks`.

--- a/docs/reference/compatibility-libraries/index.rst
+++ b/docs/reference/compatibility-libraries/index.rst
@@ -1,0 +1,68 @@
+=======================
+Compatibility Libraries
+=======================
+
+IronPLC bundles *compatibility libraries*: independently authored
+implementations of functions, function blocks, and constants from vendor
+PLC libraries, under their exact vendor names. They exist so that source
+code written against a vendor's library checks, compiles, and runs in
+IronPLC without changes.
+
+Compatibility libraries stay dormant until **activated**. A library is
+activated in one of three ways:
+
+1. **Project reference** — a discovered project file (for example a
+   TwinCAT :file:`.plcproj`) references the library by name. This is the
+   normal path; see :doc:`/how-to-guides/twincat/use-beckhoff-libraries`.
+2. **Explicit option** — ``ironplcc check --library <name>`` (repeatable),
+   for sources without a project file.
+3. **Implicit** — a library that the vendor's environment provides to
+   every project with no reference (for example ``Tc2_BuiltIns``) is
+   activated automatically whenever a project for that vendor is
+   discovered.
+
+Referencing a library that IronPLC does not bundle reports problem
+:doc:`P6011 </reference/compiler/problems/P6011>`. Library names are
+matched exactly and case-sensitively.
+
+Bundled Libraries
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 60 15
+
+   * - Library
+     - Provides
+     - Activation
+   * - :doc:`Tc2_System <tc2-system>`
+     - System constants (``PI``)
+     - Reference
+   * - :doc:`Tc2_Math <tc2-math>`
+     - ``LREAL`` math functions (``LTRUNC``, ``LMOD``, ``MODABS``,
+       ``FRAC``)
+     - Reference
+   * - :doc:`Tc2_Utilities <tc2-utilities>`
+     - Formatting functions (``LREAL_TO_FMTSTR``)
+     - Reference
+   * - :doc:`Tc2_BuiltIns <tc2-builtins>`
+     - TwinCAT's implicit built-in operators (``BOOL_TO_STRING``)
+     - Implicit
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   Tc2_System <tc2-system>
+   Tc2_Math <tc2-math>
+   Tc2_Utilities <tc2-utilities>
+   Tc2_BuiltIns <tc2-builtins>
+
+Independence
+------------
+
+IronPLC is an independent open-source project and is not affiliated with,
+endorsed by, or sponsored by the vendors whose library interfaces these
+compatibility libraries reproduce. Each library is authored independently
+from the vendor's public documentation and contains no vendor code. See
+:doc:`/trademarks`.

--- a/docs/reference/compatibility-libraries/index.rst
+++ b/docs/reference/compatibility-libraries/index.rst
@@ -61,8 +61,4 @@ Bundled Libraries
 Independence
 ------------
 
-IronPLC is an independent open-source project and is not affiliated with,
-endorsed by, or sponsored by the vendors whose library interfaces these
-compatibility libraries reproduce. Each library is authored independently
-from the vendor's public documentation and contains no vendor code. See
-:doc:`/trademarks`.
+.. include:: ../../includes/compat-library-independence.rst

--- a/docs/reference/compatibility-libraries/tc2-builtins.rst
+++ b/docs/reference/compatibility-libraries/tc2-builtins.rst
@@ -30,6 +30,11 @@ Example
 
    statusText := BOOL_TO_STRING(running);
 
+Independence
+------------
+
+.. include:: ../../includes/compat-library-independence.rst
+
 See Also
 --------
 

--- a/docs/reference/compatibility-libraries/tc2-builtins.rst
+++ b/docs/reference/compatibility-libraries/tc2-builtins.rst
@@ -1,0 +1,40 @@
+============
+Tc2_BuiltIns
+============
+
+Compatibility library for the operators that TwinCAT 3 provides to every
+PLC project *without* any library reference. Because the vendor
+environment treats these as implicitly available, IronPLC activates this
+library automatically whenever it discovers a TwinCAT project — no
+project reference or ``--library`` option is needed.
+
+Functions
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 30 45
+
+   * - Name
+     - Signature
+     - Description
+   * - ``BOOL_TO_STRING``
+     - ``BOOL_TO_STRING(IN : BOOL) : STRING``
+     - Converts a boolean to its text form: ``TRUE`` returns
+       ``'TRUE'``, ``FALSE`` returns ``'FALSE'``.
+
+Example
+-------
+
+.. code-block::
+
+   statusText := BOOL_TO_STRING(running);
+
+See Also
+--------
+
+* :doc:`index` — how compatibility libraries are activated
+* :doc:`/reference/standard-library/functions/type-conversions` — the IEC
+  standard conversion functions
+* `Beckhoff TwinCAT 3: type conversion operators <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/3998090635.html>`_
+  — the vendor documentation this interface reproduces

--- a/docs/reference/compatibility-libraries/tc2-math.rst
+++ b/docs/reference/compatibility-libraries/tc2-math.rst
@@ -43,6 +43,11 @@ Example
 
    angle := MODABS(IN := rawAngle, IM := 360.0);
 
+Independence
+------------
+
+.. include:: ../../includes/compat-library-independence.rst
+
 See Also
 --------
 

--- a/docs/reference/compatibility-libraries/tc2-math.rst
+++ b/docs/reference/compatibility-libraries/tc2-math.rst
@@ -1,0 +1,51 @@
+========
+Tc2_Math
+========
+
+Compatibility library for Beckhoff's TwinCAT 3 ``Tc2_Math`` PLC library:
+``LREAL`` math functions. Activated by a project reference or
+``--library Tc2_Math``.
+
+Functions
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 25 55
+
+   * - Name
+     - Signature
+     - Description
+   * - ``LTRUNC``
+     - ``LTRUNC(IN : LREAL) : LREAL``
+     - Integer part of *IN*, rounding toward zero. Unlike the IEC
+       :doc:`TRUNC </reference/standard-library/functions/trunc>` (which
+       returns an integer type), the result stays ``LREAL``, so values
+       beyond any integer type's range truncate exactly without clamping.
+   * - ``LMOD``
+     - ``LMOD(IN1 : LREAL, IN2 : LREAL) : LREAL``
+     - Floating modulo returning the signed remainder (IEEE-754
+       ``fmod``): the result has the sign of *IN1* and a magnitude less
+       than that of *IN2*.
+   * - ``MODABS``
+     - ``MODABS(IN : LREAL, IM : LREAL) : LREAL``
+     - Modulo returning the unsigned representative in ``[0.0, |IM|)`` —
+       the wrap-around commonly used for positioning.
+   * - ``FRAC``
+     - ``FRAC(IN : LREAL) : LREAL``
+     - Fractional part of *IN*: keeps the sign of the input, with a
+       magnitude less than 1.0.
+
+Example
+-------
+
+.. code-block::
+
+   angle := MODABS(IN := rawAngle, IM := 360.0);
+
+See Also
+--------
+
+* :doc:`index` — how compatibility libraries are activated
+* `Beckhoff TwinCAT 3: Tc2_Math functions <https://infosys.beckhoff.com/content/1033/tcplclib_tc2_math/68440331.html>`_
+  — the vendor documentation this interface reproduces

--- a/docs/reference/compatibility-libraries/tc2-system.rst
+++ b/docs/reference/compatibility-libraries/tc2-system.rst
@@ -1,0 +1,40 @@
+==========
+Tc2_System
+==========
+
+Compatibility library for Beckhoff's TwinCAT 3 ``Tc2_System`` PLC
+library. Activated by a project reference or ``--library Tc2_System``.
+
+Constants
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Name
+     - Type
+     - Description
+   * - ``PI``
+     - ``LREAL``
+     - The mathematical constant π (3.14159265358979...), as a global
+       constant.
+
+Example
+-------
+
+.. code-block::
+
+   FUNCTION F_DegreesToRadians : LREAL
+   VAR_INPUT
+       degrees : LREAL;
+   END_VAR
+   F_DegreesToRadians := degrees * PI / 180.0;
+   END_FUNCTION
+
+See Also
+--------
+
+* :doc:`index` — how compatibility libraries are activated
+* `Beckhoff TwinCAT 3: Tc2_System PI constant <https://infosys.beckhoff.com/english.php?content=../content/1033/tcplclib_tc2_system/31084171.html&id=>`_
+  — the vendor documentation this interface reproduces

--- a/docs/reference/compatibility-libraries/tc2-system.rst
+++ b/docs/reference/compatibility-libraries/tc2-system.rst
@@ -32,6 +32,11 @@ Example
    F_DegreesToRadians := degrees * PI / 180.0;
    END_FUNCTION
 
+Independence
+------------
+
+.. include:: ../../includes/compat-library-independence.rst
+
 See Also
 --------
 

--- a/docs/reference/compatibility-libraries/tc2-utilities.rst
+++ b/docs/reference/compatibility-libraries/tc2-utilities.rst
@@ -25,9 +25,8 @@ Functions
        rendered (NaN, infinities, magnitudes of 2\ :sup:`63` or more)
        return an empty string.
 
-The formal parameter names (``in``, ``iPrecision``, ``bRound``) match the
-vendor's documented names, so source that passes arguments by name
-resolves unchanged.
+The formal parameter names (``in``, ``iPrecision``, ``bRound``) match
+the vendor's documented names.
 
 Example
 -------
@@ -36,6 +35,11 @@ Example
 
    text := LREAL_TO_FMTSTR(in := 3.14159, iPrecision := 2, bRound := TRUE);
    (* text = '3.14' *)
+
+Independence
+------------
+
+.. include:: ../../includes/compat-library-independence.rst
 
 See Also
 --------

--- a/docs/reference/compatibility-libraries/tc2-utilities.rst
+++ b/docs/reference/compatibility-libraries/tc2-utilities.rst
@@ -1,0 +1,46 @@
+=============
+Tc2_Utilities
+=============
+
+Compatibility library for Beckhoff's TwinCAT 3 ``Tc2_Utilities`` PLC
+library: utility and formatting functions. Activated by a project
+reference or ``--library Tc2_Utilities``.
+
+Functions
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 30 45
+
+   * - Name
+     - Signature
+     - Description
+   * - ``LREAL_TO_FMTSTR``
+     - ``LREAL_TO_FMTSTR(in : LREAL, iPrecision : INT, bRound : BOOL) : STRING``
+     - Formats *in* as a fixed-point decimal string with *iPrecision*
+       digits after the decimal point (clamped to 0..15). When *bRound*
+       is ``TRUE`` the last place is rounded (half away from zero);
+       when ``FALSE`` it is truncated toward zero. Values that cannot be
+       rendered (NaN, infinities, magnitudes of 2\ :sup:`63` or more)
+       return an empty string.
+
+The formal parameter names (``in``, ``iPrecision``, ``bRound``) match the
+vendor's documented names, so source that passes arguments by name
+resolves unchanged.
+
+Example
+-------
+
+.. code-block::
+
+   text := LREAL_TO_FMTSTR(in := 3.14159, iPrecision := 2, bRound := TRUE);
+   (* text = '3.14' *)
+
+See Also
+--------
+
+* :doc:`index` — how compatibility libraries are activated
+* `Beckhoff Information System <https://infosys.beckhoff.com/>`_ — the
+  vendor documentation this interface reproduces (TwinCAT 3 → PLC
+  libraries → Tc2_Utilities)

--- a/docs/reference/compiler/ironplcc.rst
+++ b/docs/reference/compiler/ironplcc.rst
@@ -44,13 +44,13 @@ Build Commands
    Compile source files into a bytecode container (``.iplc``) file. Requires
    the ``--output`` (``-o``) flag to specify the output file path.
 
-   .. warning::
+   .. note::
 
-      The compile command currently supports only trivial programs. Supported
-      features include: ``PROGRAM`` declarations, ``INT`` variable declarations,
-      assignment statements, integer literal constants, and the ``+`` (add)
-      operator. Programs using other features will produce a code generation
-      error.
+      The compile command supports Structured Text programs, including
+      functions, function blocks, the standard library, and activated
+      compatibility libraries. A program that uses a feature code
+      generation does not yet support produces a code generation error
+      rather than incorrect bytecode.
 
 Diagnostic Commands
 -------------------
@@ -98,6 +98,13 @@ Options
    override the dialect's defaults. Available values: ``iec61131-3-ed2``
    (default), ``iec61131-3-ed3``, ``rusty``, ``codesys``, ``twincat``. See
    :doc:`/explanation/enabling-dialects-and-features` for details.
+
+``--library`` *NAME*
+   Activate a :doc:`compatibility library </reference/compatibility-libraries/index>`
+   by name (for example ``--library Tc2_System``). Repeat the option to
+   activate several libraries. Applies to the ``check`` and ``compile``
+   commands. Libraries referenced by a discovered project file are
+   activated automatically and do not need this option.
 
 ``--allow-c-style-comments``
    Allow C-style comments (``//`` line comments and ``/* */`` block

--- a/docs/reference/compiler/source-formats/twincat.rst
+++ b/docs/reference/compiler/source-formats/twincat.rst
@@ -34,6 +34,43 @@ Supported Elements
 Project Discovery
 -----------------
 
-When you point IronPLC at a directory containing a TwinCAT project, the compiler
-detects TwinCAT 3 projects by the presence of a :file:`.plcproj` file. It then
-reads the project file to discover which source files to analyze.
+When you point IronPLC at a directory, the compiler searches it
+recursively for :file:`.plcproj` files — the marker of a TwinCAT 3 PLC
+project. This means you can point IronPLC at any level of the Visual
+Studio solution layout that TwinCAT XAE creates:
+
+.. code-block:: text
+
+   MySolution/
+   ├── MySolution.sln
+   └── MySolution/
+       ├── MySolution.tsproj
+       └── PlcProject/
+           ├── PlcProject.plcproj
+           └── POUs/
+               ├── MAIN.TcPOU
+               └── F_Helper.TcPOU
+
+The :file:`.sln` and :file:`.tsproj` files are not themselves parsed;
+discovery walks past them to each :file:`.plcproj`, which it reads to
+determine the source files to analyze (the ``<Compile>`` items).
+
+When discovery finds more than one :file:`.plcproj`, all discovered
+projects are merged into a single compilation unit, so code in one
+project can use declarations from another. A project entry that cannot
+be resolved does not abort discovery of the remaining sources.
+
+------------------
+Library References
+------------------
+
+Discovery also reads each :file:`.plcproj` project's library references
+(``<PlaceholderReference>`` and ``<LibraryReference>`` items). A
+reference whose name matches a bundled
+:doc:`compatibility library </reference/compatibility-libraries/index>`
+activates that library automatically; a reference to a library IronPLC
+does not bundle reports problem
+:doc:`P6011 </reference/compiler/problems/P6011>`. Names are matched
+exactly and case-sensitively; the declared version is not used to select
+a package. Precompiled library files (:file:`.library` /
+:file:`.compiled-library`) are not read.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -10,6 +10,7 @@ Technical reference material for IronPLC tools.
    Language <language/index>
    Standard Library <standard-library/index>
    Extension Library <extension-library/index>
+   Compatibility Libraries <compatibility-libraries/index>
    Compiler <compiler/index>
    Runtime <runtime/index>
    MCP Server <mcp/index>

--- a/docs/trademarks.rst
+++ b/docs/trademarks.rst
@@ -16,9 +16,14 @@ documentation, or its source code. All trademarks are the property of
 their respective owners.
 
 * **TwinCAT** is a trademark of Beckhoff Automation GmbH & Co. KG.
-  IronPLC reads ``.TcPOU``, ``.TcGVL``, and ``.TcDUT`` files, which are
-  PLCopen XML payloads produced by TwinCAT. IronPLC is not a product of,
-  affiliated with, or endorsed by Beckhoff Automation.
+  IronPLC reads ``.TcPOU``, ``.TcGVL``, ``.TcDUT``, and ``.TcIO`` files,
+  which are PLCopen XML payloads produced by TwinCAT, and the
+  ``.plcproj`` project files that organize them. IronPLC also bundles
+  independently authored compatibility libraries that reproduce
+  documented interfaces of TwinCAT PLC libraries (``Tc2_System``,
+  ``Tc2_Math``, ``Tc2_Utilities``, ``Tc2_BuiltIns``) for
+  interoperability. IronPLC is not a product of, affiliated with, or
+  endorsed by Beckhoff Automation.
 * **CODESYS** is a trademark of CODESYS GmbH. IronPLC provides a
   ``codesys`` dialect preset to read code written for CODESYS-based
   environments. IronPLC is not a product of, affiliated with, or endorsed

--- a/specs/steering/coming-from-guide-authoring.md
+++ b/specs/steering/coming-from-guide-authoring.md
@@ -1,0 +1,138 @@
+# "Coming from X" Guide Authoring
+
+This file governs how the documentation website's **"Coming from X" how-to
+sections** (`docs/how-to-guides/<product>/`) are written, so that every
+section reads the same way regardless of which source product it covers and
+regardless of who — human or AI — writes it. The TwinCAT section is the
+reference implementation of this pattern; the Beremiz section predates parts
+of it and converges over time.
+
+## Purpose and audience
+
+A "Coming from X" section is for an engineer who **already uses product X**
+and wants to use IronPLC *alongside* it — not replace it. The section's job
+is to walk their existing, unmodified project through the IronPLC journey:
+
+1. **Check** — get diagnostics on the project as-is
+2. **Run** — execute the project's logic without the vendor's runtime,
+   license, or hardware
+3. **Libraries** — use the vendor libraries the project references
+   (only when IronPLC bundles compatibility libraries for that vendor)
+
+These are how-to guides in the [Diátaxis](https://diataxis.fr/) sense:
+task-oriented, one goal per page, no teaching of concepts. Concepts belong
+in `docs/explanation/`, exhaustive detail in `docs/reference/`.
+
+## URL stability policy
+
+**Published URLs are permanent. Never delete or rename a page that has
+shipped.** External sites, search engines, and diagnostics link to these
+pages; a removed page is a broken link we cannot fix from our side.
+
+- Improve a page by **rewriting its content in place**, keeping its file
+  name (and therefore its URL).
+- Add capability coverage as **new pages** with slugs from the standard set
+  below — never by renaming an existing page.
+- If a page's task becomes genuinely obsolete, keep the page as a short
+  stub that states what changed and links to the replacement. Do not
+  remove the file.
+- Choose new slugs expecting them to live forever: task-first, no version
+  numbers, no words tied to a capability's current maturity (avoid e.g.
+  `preview`, `experimental`, `new`).
+
+## Standard page set and slugs
+
+Every "Coming from X" section uses the same slugs so the sections stay
+parallel across products (`<product>` is the lowercase directory name,
+e.g. `twincat`):
+
+| Slug | Task | When present |
+|---|---|---|
+| `index` | Section landing page | Always |
+| `check-<product>-projects` | Check a project for problems | Always |
+| `run-<product>-projects` | Compile and run without the vendor runtime | When the product's projects can execute on the IronPLC VM |
+| `use-<vendor>-libraries` | Use vendor libraries the project references | When compatibility libraries exist for the vendor (see the [glossary](glossary.md) for *vendor* vs. *dialect*) |
+
+Additional tasks get their own pages with **verb-first slugs**
+(`<verb>-<object>`), added to the section's toctree in journey order:
+check, then run, then libraries, then anything else.
+
+## The index page
+
+The landing page must contain, in order:
+
+1. **The promise, concretely.** One short paragraph: IronPLC reads the
+   product's projects **as-is** — name the actual file and project
+   extensions — and what the reader gets (check it, run it, use its
+   libraries). Lead with what works on their existing files, not with
+   what IronPLC is.
+2. **The journey.** The toctree, in journey order, with explicit titles.
+3. **What works today.** A short, honest expectations paragraph: the
+   maturity of support (e.g. which language IronPLC executes, that library
+   support is early), linking to the reference pages that carry the
+   details. Understating and delivering beats overstating; a reader who
+   hits an undocumented wall does not come back.
+
+## Task page structure
+
+Each task page follows this shape:
+
+- **Title**: the task as an imperative or gerund phrase matching the slug.
+- **Goal sentence**: one sentence stating what the reader accomplishes.
+- The `requires-compiler` include (or the appropriate prerequisite
+  include from `docs/includes/`).
+- **Lead with the realistic case.** The first command operates on the
+  reader's *whole project or solution directory*, exactly as the vendor
+  tool laid it out — not on a single hand-made file. Single-file and
+  special-case variants come after.
+- **Show both surfaces** where both exist: the command line and the
+  VS Code extension (settings, not flags, for the editor).
+- **Show expected output** when seeing it builds confidence (a variable
+  dump, a specific diagnostic) — readers use it to confirm they are on
+  the happy path.
+- **See Also**: links to the relevant reference pages, so the task page
+  can stay short.
+
+## Content rules
+
+- **Do not enumerate syntax support.** The product's dialect preset
+  (`--dialect <name>`) makes vendor syntax work by default; that is one
+  sentence and a link to
+  `docs/explanation/enabling-dialects-and-features.rst`. Per-feature
+  syntax lists live in the reference section and go stale in how-to prose.
+- **Every command must be verified before it ships.** Run each documented
+  command against a checked-in fixture (prefer the end-to-end fixtures
+  under `compiler/*/resources/test/`) and confirm the documented output.
+  A how-to whose first command fails costs more trust than no how-to.
+- **State the failure mode next to the feature.** When a capability has a
+  visible boundary (e.g. a referenced library IronPLC does not bundle),
+  say what the reader will see — including the problem code — and what to
+  do about it.
+- **Name what is not supported** when a reader coming from the product
+  will predictably look for it (e.g. precompiled library files). One
+  sentence, plus the workaround if one exists.
+- **Trademarks.** Use the vendor's product names only nominatively — to
+  identify the files and libraries being read. On pages that reproduce a
+  vendor library surface, include the independence disclaimer (IronPLC is
+  independent and not affiliated with or endorsed by the vendor). Keep
+  `docs/trademarks.rst` in sync when referencing a mark it does not yet
+  list. See also
+  [compatibility-library-authoring.md](compatibility-library-authoring.md)
+  for what may legally ship in library content itself.
+- **House style**: Sphinx roles as used elsewhere in `docs/` —
+  `:file:` for file names and extensions, `:program:` for tools,
+  `:doc:` for internal links; `code-block:: shell` for commands. Match
+  the section-underline characters of the existing pages.
+
+## Checklist: adding a new "Coming from X" section
+
+1. Create `docs/how-to-guides/<product>/index.rst` plus at least
+   `check-<product>-projects.rst`, following the templates above.
+2. Add a grid card **and** a hidden-toctree entry in
+   `docs/how-to-guides/index.rst` ("Coming from X").
+3. Confirm a reference page exists for the product's source format under
+   `docs/reference/compiler/source-formats/` and link it from the check
+   page.
+4. Verify every command against fixtures; add a fixture if none exists.
+5. Check `docs/trademarks.rst` covers the product's marks.
+6. Build the docs and fix any new warnings before pushing.


### PR DESCRIPTION
## Summary

This PR establishes the documentation foundation for IronPLC's TwinCAT 3 support by adding comprehensive how-to guides and reference documentation for bundled compatibility libraries. It includes an authoring standard for "Coming from X" guides to ensure consistency across vendor-specific documentation.

## Key Changes

- **Authoring Standard** (`specs/steering/coming-from-guide-authoring.md`): Defines the structure, URL stability policy, standard page set, and content rules for "Coming from X" guides. Establishes that published URLs are permanent and that every documented command must be verified against checked-in fixtures.

- **TwinCAT How-To Guides**:
  - Expanded `check-twincat-projects.rst` with command-line examples, solution-level checking, and VS Code extension setup
  - Added `run-twincat-projects.rst` showing how to compile and execute TwinCAT projects in the IronPLC VM without vendor runtime or hardware
  - Added `use-beckhoff-libraries.rst` explaining automatic library activation, bundled library coverage, and how to structure custom libraries
  - Updated `index.rst` with concrete promises, the journey structure, and maturity expectations

- **Compatibility Library Reference**:
  - Added `docs/reference/compatibility-libraries/index.rst` documenting how libraries are activated (project reference, explicit option, or implicit)
  - Added reference pages for bundled libraries:
    - `tc2-system.rst` (PI constant)
    - `tc2-math.rst` (LTRUNC, LMOD, MODABS, FRAC functions)
    - `tc2-utilities.rst` (LREAL_TO_FMTSTR function)
    - `tc2-builtins.rst` (BOOL_TO_STRING operator)

- **Compiler Documentation Updates**:
  - Enhanced `source-formats/twincat.rst` with detailed project discovery explanation, solution layout examples, and library reference handling
  - Updated `ironplcc.rst` compile command note to reflect actual capabilities (Structured Text, functions, function blocks, standard library, compatibility libraries)
  - Added `--library` option documentation

- **Metadata Updates**:
  - Added compatibility libraries to `docs/reference/index.rst` toctree
  - Updated `docs/trademarks.rst` to cover TwinCAT file formats and compatibility library independence
  - Added steering file reference in `.kiro/` for guide authoring consistency checks
  - Updated `CLAUDE.md` and `CURSOR.md` to reference the new authoring standard

## Notable Implementation Details

- All how-to guides follow the established pattern: concrete promise, journey structure, and honest expectations about maturity
- Compatibility libraries are documented with exact function signatures and parameter names matching vendor documentation
- Library activation is explained through three mechanisms (project reference, explicit option, implicit) with clear examples
- The authoring standard emphasizes URL permanence and command verification, establishing practices that will scale as more vendor support is added

https://claude.ai/code/session_016ufB73khmyBcausabtGiTb