### PR TITLE
Add function block member access type resolution

### DIFF
--- a/compiler/analyzer/src/intermediate_type.rs
+++ b/compiler/analyzer/src/intermediate_type.rs
@@ -194,6 +194,29 @@ impl IntermediateType {
         matches!(self, IntermediateType::Function { .. })
     }
 
+    /// Returns if the type exposes named members reachable with `.` access.
+    ///
+    /// Structures and function block instances both expose named fields, so
+    /// both answer `true`.
+    pub fn has_members(&self) -> bool {
+        self.member_fields().is_some()
+    }
+
+    /// Returns the named fields reachable with `.` access, None if the type
+    /// has no such members.
+    ///
+    /// A function block instance exposes its variables (`timer.Q`) the same way
+    /// a structure exposes its fields (`setup.FLAG`), so both are returned
+    /// here. Use [`IntermediateType::is_structure`] instead when the caller
+    /// needs a structure specifically.
+    pub fn member_fields(&self) -> Option<&Vec<IntermediateStructField>> {
+        match self {
+            IntermediateType::Structure { fields }
+            | IntermediateType::FunctionBlock { fields, .. } => Some(fields),
+            _ => None,
+        }
+    }
+
     /// Returns if the type is a reference (REF_TO).
     pub fn is_reference(&self) -> bool {
         matches!(self, IntermediateType::Reference { .. })
@@ -1558,6 +1581,60 @@ mod tests {
         let struct_type = IntermediateType::Structure { fields };
         // Should return None because one field has unknown size
         assert_eq!(struct_type.size_in_bytes(), None);
+    }
+
+    #[test]
+    fn member_fields_when_structure_then_returns_fields() {
+        use super::IntermediateStructField;
+        use ironplc_dsl::core::Id;
+
+        let fields = vec![IntermediateStructField {
+            name: Id::from("field1"),
+            field_type: IntermediateType::Bool,
+            offset: 0,
+            var_type: None,
+            has_default: false,
+        }];
+        let struct_type = IntermediateType::Structure {
+            fields: fields.clone(),
+        };
+
+        assert!(struct_type.has_members());
+        assert_eq!(struct_type.member_fields(), Some(&fields));
+    }
+
+    #[test]
+    fn member_fields_when_function_block_then_returns_fields() {
+        use super::{FunctionBlockVarType, IntermediateStructField};
+        use ironplc_dsl::core::Id;
+
+        let fields = vec![IntermediateStructField {
+            name: Id::from("Q"),
+            field_type: IntermediateType::Bool,
+            offset: 0,
+            var_type: Some(FunctionBlockVarType::Output),
+            has_default: false,
+        }];
+        let fb_type = IntermediateType::FunctionBlock {
+            name: "MyFB".to_string(),
+            fields: fields.clone(),
+        };
+
+        assert!(fb_type.has_members());
+        assert_eq!(fb_type.member_fields(), Some(&fields));
+    }
+
+    #[test]
+    fn member_fields_when_not_composite_then_returns_none() {
+        assert!(!IntermediateType::Bool.has_members());
+        assert_eq!(IntermediateType::Bool.member_fields(), None);
+
+        let array_type = IntermediateType::Array {
+            element_type: Box::new(IntermediateType::Bool),
+            dimensions: vec![],
+        };
+        assert!(!array_type.has_members());
+        assert_eq!(array_type.member_fields(), None);
     }
 
     #[test]

--- a/compiler/analyzer/src/type_environment.rs
+++ b/compiler/analyzer/src/type_environment.rs
@@ -351,6 +351,18 @@ impl TypeEnvironment {
         }
     }
 
+    /// Returns the intermediate type for a named type that exposes members
+    /// reachable with `.` access.
+    ///
+    /// Returns `Some` with the `IntermediateType::Structure` or
+    /// `IntermediateType::FunctionBlock` if the type is found and has named
+    /// members, or `None` otherwise. Use [`TypeEnvironment::resolve_struct_type`]
+    /// instead when the caller needs a structure specifically.
+    pub fn resolve_member_access_type(&self, type_name: &TypeName) -> Option<&IntermediateType> {
+        let attrs = self.get(type_name)?;
+        attrs.representation.has_members().then_some(&attrs.representation)
+    }
+
     /// An iterator for all types in the environment
     pub fn iter(
         &self,
@@ -1074,6 +1086,61 @@ mod tests {
         assert!(env.resolve_struct_type(&TypeName::from("MY_INT")).is_none());
         assert!(env
             .resolve_struct_type(&TypeName::from("NOT_FOUND"))
+            .is_none());
+    }
+
+    #[test]
+    fn resolve_member_access_type_when_function_block_then_returns_type() {
+        // Unlike resolve_struct_type, member access must also see function
+        // block instances so `timer.Q` resolves.
+        let mut env = TypeEnvironment::new();
+        let fb_type = IntermediateType::FunctionBlock {
+            name: "MyFB".to_string(),
+            fields: vec![],
+        };
+        env.insert_type(
+            &TypeName::from("MY_FB"),
+            TypeAttributes::new(SourceSpan::default(), fb_type.clone()),
+        )
+        .unwrap();
+
+        assert!(env.resolve_struct_type(&TypeName::from("MY_FB")).is_none());
+        assert_eq!(
+            env.resolve_member_access_type(&TypeName::from("MY_FB")),
+            Some(&fb_type)
+        );
+    }
+
+    #[test]
+    fn resolve_member_access_type_when_structure_then_returns_type() {
+        let mut env = TypeEnvironment::new();
+        let struct_type = IntermediateType::Structure { fields: vec![] };
+        env.insert_type(
+            &TypeName::from("MY_STRUCT"),
+            TypeAttributes::new(SourceSpan::default(), struct_type.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            env.resolve_member_access_type(&TypeName::from("MY_STRUCT")),
+            Some(&struct_type)
+        );
+    }
+
+    #[test]
+    fn resolve_member_access_type_when_no_members_then_returns_none() {
+        let mut env = TypeEnvironment::new();
+        env.insert_type(
+            &TypeName::from("MY_BOOL"),
+            TypeAttributes::new(SourceSpan::default(), IntermediateType::Bool),
+        )
+        .unwrap();
+
+        assert!(env
+            .resolve_member_access_type(&TypeName::from("MY_BOOL"))
+            .is_none());
+        assert!(env
+            .resolve_member_access_type(&TypeName::from("NOT_FOUND"))
             .is_none());
     }
 }

--- a/compiler/analyzer/src/type_environment.rs
+++ b/compiler/analyzer/src/type_environment.rs
@@ -360,7 +360,10 @@ impl TypeEnvironment {
     /// instead when the caller needs a structure specifically.
     pub fn resolve_member_access_type(&self, type_name: &TypeName) -> Option<&IntermediateType> {
         let attrs = self.get(type_name)?;
-        attrs.representation.has_members().then_some(&attrs.representation)
+        attrs
+            .representation
+            .has_members()
+            .then_some(&attrs.representation)
     }
 
     /// An iterator for all types in the environment

--- a/compiler/analyzer/src/xform_resolve_expr_types.rs
+++ b/compiler/analyzer/src/xform_resolve_expr_types.rs
@@ -364,7 +364,10 @@ impl ExprTypeResolver<'_> {
     /// definition, then finds the leaf member's type.
     fn resolve_structured_variable_type(&self, sv: &StructuredVariable) -> Option<TypeName> {
         let parent_type = self.resolve_parent_struct_type(sv.record.as_ref())?;
-        let field = parent_type.member_fields()?.iter().find(|f| f.name == sv.field)?;
+        let field = parent_type
+            .member_fields()?
+            .iter()
+            .find(|f| f.name == sv.field)?;
         self.type_environment
             .elementary_type_name_for(&field.field_type)
     }
@@ -386,7 +389,10 @@ impl ExprTypeResolver<'_> {
             }
             SymbolicVariableKind::Structured(sv) => {
                 let parent_type = self.resolve_parent_struct_type(sv.record.as_ref())?;
-                let field = parent_type.member_fields()?.iter().find(|f| f.name == sv.field)?;
+                let field = parent_type
+                    .member_fields()?
+                    .iter()
+                    .find(|f| f.name == sv.field)?;
                 if field.field_type.has_members() {
                     Some(&field.field_type)
                 } else {
@@ -1348,7 +1354,9 @@ END_FUNCTION_BLOCK";
         let result = run_pass(program);
         let types = collect_all_expr_types(&result);
         assert!(
-            types.iter().any(|t| type_name_upper(t).as_deref() == Some("BOOL")),
+            types
+                .iter()
+                .any(|t| type_name_upper(t).as_deref() == Some("BOOL")),
             "condition `timer.Q` should resolve to BOOL, got {types:?}"
         );
         assert!(

--- a/compiler/analyzer/src/xform_resolve_expr_types.rs
+++ b/compiler/analyzer/src/xform_resolve_expr_types.rs
@@ -357,27 +357,24 @@ impl ExprTypeResolver<'_> {
         }
     }
 
-    /// Resolves the type of a struct field access expression (e.g., `setup.FLAG`).
+    /// Resolves the type of a member access expression (e.g., `setup.FLAG` or
+    /// `timer.Q`).
     ///
-    /// Walks the struct chain to find the root variable, looks up its struct
-    /// type definition, then finds the leaf field's type.
+    /// Walks the member chain to find the root variable, looks up its type
+    /// definition, then finds the leaf member's type.
     fn resolve_structured_variable_type(&self, sv: &StructuredVariable) -> Option<TypeName> {
         let parent_type = self.resolve_parent_struct_type(sv.record.as_ref())?;
-        match parent_type {
-            IntermediateType::Structure { fields } => {
-                let field = fields.iter().find(|f| f.name == sv.field)?;
-                self.type_environment
-                    .elementary_type_name_for(&field.field_type)
-            }
-            _ => None,
-        }
+        let field = parent_type.member_fields()?.iter().find(|f| f.name == sv.field)?;
+        self.type_environment
+            .elementary_type_name_for(&field.field_type)
     }
 
-    /// Resolves a `SymbolicVariableKind` to its struct `IntermediateType`.
+    /// Resolves a `SymbolicVariableKind` to the `IntermediateType` whose
+    /// members it exposes.
     ///
     /// For `Named`, looks up the variable's declared type and resolves it as a
-    /// struct. For `Structured`, recursively resolves the parent and finds the
-    /// nested struct field type.
+    /// structure or function block instance. For `Structured`, recursively
+    /// resolves the parent and finds the nested member type.
     fn resolve_parent_struct_type<'b>(
         &'b self,
         kind: &SymbolicVariableKind,
@@ -385,20 +382,15 @@ impl ExprTypeResolver<'_> {
         match kind {
             SymbolicVariableKind::Named(nv) => {
                 let var_type = self.var_types.get(&nv.name)?;
-                self.type_environment.resolve_struct_type(var_type)
+                self.type_environment.resolve_member_access_type(var_type)
             }
             SymbolicVariableKind::Structured(sv) => {
                 let parent_type = self.resolve_parent_struct_type(sv.record.as_ref())?;
-                match parent_type {
-                    IntermediateType::Structure { fields } => {
-                        let field = fields.iter().find(|f| f.name == sv.field)?;
-                        if field.field_type.is_structure() {
-                            Some(&field.field_type)
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
+                let field = parent_type.member_fields()?.iter().find(|f| f.name == sv.field)?;
+                if field.field_type.has_members() {
+                    Some(&field.field_type)
+                } else {
+                    None
                 }
             }
             _ => None,
@@ -413,10 +405,10 @@ impl ExprTypeResolver<'_> {
     /// canonical `TypeName`.
     fn resolve_struct_field_array_element_type(&self, sv: &StructuredVariable) -> Option<TypeName> {
         let parent_type = self.resolve_parent_struct_type(sv.record.as_ref())?;
-        let IntermediateType::Structure { fields } = parent_type else {
-            return None;
-        };
-        let field = fields.iter().find(|f| f.name == sv.field)?;
+        let field = parent_type
+            .member_fields()?
+            .iter()
+            .find(|f| f.name == sv.field)?;
         let IntermediateType::Array { element_type, .. } = &field.field_type else {
             return None;
         };
@@ -1292,6 +1284,42 @@ END_VAR
 END_FUNCTION_BLOCK",
         "DINT"
     )]
+    // A function block instance exposes its variables as named members, the
+    // same as a struct field. Leaving these unresolved made codegen fail with
+    // P9999 wherever the expression's own type was needed (issue #1375).
+    #[case::function_block_bool_output(
+        "
+FUNCTION_BLOCK FB_TEST
+VAR
+    timer : TON;
+    result : BOOL;
+END_VAR
+    result := timer.Q;
+END_FUNCTION_BLOCK",
+        "BOOL"
+    )]
+    #[case::function_block_time_output(
+        "
+FUNCTION_BLOCK FB_TEST
+VAR
+    timer : TON;
+    result : TIME;
+END_VAR
+    result := timer.ET;
+END_FUNCTION_BLOCK",
+        "TIME"
+    )]
+    #[case::function_block_input(
+        "
+FUNCTION_BLOCK FB_TEST
+VAR
+    timer : TON;
+    result : BOOL;
+END_VAR
+    result := timer.IN;
+END_FUNCTION_BLOCK",
+        "BOOL"
+    )]
     fn apply_when_single_assignment_then_resolves_expected_type(
         #[case] program: &str,
         #[case] expected: &str,
@@ -1300,5 +1328,50 @@ END_FUNCTION_BLOCK",
         let types = collect_assignment_types(&result);
         assert_eq!(types.len(), 1);
         assert_type_eq(&types[0], expected);
+    }
+
+    #[test]
+    fn apply_when_function_block_output_in_condition_then_resolves_type() {
+        // An IF condition has no assignment target to borrow a type from, so
+        // codegen reads the condition's own resolved_type. Leaving it unset
+        // for `timer.Q` produced P9999 (issue #1375).
+        let program = "
+FUNCTION_BLOCK FB_TEST
+VAR
+    timer : TON;
+    done : BOOL;
+END_VAR
+    IF timer.Q THEN
+        done := TRUE;
+    END_IF;
+END_FUNCTION_BLOCK";
+        let result = run_pass(program);
+        let types = collect_all_expr_types(&result);
+        assert!(
+            types.iter().any(|t| type_name_upper(t).as_deref() == Some("BOOL")),
+            "condition `timer.Q` should resolve to BOOL, got {types:?}"
+        );
+        assert!(
+            types.iter().all(|t| t.is_some()),
+            "every expression should resolve, got {types:?}"
+        );
+    }
+
+    #[test]
+    fn apply_when_unknown_function_block_field_then_type_is_unresolved() {
+        // A misspelled member has no field to resolve against; the pass must
+        // leave it unset rather than inventing a type.
+        let program = "
+FUNCTION_BLOCK FB_TEST
+VAR
+    timer : TON;
+    result : BOOL;
+END_VAR
+    result := timer.NOT_A_FIELD;
+END_FUNCTION_BLOCK";
+        let result = run_pass(program);
+        let types = collect_assignment_types(&result);
+        assert_eq!(types.len(), 1);
+        assert_eq!(types[0], None);
     }
 }

--- a/compiler/codegen/tests/it/end_to_end_fb_ton.rs
+++ b/compiler/codegen/tests/it/end_to_end_fb_ton.rs
@@ -134,6 +134,67 @@ PROGRAM main
 END_PROGRAM
 ";
 
+// Dot-access read of Q as an IF condition: timer=var0, done=var1.
+const TON_DOT_READ_Q_IN_IF: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    done : BOOL := FALSE;
+  END_VAR
+  timer(IN := TRUE, PT := T#500ms);
+  IF timer.Q THEN
+    done := TRUE;
+  END_IF;
+END_PROGRAM
+";
+
+// Dot-access read of Q inside a boolean expression: timer=var0, gate=var1,
+// result=var2.
+const TON_DOT_READ_Q_IN_EXPR: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    gate : BOOL;
+    result : BOOL := FALSE;
+  END_VAR
+  timer(IN := TRUE, PT := T#500ms);
+  IF gate AND NOT timer.Q THEN
+    result := TRUE;
+  ELSE
+    result := FALSE;
+  END_IF;
+END_PROGRAM
+";
+
+// Dot-access read of the TIME output ET in a comparison: timer=var0,
+// past=var1.
+const TON_DOT_READ_ET_IN_IF: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    past : BOOL := FALSE;
+  END_VAR
+  timer(IN := TRUE, PT := T#10s);
+  IF timer.ET > T#2s THEN
+    past := TRUE;
+  END_IF;
+END_PROGRAM
+";
+
+// Dot-access read of Q as a WHILE condition guard: timer=var0, count=var1.
+const TON_DOT_READ_Q_IN_WHILE: &str = "
+PROGRAM main
+  VAR
+    timer : TON;
+    count : DINT := 0;
+  END_VAR
+  timer(IN := TRUE, PT := T#500ms);
+  WHILE NOT timer.Q AND count < 3 DO
+    count := count + 1;
+  END_WHILE;
+END_PROGRAM
+";
+
 #[rstest]
 // Plain TIME literal assignment: T#5s stored as 5000 ms (i32).
 #[case::time_value_i32_ms(TON_TIME_ONLY, &[Run(0), Expect(0, 5000)])]
@@ -183,6 +244,28 @@ END_PROGRAM
 // Dot-access write of PT uses the new (longer) period.
 #[case::dot_access_writes_pt(TON_DOT_WRITE_2S, &[
     Run(0), Run(1_000_000), Expect(1, 0), Run(3_000_000), Expect(1, 1),
+])]
+// Dot-access read of Q as an IF condition (issue #1375).
+#[case::dot_access_reads_q_in_if(TON_DOT_READ_Q_IN_IF, &[
+    Run(0), Run(100_000), Expect(1, 0), Run(600_000), Expect(1, 1),
+])]
+// Dot-access read of Q combined with other terms in a boolean expression.
+#[case::dot_access_reads_q_in_expr(TON_DOT_READ_Q_IN_EXPR, &[
+    // gate FALSE: result stays FALSE regardless of Q.
+    Run(0), Expect(2, 0),
+    // gate TRUE and Q still FALSE: result TRUE.
+    Write(1, 1), Run(100_000), Expect(2, 1),
+    // gate TRUE but Q now TRUE: result back to FALSE.
+    Run(600_000), Expect(2, 0),
+])]
+// Dot-access read of the TIME output ET in a comparison.
+#[case::dot_access_reads_et_in_if(TON_DOT_READ_ET_IN_IF, &[
+    Run(0), Run(1_000_000), Expect(1, 0), Run(3_000_000), Expect(1, 1),
+])]
+// Dot-access read of Q as a WHILE loop guard.
+#[case::dot_access_reads_q_in_while(TON_DOT_READ_Q_IN_WHILE, &[
+    // Q still FALSE, so the loop runs to its count bound.
+    Run(0), Run(100_000), Expect(1, 3),
 ])]
 fn end_to_end_fb_ton(#[case] source: &str, #[case] steps: &[FbStep]) {
     drive_fb(source, &CompilerOptions::default(), steps);

--- a/specs/plans/fb-member-expr-type-resolution.md
+++ b/specs/plans/fb-member-expr-type-resolution.md
@@ -1,0 +1,99 @@
+# Plan: Resolve expression types for function block member access
+
+## Problem
+
+Reading a function block output in an expression that needs the expression's own
+resolved type — for example `IF timer.Q THEN` — fails codegen with `P9999`
+pointing at `codegen/src/compile_expr.rs` (`op_type`). Reported in
+[issue #1375](https://github.com/ironplc/ironplc/issues/1375).
+
+Minimal reproduction:
+
+```iecst
+PROGRAM p
+VAR
+  tmr : TON;
+  done : BOOL := FALSE;
+END_VAR
+  IF tmr.Q THEN      (* P9999 *)
+    done := TRUE;
+  END_IF;
+END_PROGRAM
+```
+
+`done := tmr.Q;` compiles because the assignment path derives the op type from
+the assignment target, never consulting `Expr::resolved_type`. A condition has
+no such target, so `condition_op_type` falls through to `op_type`, which
+requires `resolved_type` to be populated and reports "not implemented" when it
+is not.
+
+## Root cause
+
+`xform_resolve_expr_types` annotates `Expr::resolved_type`. Its struct-chain
+walk resolves member access only through `IntermediateType::Structure`:
+
+- `TypeEnvironment::resolve_struct_type` matches `Structure` and nothing else.
+- `resolve_structured_variable_type` / `resolve_parent_struct_type` /
+  `resolve_struct_field_array_element_type` all destructure
+  `IntermediateType::Structure { fields }`.
+
+A function block instance is registered as
+`IntermediateType::FunctionBlock { name, fields }` — it carries the same
+`IntermediateStructField` list (`TON` has `IN`, `PT`, `Q`, `ET`), but no branch
+matches it. So `tmr.Q` resolves to `None` and the annotation is left unset.
+
+Codegen already handles the FB member *read* correctly
+(`compile_variable_read` emits `FB_LOAD_INSTANCE` + `FB_LOAD_PARAM` for
+`ctx.fb_instances`). Only the analyzer annotation is missing, so the fix belongs
+in the analyzer.
+
+## Design Decisions
+
+- Fix in the analyzer, not codegen. Codegen's requirement that the analyzer
+  populate `resolved_type` is correct; the analyzer was not holding up its end.
+- Treat `Structure` and `FunctionBlock` uniformly for *member access only*. Both
+  expose a named `IntermediateStructField` list, so a shared accessor removes
+  the duplicated `match` arms rather than adding a parallel FB code path.
+- Keep `resolve_struct_type` unchanged. Other callers use it to ask "is this
+  specifically a structure?" and must keep that meaning; add a separate
+  member-access-oriented lookup instead.
+
+## Implementation Steps
+
+### Step 1: Add a member-field accessor to `IntermediateType`
+
+**File**: `compiler/analyzer/src/intermediate_type.rs`
+
+Add `member_fields()` returning `Option<&Vec<IntermediateStructField>>` for
+`Structure` and `FunctionBlock`, `None` otherwise, and `has_members()` for the
+matching predicate.
+
+### Step 2: Add a member-access type lookup to `TypeEnvironment`
+
+**File**: `compiler/analyzer/src/type_environment.rs`
+
+Add `resolve_member_access_type(&self, type_name)` returning the representation
+when it is a `Structure` or a `FunctionBlock`.
+
+### Step 3: Use the new accessors in the type-resolution transform
+
+**File**: `compiler/analyzer/src/xform_resolve_expr_types.rs`
+
+- `resolve_parent_struct_type`: `Named` arm uses `resolve_member_access_type`;
+  `Structured` arm uses `member_fields()` and `has_members()`.
+- `resolve_structured_variable_type`: use `member_fields()`.
+- `resolve_struct_field_array_element_type`: use `member_fields()`.
+
+### Step 4: Tests
+
+- `compiler/analyzer/src/xform_resolve_expr_types.rs`: unit test that a
+  `timer.Q` condition gets a resolved type.
+- `compiler/codegen/tests/it/end_to_end_fb_ton.rs`: end-to-end cases driving a
+  TON whose `Q` is read from an `IF` condition and from a boolean expression,
+  covering both a BOOL output (`Q`) and a TIME output (`ET`) compared in a
+  condition.
+
+## Verification
+
+- Original issue #1375 program compiles.
+- `cd compiler && just` passes (compile, coverage ≥ 85%, clippy, fmt).


### PR DESCRIPTION
Plan for fixing P9999 when a function block output is read in an
expression that needs its own resolved type (e.g. IF timer.Q THEN).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G2MurUwzXkoT3gdgjhtptV