### PR TITLE
docs: stop enumerating installed binaries

### DIFF
--- a/compiler/install.sh
+++ b/compiler/install.sh
@@ -62,9 +62,9 @@ Options:
   --force              Reinstall even if the requested version is already present.
   -h, --help           Show this help.
 
-Installs ironplcc, ironplcvm, and ironplcmcp from the latest IronPLC
-GitHub release into $HOME/.ironplc/bin and (unless --no-modify-path)
-adds that directory to your PATH via your shell profile.
+Installs IronPLC from the latest IronPLC GitHub release into
+$HOME/.ironplc/bin and (unless --no-modify-path) adds that directory
+to your PATH via your shell profile.
 USAGE
 }
 

--- a/docs/explanation/ironplc-ecosystem.rst
+++ b/docs/explanation/ironplc-ecosystem.rst
@@ -33,7 +33,9 @@ Structured Text code. Today it provides:
 - **A Visual Studio Code extension** that provides auto-completion, syntax highlighting
   and real-time error checking as you type.
 - **A runtime** (:program:`ironplcvm`) that can execute compiled programs.
-- **An MCP server** (:program:`ironplcvm`) that AI agents can use to understand and run programs.
+- **An MCP server** (:program:`ironplcmcp`) that AI agents can use to understand and run programs.
+- **A debug server** (:program:`ironplcdap`) that the extension uses to set
+  breakpoints, step through code, and inspect variables while a program runs.
 
 Try it now — this program increments a counter on every scan cycle:
 

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -93,9 +93,8 @@ Follow the steps below to install IronPLC.
 
       curl -fsSL https://www.ironplc.com/install.sh | sh
 
-   This installs ``ironplcc``, ``ironplcvm``, and ``ironplcmcp`` into
-   ``$HOME/.ironplc/bin`` and adds that directory to your ``PATH`` via
-   your shell profile.
+   This installs IronPLC into ``$HOME/.ironplc/bin`` and adds that
+   directory to your ``PATH`` via your shell profile.
 
    .. rubric:: Install IronPLC Extension
 
@@ -121,9 +120,8 @@ Follow the steps below to install IronPLC.
 
       curl -fsSL https://www.ironplc.com/install.sh | sh
 
-   This installs ``ironplcc``, ``ironplcvm``, and ``ironplcmcp`` into
-   ``$HOME/.ironplc/bin`` and adds that directory to your ``PATH`` via
-   your shell profile.
+   This installs IronPLC into ``$HOME/.ironplc/bin`` and adds that
+   directory to your ``PATH`` via your shell profile.
 
    To install a specific version:
 


### PR DESCRIPTION
The install docs named ironplcc, ironplcvm, and ironplcmcp as the set the
install script writes to $HOME/.ironplc/bin. That list has been out of
date since the tarball grew ironplcdap and the bundled compatibility
libraries, and it goes stale again every time the release adds a file.
Say that the script installs IronPLC and leave the contents to the
release.

Same wording change in the install script's own --help text, which
carried the same list.

The ecosystem page named ironplcvm as the MCP server binary; it is
ironplcmcp. That page also predates the debug server, so add it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012rqaX8iePPxxoHND21hY1t