### PR TITLE
Apply cross-crate test-ownership conventions (Stage B)

### DIFF
--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -108,65 +108,13 @@ mod test {
         }
     }
 
-    #[test]
-    fn tokenize_array() {
-        let source = read_shared_resource("array.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
+    // Tokenizing a corpus resource is strictly weaker than parsing it, and a
+    // plc2plc round-trip test parses (and unwraps) every corpus resource it
+    // renders — so a `tokenize_<resource>` test only carries signal for a
+    // resource with no round-trip case. `comment.st` is the one such file.
     #[test]
     fn tokenize_comment() {
         let source = read_shared_resource("comment.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
-    #[test]
-    fn tokenize_conditional() {
-        let source = read_shared_resource("conditional.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
-    #[test]
-    fn tokenize_expressions() {
-        let source = read_shared_resource("expressions.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
-    #[test]
-    fn tokenize_nested() {
-        let source = read_shared_resource("nested.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
-    #[test]
-    fn tokenize_strings() {
-        let source = read_shared_resource("strings.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
-    #[test]
-    fn tokenize_textual() {
-        let source = read_shared_resource("textual.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
-    #[test]
-    fn tokenize_type_decl() {
-        let source = read_shared_resource("type_decl.st");
-        let mut lex = TokenType::lexer(source.as_str());
-        assert_no_err(&mut lex);
-    }
-
-    #[test]
-    fn tokenize_var_decl() {
-        let source = read_shared_resource("var_decl.st");
         let mut lex = TokenType::lexer(source.as_str());
         assert_no_err(&mut lex);
     }

--- a/compiler/parser/src/tests/corpus.rs
+++ b/compiler/parser/src/tests/corpus.rs
@@ -4,23 +4,15 @@
 use super::common::*;
 use rstest::rstest;
 
-/// Every corpus `.st` resource must parse without error. One `#[case]` per
-/// resource; add a new sample by adding a single line here.
+/// Corpus `.st` resources that must parse without error but have no plc2plc
+/// round-trip case. A round-trip test parses the same resource with the same
+/// `CompilerOptions::default()` and unwraps the result, so it already proves
+/// the resource parses — listing such a resource here too would assert the
+/// same thing at the same strength. Add a `#[case]` only for a resource
+/// `plc2plc/src/tests/corpus.rs` does not render.
 #[rstest]
-#[case::var_decl("var_decl.st")]
-#[case::inout_var_decl("inout_var_decl.st")]
-#[case::input_var_decl("input_var_decl.st")]
-#[case::strings("strings.st")]
-#[case::type_decl("type_decl.st")]
-#[case::textual("textual.st")]
-#[case::conditional("conditional.st")]
 // OSCAT files have a header that as far as I can tell is not valid but it is common.
 #[case::oscat("oscat.st")]
-#[case::expressions("expressions.st")]
-#[case::array("array.st")]
-#[case::nested("nested.st")]
-#[case::configuration("configuration.st")]
-#[case::program("program.st")]
 fn parse_when_corpus_resource_then_ok(#[case] name: &'static str) {
     let res = parse_resource(name);
     assert!(res.is_ok());

--- a/compiler/parser/src/tests/reference_to.rs
+++ b/compiler/parser/src/tests/reference_to.rs
@@ -1,4 +1,11 @@
 //! `REFERENCE TO` / `REF=` binding, dereference and NULL parsing.
+//!
+//! Tests here assert AST shape. A plain `REF(x)` / `myRef^` / `:= NULL`
+//! statement is round-tripped by `plc2plc/src/tests/reference_to.rs` from the
+//! same source, which parses it first — so a test asserting only that one
+//! statement parsed is subsumed and does not belong here. The `XOR` and
+//! `<> NULL` cases below stay because they guard operator disambiguation
+//! (`^` vs `XOR`, `=`/`<>` vs `REF=`) and have no round-trip counterpart.
 
 use super::common::*;
 
@@ -254,38 +261,6 @@ fn parse_when_ref_to_array_type_decl_then_ok() {
 }
 
 #[test]
-fn parse_when_ref_operator_then_ok() {
-    let lib = parse_text_edition3(
-        "PROGRAM main
-VAR
-    counter : INT;
-    x : REF_TO INT;
-END_VAR
-    x := REF(counter);
-END_PROGRAM",
-    );
-    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
-    let s = cast!(&prog.body, FunctionBlockBodyKind::Statements);
-    assert!(!s.body.is_empty());
-}
-
-#[test]
-fn parse_when_deref_then_ok() {
-    let lib = parse_text_edition3(
-        "PROGRAM main
-VAR
-    myRef : REF_TO INT;
-    value : INT;
-END_VAR
-    value := myRef^;
-END_PROGRAM",
-    );
-    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
-    let s = cast!(&prog.body, FunctionBlockBodyKind::Statements);
-    assert_eq!(s.body.len(), 1);
-}
-
-#[test]
 fn parse_when_deref_assign_then_ok() {
     let lib = parse_text_edition3(
         "PROGRAM main
@@ -300,21 +275,6 @@ END_PROGRAM",
     assert_eq!(s.body.len(), 1);
     let assignment = cast!(&s.body[0], StmtKind::Assignment);
     assert!(assignment.deref);
-}
-
-#[test]
-fn parse_when_null_literal_then_ok() {
-    let lib = parse_text_edition3(
-        "PROGRAM main
-VAR
-    myRef : REF_TO INT;
-END_VAR
-    myRef := NULL;
-END_PROGRAM",
-    );
-    let prog = cast!(&lib.elements[0], LibraryElementKind::ProgramDeclaration);
-    let s = cast!(&prog.body, FunctionBlockBodyKind::Statements);
-    assert_eq!(s.body.len(), 1);
 }
 
 #[test]

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -1989,6 +1989,14 @@ END_PROGRAM
         assert_eq!(format_time_value_ms(5000i64), "T#5s");
     }
 
+    // Whether a given dialect or `--allow-` flag accepts a construct is owned
+    // by `parser/src/tests/dialect_flags.rs` (and re-verified behaviorally
+    // across the whole flag set by mcp's feature_flag_conformance). What is
+    // playground-owned is the string plumbing: that a dialect name and a
+    // comma-separated allows list arriving from JS are resolved and actually
+    // reach the compiler. Each pair below is kept as an off/on contrast for
+    // exactly that reason — a single positive case would also pass if the
+    // strings were ignored and the baseline were simply permissive.
     #[test]
     fn compile_when_dialect_2013_then_accepts_ltime() {
         let source = "
@@ -2022,30 +2030,6 @@ END_PROGRAM
         let result: CompileResult = serde_json::from_str(&compile(source, "", "", "")).unwrap();
         assert!(!result.ok);
         assert!(!result.diagnostics.is_empty());
-    }
-
-    #[test]
-    fn load_program_when_dialect_2013_then_runs_ltime_program() {
-        reset_session();
-        let source = "
-PROGRAM main
-  VAR
-    duration : LTIME;
-  END_VAR
-  duration := LTIME#500ms;
-END_PROGRAM
-";
-        let result: StepResult =
-            serde_json::from_str(&load_program(source, 100_000, "iec61131-3-ed3", "", "")).unwrap();
-        assert!(
-            result.ok,
-            "Expected ok but got error: {:?}, diagnostics: {:?}",
-            result.error, result.diagnostics
-        );
-
-        let r1: StepResult = serde_json::from_str(&step(1)).unwrap();
-        assert!(r1.ok, "step failed: {:?}", r1.error);
-        assert!(!r1.variables.is_empty());
     }
 
     #[test]

--- a/compiler/vm/tests/it/execute_fb_tof.rs
+++ b/compiler/vm/tests/it/execute_fb_tof.rs
@@ -1,40 +1,15 @@
+//! VM-specific edge case tests for the TOF off-delay timer intrinsic.
+//!
+//! The nominal TOF matrix — IN true, before/after/at PT following the falling
+//! edge, ET readout, reset on a rising edge, and two independent timers — is
+//! covered by end_to_end_fb_tof.rs, which drives the same `intrinsic.rs`
+//! state machine through compiled ST. These tests keep only what that file
+//! does not assert: ET clamping at PT, and the cold-start case where IN was
+//! never TRUE (every codegen case drives IN TRUE first).
+
 use crate::common::VmBuffers;
 use ironplc_container::opcode;
 use ironplc_container::VarIndex;
-
-#[test]
-fn tof_when_in_true_then_q_true_et_zero() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TOF);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    // Set IN = TRUE
-    vm.write_variable(VarIndex::new(1), 1).unwrap();
-    vm.run_round(1_000_000).unwrap(); // t = 1s
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 0); // ET = 0
-}
-
-#[test]
-fn tof_when_in_false_before_pt_then_q_true_et_increasing() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TOF);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    // IN = TRUE first
-    vm.write_variable(VarIndex::new(1), 1).unwrap();
-    vm.run_round(1_000_000).unwrap(); // t=1s: Q=TRUE
-
-    // IN falls to FALSE
-    vm.write_variable(VarIndex::new(1), 0).unwrap();
-    vm.run_round(2_000_000).unwrap(); // t=2s: falling edge, starts timing
-
-    // Still timing
-    vm.run_round(4_000_000).unwrap(); // t=4s: 2s elapsed
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE (still in off-delay)
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 2000); // ET = 2s = 2000 ms
-}
 
 #[test]
 fn tof_when_in_false_after_pt_then_q_false_et_clamped() {
@@ -55,31 +30,6 @@ fn tof_when_in_false_after_pt_then_q_false_et_clamped() {
 
     assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE
     assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 5000); // ET clamped to PT (5000 ms)
-}
-
-#[test]
-fn tof_when_in_rises_during_timing_then_resets() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TOF);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    // IN = TRUE
-    vm.write_variable(VarIndex::new(1), 1).unwrap();
-    vm.run_round(1_000_000).unwrap(); // t=1s
-
-    // IN falls
-    vm.write_variable(VarIndex::new(1), 0).unwrap();
-    vm.run_round(2_000_000).unwrap(); // t=2s: falling edge
-    vm.run_round(4_000_000).unwrap(); // t=4s: 2s elapsed, timing
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE (still timing)
-
-    // IN goes TRUE again before PT expires
-    vm.write_variable(VarIndex::new(1), 1).unwrap();
-    vm.run_round(5_000_000).unwrap(); // t=5s
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 0); // ET = 0 (reset)
 }
 
 #[test]

--- a/compiler/vm/tests/it/execute_fb_ton.rs
+++ b/compiler/vm/tests/it/execute_fb_ton.rs
@@ -1,37 +1,15 @@
+//! VM-specific edge case tests for the TON on-delay timer intrinsic.
+//!
+//! The nominal TON matrix — IN false, before/after/at PT, ET readout, reset
+//! and restart, two independent timers, and every dot-access form — is
+//! covered by end_to_end_fb_ton.rs, which drives the same `intrinsic.rs`
+//! state machine through compiled ST. These tests keep only what that file
+//! does not assert: ET clamping at PT, and resetting out of the expired
+//! (Q=TRUE) state rather than out of the still-timing state.
+
 use crate::common::VmBuffers;
 use ironplc_container::opcode;
 use ironplc_container::VarIndex;
-
-#[test]
-fn ton_when_in_false_then_q_false_et_zero() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TON);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    // var[1] = IN = 0 (FALSE) — default
-    vm.run_round(1_000_000).unwrap(); // t = 1s
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 0); // ET = 0
-}
-
-#[test]
-fn ton_when_in_true_before_pt_then_q_false_et_increasing() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TON);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    // Set IN = TRUE
-    vm.write_variable(VarIndex::new(1), 1).unwrap();
-
-    // Scan at t=1s: rising edge
-    vm.run_round(1_000_000).unwrap();
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE (just started)
-
-    // Scan at t=3s: 2 seconds elapsed
-    vm.run_round(3_000_000).unwrap();
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE (< PT)
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 2000); // ET = 2s = 2000 ms
-}
 
 #[test]
 fn ton_when_in_true_after_pt_then_q_true_et_clamped() {
@@ -66,32 +44,4 @@ fn ton_when_in_falls_after_timer_expires_then_resets() {
 
     assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE
     assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 0); // ET = 0
-}
-
-#[test]
-fn ton_when_in_false_before_pt_then_resets() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TON);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    vm.write_variable(VarIndex::new(1), 1).unwrap(); // IN = TRUE
-    vm.run_round(1_000_000).unwrap(); // t=1s: rising edge
-    vm.run_round(3_000_000).unwrap(); // t=3s: 2s elapsed, not yet expired
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE
-
-    // IN goes FALSE before PT expires
-    vm.write_variable(VarIndex::new(1), 0).unwrap();
-    vm.run_round(4_000_000).unwrap();
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 0); // ET = 0
-
-    // IN goes TRUE again — timer restarts from scratch
-    vm.write_variable(VarIndex::new(1), 1).unwrap();
-    vm.run_round(5_000_000).unwrap(); // new rising edge at t=5s
-    vm.run_round(8_000_000).unwrap(); // t=8s: 3s elapsed (< 5s PT)
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE (< PT from new start)
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 3000); // ET = 3s = 3000 ms
 }

--- a/compiler/vm/tests/it/execute_fb_tp.rs
+++ b/compiler/vm/tests/it/execute_fb_tp.rs
@@ -1,3 +1,12 @@
+//! VM-specific edge case tests for the TP pulse timer intrinsic.
+//!
+//! The nominal TP matrix — pulse start, before/after/at PT, ET readout, IN
+//! falling mid-pulse (with ET clamped to PT), and two independent timers — is
+//! covered by end_to_end_fb_tp.rs, which drives the same `intrinsic.rs` state
+//! machine through compiled ST. These tests keep only what that file does not
+//! assert: the cold-start case where IN was never TRUE, and retriggering a new
+//! pulse after the previous one completed.
+
 use crate::common::VmBuffers;
 use ironplc_container::opcode;
 use ironplc_container::VarIndex;
@@ -12,63 +21,6 @@ fn tp_when_in_false_then_q_false_et_zero() {
 
     assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE
     assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 0); // ET = 0
-}
-
-#[test]
-fn tp_when_in_true_before_pt_then_q_true_et_increasing() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TP);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    // Set IN = TRUE
-    vm.write_variable(VarIndex::new(1), 1).unwrap();
-
-    // Scan at t=1s: rising edge, pulse starts
-    vm.run_round(1_000_000).unwrap();
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE (pulse active)
-
-    // Scan at t=3s: 2 seconds elapsed
-    vm.run_round(3_000_000).unwrap();
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE (< PT)
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 2000); // ET = 2s = 2000 ms
-}
-
-#[test]
-fn tp_when_in_true_after_pt_then_q_false_et_clamped() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TP);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    vm.write_variable(VarIndex::new(1), 1).unwrap(); // IN = TRUE
-
-    vm.run_round(1_000_000).unwrap(); // t=1s: rising edge, pulse starts
-    vm.run_round(7_000_000).unwrap(); // t=7s: 6s elapsed > 5s PT
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE (pulse ended)
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 5000); // ET clamped to PT (5000 ms)
-}
-
-#[test]
-fn tp_when_in_falls_during_pulse_then_pulse_continues() {
-    let c = crate::common::timer_test_container(5000, opcode::fb_type::TP);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-
-    vm.write_variable(VarIndex::new(1), 1).unwrap(); // IN = TRUE
-    vm.run_round(1_000_000).unwrap(); // t=1s: rising edge, pulse starts
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE
-
-    // IN goes FALSE mid-pulse — pulse should continue
-    vm.write_variable(VarIndex::new(1), 0).unwrap();
-    vm.run_round(3_000_000).unwrap(); // t=3s: 2s elapsed, still pulsing
-
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 1); // Q = TRUE (pulse ignores IN)
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 2000); // ET = 2s = 2000 ms
-
-    // Pulse expires
-    vm.run_round(7_000_000).unwrap(); // t=7s: 6s elapsed > 5s PT
-    assert_eq!(vm.read_variable(VarIndex::new(2)).unwrap(), 0); // Q = FALSE
-    assert_eq!(vm.read_variable(VarIndex::new(3)).unwrap(), 5000); // ET clamped to PT (5000 ms)
 }
 
 #[test]

--- a/compiler/vm/tests/it/execute_string_ops.rs
+++ b/compiler/vm/tests/it/execute_string_ops.rs
@@ -1,4 +1,14 @@
-//! Integration tests for string opcodes.
+//! VM-specific edge case tests for string opcodes.
+//!
+//! The nominal behavior of the string functions — CONCAT, FIND, LEFT/RIGHT/MID
+//! and comparison, over both STRING and WSTRING, including array elements — is
+//! covered by codegen's end_to_end_concat/find/left/right/mid/string_compare
+//! and end_to_end_wstring tests, which assert the resulting content (not just
+//! its length) and in several cases add a proptest oracle. These tests keep
+//! what those cannot reach: the STR_INIT header contract and store/load
+//! roundtrip at the opcode level, the ADR-0034 encoding-mismatch traps, an
+//! invalid char_width (codegen never emits one), and wide data in a
+//! narrow-stride array descriptor.
 
 use crate::common::VmBuffers;
 use ironplc_container::opcode;
@@ -67,7 +77,7 @@ fn wstring_container(
 
 /// Hand-writes a 6-byte string header (max_len, cur_len, char_width — all
 /// counts of code units / a width byte) at `off` in a data region, for
-/// fixtures that need a wide variable the codegen cannot yet emit.
+/// fixtures that need a wide variable in a state codegen would not emit.
 fn write_str_header(dr: &mut [u8], off: usize, max_len: u16, cur_len: u16, char_width: u16) {
     dr[off..off + 2].copy_from_slice(&max_len.to_le_bytes());
     dr[off + 2..off + 4].copy_from_slice(&cur_len.to_le_bytes());
@@ -122,150 +132,13 @@ fn execute_when_str_store_and_load_then_roundtrips() {
     assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 2);
 }
 
-#[test]
-fn execute_when_concat_str_then_correct_length() {
-    // Init two strings at offset 0 (max=20) and offset 28 (max=20).
-    // Store "AB" at offset 0, "CD" at offset 28, concat them, store
-    // result at offset 0, read length.
-    // String header is 4 bytes + max_len bytes. For max=20: 4+20=24 bytes.
-    // So second string starts at offset 28 (rounded to allow space).
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::STR_INIT, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01,   // STR_INIT offset=0, max_len=20
-        opcode::STR_INIT, 0x1C, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01,   // STR_INIT offset=28, max_len=20
-        // Store "AB" at offset 0
-        opcode::LOAD_CONST_STR, 0x00, 0x00,
-        opcode::STR_STORE_VAR, 0x00, 0x00, 0x00, 0x00,
-        // Store "CD" at offset 28
-        opcode::LOAD_CONST_STR, 0x01, 0x00,
-        opcode::STR_STORE_VAR, 0x1C, 0x00, 0x00, 0x00,
-        // Concat offset 0 and offset 28
-        opcode::CONCAT_STR, 0x00, 0x00, 0x00, 0x00, 0x1C, 0x00, 0x00, 0x00,
-        opcode::STR_STORE_VAR, 0x00, 0x00, 0x00, 0x00,
-        // Read length
-        opcode::LEN_STR, 0x00, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = string_container(&bytecode, 1, &[], &[b"AB", b"CD"], 64);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    // "AB" + "CD" = "ABCD", length 4
-    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 4);
-}
-
-#[test]
-fn execute_when_find_str_found_then_returns_position() {
-    // Init "HELLO" at offset 0, "LL" at offset 28.
-    // FIND_STR should return 1-based position of "LL" in "HELLO" = 3.
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::STR_INIT, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01,
-        opcode::STR_INIT, 0x1C, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01,
-        // Store "HELLO" at offset 0
-        opcode::LOAD_CONST_STR, 0x00, 0x00,
-        opcode::STR_STORE_VAR, 0x00, 0x00, 0x00, 0x00,
-        // Store "LL" at offset 28
-        opcode::LOAD_CONST_STR, 0x01, 0x00,
-        opcode::STR_STORE_VAR, 0x1C, 0x00, 0x00, 0x00,
-        // FIND
-        opcode::FIND_STR, 0x00, 0x00, 0x00, 0x00, 0x1C, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = string_container(&bytecode, 1, &[], &[b"HELLO", b"LL"], 64);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    // "LL" starts at position 3 (1-based)
-    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 3);
-}
-
-#[test]
-fn execute_when_find_str_not_found_then_returns_zero() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::STR_INIT, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01,
-        opcode::STR_INIT, 0x1C, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01,
-        opcode::LOAD_CONST_STR, 0x00, 0x00,
-        opcode::STR_STORE_VAR, 0x00, 0x00, 0x00, 0x00,
-        opcode::LOAD_CONST_STR, 0x01, 0x00,
-        opcode::STR_STORE_VAR, 0x1C, 0x00, 0x00, 0x00,
-        opcode::FIND_STR, 0x00, 0x00, 0x00, 0x00, 0x1C, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = string_container(&bytecode, 1, &[], &[b"HELLO", b"XY"], 64);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 0);
-}
-
-#[test]
-fn execute_when_left_str_then_correct_length() {
-    // Init "ABCDE" at offset 0. LEFT_STR with L=3 gives "ABC" (length 3).
-    // Constant pool: pool[0] = i32(3), pool[1] = str("ABCDE")
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::STR_INIT, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01,
-        opcode::LOAD_CONST_STR, 0x01, 0x00,                     // load str pool[1] ("ABCDE")
-        opcode::STR_STORE_VAR, 0x00, 0x00, 0x00, 0x00,
-        // LEFT_STR: push L=3, then LEFT_STR offset=0 (u32)
-        opcode::LOAD_CONST_I32, 0x00, 0x00,                     // push i32 pool[0] = 3
-        opcode::LEFT_STR, 0x00, 0x00, 0x00, 0x00,               // LEFT_STR in=0 (u32), pops L -> buf_idx
-        opcode::STR_STORE_VAR, 0x00, 0x00, 0x00, 0x00,          // store result back
-        opcode::LEN_STR, 0x00, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = string_container(&bytecode, 1, &[3], &[b"ABCDE"], 32);
-    let mut b = VmBuffers::from_container(&c);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 3);
-}
-
 // --- Wide (WSTRING / char_width = 2) synthetic tests ---
 //
-// Codegen cannot emit wide strings yet (PR D), so these hand-assemble
-// bytecode and, where a wide variable is needed, hand-write its v3 header
-// into the data region. They prove the VM's data-driven width handling and
-// the ADR-0034 encoding-mismatch verification added in PR C1.
-
-#[test]
-fn execute_when_wide_const_stored_into_wide_var_then_len_in_code_units() {
-    // dest wide var at offset 0 (max_len=10 units, char_width=2).
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_STR, 0x00, 0x00,             // wide "Hi" -> wide temp
-        opcode::STR_STORE_VAR, 0x00, 0x00, 0x00, 0x00,  // store into wide var at 0
-        opcode::LEN_STR, 0x00, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    // "Hi" as UTF-16LE: H=0x48, i=0x69.
-    let hi: &[u8] = &[0x48, 0x00, 0x69, 0x00];
-    let c = wstring_container(&bytecode, 1, &[], &[hi], 64);
-    let mut b = VmBuffers::from_container(&c);
-    write_str_header(&mut b.data_region, 0, 10, 0, 2);
-    let len = {
-        let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-        vm.run_round(0).unwrap();
-        vm.read_variable(VarIndex::new(0)).unwrap()
-    };
-    // LEN reports code units, not bytes.
-    assert_eq!(len, 2);
-    // The stored data is the two UTF-16LE code units of "Hi".
-    assert_eq!(&b.data_region[6..10], &[0x48, 0x00, 0x69, 0x00]);
-    // The destination header kept char_width = 2.
-    assert_eq!(u16::from_le_bytes([b.data_region[4], b.data_region[5]]), 2);
-}
+// Codegen does emit wide strings, so the nominal wide behavior lives in
+// end_to_end_wstring.rs. What remains here are the mismatched-encoding
+// states codegen cannot produce — the analyzer rejects assigning a WSTRING
+// to a STRING before codegen runs — so these hand-assemble bytecode and
+// hand-write the v3 header to reach the VM's ADR-0034 verification directly.
 
 #[test]
 fn execute_when_wide_const_stored_into_narrow_var_then_encoding_mismatch() {
@@ -308,60 +181,6 @@ fn execute_when_load_var_with_invalid_char_width_then_trap() {
 }
 
 #[test]
-fn execute_when_wide_var_roundtrip_then_preserves_utf16le_bytes() {
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::STR_LOAD_VAR, 0x00, 0x00, 0x00, 0x00,  // load wide var at 0 -> wide temp
-        opcode::STR_STORE_VAR, 0x20, 0x00, 0x00, 0x00, // store into wide var at 32
-        opcode::LEN_STR, 0x20, 0x00, 0x00, 0x00,       // len of var at 32
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = wstring_container(&bytecode, 1, &[], &[], 64);
-    let mut b = VmBuffers::from_container(&c);
-    // Source wide var "ABC" at offset 0.
-    write_str_header(&mut b.data_region, 0, 10, 3, 2);
-    b.data_region[6..12].copy_from_slice(&[0x41, 0x00, 0x42, 0x00, 0x43, 0x00]);
-    // Dest wide var at offset 32.
-    write_str_header(&mut b.data_region, 32, 10, 0, 2);
-    let len = {
-        let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-        vm.run_round(0).unwrap();
-        vm.read_variable(VarIndex::new(0)).unwrap()
-    };
-    assert_eq!(len, 3);
-    // Bytes survive the wide load -> temp -> wide store round trip.
-    assert_eq!(
-        &b.data_region[38..44],
-        &[0x41, 0x00, 0x42, 0x00, 0x43, 0x00]
-    );
-}
-
-#[test]
-fn execute_when_cmp_wide_equal_then_zero() {
-    let cmp = opcode::builtin::CMP_STR.to_le_bytes();
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_I32, 0x00, 0x00,  // left_offset = i32 pool[0] = 0
-        opcode::LOAD_CONST_I32, 0x01, 0x00,  // right_offset = i32 pool[1] = 32
-        opcode::BUILTIN, cmp[0], cmp[1],
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = wstring_container(&bytecode, 1, &[0, 32], &[], 64);
-    let mut b = VmBuffers::from_container(&c);
-    // Two equal wide "AB" strings.
-    write_str_header(&mut b.data_region, 0, 10, 2, 2);
-    b.data_region[6..10].copy_from_slice(&[0x41, 0x00, 0x42, 0x00]);
-    write_str_header(&mut b.data_region, 32, 10, 2, 2);
-    b.data_region[38..42].copy_from_slice(&[0x41, 0x00, 0x42, 0x00]);
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 0);
-}
-
-#[test]
 fn execute_when_cmp_mixed_encoding_then_trap() {
     let cmp = opcode::builtin::CMP_STR.to_le_bytes();
     #[rustfmt::skip]
@@ -391,36 +210,6 @@ fn execute_when_cmp_mixed_encoding_then_trap() {
 // --- Wide string-function tests (PR C2) ---
 
 #[test]
-fn execute_when_concat_wide_then_joins_code_units() {
-    // Wide "AB" at 0, wide "CD" at 16, concat -> wide dest at 32.
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::CONCAT_STR, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
-        opcode::STR_STORE_VAR, 0x20, 0x00, 0x00, 0x00,
-        opcode::LEN_STR, 0x20, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = wstring_container(&bytecode, 1, &[], &[], 64);
-    let mut b = VmBuffers::from_container(&c);
-    write_str_header(&mut b.data_region, 0, 5, 2, 2);
-    b.data_region[6..10].copy_from_slice(&[0x41, 0x00, 0x42, 0x00]); // "AB"
-    write_str_header(&mut b.data_region, 16, 5, 2, 2);
-    b.data_region[22..26].copy_from_slice(&[0x43, 0x00, 0x44, 0x00]); // "CD"
-    write_str_header(&mut b.data_region, 32, 5, 0, 2);
-    let len = {
-        let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-        vm.run_round(0).unwrap();
-        vm.read_variable(VarIndex::new(0)).unwrap()
-    };
-    assert_eq!(len, 4);
-    assert_eq!(
-        &b.data_region[38..46],
-        &[0x41, 0x00, 0x42, 0x00, 0x43, 0x00, 0x44, 0x00] // "ABCD"
-    );
-}
-
-#[test]
 fn execute_when_concat_mixed_encoding_then_trap() {
     #[rustfmt::skip]
     let bytecode: Vec<u8> = vec![
@@ -441,92 +230,6 @@ fn execute_when_concat_mixed_encoding_then_trap() {
             actual: 1,
         }
     );
-}
-
-#[test]
-fn execute_when_left_wide_then_returns_leading_code_units() {
-    // LEFT("ABCDE", 3) over a wide source -> "ABC".
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_I32, 0x00, 0x00,            // L = i32 pool[0] = 3
-        opcode::LEFT_STR, 0x00, 0x00, 0x00, 0x00,
-        opcode::STR_STORE_VAR, 0x20, 0x00, 0x00, 0x00,
-        opcode::LEN_STR, 0x20, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = wstring_container(&bytecode, 1, &[3], &[], 64);
-    let mut b = VmBuffers::from_container(&c);
-    write_str_header(&mut b.data_region, 0, 8, 5, 2);
-    b.data_region[6..16].copy_from_slice(&[
-        0x41, 0x00, 0x42, 0x00, 0x43, 0x00, 0x44, 0x00, 0x45, 0x00, // "ABCDE"
-    ]);
-    write_str_header(&mut b.data_region, 32, 8, 0, 2);
-    let len = {
-        let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-        vm.run_round(0).unwrap();
-        vm.read_variable(VarIndex::new(0)).unwrap()
-    };
-    assert_eq!(len, 3);
-    assert_eq!(
-        &b.data_region[38..44],
-        &[0x41, 0x00, 0x42, 0x00, 0x43, 0x00] // "ABC"
-    );
-}
-
-#[test]
-fn execute_when_mid_wide_then_returns_middle_code_units() {
-    // MID("ABCDE", P=2, L=3) over a wide source -> "BCD".
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::LOAD_CONST_I32, 0x00, 0x00,            // L = i32 pool[0] = 3 (pushed first)
-        opcode::LOAD_CONST_I32, 0x01, 0x00,            // P = i32 pool[1] = 2 (top)
-        opcode::MID_STR, 0x00, 0x00, 0x00, 0x00,
-        opcode::STR_STORE_VAR, 0x20, 0x00, 0x00, 0x00,
-        opcode::LEN_STR, 0x20, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = wstring_container(&bytecode, 1, &[3, 2], &[], 64);
-    let mut b = VmBuffers::from_container(&c);
-    write_str_header(&mut b.data_region, 0, 8, 5, 2);
-    b.data_region[6..16].copy_from_slice(&[
-        0x41, 0x00, 0x42, 0x00, 0x43, 0x00, 0x44, 0x00, 0x45, 0x00, // "ABCDE"
-    ]);
-    write_str_header(&mut b.data_region, 32, 8, 0, 2);
-    let len = {
-        let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-        vm.run_round(0).unwrap();
-        vm.read_variable(VarIndex::new(0)).unwrap()
-    };
-    assert_eq!(len, 3);
-    assert_eq!(
-        &b.data_region[38..44],
-        &[0x42, 0x00, 0x43, 0x00, 0x44, 0x00] // "BCD"
-    );
-}
-
-#[test]
-fn execute_when_find_wide_then_returns_code_unit_position() {
-    // FIND("LL" in "HELLO") over wide sources -> 3 (1-based code units).
-    #[rustfmt::skip]
-    let bytecode: Vec<u8> = vec![
-        opcode::FIND_STR, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,
-        opcode::STORE_VAR_I32, 0x00, 0x00,
-        opcode::RET_VOID,
-    ];
-    let c = wstring_container(&bytecode, 1, &[], &[], 64);
-    let mut b = VmBuffers::from_container(&c);
-    write_str_header(&mut b.data_region, 0, 8, 5, 2);
-    b.data_region[6..16].copy_from_slice(&[
-        0x48, 0x00, 0x45, 0x00, 0x4C, 0x00, 0x4C, 0x00, 0x4F, 0x00, // "HELLO"
-    ]);
-    write_str_header(&mut b.data_region, 32, 4, 2, 2);
-    b.data_region[38..42].copy_from_slice(&[0x4C, 0x00, 0x4C, 0x00]); // "LL"
-    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
-    vm.run_round(0).unwrap();
-
-    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 3);
 }
 
 // --- Wide string-array tests (PR C3) ---

--- a/specs/plans/2026-08-06-reduce-cross-crate-test-duplication.md
+++ b/specs/plans/2026-08-06-reduce-cross-crate-test-duplication.md
@@ -232,16 +232,40 @@ its own plan/PR per item.
 
 ## Tasks
 
-- [ ] Stage A1–A3: vm-cli re-home + project/vm deletions (one PR)
-- [ ] Stage A4: mcp test_support + boilerplate collapse (one PR)
-- [ ] Stage A5: ironplc-cli dedup + miswired-test fixes (one PR)
-- [ ] Stage B1: codegen↔vm timer/string ownership pass
-- [ ] Stage B2–B4: parser corpus/reference_to reduction + guide update
-- [ ] Stage B5: playground dialect trim
+- [x] Stage A1–A3: vm-cli re-home + project/vm deletions (one PR)
+- [x] Stage A4: mcp test_support + boilerplate collapse (one PR)
+- [x] Stage A5: ironplc-cli dedup + miswired-test fixes (one PR)
+- [x] Stage B1: codegen↔vm timer/string ownership pass
+- [x] Stage B2–B4: parser corpus/reference_to reduction + guide update
+- [x] Stage B5: playground dialect trim
 - [ ] Stage C1: plan for single compile owner
 - [ ] Stage C2: shared fixtures in ironplc-test
 - [ ] Stage C3: shared container test builders
 - [ ] Stage C4: logger unification
+
+## Outcome of Stages A and B
+
+Where a per-test check disagreed with an estimate above, the check won. The
+estimates were derived from a survey; each deletion was then verified against
+its claimed owner individually, and several claims did not hold:
+
+| Cluster | Estimated | Actually deleted | Why the difference |
+|---|---|---|---|
+| codegen↔vm timers | ~15 | 9 | ET clamping, reset-from-expired, cold-start (IN never TRUE) and TP retrigger have no codegen twin |
+| codegen↔vm strings | ~10 | 11 | Traps, the STR_INIT header contract and a narrow-stride wide array descriptor stay; the function cases went |
+| parser `reference_to` | 6 | 3 | The `XOR` and `<> NULL` cases guard operator disambiguation and are not round-tripped |
+| playground dialect | ~6 | 1 | The off/on contrast pairs are the only proof the dialect/allows strings reach the compiler |
+| ironplc-cli `.plcproj` | 2 | 1 | Main's #1360 rewrote the second one to assert analysis still runs — a CLI-owned contract `sources` cannot test |
+
+Coverage held throughout. Stage A moved the total 91.549% → 91.530% purely by
+removing covered *test* lines; no production line lost coverage (uncovered
+counts per touched file were identical before and after). For Stage B the
+decisive check was that `vm/src/intrinsic.rs` stayed at 186/186 and
+`vm/src/string_ops.rs` at 225/225 after deleting 20 VM tests, confirming the
+codegen e2e suite genuinely exercises those paths.
+
+Lesson for Stage C: a "this is redundant" claim from a survey is a hypothesis.
+Before deleting, read both sides and name the specific assertion that survives.
 
 ## Verification
 

--- a/specs/steering/syntax-support-guide.md
+++ b/specs/steering/syntax-support-guide.md
@@ -23,6 +23,10 @@ When adding new syntax, ensure every applicable item is complete:
 
 Not every syntax change requires all items. A new operator might not need new tokens. A token-level fix might not need codegen changes. Use judgment, but **always** include both round-trip and execution tests when the syntax produces executable code.
 
+Each test leg must assert something the others do not — a parser test that only
+checks "it parses" is subsumed by the round-trip test on the same snippet. See
+[Which leg asserts what](#which-leg-asserts-what-avoid-duplicate-tests).
+
 ## Test File Organization (avoid merge conflicts)
 
 Tests are split into **small, feature-focused files** so that two feature
@@ -44,6 +48,31 @@ Prefer a **new** file for a new sub-feature over appending to an existing
 one: appending puts every branch's new tests on the same trailing lines,
 which is exactly what causes the recurring conflicts. Only add to an
 existing file when the new tests genuinely extend that same narrow feature.
+
+### Which leg asserts what (avoid duplicate tests)
+
+A feature gets tests in several crates, and each leg must assert something
+the others do not. A round-trip test already parses the source with the same
+options, so a parser test that only asserts `is_ok()` on that same snippet
+adds no signal — it is subsumed. Keep the legs distinct:
+
+| Leg | Asserts | Do **not** write |
+|---|---|---|
+| **Parser** (`parser/src/tests/`) | The AST *shape*: the node variant, its fields, counts, nesting | A bare "it parses" on a snippet a plc2plc round-trip already covers |
+| **plc2plc** (`plc2plc/src/tests/`) | Text → AST → text fidelity against a golden file | A second assertion that the source parsed |
+| **Analyzer** (`analyzer/src/rule_*.rs`) | The semantic outcome (accepted, or a specific problem code) | Anything about parse success or failure |
+| **codegen `compile_*`** | The emitted instruction sequence / container structure | Run results |
+| **codegen `end_to_end_*`** | Run results — the nominal behavior matrix reachable from ST | — |
+| **VM** (`vm/tests/it/`) | Traps, overflow/wrap edges, and states codegen cannot emit | A nominal case its codegen twin already runs |
+
+Parser tests asserting only `is_ok()` are still right when there is **no**
+round-trip counterpart — a dialect-flag rejection, a pragma, or a corpus file
+plc2plc does not render. The rule is about the same snippet being asserted
+twice at the same strength, not about `is_ok()` itself.
+
+When a VM test and a codegen end-to-end test would cover the same behavior,
+the codegen test owns it and the VM file says so in its module header (see
+`vm/tests/it/execute_fb_ton.rs` or `execute_string_ops.rs` for the wording).
 
 ## Lexer and Token Patterns
 


### PR DESCRIPTION
Stage B of [the cross-crate test-duplication plan](specs/plans/2026-08-06-reduce-cross-crate-test-duplication.md), following Stage A (#1339). Removes 32 tests that re-assert behavior another crate owns, and writes the ownership rules into the steering guide so the pattern does not regrow.

**630 lines of test code deleted, zero production coverage lost.**

## Every deletion was verified individually

Each claimed duplicate was checked by reading both sides. Where the plan's estimate did not survive that check, the tests were kept:

| Cluster | Plan estimated | Actually deleted | Why the difference |
|---|---|---|---|
| codegen↔vm timers | ~15 | **9** | ET clamping, reset-from-*expired* state, cold-start (IN never TRUE) and TP retrigger have no codegen twin |
| codegen↔vm strings | ~10 | **11** | Traps, the `STR_INIT` header contract and a narrow-stride wide array descriptor stay; the function cases went |
| parser `reference_to` | 6 | **3** | The `XOR` and `<> NULL` cases guard operator disambiguation and are not round-tripped |
| playground dialect | ~6 | **1** | The off/on contrast pairs are the only proof the dialect/allows strings reach the compiler |

Two cases where the estimate would have cost real coverage:

- The codegen TON reset case drops `IN` **before** PT expires; the VM test drops it **after** the timer expired. Different state-machine paths, so the VM test stays.
- On playground, deleting both halves of an off/on contrast would leave a single positive test that passes just as happily if the dialect string were ignored and the baseline were permissive.

## codegen ↔ vm (20 VM tests)

**Timers** — the nominal TON/TOF/TP matrix is driven through compiled ST by `end_to_end_fb_*`, which exercises the same `intrinsic.rs` state machine. Deleted the 9 cases with an exact counterpart; kept ET clamping at PT, resetting out of the expired (Q=TRUE) state, the cold-start cases where IN was never TRUE, and TP retrigger after a completed pulse.

**Strings** — deleted the 11 narrow/wide function cases whose codegen twins assert the resulting *content* (and in several cases add a proptest oracle) rather than only its length. Kept the `STR_INIT` header contract, the store/load roundtrip, all five encoding-mismatch traps, invalid `char_width` (codegen never emits one), and wide data in a narrow-stride array descriptor.

Each affected VM file now carries a module header naming the codegen file that owns the nominal matrix.

Also corrects a stale comment claiming codegen cannot emit wide strings — `end_to_end_wstring.rs` has covered that since PR D landed, so the stated rationale for those hand-assembled fixtures no longer held.

## parser ↔ plc2plc (11 parser tests)

A plc2plc round-trip test parses the same resource with the same `CompilerOptions::default()` and unwraps the result, so it already proves the resource parses.

- `corpus.rs`: reduced the 13-case `is_ok` table to `oscat.st`, the only resource plc2plc does not render.
- `lexer.rs`: dropped the 8 `tokenize_<resource>` tests whose resources a round-trip test parses (tokenizing is strictly weaker); kept `comment.st`, which has no round-trip case.
- `reference_to.rs`: deleted the 3 tests asserting only that one statement parsed.

## playground (1 test)

Dropped the third restatement of ed3-accepts-LTIME (via `load_program`). Kept both off/on contrast pairs for the reason above.

## Guide update

`specs/steering/syntax-support-guide.md` gains a table of which leg asserts what — parser asserts AST shape, plc2plc text fidelity, analyzer semantics, codegen `compile_*` instructions, `end_to_end_*` run results, VM traps and unreachable states — plus the rule that a bare "it parses" is delegated to the round-trip leg. The rule is scoped: `is_ok()` is still correct where there is no round-trip counterpart (dialect-flag rejections, pragmas, un-rendered corpus files).

## Verification

Full `just` pipeline green: compile, coverage **91.878%** (floor 85%), clippy, `fmt --check`, dupes 7.9% exact / 3.1% near (gate 10%/5%).

The decisive check was per-file uncovered-line counts before and after — every file whose tests were deleted holds exactly its prior count:

| File | Uncovered before | After |
|---|---|---|
| `vm/src/intrinsic.rs` | 0 (186/186) | **0** |
| `vm/src/string_ops.rs` | 0 (225/225) | **0** |
| `parser/src/lexer.rs` | 0 | **0** |
| `playground/src/lib.rs` | 181 | **181** |

The −0.011pt total movement is the deleted (fully covered) test lines leaving the denominator. Nothing went dark — direct confirmation that the codegen e2e and plc2plc round-trip suites own those paths, rather than an inference from test names.

No `#[spec_test]` was touched; the build enforces those bidirectionally.

## Next

Stage C is the structural half and is not in this PR: a single `compile()` owner in `project` (the root cause of the ~130-test wrapper cluster), shared fixtures in `ironplc-test`, shared container test builders, and logger unification. Each wants its own plan and PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXxfbhz7rSSL6X1b7ETbAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXxfbhz7rSSL6X1b7ETbAE)_