### PR TITLE
fix(cli): don't let discovery diagnostics skip analysis entirely

### DIFF
--- a/compiler/ironplc-cli/src/cli.rs
+++ b/compiler/ironplc-cli/src/cli.rs
@@ -36,13 +36,18 @@ pub fn check(
     libraries: &[LibraryName],
     suppress_output: bool,
 ) -> Result<(), String> {
-    let mut project = create_project(paths, compiler_options, libraries, suppress_output)?;
+    let (mut project, had_discovery_error) =
+        create_project(paths, compiler_options, libraries, suppress_output);
 
     // Analyze the set
     if let Err(err) = project.semantic() {
         trace!("Errors {err:?}");
         handle_diagnostics(&err, Some(&project), suppress_output);
         return Err(String::from("Error during analysis"));
+    }
+
+    if had_discovery_error {
+        return Err(String::from("Error enumerating or reading source files"));
     }
 
     Ok(())
@@ -54,7 +59,8 @@ pub fn echo(
     suppress_output: bool,
 ) -> Result<(), String> {
     // Echo renders parsed source; it runs no analysis, so no library activation.
-    let mut project = create_project(paths, compiler_options, &[], suppress_output)?;
+    let (mut project, had_discovery_error) =
+        create_project(paths, compiler_options, &[], suppress_output);
 
     // Collect the results and output after because getting the results may change
     // the project itself
@@ -87,9 +93,10 @@ pub fn echo(
         }
     }
 
-    match has_error {
-        true => Err("Tokenize error".to_owned()),
-        false => Ok(()),
+    match (has_error, had_discovery_error) {
+        (true, _) => Err("Tokenize error".to_owned()),
+        (false, true) => Err(String::from("Error enumerating or reading source files")),
+        (false, false) => Ok(()),
     }
 }
 
@@ -99,10 +106,15 @@ pub fn tokenize(
     suppress_output: bool,
 ) -> Result<(), String> {
     // Tokenize only lexes each source; library activation is irrelevant here.
-    let project = create_project(paths, compiler_options, &[], suppress_output)?;
+    let (project, had_discovery_error) =
+        create_project(paths, compiler_options, &[], suppress_output);
 
     for src in project.sources() {
         tokenizer::tokenize_source(src, &project, suppress_output, &handle_diagnostics)?;
+    }
+
+    if had_discovery_error {
+        return Err(String::from("Error enumerating or reading source files"));
     }
 
     Ok(())
@@ -119,7 +131,8 @@ pub fn compile(
     libraries: &[LibraryName],
     suppress_output: bool,
 ) -> Result<(), String> {
-    let mut project = create_project(paths, compiler_options, libraries, suppress_output)?;
+    let (mut project, had_discovery_error) =
+        create_project(paths, compiler_options, libraries, suppress_output);
 
     // Refuse to write the container over a loaded source file. `File::create`
     // truncates immediately, so this must run before any output is opened to
@@ -209,6 +222,10 @@ pub fn compile(
         .write_to(&mut out_file)
         .map_err(|e| format!("Failed to write output file: {e}"))?;
 
+    if had_discovery_error {
+        return Err(String::from("Error enumerating or reading source files"));
+    }
+
     Ok(())
 }
 
@@ -223,12 +240,24 @@ impl ironplc_codegen::SourceLookup for HashMapSourceLookup {
     }
 }
 
+/// Builds a project from `paths`, running discovery and loading every
+/// resolvable file.
+///
+/// The returned `bool` is `true` when discovery produced any diagnostic
+/// (an unresolvable `.plcproj` entry, a referenced-but-unbundled
+/// compatibility library, or an unreadable source file) -- these are
+/// already printed via [`handle_diagnostics`] before this returns. The
+/// project itself still contains every file that DID resolve: callers
+/// must still run their normal work (analysis, codegen, ...) against it
+/// so real diagnostics in the resolvable files are not hidden behind a
+/// discovery-time problem, then fold the returned `bool` into their own
+/// final result so the overall command still fails when it's `true`.
 fn create_project(
     paths: &[PathBuf],
     compiler_options: CompilerOptions,
     libraries: &[LibraryName],
     suppress_output: bool,
-) -> Result<FileBackedProject, String> {
+) -> (FileBackedProject, bool) {
     trace!("Reading paths {paths:?}");
     let mut files: Vec<PathBuf> = vec![];
     // Explicit `--library` activation, plus any libraries discovered project
@@ -271,11 +300,7 @@ fn create_project(
         had_error = true;
     }
 
-    if had_error {
-        return Err(String::from("Error enumerating or reading source files"));
-    }
-
-    Ok(project)
+    (project, had_error)
 }
 
 /// Enumerates all files at the path.
@@ -567,12 +592,22 @@ mod tests {
     }
 
     #[test]
-    fn check_when_plcproj_has_valid_and_missing_entries_then_error_but_valid_file_still_checked() {
-        // The valid entry must still be loaded and checked (and would
-        // surface its own diagnostics if invalid) even though the
-        // command as a whole fails because of the missing entry.
+    fn check_when_plcproj_has_valid_and_missing_entries_then_semantic_error_still_surfaces() {
+        // The valid entry must still be loaded and checked -- not just
+        // that the overall command fails (which a discovery-time-only
+        // failure would also produce), but specifically that
+        // project.semantic() actually ran against it. A.st here has a
+        // real semantic error (an undeclared variable): if analysis
+        // never ran, check() would still return Err, but with the
+        // discovery-stage message ("Error enumerating..."), not the
+        // analysis-stage one -- this is what distinguishes "aborted
+        // before checking" from "checked, and found a real bug".
         let dir = tempfile::TempDir::new().unwrap();
-        std::fs::write(dir.path().join("A.st"), "PROGRAM A END_PROGRAM").unwrap();
+        std::fs::write(
+            dir.path().join("A.st"),
+            "PROGRAM A\nVAR\n    x : INT;\nEND_VAR\n    x := UNDECLARED_VAR;\nEND_PROGRAM",
+        )
+        .unwrap();
         std::fs::write(
             dir.path().join("project.plcproj"),
             r#"<Project>
@@ -586,7 +621,35 @@ mod tests {
 
         let paths = vec![dir.path().to_path_buf()];
         let result = check(&paths, CompilerOptions::default(), &[], true);
-        assert!(result.is_err())
+        assert_eq!(result, Err(String::from("Error during analysis")));
+    }
+
+    #[test]
+    fn check_when_plcproj_references_unbundled_library_then_still_runs_analysis() {
+        // A project referencing a library IronPLC doesn't bundle (P6011)
+        // must not prevent analysis of the project's own files -- same
+        // reasoning as the missing-.plcproj-entry case above, for the
+        // other kind of discovery-time diagnostic.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("A.st"),
+            "PROGRAM A\nVAR\n    x : INT;\nEND_VAR\n    x := UNDECLARED_VAR;\nEND_PROGRAM",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("project.plcproj"),
+            r#"<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="A.st" />
+    <PlaceholderReference Include="NotBundled" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let paths = vec![dir.path().to_path_buf()];
+        let result = check(&paths, CompilerOptions::default(), &[], true);
+        assert_eq!(result, Err(String::from("Error during analysis")));
     }
 
     #[test]
@@ -632,6 +695,40 @@ mod tests {
         let output = tempfile::NamedTempFile::new().unwrap();
         let result = compile(&paths, output.path(), CompilerOptions::default(), &[], true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn compile_when_plcproj_references_unbundled_library_and_unused_then_still_produces_container()
+    {
+        // A discovery-time diagnostic (P6011, unbundled library) must not
+        // stop the compile pipeline from running: the program here never
+        // calls anything from the unbundled library, so compilation is
+        // genuinely valid -- compile() must still produce a real
+        // container (proving analysis/codegen ran to completion) while
+        // still reporting overall failure via its Err return.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("A.st"),
+            "PROGRAM A\nVAR\n    x : INT;\nEND_VAR\n    x := 1;\nEND_PROGRAM",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("project.plcproj"),
+            r#"<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="A.st" />
+    <PlaceholderReference Include="NotBundled" />
+  </ItemGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let paths = vec![dir.path().to_path_buf()];
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let result = compile(&paths, output.path(), CompilerOptions::default(), &[], true);
+
+        assert!(result.is_err());
+        assert!(output.path().metadata().unwrap().len() > 0);
     }
 
     #[test]

--- a/specs/plans/2026-08-12-discovery-diagnostics-dont-abort-analysis.md
+++ b/specs/plans/2026-08-12-discovery-diagnostics-dont-abort-analysis.md
@@ -1,0 +1,133 @@
+# Plan: don't let discovery-time diagnostics skip analysis entirely
+
+## Problem
+
+`create_project` in `compiler/ironplc-cli/src/cli.rs` treats any
+discovery-time diagnostic (a `.plcproj` `<Compile Include="...">` entry
+that doesn't resolve, or -- newly, since #1320 -- a project-referenced
+compatibility library IronPLC doesn't bundle, `P6011`) as immediately
+fatal for the whole command:
+
+```rust
+if had_error {
+    return Err(String::from("Error enumerating or reading source files"));
+}
+```
+
+Every caller (`check`, `echo`, `tokenize`, `compile`) does
+`create_project(...)?`, so this `Err` propagates before the caller ever
+runs `project.semantic()` (or the equivalent per-command work). The
+already-resolved files are fully loaded into `project` at that point --
+they're just discarded, unused, un-analyzed.
+
+**Real-world impact**: `ironplc-cli/src/cli.rs:1215`'s original PR
+(`afefbc566`, "don't abort project discovery on one unresolvable
+.plcproj entry") intended the opposite -- its own commit message says
+`had_error` should be set "**without dropping the already-resolved
+files from the check**". That intent was never actually implemented:
+`check()`'s `create_project(...)?` drops the whole project, so the
+"still checked" files never actually get checked. The one test covering
+this (`check_when_plcproj_has_valid_and_missing_entries_then_error_but_valid_file_still_checked`)
+only asserts `result.is_err()` -- it never asserts the valid file's own
+diagnostics actually surfaced, so the gap was never caught.
+
+This was a latent, low-impact bug when the only source was a single
+`.plcproj` missing-file entry (rare). It became a real-world blocker
+once `P6011` (referenced-but-unbundled library) started flowing through
+the same path (#1320, 2026-08-04): IronPLC bundles only four
+compatibility libraries so far (`Tc2_System`, `Tc2_Math`,
+`Tc2_Utilities`, `Tc2_BuiltIns`), so any real TwinCAT solution
+referencing a vendor library outside that set (visualization libraries,
+motion control, IoT, ...) -- which is most of them -- now gets zero
+analysis output at all, just the library-not-found diagnostics.
+Verified directly: all 8 of a real private TwinCAT-solution corpus fail
+`ironplcc check --dialect twincat` this way, where before #1320 they at
+least ran full analysis.
+
+## Fix
+
+Change `create_project` to still return the built project when
+discovery produced diagnostics, instead of discarding it:
+
+```rust
+fn create_project(...) -> Result<(FileBackedProject, bool), String>
+```
+
+The `bool` (`had_discovery_error`) is `true` when any diagnostic was
+collected during enumeration/file-loading (unresolvable `.plcproj`
+entry, unbundled library reference, unreadable file). Those diagnostics
+are still printed via `handle_diagnostics` exactly as today -- only the
+control flow changes: the caller gets the project either way and can
+still do its real work.
+
+Each of the four callers destructures the tuple, does its normal work
+against the returned project, and folds `had_discovery_error` into the
+final result **after** that work runs, so discovery diagnostics still
+fail the overall command (matching the safety-first precedent from
+`afefbc566`'s review: a partial project must not silently look clean)
+without hiding real syntax/semantic diagnostics behind them:
+
+- `check`: run `project.semantic()` as today; if that also errors,
+  report and return `Err` (unchanged). Only if semantic analysis is
+  clean, check `had_discovery_error` and return
+  `Err("Error enumerating or reading source files")` if set.
+- `tokenize`: run tokenization over all sources as today (still
+  short-circuits via `?` inside the loop on the first per-source
+  tokenize failure, unchanged); check `had_discovery_error` after the
+  loop.
+- `echo`: run the existing per-source render loop as today; combine
+  `has_error` (its own existing flag) with `had_discovery_error` when
+  deciding the final `Result`.
+- `compile`: run the existing parse -> load-libraries -> analyze ->
+  codegen -> write pipeline unchanged; check `had_discovery_error`
+  immediately before the final `Ok(())`. Writing the `.iplc` on a
+  discovery-diagnostic project is intentional and consistent with the
+  other three commands: if a missing/unbundled reference's symbols are
+  actually used, `analyze()` already fails compilation earlier via its
+  own undeclared-symbol diagnostics (e.g. `P4017`); if unused, the
+  output is genuinely correct and the command still reports overall
+  failure via its exit code.
+
+No change to `enumerate_files`, `LibraryRegistry::resolve_references`,
+or discovery itself -- they already do the right thing (collect,
+don't abort). This is purely a control-flow fix in `create_project` and
+its four callers.
+
+## Files
+
+- `compiler/ironplc-cli/src/cli.rs` -- `create_project` return type and
+  final block; `check`, `echo`, `tokenize`, `compile`.
+
+## Tests
+
+- Strengthen the existing
+  `check_when_plcproj_has_valid_and_missing_entries_then_error_but_valid_file_still_checked`
+  to actually prove the claim in its own name: make the valid entry
+  contain a real semantic error (e.g. an undeclared variable) and
+  assert that error's diagnostic is present in the output, not just
+  that `check()` returns `Err`. This is the test that should have
+  caught the original gap.
+- New: `check_when_plcproj_references_unbundled_library_then_still_runs_analysis`
+  -- a `.plcproj` referencing an unbundled library plus a source file
+  with a real, unrelated semantic error (e.g. calling an undeclared
+  function); asserts `check()` returns `Err` (command still fails) but
+  the real semantic diagnostic is present in the reported output, not
+  just the `P6011`.
+- New (compile): `compile_when_plcproj_references_unbundled_library_and_unused_then_still_produces_container`
+  -- a `.plcproj` referencing an unbundled library that the program
+  never actually calls anything from; asserts `compile()` still writes
+  a valid `.iplc` container (proving the pipeline doesn't stop early)
+  while still returning `Err` overall.
+- Existing `check_when_plcproj_references_missing_file_then_error` must
+  keep passing unchanged (still `Err`, now for the right reason: ran
+  successfully but discovery had diagnostics, not "aborted before
+  running").
+
+## Verification
+
+After the fix, re-run the real-corpus regression check that surfaced
+this: `ironplcc check --dialect twincat <path-to-a-real-solution-that-
+references-an-unbundled-library>` should now print both the `P6011`
+library diagnostics *and* any real syntax/semantic diagnostics from the
+project's own files, and exit non-zero -- not just the `P6011` noise
+with no other output.


### PR DESCRIPTION
## Summary

`create_project` in `compiler/ironplc-cli/src/cli.rs` treated any discovery-time diagnostic -- an unresolvable `.plcproj` `<Compile Include="...">` entry, or (since #1320) a `P6011` referenced-but-unbundled compatibility library -- as immediately fatal for the whole command, discarding the fully-built project before any caller (`check`, `echo`, `tokenize`, `compile`) ever ran its actual work (`project.semantic()`, codegen, etc.).

This was a latent, low-impact gap when the only source was a rare single missing `.plcproj` entry. The original PR that introduced the "keep discovering, but still fail overall" behavior (#1215) intended for already-resolved files to still be checked -- its own commit message says `had_error` should be set "without dropping the already-resolved files from the check" -- but the implementation never actually did that, and the one test covering it only asserted `result.is_err()`, never that a real diagnostic in the valid file actually surfaced.

It became a real-world blocker once `P6011` started flowing through the same path (#1320): IronPLC bundles only four compatibility libraries so far (`Tc2_System`, `Tc2_Math`, `Tc2_Utilities`, `Tc2_BuiltIns`), so any real TwinCAT solution referencing a vendor library outside that set -- which is most of them (visualization, motion control, IoT, ...) -- now gets **zero analysis output at all**, just library-not-found noise, regardless of whether the project's own PLC logic has real bugs. Verified directly: all 8 solutions in a real private TwinCAT corpus hit this.

## Fix

`create_project` now returns `(FileBackedProject, bool)` instead of `Result<FileBackedProject, String>` -- there was no other error case left once the always-continue path stopped short-circuiting, so wrapping in `Result` was dead weight. The `bool` (`had_discovery_error`) is `true` when discovery produced any diagnostic; those are still printed exactly as before. Each caller (`check`/`echo`/`tokenize`/`compile`) now runs its normal work against the returned project first, then folds the bool into its own final result -- so the overall command still fails when discovery had diagnostics, but without hiding real syntax/semantic bugs behind them.

## Test plan
- [x] Strengthened `check_when_plcproj_has_valid_and_missing_entries_then_error_but_valid_file_still_checked` (renamed to `..._then_semantic_error_still_surfaces`) to actually prove analysis ran: the valid file now has a real semantic error, and the test asserts the specific `"Error during analysis"` message (proving `project.semantic()` ran), not just `is_err()`
- [x] New: `check_when_plcproj_references_unbundled_library_then_still_runs_analysis` -- same proof for the `P6011` case
- [x] New: `compile_when_plcproj_references_unbundled_library_and_unused_then_still_produces_container` -- asserts `compile()` still writes a valid `.iplc` (pipeline runs to completion) while still returning `Err` overall
- [x] Existing `check_when_plcproj_references_missing_file_then_error` still passes unchanged
- [x] Verified against a real TwinCAT solution (`MONETN`, referencing multiple unbundled libraries): before this fix, `check` stopped dead at 28 `P6011` diagnostics with nothing else; after, it reports the same 28 `P6011` diagnostics *and* 22 additional real semantic diagnostics (`P2008`, `P4012`, `P4007`) in the project's own POUs, ending in `"Error during analysis"`
- [x] Full CI (`cd compiler && just`): build, coverage ≥85%, clippy, fmt, dupes check -- all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)