### PR TITLE
Extract shared logger configuration into cli-support crate

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "encoding_rs",
  "env_logger",
  "ironplc-analyzer",
+ "ironplc-cli-support",
  "ironplc-codegen",
  "ironplc-container",
  "ironplc-dsl",
@@ -963,6 +964,15 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "ironplc-cli-support"
+version = "0.238.0"
+dependencies = [
+ "env_logger",
+ "log",
  "tempfile",
  "time",
 ]
@@ -1166,6 +1176,7 @@ dependencies = [
  "ctor",
  "ctrlc",
  "env_logger",
+ "ironplc-cli-support",
  "ironplc-container",
  "ironplc-spec-requirements-gen",
  "ironplc-vm",
@@ -1175,7 +1186,6 @@ dependencies = [
  "serde_json",
  "spec_test_macro",
  "tempfile",
- "time",
 ]
 
 [[package]]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "analyzer",
     "benchmarks",
+    "cli-support",
     "codegen",
     "container",
     "container_derive",

--- a/compiler/cli-support/Cargo.toml
+++ b/compiler/cli-support/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ironplc-cli-support"
+description = "Shared building blocks for the IronPLC command line programs"
+version = "0.238.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[badges]
+maintenance = { status = "experimental" }
+
+[dependencies]
+env_logger = "0.11.10"
+log = "0.4.29"
+time = "0.3.47"
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/compiler/cli-support/src/lib.rs
+++ b/compiler/cli-support/src/lib.rs
@@ -1,0 +1,10 @@
+//! Building blocks shared by the IronPLC command line programs.
+//!
+//! The command line programs (`ironplcc`, `ironplcvm`) are separate crates
+//! with deliberately different dependency trees. This crate holds the small
+//! amount of behavior they genuinely share, so that it is written and tested
+//! once. Each program keeps ownership of how it reports failures: functions
+//! here return this crate's own error types, and each program maps those onto
+//! its own user-facing error type at its boundary.
+
+pub mod logger;

--- a/compiler/cli-support/src/logger.rs
+++ b/compiler/cli-support/src/logger.rs
@@ -140,9 +140,10 @@ mod test {
         let err = builder(0, Some(&log_file)).unwrap_err();
 
         assert!(matches!(err, LogError::LogFileCreate(ref path, _) if path == &log_file));
-        assert!(err
-            .to_string()
-            .starts_with(&format!("Unable to create log file {}.", log_file.display())));
+        assert!(err.to_string().starts_with(&format!(
+            "Unable to create log file {}.",
+            log_file.display()
+        )));
     }
 
     #[test]

--- a/compiler/cli-support/src/logger.rs
+++ b/compiler/cli-support/src/logger.rs
@@ -1,0 +1,155 @@
+//! Provides configuration of a logger.
+//!
+//! Both command line programs accept the same `--verbose`/`--log-file`
+//! options and want the same logger behavior from them. They differ only in
+//! how they report a failure to the user, so [`configure`] returns
+//! [`LogError`] and each program maps that onto its own error type.
+
+use env_logger::Builder;
+use log::trace;
+use log::LevelFilter;
+use std::fmt;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use time::OffsetDateTime;
+
+/// The highest verbosity level that the command line programs accept.
+const MAX_VERBOSITY: u8 = 4;
+
+/// A failure to configure the logger.
+///
+/// The [`fmt::Display`] text is the default message for each failure. A
+/// command line program that wants different wording matches on the variant
+/// instead.
+#[derive(Debug)]
+pub enum LogError {
+    /// The requested verbosity is greater than [`MAX_VERBOSITY`].
+    VerbosityOutOfRange(u8),
+    /// The file named by `--log-file` could not be created.
+    LogFileCreate(PathBuf, std::io::Error),
+}
+
+impl fmt::Display for LogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LogError::VerbosityOutOfRange(_) => {
+                write!(f, "Verbosity level must be between 0 and {MAX_VERBOSITY}")
+            }
+            LogError::LogFileCreate(path, err) => {
+                write!(f, "Unable to create log file {}. {}", path.display(), err)
+            }
+        }
+    }
+}
+
+/// Configures the log with the specified verbosity.
+///
+/// Higher verbosity results in additional log messages
+/// up to a maximum verbosity level.
+///
+/// This installs the process-wide logger and therefore succeeds at most once
+/// in the lifetime of a program.
+pub fn configure(verbosity: u8, log_file: Option<PathBuf>) -> Result<(), LogError> {
+    builder(verbosity, log_file.as_deref())?.init();
+
+    Ok(())
+}
+
+/// Builds the logger for the specified verbosity without installing it.
+///
+/// Separated from [`configure`] so that the mapping from verbosity to level,
+/// and the log file handling, are testable. Installing the logger is
+/// process-wide and can only happen once, so it cannot be part of what tests
+/// exercise repeatedly.
+fn builder(verbosity: u8, log_file: Option<&Path>) -> Result<Builder, LogError> {
+    let log_level = match verbosity {
+        0 => LevelFilter::Error,
+        1 => LevelFilter::Warn,
+        2 => LevelFilter::Info,
+        3 => LevelFilter::Debug,
+        4 => LevelFilter::Trace,
+        _ => return Err(LogError::VerbosityOutOfRange(verbosity)),
+    };
+
+    trace!("Logger verbosity {log_level}");
+
+    let mut builder = Builder::new();
+
+    if let Some(log_location) = log_file {
+        let file = File::create(log_location)
+            .map_err(|e| LogError::LogFileCreate(log_location.to_path_buf(), e))?;
+
+        // Configure the logger with this file as the output target
+        let target = Box::new(file);
+
+        builder.target(env_logger::Target::Pipe(target));
+    }
+
+    builder
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "[{} {}:{} {:?}] {}",
+                record.level(),
+                record.file().unwrap_or("unknown"),
+                record.line().unwrap_or(0),
+                OffsetDateTime::now_utc(),
+                record.args()
+            )
+        })
+        .filter_level(log_level);
+
+    Ok(builder)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn builder_when_verbosity_within_range_then_return_ok() {
+        for verbosity in 0..=MAX_VERBOSITY {
+            assert!(builder(verbosity, None).is_ok());
+        }
+    }
+
+    #[test]
+    fn builder_when_verbosity_above_maximum_then_return_verbosity_out_of_range() {
+        let err = builder(MAX_VERBOSITY + 1, None).unwrap_err();
+
+        assert!(matches!(err, LogError::VerbosityOutOfRange(5)));
+        assert_eq!(err.to_string(), "Verbosity level must be between 0 and 4");
+    }
+
+    #[test]
+    fn builder_when_log_file_writable_then_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_file = dir.path().join("ironplc.log");
+
+        assert!(builder(0, Some(&log_file)).is_ok());
+        assert!(log_file.exists());
+    }
+
+    #[test]
+    fn builder_when_log_file_not_creatable_then_return_log_file_create() {
+        let dir = tempfile::tempdir().unwrap();
+        // The parent directory does not exist, so the file cannot be created.
+        let log_file = dir.path().join("missing").join("ironplc.log");
+
+        let err = builder(0, Some(&log_file)).unwrap_err();
+
+        assert!(matches!(err, LogError::LogFileCreate(ref path, _) if path == &log_file));
+        assert!(err
+            .to_string()
+            .starts_with(&format!("Unable to create log file {}.", log_file.display())));
+    }
+
+    #[test]
+    fn configure_when_verbosity_above_maximum_then_return_err() {
+        // `configure` installs the process-wide logger on success, which can
+        // only happen once per program, so only the failing path is exercised
+        // here. The success path is covered through `builder`.
+        assert!(configure(MAX_VERBOSITY + 1, None).is_err());
+    }
+}

--- a/compiler/ironplc-cli/Cargo.toml
+++ b/compiler/ironplc-cli/Cargo.toml
@@ -25,8 +25,8 @@ ironplc-test = { path = "../test", version = "0.238.0" }
 ironplc-codegen = { path = "../codegen", version = "0.238.0" }
 ironplc-container = { path = "../container", version = "0.238.0" }
 ironplc-vm = { path = "../vm", version = "0.238.0" }
+ironplc-cli-support = { path = "../cli-support", version = "0.238.0" }
 
-time = "0.3.47"
 clap = { version = "4.6", features = ["derive", "wrap_help"] }
 codespan-reporting = { version = "0.13" }
 lsp-server = "0.10"

--- a/compiler/ironplc-cli/src/logger.rs
+++ b/compiler/ironplc-cli/src/logger.rs
@@ -1,61 +1,20 @@
 //! Provides configuration of a logger.
-use env_logger::Builder;
-use log::trace;
-use log::LevelFilter;
-use std::fs::File;
-use std::io::Write;
+//!
+//! The logger itself is shared with the other IronPLC command line programs
+//! (see `ironplc_cli_support::logger`). This module owns only how a
+//! configuration failure is reported to the user of `ironplcc`.
+use ironplc_cli_support::logger::LogError;
 use std::path::PathBuf;
-use time::OffsetDateTime;
 
 /// Configures the log with the specified verbosity.
 ///
 /// Higher verbosity results in additional log messages
 /// up to a maximum verbosity level.
 pub fn configure(verbosity: u8, log_file: Option<PathBuf>) -> Result<(), String> {
-    let log_level = match verbosity {
-        0 => LevelFilter::Error,
-        1 => LevelFilter::Warn,
-        2 => LevelFilter::Info,
-        3 => LevelFilter::Debug,
-        4 => LevelFilter::Trace,
-        _ => return Err(String::from("Don't be crazy with verbose")),
-    };
-
-    trace!("Logger verbosity {log_level}");
-
-    let mut builder = Builder::new();
-
-    if let Some(log_location) = log_file {
-        let file = File::create(&log_location).map_err(|e| {
-            format!(
-                "Unable to create log file {}. {}",
-                log_location.display(),
-                e
-            )
-        })?;
-
-        // Configure the logger with this file as the output target
-        let target = Box::new(file);
-
-        builder.target(env_logger::Target::Pipe(target));
-    }
-
-    builder
-        .format(|buf, record| {
-            writeln!(
-                buf,
-                "[{} {}:{} {:?}] {}",
-                record.level(),
-                record.file().unwrap_or("unknown"),
-                record.line().unwrap_or(0),
-                OffsetDateTime::now_utc(),
-                record.args()
-            )
-        })
-        .filter_level(log_level)
-        .init();
-
-    Ok(())
+    ironplc_cli_support::logger::configure(verbosity, log_file).map_err(|err| match err {
+        LogError::VerbosityOutOfRange(_) => String::from("Don't be crazy with verbose"),
+        LogError::LogFileCreate(..) => err.to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -66,6 +25,6 @@ mod test {
     fn configure_when_verbosity_is_5_then_return_err() {
         let result = configure(5, None);
 
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Don't be crazy with verbose");
     }
 }

--- a/compiler/vm-cli/Cargo.toml
+++ b/compiler/vm-cli/Cargo.toml
@@ -28,13 +28,13 @@ dap = ["dep:serde"]
 [dependencies]
 ironplc-vm = { path = "../vm", version = "0.238.0" }
 ironplc-container = { path = "../container", version = "0.238.0" }
+ironplc-cli-support = { path = "../cli-support", version = "0.238.0" }
 clap = { version = "4.6", features = ["derive", "wrap_help"] }
 ctrlc = "3"
 env_logger = "0.11.10"
 log = "0.4.29"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = "1.0"
-time = "0.3.47"
 
 [build-dependencies]
 csv = "1"

--- a/compiler/vm-cli/src/logger.rs
+++ b/compiler/vm-cli/src/logger.rs
@@ -1,11 +1,9 @@
 //! Provides configuration of a logger.
-use env_logger::Builder;
-use log::trace;
-use log::LevelFilter;
-use std::fs::File;
-use std::io::Write;
+//!
+//! The logger itself is shared with the other IronPLC command line programs
+//! (see `ironplc_cli_support::logger`). This module owns only how a
+//! configuration failure is reported to the user of `ironplcvm`.
 use std::path::PathBuf;
-use time::OffsetDateTime;
 
 use crate::error::{self, VmError};
 
@@ -14,58 +12,8 @@ use crate::error::{self, VmError};
 /// Higher verbosity results in additional log messages
 /// up to a maximum verbosity level.
 pub fn configure(verbosity: u8, log_file: Option<PathBuf>) -> Result<(), VmError> {
-    let log_level = match verbosity {
-        0 => LevelFilter::Error,
-        1 => LevelFilter::Warn,
-        2 => LevelFilter::Info,
-        3 => LevelFilter::Debug,
-        4 => LevelFilter::Trace,
-        _ => {
-            return Err(VmError::io(
-                error::LOG_CONFIG,
-                "Verbosity level must be between 0 and 4".to_string(),
-            ))
-        }
-    };
-
-    trace!("Logger verbosity {log_level}");
-
-    let mut builder = Builder::new();
-
-    if let Some(log_location) = log_file {
-        let file = File::create(&log_location).map_err(|e| {
-            VmError::io(
-                error::LOG_CONFIG,
-                format!(
-                    "Unable to create log file {}. {}",
-                    log_location.display(),
-                    e
-                ),
-            )
-        })?;
-
-        // Configure the logger with this file as the output target
-        let target = Box::new(file);
-
-        builder.target(env_logger::Target::Pipe(target));
-    }
-
-    builder
-        .format(|buf, record| {
-            writeln!(
-                buf,
-                "[{} {}:{} {:?}] {}",
-                record.level(),
-                record.file().unwrap_or("unknown"),
-                record.line().unwrap_or(0),
-                OffsetDateTime::now_utc(),
-                record.args()
-            )
-        })
-        .filter_level(log_level)
-        .init();
-
-    Ok(())
+    ironplc_cli_support::logger::configure(verbosity, log_file)
+        .map_err(|err| VmError::io(error::LOG_CONFIG, err.to_string()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Consolidates duplicated logger configuration logic from `ironplcc` and `ironplcvm` into a new shared `ironplc-cli-support` crate. Both CLI programs now use the same logger implementation while maintaining their own error reporting conventions.

## Key Changes

- **New crate**: `compiler/cli-support/` provides shared logger configuration
  - `logger::configure()` handles verbosity levels (0-4) and log file creation
  - `LogError` enum captures configuration failures with detailed context
  - Comprehensive unit tests for builder logic and error cases
  
- **Updated `ironplcc`**: Delegates to shared logger, maps `LogError::VerbosityOutOfRange` to custom message ("Don't be crazy with verbose")

- **Updated `ironplcvm`**: Delegates to shared logger, maps errors to `VmError::io()` with `LOG_CONFIG` code

- **Workspace updates**: Added `cli-support` to workspace members and dependencies

## Implementation Details

The shared logger is separated into two layers:
- `builder()` function (testable, non-installing) handles the core logic
- `configure()` function (process-wide, installs once) wraps the builder

Each CLI program owns only the error mapping at its boundary, preserving their distinct error types and user-facing messages. The logger format, verbosity mapping, and file handling are now written and tested once.

https://claude.ai/code/session_01ExPPCdCmbG7NzyML7NXQMw