### PR TITLE
Add write_variable_raw() for 64-bit variable storage

### DIFF
--- a/compiler/codegen/tests/it/end_to_end_write_variable_raw.rs
+++ b/compiler/codegen/tests/it/end_to_end_write_variable_raw.rs
@@ -1,0 +1,170 @@
+//! End-to-end tests for embedder-supplied 64-bit variable values.
+//!
+//! These exercise the full pipeline — parse -> compile -> VM execution —
+//! for the two embedder use cases that `VmRunning::write_variable_raw`
+//! enables:
+//!
+//! - **Fieldbus input mapping**: a host writes a 64-bit process input
+//!   (`LINT`, `LREAL`, `LWORD`) into a program variable before the scan, and
+//!   the ST body computes on the full-width value.
+//! - **RETAIN persistence**: a host reads a 64-bit slot with
+//!   `read_variable_raw` at shutdown and restores it with
+//!   `write_variable_raw` on the next start, so an accumulator resumes where
+//!   it left off.
+//!
+//! Every test here fails without a raw write path: the pre-existing
+//! `write_variable` takes an `i32` and stores through `Slot::from_i32`, which
+//! truncates each of these values to its low 32 bits. The truncation itself is
+//! pinned by
+//! [`end_to_end_when_lint_input_written_as_i32_then_program_sees_truncated_value`].
+
+use ironplc_container::VarIndex;
+use ironplc_parser::options::CompilerOptions;
+use ironplc_vm::test_support::load_and_start;
+
+use crate::common::{parse_and_compile, parse_and_run_rounds, VmBuffers};
+
+/// Doubles a 64-bit fieldbus input. `fieldbus_in` is var 0, `scaled` is var 1.
+const SCALE_LINT_INPUT: &str = "
+PROGRAM main
+  VAR
+    fieldbus_in : LINT;
+    scaled : LINT;
+  END_VAR
+  scaled := fieldbus_in * 2;
+END_PROGRAM
+";
+
+/// A 64-bit process input that does not survive a trip through `i32`.
+const LINT_INPUT: i64 = 5_000_000_000;
+
+#[test]
+fn end_to_end_when_lint_input_written_raw_then_program_sees_full_64_bits() {
+    parse_and_run_rounds(SCALE_LINT_INPUT, &CompilerOptions::default(), |vm| {
+        vm.write_variable_raw(VarIndex::new(0), LINT_INPUT as u64)
+            .unwrap();
+        vm.run_round(0).unwrap();
+
+        assert_eq!(vm.read_variable_i64(VarIndex::new(0)).unwrap(), LINT_INPUT);
+        assert_eq!(
+            vm.read_variable_i64(VarIndex::new(1)).unwrap(),
+            LINT_INPUT * 2
+        );
+    });
+}
+
+/// Pins the truncation that made `write_variable_raw` necessary: the `i32`
+/// write path drops the upper 32 bits, so the program computes on a different
+/// number than the embedder supplied.
+#[test]
+fn end_to_end_when_lint_input_written_as_i32_then_program_sees_truncated_value() {
+    parse_and_run_rounds(SCALE_LINT_INPUT, &CompilerOptions::default(), |vm| {
+        vm.write_variable(VarIndex::new(0), LINT_INPUT as i32)
+            .unwrap();
+        vm.run_round(0).unwrap();
+
+        let truncated = LINT_INPUT as i32 as i64;
+        assert_ne!(truncated, LINT_INPUT);
+        assert_eq!(
+            vm.read_variable_i64(VarIndex::new(1)).unwrap(),
+            truncated * 2
+        );
+    });
+}
+
+#[test]
+fn end_to_end_when_lreal_input_written_raw_then_program_keeps_full_precision() {
+    let source = "
+PROGRAM main
+  VAR
+    sensor : LREAL;
+    doubled : LREAL;
+  END_VAR
+  doubled := sensor * 2.0;
+END_PROGRAM
+";
+    // A value whose low 32 bits alone say nothing about the number.
+    let sensor = std::f64::consts::PI;
+
+    parse_and_run_rounds(source, &CompilerOptions::default(), |vm| {
+        vm.write_variable_raw(VarIndex::new(0), sensor.to_bits())
+            .unwrap();
+        vm.run_round(0).unwrap();
+
+        let doubled = f64::from_bits(vm.read_variable_raw(VarIndex::new(1)).unwrap());
+        assert_eq!(doubled, sensor * 2.0);
+    });
+}
+
+#[test]
+fn end_to_end_when_lword_input_written_raw_then_high_word_bits_survive() {
+    let source = "
+PROGRAM main
+  VAR
+    status : LWORD;
+    high_bits : LWORD;
+  END_VAR
+  high_bits := status AND LWORD#16#FFFF_FFFF_0000_0000;
+END_PROGRAM
+";
+    let status = 0xDEAD_BEEF_0BAD_F00D_u64;
+
+    parse_and_run_rounds(source, &CompilerOptions::default(), |vm| {
+        vm.write_variable_raw(VarIndex::new(0), status).unwrap();
+        vm.run_round(0).unwrap();
+
+        assert_eq!(vm.read_variable_raw(VarIndex::new(0)).unwrap(), status);
+        assert_eq!(
+            vm.read_variable_raw(VarIndex::new(1)).unwrap(),
+            0xDEAD_BEEF_0000_0000_u64
+        );
+    });
+}
+
+/// RETAIN round-trip across a restart: run the accumulator past `i32` range,
+/// snapshot the raw slot as a host would at shutdown, then restore it into a
+/// freshly started VM and confirm the totals continue rather than restart.
+#[test]
+fn end_to_end_when_retained_lint_restored_raw_then_accumulator_resumes() {
+    let source = "
+PROGRAM main
+  VAR
+    total : LINT;
+    step : LINT;
+  END_VAR
+  step := 1000000000;
+  total := total + step;
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+
+    // First run: five scans accumulate 5e9, which exceeds i32 range.
+    let mut bufs = VmBuffers::from_container(&container);
+    let snapshot = {
+        let mut vm = load_and_start(&container, &mut bufs).unwrap();
+        for round in 0..5 {
+            vm.run_round(round).unwrap();
+        }
+        assert_eq!(
+            vm.read_variable_i64(VarIndex::new(0)).unwrap(),
+            5_000_000_000
+        );
+        vm.read_variable_raw(VarIndex::new(0)).unwrap()
+    };
+
+    // Restart: a fresh VM zeroes the accumulator during init, and the host
+    // restores the retained slot before the first scan.
+    let mut bufs = VmBuffers::from_container(&container);
+    let mut vm = load_and_start(&container, &mut bufs).unwrap();
+    assert_eq!(vm.read_variable_i64(VarIndex::new(0)).unwrap(), 0);
+
+    vm.write_variable_raw(VarIndex::new(0), snapshot).unwrap();
+    for round in 0..2 {
+        vm.run_round(round).unwrap();
+    }
+
+    assert_eq!(
+        vm.read_variable_i64(VarIndex::new(0)).unwrap(),
+        7_000_000_000
+    );
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -143,5 +143,6 @@ mod end_to_end_types;
 mod end_to_end_user_fb;
 mod end_to_end_user_function;
 mod end_to_end_var_temp;
+mod end_to_end_write_variable_raw;
 mod end_to_end_wstring;
 mod wire_format;

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -604,6 +604,17 @@ impl<'a> VmRunning<'a> {
         self.variables.store(index, Slot::from_i32(value))
     }
 
+    /// Writes a variable's raw 64-bit slot value.
+    ///
+    /// The counterpart to [`read_variable_raw`](Self::read_variable_raw): the
+    /// slot is stored verbatim, so 64-bit values (`LREAL`, `LINT`, `ULINT`,
+    /// `LWORD`) round-trip without truncation. Embedders use this to restore
+    /// RETAIN variables at startup and to map wide process inputs into the
+    /// variable table.
+    pub fn write_variable_raw(&mut self, index: VarIndex, value: u64) -> Result<(), Trap> {
+        self.variables.store(index, Slot::from_u64(value))
+    }
+
     /// Returns a reference to the data region.
     pub fn data_region(&self) -> &[u8] {
         self.data_region
@@ -3012,6 +3023,73 @@ mod tests {
 
         assert_eq!(ready.read_variable_raw(VarIndex::new(0)).unwrap(), 0u64);
         assert_eq!(ready.read_variable_raw(VarIndex::new(1)).unwrap(), 0u64);
+    }
+
+    #[test]
+    fn write_variable_raw_when_lword_pattern_then_round_trips_without_truncation() {
+        let c = steel_thread_container();
+        let mut b = VmBuffers::from_container(&c);
+        let mut vm = Vm::new().load(&c, &mut b).start().unwrap();
+
+        // A bit pattern that is non-zero in both halves of the slot.
+        let value = 0xDEAD_BEEF_0BAD_F00D_u64;
+        vm.write_variable_raw(VarIndex::new(0), value).unwrap();
+
+        assert_eq!(vm.read_variable_raw(VarIndex::new(0)).unwrap(), value);
+    }
+
+    #[test]
+    fn write_variable_raw_when_lreal_pattern_then_reads_back_same_float() {
+        let c = steel_thread_container();
+        let mut b = VmBuffers::from_container(&c);
+        let mut vm = Vm::new().load(&c, &mut b).start().unwrap();
+
+        let value = std::f64::consts::PI;
+        vm.write_variable_raw(VarIndex::new(1), value.to_bits())
+            .unwrap();
+
+        let raw = vm.read_variable_raw(VarIndex::new(1)).unwrap();
+        assert_eq!(f64::from_bits(raw), value);
+    }
+
+    #[test]
+    fn write_variable_raw_when_lint_value_then_read_variable_i64_agrees() {
+        let c = steel_thread_container();
+        let mut b = VmBuffers::from_container(&c);
+        let mut vm = Vm::new().load(&c, &mut b).start().unwrap();
+
+        let value = -9_007_199_254_740_993_i64;
+        vm.write_variable_raw(VarIndex::new(0), value as u64)
+            .unwrap();
+
+        assert_eq!(vm.read_variable_i64(VarIndex::new(0)).unwrap(), value);
+    }
+
+    #[test]
+    fn write_variable_when_64_bit_value_then_truncates_unlike_write_variable_raw() {
+        let c = steel_thread_container();
+        let mut b = VmBuffers::from_container(&c);
+        let mut vm = Vm::new().load(&c, &mut b).start().unwrap();
+
+        let value = 0x0000_0001_0000_002A_u64;
+        vm.write_variable(VarIndex::new(0), value as i32).unwrap();
+        vm.write_variable_raw(VarIndex::new(1), value).unwrap();
+
+        assert_eq!(vm.read_variable_raw(VarIndex::new(0)).unwrap(), 0x2A);
+        assert_eq!(vm.read_variable_raw(VarIndex::new(1)).unwrap(), value);
+    }
+
+    #[test]
+    fn write_variable_raw_when_index_out_of_range_then_invalid_variable_index_trap() {
+        let c = steel_thread_container();
+        let mut b = VmBuffers::from_container(&c);
+        let mut vm = Vm::new().load(&c, &mut b).start().unwrap();
+
+        let index = VarIndex::new(99);
+        assert_eq!(
+            vm.write_variable_raw(index, 1).unwrap_err(),
+            Trap::InvalidVariableIndex(index)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds `write_variable_raw()` method to complement the existing `read_variable_raw()` API, enabling embedders to store full 64-bit values without truncation. This is essential for restoring RETAIN variables at startup and mapping wide process inputs.

## Changes
- **New public method `write_variable_raw()`**: Stores a full 64-bit slot value verbatim, preserving all bits for 64-bit types (`LREAL`, `LINT`, `ULINT`, `LWORD`)
- **Comprehensive test coverage** (5 new tests):
  - Round-trip test for `LWORD` bit patterns with non-zero values in both halves
  - Round-trip test for `LREAL` (floating-point) values via bit representation
  - Compatibility test verifying `LINT` values read back correctly via `read_variable_i64()`
  - Comparison test demonstrating truncation behavior difference between `write_variable()` (32-bit) and `write_variable_raw()` (64-bit)
  - Error handling test for out-of-range variable indices

## Implementation Details
- Method signature mirrors `read_variable_raw()` for API consistency
- Uses `Slot::from_u64()` to store the raw value without interpretation
- Returns `Result<(), Trap>` to handle invalid variable indices
- Includes detailed doc comments explaining use cases and relationship to `read_variable_raw()`

https://claude.ai/code/session_013tYSoKSFKuakdxgguZagUB