### PR TITLE
docs: Phase 3 documentation sweep for ADR() and POINTER TO

### DIFF
--- a/docs/explanation/enabling-dialects-and-features.rst
+++ b/docs/explanation/enabling-dialects-and-features.rst
@@ -244,7 +244,8 @@ which flags a dialect already enables by default, see `Supported Dialects`_.
    ``ADR(x)`` in IronPLC has the type ``POINTER TO`` *typeof(x)* and is
    type-checked against the destination pointer's target type. Addresses of
    sub-objects (array elements, structure fields) and pointer arithmetic are
-   not supported and are rejected with a diagnostic.
+   not supported and are rejected with a diagnostic. See
+   :doc:`/reference/extension-library/functions/adr`.
 
 ``--allow-ref-arithmetic``
    Allow arithmetic (``+``, ``-``) and ordering comparisons (``<``, ``>``,

--- a/docs/explanation/references.rst
+++ b/docs/explanation/references.rst
@@ -105,7 +105,7 @@ runtime work together to enforce the following guarantees:
 References identify variables, not raw memory addresses. By default, you
 cannot add, subtract, or use ordering comparisons on a reference. If you need
 pointer arithmetic for compatibility with other PLC environments, you can
-enable it with ``--allow-pointer-arithmetic``.
+enable it with ``--allow-ref-arithmetic``.
 
 **Type safety.**
 A ``REF_TO INT`` can only point to an ``INT``. Assigning it to a
@@ -214,7 +214,7 @@ References in IronPLC have intentional limits that keep programs predictable:
   well-defined location in the variable table.
 - By default, only ``=`` and ``<>`` comparisons are allowed on references.
   Arithmetic and ordering comparisons can be enabled with
-  ``--allow-pointer-arithmetic``.
+  ``--allow-ref-arithmetic``.
 
 For the complete list of restrictions and related compiler diagnostics, see
 :doc:`/reference/language/data-types/derived/reference-types`.

--- a/docs/reference/editor/settings.rst
+++ b/docs/reference/editor/settings.rst
@@ -98,8 +98,9 @@ and a default set of extensions.
   extensions that the CODESYS IDE accepts.
 * ``twincat``: TwinCAT-compatible — Edition 2 base with the extensions
   Beckhoff TwinCAT shares with CODESYS. Unlike ``codesys`` it does not enable
-  the ``REF_TO`` reference extensions, since TwinCAT uses ``REFERENCE TO`` /
-  ``POINTER TO`` (not yet parsed by IronPLC).
+  the ``REF_TO`` reference extensions, since TwinCAT uses ``REFERENCE TO``
+  (bound with ``REF=``) and ``POINTER TO`` (bound with ``ADR()``), which it
+  enables instead.
 
 This setting corresponds to the ``--dialect`` command-line option documented in
 :doc:`/reference/compiler/ironplcc`.

--- a/docs/reference/extension-library/functions/adr.rst
+++ b/docs/reference/extension-library/functions/adr.rst
@@ -1,0 +1,108 @@
+===
+ADR
+===
+
+Returns the address of a variable as a typed pointer.
+
+.. list-table::
+   :widths: 30 70
+
+   * - **IEC 61131-3**
+     - Not part of the standard (Beckhoff TwinCAT / CODESYS extension)
+   * - **Support**
+     - Supported (requires ``--allow-adr``)
+
+Signatures
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 30 30 30
+
+   * - #
+     - Input (IN)
+     - Return Type
+     - Support
+   * - 1
+     - ``ANY`` (a named variable)
+     - ``POINTER TO`` *type of input*
+     - Supported
+
+Description
+-----------
+
+``ADR`` returns the address of a variable, typically for assignment to a
+:doc:`POINTER TO </reference/language/data-types/derived/reference-types>`
+variable that is later dereferenced with ``^``. It is not part of the
+IEC 61131-3 standard but is a Beckhoff TwinCAT / CODESYS extension:
+
+.. code-block::
+
+   pNumber := ADR(iNumber1);   (* point at iNumber1 *)
+   iNumber2 := pNumber^;       (* read through the pointer *)
+   pNumber^ := 7;              (* write through the pointer *)
+
+In TwinCAT and CODESYS, ``ADR`` yields a raw machine address (``PVOID``)
+that those environments also allow assigning to integer types such as
+``DWORD`` or ``LWORD``. IronPLC variables do not have byte addresses, so
+``ADR(x)`` instead has the typed result ``POINTER TO`` *type of x* and is
+type-checked against the destination pointer's target type. This is
+stricter than TwinCAT and CODESYS — see Restrictions below for the
+address-manipulation patterns that do not carry over.
+
+Enabling
+--------
+
+``ADR`` is a language extension and must be explicitly enabled:
+
+.. code-block:: shell
+
+   ironplcc check --allow-pointer-to --allow-adr main.st
+
+.. |flag| replace:: ``--allow-adr``
+.. include:: /includes/enabled-by-flag.rst
+
+Example
+-------
+
+.. playground-with-program::
+   :vars: counter : INT := 42; p : POINTER TO INT; value : INT;
+   :allows: pointer-to,adr
+
+   p := ADR(counter);
+   value := p^;     (* value = 42 *)
+   p^ := 99;        (* counter = 99 *)
+
+Restrictions
+------------
+
+- The operand must be a simple named variable. Addresses of sub-objects —
+  array elements (``ADR(arr[i])``), structure fields (``ADR(s.field)``) —
+  and of literals or call results are rejected.
+- The operand must not be a stack-allocated variable (``VAR_TEMP``, function
+  parameters), which would produce a dangling pointer.
+- The result must be assigned to a pointer or reference variable. Assigning
+  an address to an integer variable (``DWORD``/``LWORD``), pointer
+  arithmetic, and byte-level tricks such as ``MEMCPY`` do not carry over
+  from TwinCAT / CODESYS.
+
+Related Problem Codes
+---------------------
+
+- :doc:`/reference/compiler/problems/P2028` — operand must be a simple variable
+- :doc:`/reference/compiler/problems/P2029` — operand is a stack-allocated variable
+- :doc:`/reference/compiler/problems/P2030` — operand is an array element
+- :doc:`/reference/compiler/problems/P2032` — pointer target type mismatch
+
+External References
+-------------------
+
+- `Beckhoff TwinCAT: ADR <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529015179.html>`__
+- `CODESYS: Operator ADR <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_operator_adr.html>`__
+- `ABB: Operator ADR <https://help.plc.abb.com/_cds_operator_ADR.html>`__
+
+See Also
+--------
+
+- :doc:`/reference/language/data-types/derived/reference-types` — ``POINTER TO``, ``REF_TO``, and ``REFERENCE TO``
+- :doc:`/explanation/enabling-dialects-and-features` — enabling language extensions

--- a/docs/reference/extension-library/functions/index.rst
+++ b/docs/reference/extension-library/functions/index.rst
@@ -11,6 +11,8 @@ IEC 61131-3 standard but are widely supported across PLC environments.
 
    * - Function
      - Description
+   * - :doc:`ADR <adr>`
+     - Address of a variable as a typed pointer (requires ``--allow-adr``)
    * - :doc:`SIZEOF <sizeof>`
      - Size in bytes of a variable or type (requires ``--allow-sizeof``)
    * - :doc:`__ISVALIDREF <isvalidref>`
@@ -20,5 +22,6 @@ IEC 61131-3 standard but are widely supported across PLC environments.
    :maxdepth: 1
    :hidden:
 
+   adr
    sizeof
    isvalidref

--- a/docs/reference/language/data-types/derived/reference-types.rst
+++ b/docs/reference/language/data-types/derived/reference-types.rst
@@ -33,6 +33,24 @@ variable.
       r := 99;                (* write through the reference (implicit deref) *)
       valid := __ISVALIDREF(r);  (* TRUE once bound, FALSE while unbound *)
 
+.. note::
+
+   Beckhoff TwinCAT and CODESYS also have a pointer type, spelled
+   ``POINTER TO`` and bound with the
+   :doc:`ADR() </reference/extension-library/functions/adr>` address-of
+   operator. Enable it with ``--allow-pointer-to`` and ``--allow-adr``, or a
+   dialect that includes them. A ``POINTER TO`` variable behaves like
+   ``REF_TO``: reading or writing the target requires the explicit
+   dereference operator ``^``, unlike the auto-dereferencing
+   ``REFERENCE TO``:
+
+   .. code-block::
+
+      p : POINTER TO INT;
+      p := ADR(counter);      (* point at counter *)
+      value := p^;            (* read through the pointer *)
+      p^ := 99;               (* write through the pointer *)
+
 .. list-table::
    :widths: 30 70
 
@@ -122,9 +140,9 @@ Restrictions
   are not allowed.
 - Nested references (``REF_TO REF_TO``) are not supported.
 - Arithmetic on references is not supported by default. Use
-  ``--allow-pointer-arithmetic`` to enable it.
+  ``--allow-ref-arithmetic`` to enable it.
 - Only ``=`` and ``<>`` comparison operators work with references by default.
-  Use ``--allow-pointer-arithmetic`` to enable ordering comparisons.
+  Use ``--allow-ref-arithmetic`` to enable ordering comparisons.
 
 Related Problem Codes
 ---------------------
@@ -134,9 +152,19 @@ Related Problem Codes
 - :doc:`/reference/compiler/problems/P2032` — Reference type mismatch
 - :doc:`/reference/compiler/problems/P2034` — NULL can only be assigned to REF_TO types
 
+External References
+-------------------
+
+- `Beckhoff TwinCAT: POINTER <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529453451.html>`__
+- `Beckhoff TwinCAT: REFERENCE <https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529458827.html>`__
+- `CODESYS: Data Type POINTER TO <https://content.helpme-codesys.com/en/CODESYS%20Development%20System/_cds_datatype_pointer.html>`__
+- `Schneider Machine Expert: Pointers <https://product-help.schneider-electric.com/Machine%20Expert/V1.1/en/SoMProg/SoMProg/Data_Types/Data_Types-8.htm>`__
+- `ABB: Pointers <https://help.plc.abb.com/AB270_en/_cds_datatype_pointer.html>`__
+
 See Also
 --------
 
+- :doc:`/reference/extension-library/functions/adr` — ``ADR``, the TwinCAT/CODESYS address-of operator
 - :doc:`/reference/extension-library/functions/isvalidref` — ``__ISVALIDREF``, the TwinCAT/CODESYS reference-validity builtin
 - :doc:`/reference/language/edition-support` — edition flags
 - :doc:`/reference/language/variables/scope` — variable scope keywords

--- a/specs/design/reference-to-twincat.md
+++ b/specs/design/reference-to-twincat.md
@@ -252,7 +252,8 @@ bare operand with its dereference.
 
 ## Out of scope (this document)
 
-- `POINTER TO` and the `ADR()`/`^` pointer model.
+- `POINTER TO` and the `ADR()`/`^` pointer model — since implemented; see
+  [adr-and-pointer-to.md](adr-and-pointer-to.md).
 - `S=` / `R=` extended assignment operators.
 - TwinCAT OOP features (methods, properties, interfaces).
 - Implicit dereference of `REFERENCE TO` **array elements** and

--- a/specs/plans/2026-08-11-adr-operator-and-pointer-to.md
+++ b/specs/plans/2026-08-11-adr-operator-and-pointer-to.md
@@ -228,8 +228,8 @@ It supersedes the "out of scope" notes in
 - [x] `cd compiler && just` — all checks pass
 
 ### Phase 3 — docs
-- [ ] Docs + stale-comment sweep per Phase 3 file map
-- [ ] `cd compiler && just` — all checks pass
+- [x] Docs + stale-comment sweep per Phase 3 file map — `adr.rst` feature doc with vendor references; `POINTER TO` section + vendor references in `reference-types.rst`; stale `--allow-pointer-arithmetic` mentions corrected to `--allow-ref-arithmetic`; editor settings, steering dialect table, and `reference-to-twincat.md` deferral note updated. (`integrations/vscode/package.json` needed no change — its dialect description was already accurate; the `enabling-dialects-and-features.rst` / `ironplcc.rst` entries landed with Phase 2 since the website build enforces them.)
+- [x] `cd compiler && just` — all checks pass
 
 ## Out of scope
 

--- a/specs/steering/syntax-support-guide.md
+++ b/specs/steering/syntax-support-guide.md
@@ -207,7 +207,7 @@ Dialects (`--dialect`) set the base configuration. Individual `--allow-*` flags 
 | IEC 61131-3 Ed 3 | `iec61131-3-ed3` | ON | ON | all OFF |
 | RuSTy | `rusty` | OFF | ON | all ON |
 | CODESYS | `codesys` | OFF | ON | all ON except `allow_system_uptime_global` |
-| TwinCAT | `twincat` | OFF | OFF | CODESYS set minus the whole `REF_TO` family (`allow_ref_to`, `allow_ref_arithmetic`, `allow_ref_stack_variables`, `allow_ref_type_punning`), plus `allow_reference_to` — TwinCAT uses `REFERENCE TO` (parsed) / `POINTER TO` (not yet parsed) |
+| TwinCAT | `twincat` | OFF | OFF | CODESYS set minus the whole `REF_TO` family (`allow_ref_to`, `allow_ref_arithmetic`, `allow_ref_stack_variables`, `allow_ref_type_punning`), plus `allow_reference_to`, `allow_pointer_to`, and `allow_adr` — TwinCAT spells references `REFERENCE TO` (bound with `REF=`) and pointers `POINTER TO` (bound with `ADR()`) |
 
 ### Grouping Guidance
 


### PR DESCRIPTION
Completes Phase 3 (the final phase) of `specs/plans/2026-08-11-adr-operator-and-pointer-to.md`, following the ADR() operator implementation merged in #1356.

## Changes

- **New `docs/reference/extension-library/functions/adr.rst`** — ADR feature page alongside `sizeof.rst`: typed-pointer semantics (contrasted with TwinCAT/CODESYS's untyped `PVOID` result, which those environments allow assigning to `DWORD`/`LWORD` — a pattern that does not carry over), operand restrictions, related problem codes (P2028/P2029/P2030/P2032), and a playground example. Linked from the functions index and the `--allow-adr` flag entry.
- **`reference-types.rst`** — documents the `POINTER TO` spelling (explicit `^`, bound with `ADR()`) alongside `REF_TO` and `REFERENCE TO`.
- **Vendor documentation references** — Beckhoff, CODESYS, ABB, and Schneider links added to `adr.rst` and `reference-types.rst` in "External References" sections.
- **Stale-comment sweep** — corrects four mentions of a flag that never existed (`--allow-pointer-arithmetic` → `--allow-ref-arithmetic`) in `references.rst` and `reference-types.rst`; removes "`POINTER TO` (not yet parsed)" from `docs/reference/editor/settings.rst` and the steering `syntax-support-guide.md` dialect table; notes in `specs/design/reference-to-twincat.md` that the pointer-model deferral is now implemented.
- **Plan** — Phase 3 checkboxes marked complete, finishing the plan.

Deviation from the Phase 3 file map: `integrations/vscode/package.json` needed no change — its dialect description was already accurate. The `enabling-dialects-and-features.rst` / `ironplcc.rst` flag entries landed with Phase 2 because the website build enforces them.

## Validation

- `cd compiler && just` — full CI pipeline passes (compile, coverage, clippy, fmt, dupes)
- `cd docs && just` — website build passes, including the `ironplc_flags.py` flag-documentation enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UostSaNZ6S5kmVU9iWTtKA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UostSaNZ6S5kmVU9iWTtKA)_