### PR TITLE
Fix array-typed struct fields missing element type dependency

### DIFF
--- a/compiler/analyzer/src/xform_toposort_declarations.rs
+++ b/compiler/analyzer/src/xform_toposort_declarations.rs
@@ -581,7 +581,23 @@ impl Visitor<Diagnostic> for RuleGraphReferenceableElements {
                         let to = self.declarations.add_node(&struct_init.type_name.name);
                         self.declarations.graph.add_edge(to, from, ());
                     }
-                    InitialValueAssignmentKind::Array(_) => {}
+                    InitialValueAssignmentKind::Array(array_init) => {
+                        // An array-typed field depends on its element type
+                        // exactly as `visit_array_declaration` does for a
+                        // top-level array type. Without this edge, the
+                        // element type may be ordered after the containing
+                        // declaration and is then missing from the type
+                        // environment, surfacing as a spurious P2013.
+                        let element_type_name = match &array_init.spec {
+                            SpecificationKind::Named(parent) => parent.name.clone(),
+                            SpecificationKind::Inline(subranges) => {
+                                subranges.type_name.to_type_name().name
+                            }
+                        };
+                        let from = self.declarations.add_node(from);
+                        let to = self.declarations.add_node(&element_type_name);
+                        self.declarations.graph.add_edge(to, from, ());
+                    }
                     InitialValueAssignmentKind::Reference(_) => {}
                     InitialValueAssignmentKind::LateResolvedType(lrt) => {
                         // We only care about these because these may be references to a function block
@@ -1167,5 +1183,160 @@ END_TYPE";
             first,
             LibraryElementKind::GlobalVarDeclarations(_)
         ));
+    }
+
+    // ---------------------------------------------------------------------
+    // Array element type dependency edge for array-typed struct fields.
+    // See specs/plans/2026-08-16-array-element-type-decl-order.md.
+    // ---------------------------------------------------------------------
+
+    /// Returns the position of the named structure declaration in the sorted
+    /// library, or `None` when the library does not declare that structure.
+    fn structure_position(library: &Library, name: &str) -> Option<usize> {
+        library.elements.iter().position(|element| match element {
+            LibraryElementKind::DataTypeDeclaration(DataTypeDeclarationKind::Structure(decl)) => {
+                decl.type_name == TypeName::from(name)
+            }
+            _ => false,
+        })
+    }
+
+    #[test]
+    fn apply_when_struct_array_field_element_declared_first_then_element_ordered_first() {
+        // Declaration order already matches dependency order. The element type
+        // must still be ordered ahead of the struct that arrays over it --
+        // without a dependency edge the sort is free to emit either order.
+        let program = "
+TYPE Item : STRUCT
+    Flag : BOOL;
+END_STRUCT;
+END_TYPE
+
+TYPE Holder : STRUCT
+    Items : ARRAY[1..6] OF Item;
+END_STRUCT;
+END_TYPE";
+
+        let library = parse_only(program);
+        let (library, _reachable) = apply(library).unwrap();
+
+        let item = structure_position(&library, "Item").unwrap();
+        let holder = structure_position(&library, "Holder").unwrap();
+        assert!(item < holder, "Item must be ordered before Holder");
+    }
+
+    #[test]
+    fn apply_when_struct_array_field_element_declared_last_then_element_ordered_first() {
+        // Forward reference: the element type is declared textually *after*
+        // the struct whose array field references it.
+        let program = "
+TYPE Holder : STRUCT
+    Items : ARRAY[1..6] OF Item;
+END_STRUCT;
+END_TYPE
+
+TYPE Item : STRUCT
+    Flag : BOOL;
+END_STRUCT;
+END_TYPE";
+
+        let library = parse_only(program);
+        let (library, _reachable) = apply(library).unwrap();
+
+        let item = structure_position(&library, "Item").unwrap();
+        let holder = structure_position(&library, "Holder").unwrap();
+        assert!(item < holder, "Item must be ordered before Holder");
+    }
+
+    #[test]
+    fn apply_when_struct_array_field_element_is_elementary_then_return_ok() {
+        // Elementary element types have no declaration to order against. The
+        // added edge must not make the graph unsortable.
+        let program = "
+TYPE Holder : STRUCT
+    Nums : ARRAY[1..4] OF INT;
+    Flags : ARRAY[1..2] OF BOOL;
+END_STRUCT;
+END_TYPE";
+
+        let library = parse_only(program);
+        let (library, _reachable) = apply(library).unwrap();
+
+        assert!(structure_position(&library, "Holder").is_some());
+    }
+
+    #[test]
+    fn apply_when_struct_array_field_is_self_recursive_then_return_error() {
+        // An array of the enclosing struct is infinitely sized. The new edge
+        // makes this a genuine cycle, which must be reported as such.
+        let program = "
+TYPE A : STRUCT
+    Items : ARRAY[1..2] OF A;
+END_STRUCT;
+END_TYPE";
+
+        let library = parse_only(program);
+        let result = apply(library);
+        assert_eq!(
+            result.unwrap_err().first().unwrap().code,
+            Problem::RecursiveCycle.code().to_string()
+        );
+    }
+
+    #[test]
+    fn apply_when_struct_array_fields_are_mutually_recursive_then_return_error() {
+        let program = "
+TYPE A : STRUCT
+    Items : ARRAY[1..2] OF B;
+END_STRUCT;
+END_TYPE
+
+TYPE B : STRUCT
+    Items : ARRAY[1..2] OF A;
+END_STRUCT;
+END_TYPE";
+
+        let library = parse_only(program);
+        let result = apply(library);
+        assert_eq!(
+            result.unwrap_err().first().unwrap().code,
+            Problem::RecursiveCycle.code().to_string()
+        );
+    }
+
+    #[test]
+    fn resolve_types_when_struct_array_field_element_declared_before_program_then_return_ok() {
+        // Pipeline-level regression guard for the reported symptom: this
+        // layout previously failed with P2013 because the element type was
+        // absent from the type environment when the array field was resolved.
+        // See https://github.com/ironplc/ironplc/issues/1376.
+        use ironplc_parser::options::CompilerOptions;
+
+        let program = "
+TYPE Item : STRUCT
+    Flag : BOOL;
+END_STRUCT;
+END_TYPE
+
+TYPE Holder : STRUCT
+    Items : ARRAY[1..6] OF Item;
+    Other : BOOL;
+END_STRUCT;
+END_TYPE
+
+PROGRAM Main
+VAR
+    H : Holder;
+END_VAR
+    H.Other := TRUE;
+END_PROGRAM";
+
+        let library = parse_only(program);
+        let result = crate::stages::resolve_types(&[&library], &CompilerOptions::default());
+        assert!(
+            result.is_ok(),
+            "expected type resolution to succeed, got {:?}",
+            result.err()
+        );
     }
 }

--- a/specs/plans/2026-08-16-array-element-type-decl-order.md
+++ b/specs/plans/2026-08-16-array-element-type-decl-order.md
@@ -1,0 +1,89 @@
+# Plan: Fix Declaration-Order Sensitivity for Array-Typed Struct Fields
+
+## Context
+
+A structure field declared as an array of a user-defined type — for example
+`Items : ARRAY[1..6] OF Item;` — is rejected with a spurious
+P2013 `ArrayElementTypeNotDeclared` depending on where the declarations
+appear in the file. The behaviour is deterministic, not flaky:
+
+| File layout (identical declarations)               | `check`        |
+| -------------------------------------------------- | -------------- |
+| `PROGRAM` … then `TYPE Item`, `TYPE Holder`         | passes         |
+| `TYPE Item`, `TYPE Holder` … then `PROGRAM`         | **fails P2013** |
+
+Reported from the playground in
+[#1376](https://github.com/ironplc/ironplc/issues/1376), where the reporter's
+source only escaped the error because its `TYPE` blocks happened to sit after
+`END_PROGRAM`.
+
+### Root cause
+
+`xform_toposort_declarations` orders declarations so that a type is always
+emitted before anything that references it. Struct fields contribute their
+dependency edges in `visit_initial_value_assignment_kind`, which handles
+`Structure`, `FunctionBlock`, `FunctionBlockCall` and `LateResolvedType` —
+but the `Array` arm is empty:
+
+```rust
+InitialValueAssignmentKind::Array(_) => {}
+```
+
+So an array-typed struct field records no dependency on its element type. The
+toposort is then free to order the containing struct before the element type,
+and `intermediates::array::try_from` looks the element type up in a
+`TypeEnvironment` that does not yet contain it, producing P2013.
+
+`visit_array_declaration` already adds exactly this edge for a *top-level*
+`TYPE MyArr : ARRAY[1..6] OF Item; END_TYPE`, which is why only the
+struct-field form is affected.
+
+## Approach
+
+Populate the `Array` arm with the same edge `visit_array_declaration` adds,
+using the referenced-type-before-container direction (`add_edge(to, from)`)
+that the neighbouring arms in this function already use.
+
+Both `SpecificationKind` variants carry an element type name:
+
+- `Named(type_name)` — field declared via a named array type
+- `Inline(subranges)` — `subranges.type_name.to_type_name()`
+
+`ArrayElementType::to_type_name()` also yields a name for `STRING`/`WSTRING`
+elements; adding a node for an elementary type name is already what
+`visit_array_declaration` does, and unresolvable nodes are dropped by the
+`filter_map` in `apply()`, so no special-casing is needed.
+
+### Cycle safety
+
+Adding edges can turn a previously unordered graph into a cyclic one. A cycle
+here requires a genuinely recursive declaration (`TYPE A : STRUCT x : ARRAY[1..2]
+OF A; END_STRUCT`), which is infinite-sized and must be rejected. Confirm the
+existing P2011 `RecursiveCycle` path reports it rather than hanging.
+
+## Changes
+
+1. **`xform_toposort_declarations.rs`** — replace the empty
+   `InitialValueAssignmentKind::Array(_)` arm with element-type edge
+   construction for both `SpecificationKind` variants.
+
+2. **Unit tests** (same file) — declaration-order independence for an
+   array-of-struct field, plus recursive-array-field cycle detection.
+
+3. **Integration test** — an end-to-end `check` over the ordering that
+   previously failed, guarding the analyzer pipeline as a whole.
+
+## Scope
+
+This fixes only the analyzer ordering bug. Codegen support for arrays whose
+element type is a struct remains unimplemented (`compile_struct.rs` L308 and
+`compile_array.rs` "Unsupported array element type"); that is the separate,
+larger piece of work tracked by #1376 itself. After this change the reported
+source reaches codegen and fails there instead of in `check`.
+
+## Files
+
+| File                                                        | Change                     |
+| ----------------------------------------------------------- | -------------------------- |
+| `compiler/analyzer/src/xform_toposort_declarations.rs`       | Edge construction + tests  |
+| `compiler/analyzer/src/lib.rs` (or integration test module)   | Pipeline-level order test  |


### PR DESCRIPTION
## Summary

Fixes a declaration-order sensitivity bug where array-typed struct fields were rejected with spurious P2013 `ArrayElementTypeNotDeclared` errors depending on the relative position of the element type declaration in the source file.

The root cause was that `xform_toposort_declarations` did not add a dependency edge from array-typed struct fields to their element types, allowing the topological sort to order the containing struct before the element type. This caused the element type to be missing from the type environment during array resolution.

## Changes

- **`xform_toposort_declarations.rs`** — Populate the previously empty `InitialValueAssignmentKind::Array` arm to add element-type dependency edges, mirroring the logic already present in `visit_array_declaration` for top-level array types. Handles both `SpecificationKind::Named` and `SpecificationKind::Inline` variants.

- **Unit tests** — Added five test cases covering:
  - Declaration-order independence (element declared before and after struct)
  - Elementary element types (no declaration to order against)
  - Self-recursive arrays (must be detected as cycles)
  - Mutually recursive arrays (must be detected as cycles)
  - End-to-end pipeline test confirming the reported issue is resolved

## Implementation Details

The fix extracts the element type name from both `SpecificationKind` variants and adds a graph edge directing the element type to be ordered before the containing struct. Elementary type names (INT, BOOL, STRING, etc.) are handled naturally—the existing `filter_map` in `apply()` drops unresolvable nodes, so no special-casing is needed.

Cycle detection remains intact: genuinely recursive declarations (e.g., `TYPE A : STRUCT x : ARRAY[1..2] OF A`) now correctly surface as P2011 `RecursiveCycle` errors rather than being silently reordered.

See `specs/plans/2026-08-16-array-element-type-decl-order.md` for detailed analysis and scope notes.

https://claude.ai/code/session_01GNPCdtEMxkFE2t1S9Hfc4A