### PR TITLE
docs(specs): plan for the cross-platform library installer E2E fix

### DIFF
--- a/justfile
+++ b/justfile
@@ -294,15 +294,22 @@ install-script-smoke compiler-version="":
 # Library installer end-to-end test.
 #
 # Installs the published compiler with the *real* OS installer, then compiles AND
-# runs a program that depends on the bundled Tc2_System compatibility library:
-# it computes 2 * PI * 10.0 and the VM dumps the result after one scan. This is
-# the one test that proves the installer ships resources/libs beside the binary,
-# the compiler resolves library symbols (PI) from the *installed* location (not
-# the dev-tree fallback), and the whole toolchain (compile -> run) works on the
-# shipped binaries. Each OS installs differently, so the flow runs per OS:
+# runs programs that depend on the bundled compatibility libraries. This is the
+# one test that proves the installer ships resources/libs beside the binary, the
+# compiler resolves library symbols from the *installed* location (not the
+# dev-tree fallback), and the whole toolchain (compile -> run) works on the
+# shipped binaries. Each OS installs differently, so the install runs per OS:
 #   [unix]      -- tarball + install.sh          -> $HOME/.ironplc/bin
 #   [windows]   -- NSIS installer                -> %LOCALAPPDATA%\...\bin
 #   [macos]     -- Homebrew formula (library-e2e-brew) -> libexec (symlinked)
+#
+# The *verification* does not differ per OS, and is deliberately not written per
+# OS either: every leg below hands two binary paths to the single shared script
+# tests/e2e/library/verify.sh. It used to exist twice -- once in sh, once in
+# PowerShell -- and the copies drifted, so a green Linux run said nothing about
+# Windows (see specs/plans/library-e2e-cross-platform-fix.md). Windows runs the
+# same script through Git for Windows' bash. Keep new assertions in the script,
+# never in a recipe.
 #
 # Structured like endtoend-smoke: the top recipe orchestrates a `-download`
 # (acquire + install) step and a `-test` (compile + run + verify) step. Splitting
@@ -331,14 +338,10 @@ library-e2e-download compiler-version:
   @just _install-script-smoke-clean
   @just _install-script-smoke-run "{{compiler-version}}"
 
-# Compile the library-dependent program with the installed compiler, run one scan
-# on the installed VM, and assert it computed 2 * PI * 10.0 from the library PI.
+# Verify against the tarball layout: binaries and resources/libs in ~/.ironplc/bin.
 [unix]
 library-e2e-test:
-  #!/usr/bin/env sh
-  set -eu
-  BIN="$HOME/.ironplc/bin"
-  just _library-e2e-run-installed "$BIN/ironplcc" "$BIN/ironplcvm"
+  sh tests/e2e/library/verify.sh "$HOME/.ironplc/bin/ironplcc" "$HOME/.ironplc/bin/ironplcvm"
 
 # macOS additionally ships through Homebrew, whose formula installs to libexec and
 # symlinks the executables onto the PATH -- a different layout from the tarball.
@@ -354,6 +357,11 @@ library-e2e-brew compiler-version:
 # template with the release's tarball + checksum and install that. `sed` (not
 # `just publish`) avoids an envsubst/gettext dependency on macOS. The mac tarball
 # matches the runner architecture; the install logic under test is arch-agnostic.
+#
+# Homebrew refuses to install a formula that is not in a tap ("Homebrew requires
+# formulae to be in a tap"), so the filled-in formula goes into a throwaway local
+# tap. The tap name is intentionally NOT the published ironplc/brew tap, so a
+# local run cannot shadow or clobber the real one.
 [macos]
 library-e2e-brew-download compiler-version:
   #!/usr/bin/env sh
@@ -364,53 +372,23 @@ library-e2e-brew-download compiler-version:
   esac
   URL="https://github.com/ironplc/ironplc/releases/download/v{{compiler-version}}"
   SHA="$(curl -fsSL "$URL/$MAC.sha256" | cut -d' ' -f1)"
+  # Start from a clean slate so the recipe can be re-run locally.
+  brew uninstall --force ironplc >/dev/null 2>&1 || true
+  brew untap --force ironplc/e2e >/dev/null 2>&1 || true
+  brew tap-new --no-git ironplc/e2e
+  TAP="$(brew --repository ironplc/e2e)"
+  mkdir -p "$TAP/Formula"
+  # The file name must match the formula's class name (Ironplc).
   sed -e "s#\${VERSION}#{{compiler-version}}#g" -e "s#\${MACFILENAME}#$MAC#g" \
       -e "s#\${MACSHA256}#$SHA#g" -e "s#\${LINUXFILENAME}#$MAC#g" -e "s#\${LINUXSHA256}#$SHA#g" \
-      compiler/homebrew/Formula/ironplc.rb > /tmp/ironplc-e2e.rb
-  brew uninstall --force ironplc >/dev/null 2>&1 || true
-  brew install --formula /tmp/ironplc-e2e.rb
+      compiler/homebrew/Formula/ironplc.rb > "$TAP/Formula/ironplc.rb"
+  brew install --formula ironplc/e2e/ironplc
 
 # Compile + run against the Homebrew keg: binaries are symlinked into the keg bin
 # and current_exe() resolves them back to libexec, where resources/libs lives.
 [macos]
 library-e2e-brew-test:
-  #!/usr/bin/env sh
-  set -eu
-  PREFIX="$(brew --prefix ironplc)"
-  just _library-e2e-run-installed "$PREFIX/bin/ironplcc" "$PREFIX/bin/ironplcvm"
-
-# Shared verification (Unix + macOS): compile each fixture, run one scan, and
-# assert the VM computed the library-provided results (2 * PI * 10.0 = 62.8318...
-# from Tc2_System; 'TRUE'/'FALSE' from Tc2_BuiltIns' BOOL_TO_STRING). A release
-# that failed to ship a library would fail the compile here, so no separate file
-# check is needed -- the target release must ship both bundled libraries.
-[unix]
-_library-e2e-run-installed ironplcc ironplcvm:
-  #!/usr/bin/env sh
-  set -eu
-  WORK="$(mktemp -d)"
-  "{{ironplcc}}" compile --dialect twincat --library Tc2_System \
-    --output "$WORK/prog.iplc" tests/e2e/library/uses_pi.st
-  OUT="$("{{ironplcvm}}" run "$WORK/prog.iplc" --scans 1 --dump-vars -)"
-  echo "$OUT"
-  if ! echo "$OUT" | grep -q "62.8318"; then
-    echo "FAIL: VM did not compute 2 * PI * 10.0 from the library PI" >&2
-    exit 1
-  fi
-  echo "PASS: installed compiler + VM computed 2 * PI * 10.0 using the library PI"
-  "{{ironplcc}}" compile --dialect twincat --library Tc2_BuiltIns \
-    --output "$WORK/builtins.iplc" tests/e2e/library/uses_bool_to_string.st
-  OUT="$("{{ironplcvm}}" run "$WORK/builtins.iplc" --scans 1 --dump-vars -)"
-  echo "$OUT"
-  if ! echo "$OUT" | grep -q "okTrue: TRUE"; then
-    echo "FAIL: BOOL_TO_STRING(TRUE) did not return 'TRUE' from the library" >&2
-    exit 1
-  fi
-  if ! echo "$OUT" | grep -q "okFalse: TRUE"; then
-    echo "FAIL: BOOL_TO_STRING(FALSE) did not return 'FALSE' from the library" >&2
-    exit 1
-  fi
-  echo "PASS: installed compiler + VM computed BOOL_TO_STRING using the library"
+  PREFIX="$(brew --prefix ironplc)"; sh tests/e2e/library/verify.sh "$PREFIX/bin/ironplcc" "$PREFIX/bin/ironplcvm"
 
 # Windows uses the NSIS installer, which installs to a fixed Program Files path.
 # Each line is a separate PowerShell process (set windows-shell), so each step is
@@ -429,20 +407,17 @@ library-e2e-download compiler-version:
   # Install silently.
   Start-Process ironplcc-setup.exe -ArgumentList "/S" -PassThru | Wait-Process -Timeout 120
 
-# Compile the library-dependent program with the installed compiler, run one scan
-# on the installed VM, and assert it computed 2 * PI * 10.0 from the library PI.
+# Verify against the NSIS layout, running the same shared script as the other
+# platforms through Git for Windows' bash (always present on a machine that can
+# clone this repository, and on the GitHub windows runners).
+#
+# The install path is spelled with forward slashes so it needs no backslash
+# escaping inside the script's quoting, and the only PowerShell left is the
+# $LASTEXITCODE propagation -- without it a failing script would be reported as a
+# passing job. Assertions belong in verify.sh, not here.
 [windows]
 library-e2e-test:
-  # Compile the library-dependent program against the installed compiler.
-  &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcc.exe" compile --dialect twincat --library Tc2_System --output "$env:TEMP\prog.iplc" "tests\e2e\library\uses_pi.st"; if ($LASTEXITCODE -ne 0) { Write-Error "FAIL: installed compiler could not compile the library-dependent program"; exit 1 }
-  # Run one scan on the installed VM and assert it computed 2 * PI * 10.0.
-  $out = &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcvm.exe" run "$env:TEMP\prog.iplc" --scans 1 --dump-vars -; Write-Host $out; if ($out -notmatch "62.8318") { Write-Error "FAIL: VM did not compute 2 * PI * 10.0 from the library PI"; exit 1 }
-  Write-Host "PASS: installed compiler + VM computed 2 * PI * 10.0 using the library PI"
-  # Compile the Tc2_BuiltIns-dependent program against the installed compiler.
-  &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcc.exe" compile --dialect twincat --library Tc2_BuiltIns --output "$env:TEMP\builtins.iplc" "tests\e2e\library\uses_bool_to_string.st"; if ($LASTEXITCODE -ne 0) { Write-Error "FAIL: installed compiler could not compile the Tc2_BuiltIns-dependent program"; exit 1 }
-  # Run one scan and assert BOOL_TO_STRING returned 'TRUE' and 'FALSE'.
-  $out = &"{{env_var('LOCALAPPDATA')}}\Programs\IronPLC Compiler\bin\ironplcvm.exe" run "$env:TEMP\builtins.iplc" --scans 1 --dump-vars -; Write-Host $out; if (($out -notmatch "okTrue: TRUE") -or ($out -notmatch "okFalse: TRUE")) { Write-Error "FAIL: BOOL_TO_STRING did not return 'TRUE'/'FALSE' from the library"; exit 1 }
-  Write-Host "PASS: installed compiler + VM computed BOOL_TO_STRING using the library"
+  bash tests/e2e/library/verify.sh "{{ replace(env_var('LOCALAPPDATA'), '\', '/') }}/Programs/IronPLC Compiler/bin/ironplcc.exe" "{{ replace(env_var('LOCALAPPDATA'), '\', '/') }}/Programs/IronPLC Compiler/bin/ironplcvm.exe"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # OpenCode integration end-to-end test - Unix only.
 #

--- a/specs/plans/library-e2e-cross-platform-fix.md
+++ b/specs/plans/library-e2e-cross-platform-fix.md
@@ -172,6 +172,35 @@ Load failed ... error="llama-server process has terminated: signal: segmentation
 That leg passed in the previous deployment and involves no code touched here;
 `ai-action/setup-ollama` installs whatever Ollama release is current, so the
 likely cause is an upstream Ollama regression on the runner's CPU (the log shows
-the AMX backend in use). It is tracked separately — the fix there is a version
-pin or a retry, not a change to the library test — and mixing it into this change
+the AMX backend in use). It is tracked separately — mixing it into this change
 would make it impossible to tell which fix made the deployment green.
+
+A `workflow_dispatch` re-run of that leg on this branch
+([31700029937](https://github.com/ironplc/ironplc/actions/runs/31700029937))
+confirms the instability is in the Ollama/model layer and shows a *second*
+failure mode. This time `llama-server` did not crash — the pre-flight probe
+passed — and the run instead **hung** in layer 3:
+
+```
+12:27:27 Attempt 1/3: asking the agent to call ironplc_check...
+(no further output; llama-server still alive; cancelled manually)
+```
+
+So the real-agent layer fails two different ways (crash, hang) against the same
+pinned model, and `npm run agent-e2e` has no timeout wrapper — unlike the Ollama
+startup steps, which use `run_timeout`. A hang there pins a runner until the
+6-hour job limit and blocks the release with no diagnostic output.
+
+Three independent decisions are worth making deliberately rather than folding
+into this change:
+
+1. **Bound it.** Wrap `npm run agent-e2e` in `run_timeout` so a hang becomes a
+   prompt, legible failure. Unambiguously correct, but on its own it converts a
+   hang into a red deployment rather than a green one.
+2. **Pin Ollama.** `ai-action/setup-ollama` is SHA-pinned but installs the
+   *latest* Ollama, so the toolchain under test changes without a commit. A
+   version pin makes the leg reproducible.
+3. **Reconsider the gate.** A nondeterministic local-LLM test currently gates
+   `publish-website` and therefore the whole release. Layers 1 and 2 (the
+   connectivity smoke and the mock tool-call gate) are deterministic and worth
+   gating on; layer 3 may be better as a non-gating signal.

--- a/specs/plans/library-e2e-cross-platform-fix.md
+++ b/specs/plans/library-e2e-cross-platform-fix.md
@@ -1,0 +1,177 @@
+# Fix the Cross-Platform Library Installer E2E Test
+
+## Context
+
+[Deployment run 31690344796](https://github.com/ironplc/ironplc/actions/runs/31690344796)
+was the first deployment to run the library installer end-to-end test, wired in
+by #1359. Two of its four legs failed, so `publish-website` and everything
+downstream of it was skipped and version 0.237.0 never shipped.
+
+The legs are:
+
+| Leg | Installer | Result |
+|-----|-----------|--------|
+| `library-e2e` (ubuntu-latest) | tarball + `install.sh` | pass |
+| `library-e2e` (macos-latest) | tarball + `install.sh` | pass |
+| `library-e2e` (windows-2025) | NSIS | **fail** |
+| `library-e2e-brew` (macos-latest) | Homebrew formula | **fail** |
+
+Neither leg had ever been green: #1359 wired recipes into the deployment that
+had only ever been run by hand on Linux/macOS tarballs.
+
+A third job in the same run, `OpenCode Integration E2E`, also failed. That
+failure is unrelated to this change (see "Out of scope" below).
+
+### Failure 1 — Windows: PowerShell array truthiness
+
+The Windows leg *did* produce the correct result and then failed the assertion:
+
+```
+PI: 3.141592653589793 circumference: 62.83185307179586
+... FAIL: VM did not compute 2 * PI * 10.0 from the library PI
+```
+
+`ironplcvm --dump-vars` prints one line per variable, and the program pulls in
+the library's `PI` global, so there are two lines. In PowerShell, `&cmd` captures
+multi-line output as an **array of strings**, and `-notmatch` against an array is
+a *filter*, not a boolean: it returns every element that does not match. The
+`PI:` line does not contain `62.8318`, so the filter returns a one-element array,
+which is truthy, so the `if` body ran and failed the test.
+
+The single-line case would have worked, which is why the recipe looked correct
+when it was written by hand.
+
+The `sh` implementation of the same assertion (`grep -q`) has no such failure
+mode — it is line-oriented by construction. The bug exists only because the
+assertions were written **twice**, once per shell.
+
+### Failure 2 — macOS Homebrew: formulae must live in a tap
+
+```
+Homebrew requires formulae to be in a tap, rejecting:
+  /tmp/ironplc-e2e.rb
+```
+
+`brew install --formula <path>` for a file outside a tap is no longer supported.
+The recipe filled the formula template into `/tmp` and installed it from there.
+
+## Goal
+
+1. Make all four legs pass.
+2. Reduce the number of places a platform-specific bug can hide, so that a green
+   Linux run is meaningful evidence about Windows and macOS.
+
+## The simplification
+
+The honest split of this test is:
+
+* **Acquire + install** — genuinely different per OS (`install.sh` unpacks a
+  tarball into `~/.ironplc`, NSIS installs into `%LOCALAPPDATA%`, Homebrew
+  installs into `libexec` and symlinks into a keg `bin`). This difference *is*
+  the thing under test and cannot be collapsed.
+* **Compile, run, assert** — identical everywhere. Same fixtures, same flags,
+  same expected output. Only the two binary paths differ.
+
+Today the second half is implemented twice: once as `sh`
+(`_library-e2e-run-installed`) and once as PowerShell (`library-e2e-test`).
+That duplication is the entire reason Linux passing said nothing about Windows.
+
+**The fix is to have exactly one implementation of the verification, in POSIX
+`sh`, and run it on all three platforms.** GitHub's Windows runners ship Git for
+Windows, so `bash` is on `PATH` — it is what `shell: bash` already uses in
+Actions, and what every developer with Git for Windows has.
+
+Moving the verification out of the justfile and into a checked-in script
+(`tests/e2e/library/verify.sh`) rather than a `sh`-shebang recipe is deliberate:
+a `just` recipe body is still interpreted by `just`'s per-OS shell selection
+(`set windows-shell`, `[unix]`/`[windows]` attributes), whereas a plain script
+invoked as `bash tests/e2e/library/verify.sh <ironplcc> <ironplcvm>` is the same
+bytes run by the same interpreter everywhere. The per-OS recipes shrink to a
+single line each whose only job is to name the two binary paths.
+
+Two path rules keep that script genuinely portable:
+
+* **Everything the script hands to a native binary is a relative path.** The
+  script `cd`s to the repository root (derived from its own location) and uses
+  `tests/e2e/library/uses_pi.st` and `target/library-e2e/pi.iplc`. Absolute
+  POSIX paths such as `mktemp -d`'s `/tmp/tmp.XXXX` are meaningless to a native
+  Windows `.exe` and only survive today by Git Bash's implicit path
+  translation — a mechanism worth not depending on.
+* **Only the two binary paths are absolute**, and the Windows recipe writes them
+  with forward slashes so no backslash escaping is involved.
+
+The one line of PowerShell that must remain is exit-code propagation
+(`if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`), so a failing script cannot
+be reported as a passing job. That is process plumbing, not test logic.
+
+### What this buys
+
+After the change the only per-OS logic left in this test is the installer
+invocation itself: three commands, no assertions, no output parsing, no control
+flow. A bug in the *verification* now fails on Linux too. A bug in the
+*installation* is by definition platform-specific and cannot be collapsed — but
+it is now the only place to look.
+
+## Plan
+
+### 1. `tests/e2e/library/verify.sh` (new)
+
+POSIX `sh`, `set -eu`, takes `<ironplcc> <ironplcvm>`. Derives the repository
+root from `$0` and `cd`s there so all other paths are relative. For each of the
+two fixtures: compile with `--dialect twincat --library <lib>`, run one scan with
+`--scans 1 --dump-vars -`, echo the dump, and `grep -q` the expected results
+(`62.8318`; `okTrue: TRUE` and `okFalse: TRUE`). Distinct failure messages for
+compile failure, run failure, and wrong result, so a red run says which stage
+broke. Outputs go to `target/library-e2e/` (already git-ignored).
+
+### 2. `justfile`
+
+* Delete `_library-e2e-run-installed`; both `sh` call sites move to the script.
+* `[unix] library-e2e-test` → one line invoking the script with
+  `$HOME/.ironplc/bin/{ironplcc,ironplcvm}`.
+* `[macos] library-e2e-brew-test` → one line invoking the script with
+  `$(brew --prefix ironplc)/bin/{ironplcc,ironplcvm}`.
+* `[windows] library-e2e-test` → one line invoking the script through `bash`
+  with `%LOCALAPPDATA%/Programs/IronPLC Compiler/bin/{ironplcc,ironplcvm}.exe`
+  (forward slashes via `replace(env_var('LOCALAPPDATA'), '\', '/')`), plus
+  `$LASTEXITCODE` propagation. All PowerShell assertions are deleted.
+* `[macos] library-e2e-brew-download` → create a throwaway local tap with
+  `brew tap-new --no-git ironplc/e2e`, write the filled-in formula to that tap's
+  `Formula/ironplc.rb`, and `brew install --formula ironplc/e2e/ironplc`.
+  Untap/uninstall first so the recipe is re-runnable locally. The tap name
+  (`ironplc/e2e`) is deliberately not the published tap (`ironplc/brew`).
+
+### 3. `tests/e2e/library/README.md`
+
+Document the shared script, why it is a script rather than a recipe, and drop
+the stale "intentionally not wired into the release pipeline yet" note.
+
+## Validation
+
+The recipes cannot be exercised on Linux alone, and `just --dry-run` does not
+evaluate `[windows]` recipe bodies on Linux. `partial_library_e2e.yaml` already
+has a `workflow_dispatch` trigger for exactly this reason, so validation is:
+push the branch, dispatch the workflow against it with a release version that
+ships both libraries (0.237.0), and require all four legs green before merge.
+
+Locally on Linux: `sh tests/e2e/library/verify.sh` against an installed
+toolchain, plus `just --evaluate` / `just --summary` to confirm the justfile
+still parses.
+
+## Out of scope
+
+`OpenCode Integration E2E` failed in the same run because Ollama's `llama-server`
+took a **segmentation fault while warming up** `qwen2.5:1.5b`, before any IronPLC
+code ran:
+
+```
+Load failed ... error="llama-server process has terminated: signal: segmentation fault (core dumped)"
+[GIN] ... | 500 | 20.25s | POST "/v1/chat/completions"
+```
+
+That leg passed in the previous deployment and involves no code touched here;
+`ai-action/setup-ollama` installs whatever Ollama release is current, so the
+likely cause is an upstream Ollama regression on the runner's CPU (the log shows
+the AMX backend in use). It is tracked separately — the fix there is a version
+pin or a retry, not a change to the library test — and mixing it into this change
+would make it impossible to tell which fix made the deployment green.

--- a/tests/e2e/library/README.md
+++ b/tests/e2e/library/README.md
@@ -27,6 +27,28 @@ and executed correctly (`--dump-vars` does not render STRING contents, so the
 fixture folds the results into BOOLs via string comparison). The target release
 must ship both bundled libraries.
 
+## One verification, three installers
+
+`verify.sh` is the whole test: it takes an installed `ironplcc` and `ironplcvm`,
+does the compile/run/assert above, and is the *only* place those assertions
+exist. Every platform runs the same script — Windows through Git for Windows'
+`bash` — so the per-OS `just` recipes shrink to one line naming the two binary
+paths.
+
+That is deliberate. The assertions previously existed twice, once in `sh` and
+once in PowerShell, and the copies drifted: PowerShell captures multi-line
+command output as an *array*, where `-notmatch` filters instead of returning a
+boolean, so the Windows leg reported a correct result as a failure while Linux
+stayed green. Keep new assertions in `verify.sh`, never in a recipe.
+
+What genuinely cannot be shared is the install itself — tarball, NSIS, and
+Homebrew put files in different places, and that difference is the thing under
+test. Everything after the install is common.
+
+`verify.sh` hands the toolchain only *relative* paths (`tests/e2e/library/...`,
+`target/library-e2e/...`), because a native Windows `.exe` does not understand
+POSIX paths such as `mktemp -d`'s `/tmp/tmp.XXXX`. Keep it that way.
+
 ## Running it
 
 Each OS installs differently, so there are per-OS recipes. The release version is
@@ -54,7 +76,16 @@ just library-e2e-brew-download 0.234.0   # acquire + install (Homebrew)
 just library-e2e-brew-test               # compile + run + verify (repeatable)
 ```
 
-In CI this is `partial_library_e2e.yaml`, runnable from the Actions tab
-(`workflow_dispatch`): a Linux/macOS/Windows matrix for the tarball + NSIS
-installers, plus a dedicated macOS job for the Homebrew installer. It is
-intentionally not wired into the release or PR pipelines yet.
+Or drive the verification directly against any installed toolchain:
+
+```sh
+sh tests/e2e/library/verify.sh ~/.ironplc/bin/ironplcc ~/.ironplc/bin/ironplcvm
+```
+
+In CI this is `partial_library_e2e.yaml`: a Linux/macOS/Windows matrix for the
+tarball + NSIS installers, plus a dedicated macOS job for the Homebrew
+installer. It runs as part of `deployment.yaml` and gates `publish-website`, so
+a release that fails to ship the bundled libraries cannot be published. Because
+the recipes can only be exercised on a real runner, change them on a branch and
+validate with the workflow's `workflow_dispatch` trigger from the Actions tab
+before merging.

--- a/tests/e2e/library/verify.sh
+++ b/tests/e2e/library/verify.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+# Shared verification for the library installer end-to-end test.
+#
+# Compiles each library-dependent fixture with an *installed* ironplcc, runs one
+# scan on the installed ironplcvm, and asserts the dump shows the results that
+# only the bundled compatibility libraries can produce. A release that failed to
+# ship a library fails the compile here, so no separate file check is needed.
+#
+# Usage:
+#   sh tests/e2e/library/verify.sh <ironplcc> <ironplcvm>
+#
+# This is a script rather than a justfile recipe on purpose. The installers
+# differ per OS, but this verification does not, and the previous per-OS copies
+# of it drifted: the PowerShell copy compared an array of output lines with
+# `-notmatch`, which filters instead of returning a boolean, so a correct run was
+# reported as a failure. One implementation, run by the same interpreter on every
+# platform, is the only way a green Linux run says anything about Windows.
+#
+# Every path handed to the compiler and VM below is relative, because the callers
+# on Windows are native .exe files that do not understand POSIX paths such as
+# `mktemp -d`'s /tmp/tmp.XXXX. Relative paths need no translation anywhere. Only
+# the two binary paths are absolute, and the Windows caller writes them with
+# forward slashes.
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: verify.sh <ironplcc> <ironplcvm>" >&2
+  exit 2
+fi
+
+ironplcc="$1"
+ironplcvm="$2"
+
+# Work from the repository root so the fixture and output paths below are
+# relative, however the script was invoked.
+cd "$(dirname -- "$0")/../../.."
+
+work="target/library-e2e"
+rm -rf "$work"
+mkdir -p "$work"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# compile_and_run <library> <fixture> <name>
+#
+# Leaves the VM's variable dump in $work/<name>.out and echoes it, so a failing
+# run shows what the toolchain actually produced.
+compile_and_run() {
+  _library="$1"
+  _fixture="$2"
+  _name="$3"
+
+  "$ironplcc" compile --dialect twincat --library "$_library" \
+    --output "$work/$_name.iplc" "$_fixture" \
+    || fail "installed compiler could not compile $_fixture against $_library"
+
+  "$ironplcvm" run "$work/$_name.iplc" --scans 1 --dump-vars - > "$work/$_name.out" 2>&1 \
+    || { cat "$work/$_name.out"; fail "installed VM could not run $work/$_name.iplc"; }
+
+  cat "$work/$_name.out"
+}
+
+echo "Verifying with:"
+echo "  ironplcc:  $ironplcc"
+echo "  ironplcvm: $ironplcvm"
+
+# Tc2_System: `PI` is a library global, not a language built-in, so after one
+# scan `circumference` holds 2 * PI * 10.0 = 62.83185307179586.
+compile_and_run Tc2_System tests/e2e/library/uses_pi.st pi
+grep -q "62.8318" "$work/pi.out" \
+  || fail "VM did not compute 2 * PI * 10.0 from the library PI"
+echo "PASS: installed compiler + VM computed 2 * PI * 10.0 using the library PI"
+
+# Tc2_BuiltIns: BOOL_TO_STRING is a library function. --dump-vars does not render
+# STRING contents, so the fixture folds the comparisons into BOOLs.
+compile_and_run Tc2_BuiltIns tests/e2e/library/uses_bool_to_string.st builtins
+grep -q "okTrue: TRUE" "$work/builtins.out" \
+  || fail "BOOL_TO_STRING(TRUE) did not return 'TRUE' from the library"
+grep -q "okFalse: TRUE" "$work/builtins.out" \
+  || fail "BOOL_TO_STRING(FALSE) did not return 'FALSE' from the library"
+echo "PASS: installed compiler + VM computed BOOL_TO_STRING using the library"


### PR DESCRIPTION
The first deployment to run the library installer end-to-end test failed on
Windows (PowerShell treats multi-line command output as an array, so -notmatch
filters rather than returning a boolean) and on the macOS Homebrew leg (brew no
longer installs a formula from a path outside a tap).

Plan the fix around a single shared verification script so the assertions exist
once instead of once per shell, leaving only the genuinely per-OS installer
invocation platform-specific.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LLqti7KegZYgx9vrJRH7Z9