### PR TITLE
Rename ironplcdap to ironplcvmd

### DIFF
--- a/compiler/homebrew/Formula/ironplc.rb
+++ b/compiler/homebrew/Formula/ironplc.rb
@@ -33,10 +33,10 @@ class Ironplc < Formula
       # compatibility libraries from <exedir>/resources/libs at runtime, and
       # current_exe() resolves the bin symlink back to libexec -- so the
       # libraries must sit beside the real binaries here, not in bin.
-      libexec.install "ironplcc", "ironplcvm", "ironplcmcp", "ironplcdap", "resources"
+      libexec.install "ironplcc", "ironplcvm", "ironplcmcp", "ironplcvmd", "resources"
       bin.install_symlink libexec/"ironplcc"
       bin.install_symlink libexec/"ironplcvm"
       bin.install_symlink libexec/"ironplcmcp"
-      bin.install_symlink libexec/"ironplcdap"
+      bin.install_symlink libexec/"ironplcvmd"
     end
   end

--- a/compiler/justfile
+++ b/compiler/justfile
@@ -5,7 +5,7 @@ set windows-shell := ["powershell.exe", "-c"]
 # `shipped_binaries_guard` test asserts it matches the workspace's `[[bin]]`
 # targets, `setup.nsi`, and the Homebrew formula. A binary that is built but not
 # listed here fails that guard rather than silently missing from the release.
-binaries := "ironplcc ironplcvm ironplcmcp ironplcdap"
+binaries := "ironplcc ironplcvm ironplcmcp ironplcvmd"
 
 alias ci := default
 # Coverage runs all tests with instrumentation, so separate test step is redundant

--- a/compiler/setup.nsi
+++ b/compiler/setup.nsi
@@ -33,7 +33,7 @@
 !define APPFILE "ironplcc${EXTENSION}"
 !define VMFILE "ironplcvm${EXTENSION}"
 !define MCPFILE "ironplcmcp${EXTENSION}"
-!define DAPFILE "ironplcdap${EXTENSION}"
+!define VMDFILE "ironplcvmd${EXTENSION}"
 !define SLUG "${NAME} v${VERSION}"
 !define REGPATH_APPPATHSUBKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\${APPFILE}"
 !define REGPATH_UNINSTSUBKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${NAME}"
@@ -96,7 +96,7 @@ Section "Program files"
     File "${ARTIFACTSDIR}\${MCPFILE}"
     ; The debug adapter. Editors find it beside ironplcc, so it must install
     ; into the same bin directory.
-    File "${ARTIFACTSDIR}\${DAPFILE}"
+    File "${ARTIFACTSDIR}\${VMDFILE}"
 
     ; Compatibility libraries ship beside the binaries; the compiler reads them
     ; from <bindir>\resources\libs at runtime. `/r` preserves the `libs` tree.

--- a/compiler/test/tests/shipped_binaries_guard.rs
+++ b/compiler/test/tests/shipped_binaries_guard.rs
@@ -1,9 +1,10 @@
 //! Workspace-level guard that every binary we build is a binary we ship.
 //!
-//! `ironplcdap` was declared with `required-features = ["dap"]` while every
-//! packaging manifest listed only the other three binaries. Nothing compared the
-//! two, so the debug adapter was neither built by `cargo build` nor shipped by
-//! any installer, and the failure surfaced only as "the debugger doesn't work".
+//! `ironplcvmd` (then named `ironplcdap`) was declared with `required-features
+//! = ["dap"]` while every packaging manifest listed only the other three
+//! binaries. Nothing compared the two, so the debug adapter was neither built
+//! by `cargo build` nor shipped by any installer, and the failure surfaced only
+//! as "the debugger doesn't work".
 //! See `specs/plans/2026-08-16-always-build-ship-dap-server.md`.
 //!
 //! Like `spec_conformance_guard.rs`, both sides are recovered from files already
@@ -227,11 +228,13 @@ fn compare(label: &str, expected: &BTreeSet<String>, actual: &BTreeSet<String>) 
 // Live guard over the actual repository
 // ---------------------------------------------------------------------------
 
-/// Every `[[bin]]` target in the workspace is shipped by every packaging path.
-#[test]
-fn every_built_binary_is_shipped_by_every_installer() {
-    let compiler_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+/// The `compiler/` directory of the live repository.
+fn compiler_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..")
+}
 
+/// Every `[[bin]]` name declared by a workspace member of `compiler/Cargo.toml`.
+fn built_binaries(compiler_dir: &Path) -> BTreeSet<String> {
     let workspace = fs::read_to_string(compiler_dir.join("Cargo.toml")).unwrap();
     let mut built: BTreeSet<String> = BTreeSet::new();
     for member in workspace_members(&workspace) {
@@ -246,6 +249,14 @@ fn every_built_binary_is_shipped_by_every_installer() {
         !built.is_empty(),
         "shipped-binaries guard found no [[bin]] targets — did the workspace layout change?"
     );
+    built
+}
+
+/// Every `[[bin]]` target in the workspace is shipped by every packaging path.
+#[test]
+fn every_built_binary_is_shipped_by_every_installer() {
+    let compiler_dir = compiler_dir();
+    let built = built_binaries(&compiler_dir);
 
     let justfile = fs::read_to_string(compiler_dir.join("justfile")).unwrap();
     let nsi = fs::read_to_string(compiler_dir.join("setup.nsi")).unwrap();
@@ -270,6 +281,58 @@ fn every_built_binary_is_shipped_by_every_installer() {
         problems.is_empty(),
         "shipped-binaries guard failed (built: {built:?}):\n  {}",
         problems.join("\n  ")
+    );
+}
+
+/// The reference pages under `docs/reference/`, by file stem.
+///
+/// The pages live in per-area directories (`compiler/`, `runtime/`, `mcp/`),
+/// so the stem — not the path — is what has to match the binary name.
+fn reference_page_stems(docs_reference: &Path) -> BTreeSet<String> {
+    let mut stems = BTreeSet::new();
+    let mut dirs = vec![docs_reference.to_path_buf()];
+    while let Some(dir) = dirs.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rst") {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    stems.insert(stem.to_string());
+                }
+            }
+        }
+    }
+    stems
+}
+
+/// Every shipped binary has a reference page named after it.
+///
+/// The binary name is also a documentation URL — `ironplcvmd` ships as
+/// `docs/reference/runtime/ironplcvmd.rst`. Nothing else connects the two, so
+/// a rename that updates the `[[bin]]` target and the installers but leaves the
+/// page at its old slug produces docs that describe a program no longer
+/// installed under that name. This guard makes the page part of the rename.
+#[test]
+fn every_built_binary_has_a_reference_page() {
+    let compiler_dir = compiler_dir();
+    let built = built_binaries(&compiler_dir);
+    let docs_reference = compiler_dir.join("../docs/reference");
+
+    let stems = reference_page_stems(&docs_reference);
+    assert!(
+        !stems.is_empty(),
+        "reference-page guard found no .rst pages under {} — did the docs layout change?",
+        docs_reference.display()
+    );
+
+    let missing: Vec<&String> = built.difference(&stems).collect();
+    assert!(
+        missing.is_empty(),
+        "shipped binaries with no docs/reference/**/<name>.rst page: {missing:?}"
     );
 }
 
@@ -298,13 +361,13 @@ name = "ironplcvm"
 path = "src/main.rs"
 
 [[bin]]
-name = "ironplcdap"
+name = "ironplcvmd"
 path = "src/dap_main.rs"
 
 [dependencies]
 name = "not-a-binary"
 "#;
-    assert_eq!(bin_names(toml), vec!["ironplcvm", "ironplcdap"]);
+    assert_eq!(bin_names(toml), vec!["ironplcvm", "ironplcvmd"]);
 }
 
 #[test]
@@ -338,14 +401,14 @@ fn just_binaries_when_assignment_missing_then_empty() {
 fn nsis_installed_binaries_when_defines_resolve_then_strips_extension() {
     let nsi = r#"
 !define APPFILE "ironplcc${EXTENSION}"
-!define DAPFILE "ironplcdap${EXTENSION}"
+!define VMDFILE "ironplcvmd${EXTENSION}"
 Section "Program files"
     File "..\LICENSE"
     File "${ARTIFACTSDIR}\${APPFILE}"
-    File "${ARTIFACTSDIR}\${DAPFILE}"
+    File "${ARTIFACTSDIR}\${VMDFILE}"
 SectionEnd
 "#;
-    assert_eq!(nsis_installed_binaries(nsi), vec!["ironplcc", "ironplcdap"]);
+    assert_eq!(nsis_installed_binaries(nsi), vec!["ironplcc", "ironplcvmd"]);
 }
 
 #[test]
@@ -354,7 +417,7 @@ fn nsis_installed_binaries_when_define_never_installed_then_omits_it() {
     // must not be counted as though it were.
     let nsi = r#"
 !define APPFILE "ironplcc${EXTENSION}"
-!define DAPFILE "ironplcdap${EXTENSION}"
+!define VMDFILE "ironplcvmd${EXTENSION}"
     File "${ARTIFACTSDIR}\${APPFILE}"
 "#;
     assert_eq!(nsis_installed_binaries(nsi), vec!["ironplcc"]);
@@ -386,11 +449,11 @@ fn formula_symlinked_binaries_when_several_then_extracts_each() {
     let formula = r#"
       libexec.install "ironplcc", "resources"
       bin.install_symlink libexec/"ironplcc"
-      bin.install_symlink libexec/"ironplcdap"
+      bin.install_symlink libexec/"ironplcvmd"
 "#;
     assert_eq!(
         formula_symlinked_binaries(formula),
-        vec!["ironplcc", "ironplcdap"]
+        vec!["ironplcc", "ironplcvmd"]
     );
 }
 

--- a/compiler/test/tests/shipped_binaries_guard.rs
+++ b/compiler/test/tests/shipped_binaries_guard.rs
@@ -1,11 +1,8 @@
 //! Workspace-level guard that every binary we build is a binary we ship.
 //!
-//! `ironplcvmd` (then named `ironplcdap`) was declared with `required-features
-//! = ["dap"]` while every packaging manifest listed only the other three
-//! binaries. Nothing compared the two, so the debug adapter was neither built
-//! by `cargo build` nor shipped by any installer, and the failure surfaced only
-//! as "the debugger doesn't work".
-//! See `specs/plans/2026-08-16-always-build-ship-dap-server.md`.
+//! A binary that is built but not packaged fails no compiler test: it surfaces
+//! only as the program missing from an installed IronPLC. This guard catches
+//! that in CI instead.
 //!
 //! Like `spec_conformance_guard.rs`, both sides are recovered from files already
 //! in the tree, so there is no new manifest to keep in sync:

--- a/compiler/vm-cli/Cargo.toml
+++ b/compiler/vm-cli/Cargo.toml
@@ -11,17 +11,13 @@ repository.workspace = true
 name = "ironplcvm"
 path = "src/main.rs"
 
-# The debug daemon: `ironplcvm` under a debugger. It is named for what it is
-# rather than for the Debug Adapter Protocol it currently speaks, so the name
-# survives a protocol change. The DAP implementation stays in `src/dap/`.
+# The debug daemon: `ironplcvm` under a debugger. Named for the program rather
+# than for the Debug Adapter Protocol it speaks, so the name outlasts the
+# protocol; the DAP implementation lives in `src/dap/`.
 #
-# Built unconditionally, like every other shipped binary. It was once gated
-# behind a `dap` feature to keep the DAP layer out of `ironplcvm`, but that gate
-# bought nothing: `mod dap` is declared only in `dap_main.rs`, and separate
-# `[[bin]]` targets are separate compilation units, so `ironplcvm` never
-# compiled the DAP layer either way. What the gate did do was make `cargo build`
-# skip this binary, leaving whatever stale copy was last built by hand in
-# `target/` for editors to launch.
+# Built unconditionally, like every other shipped binary. `mod dap` is declared
+# only in `dap_main.rs`, and separate `[[bin]]` targets are separate compilation
+# units, so `ironplcvm` does not compile the DAP layer.
 [[bin]]
 name = "ironplcvmd"
 path = "src/dap_main.rs"

--- a/compiler/vm-cli/Cargo.toml
+++ b/compiler/vm-cli/Cargo.toml
@@ -11,15 +11,19 @@ repository.workspace = true
 name = "ironplcvm"
 path = "src/main.rs"
 
-# The Debug Adapter Protocol server. Built unconditionally, like every other
-# shipped binary. It was once gated behind a `dap` feature to keep the DAP layer
-# out of `ironplcvm`, but that gate bought nothing: `mod dap` is declared only in
-# `dap_main.rs`, and separate `[[bin]]` targets are separate compilation units,
-# so `ironplcvm` never compiled the DAP layer either way. What the gate did do
-# was make `cargo build` skip this binary, leaving whatever stale copy was last
-# built by hand in `target/` for editors to launch.
+# The debug daemon: `ironplcvm` under a debugger. It is named for what it is
+# rather than for the Debug Adapter Protocol it currently speaks, so the name
+# survives a protocol change. The DAP implementation stays in `src/dap/`.
+#
+# Built unconditionally, like every other shipped binary. It was once gated
+# behind a `dap` feature to keep the DAP layer out of `ironplcvm`, but that gate
+# bought nothing: `mod dap` is declared only in `dap_main.rs`, and separate
+# `[[bin]]` targets are separate compilation units, so `ironplcvm` never
+# compiled the DAP layer either way. What the gate did do was make `cargo build`
+# skip this binary, leaving whatever stale copy was last built by hand in
+# `target/` for editors to launch.
 [[bin]]
-name = "ironplcdap"
+name = "ironplcvmd"
 path = "src/dap_main.rs"
 
 [dependencies]

--- a/compiler/vm-cli/src/dap/mod.rs
+++ b/compiler/vm-cli/src/dap/mod.rs
@@ -1,7 +1,8 @@
 //! Debug Adapter Protocol server for IronPLC.
 //!
-//! Feature-gated behind `dap` and built into the dedicated `ironplcdap`
-//! binary. The production `ironplcvm` binary does not include this module.
+//! Built into the dedicated `ironplcvmd` binary, whose name describes the
+//! program (the VM's debug daemon) rather than the protocol it speaks. The
+//! production `ironplcvm` binary does not include this module.
 //!
 //! Phase 4 lands incrementally (see
 //! `specs/plans/2026-06-25-dap-server-scaffold.md`). So far: the wire

--- a/compiler/vm-cli/src/dap/mod.rs
+++ b/compiler/vm-cli/src/dap/mod.rs
@@ -1,8 +1,7 @@
 //! Debug Adapter Protocol server for IronPLC.
 //!
-//! Built into the dedicated `ironplcvmd` binary, whose name describes the
-//! program (the VM's debug daemon) rather than the protocol it speaks. The
-//! production `ironplcvm` binary does not include this module.
+//! Built into the dedicated `ironplcvmd` binary. The production `ironplcvm`
+//! binary does not include this module.
 //!
 //! Phase 4 lands incrementally (see
 //! `specs/plans/2026-06-25-dap-server-scaffold.md`). So far: the wire

--- a/compiler/vm-cli/src/dap/problem_codes.rs
+++ b/compiler/vm-cli/src/dap/problem_codes.rs
@@ -1,7 +1,7 @@
 //! V-code constants generated from `resources/problem-codes.csv`.
 //!
 //! The `ironplcvm` binary reaches these constants through `error.rs`; the
-//! `ironplcdap` binary does not compile that module, so this thin re-include
+//! `ironplcvmd` binary does not compile that module, so this thin re-include
 //! gives the DAP server the same generated constants from the one CSV source of
 //! truth. Only a few are used on the launch path (`FILE_OPEN`, `CONTAINER_READ`,
 //! and the `LAUNCH_*` codes); the rest are unused here, hence the allowance.

--- a/compiler/vm-cli/src/dap_main.rs
+++ b/compiler/vm-cli/src/dap_main.rs
@@ -1,4 +1,4 @@
-//! `ironplcdap` — the IronPLC Debug Adapter Protocol server.
+//! `ironplcvmd` — the IronPLC Debug Adapter Protocol server.
 //!
 //! Speaks DAP over stdin/stdout so an editor (VS Code, Phase 5) can drive a
 //! debug session. See `specs/plans/2026-06-25-dap-server-scaffold.md`.

--- a/compiler/vm-cli/src/error.rs
+++ b/compiler/vm-cli/src/error.rs
@@ -7,7 +7,7 @@ use ironplc_vm::error::Trap;
 
 // V6xxx code constants are generated from resources/problem-codes.csv. Some
 // codes (the DAP launch codes V6008–V6010) are consumed only by the
-// `ironplcdap` binary, so they are dead in this binary — the allow keeps that
+// `ironplcvmd` binary, so they are dead in this binary — the allow keeps that
 // from warning while the constants stay re-exported at `error::*`.
 #[allow(dead_code)]
 mod io_codes {

--- a/compiler/vm-cli/tests/dap.rs
+++ b/compiler/vm-cli/tests/dap.rs
@@ -1,10 +1,10 @@
-//! End-to-end handshake tests for the `ironplcdap` Debug Adapter Protocol
+//! End-to-end handshake tests for the `ironplcvmd` Debug Adapter Protocol
 //! server (Phase 4.3). These spawn the real binary and drive the
 //! `initialize` → `launch` → `disconnect` path over stdin/stdout, asserting
 //! the framed responses and events, plus the two launch-precondition failures
 //! (`NoDebugInfo`, `MultiInstanceUnsupported`).
 //!
-//! These spawn `ironplcdap`, so they also serve as the regression test for the
+//! These spawn `ironplcvmd`, so they also serve as the regression test for the
 //! binary being built at all: it is no longer behind a feature gate, and a
 //! change that stops building it stops this file from running.
 
@@ -140,10 +140,10 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-/// Spawns `ironplcdap`, sends each request framed, closes stdin, and returns
+/// Spawns `ironplcvmd`, sends each request framed, closes stdin, and returns
 /// the decoded response/event stream.
 fn run_dap(requests: &[Value]) -> Vec<Value> {
-    let mut child = Command::new(cargo::cargo_bin!("ironplcdap"))
+    let mut child = Command::new(cargo::cargo_bin!("ironplcvmd"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -167,7 +167,7 @@ fn run_dap(requests: &[Value]) -> Vec<Value> {
 }
 
 #[test]
-fn ironplcdap_when_initialize_launch_disconnect_then_handshake_succeeds() {
+fn ironplcvmd_when_initialize_launch_disconnect_then_handshake_succeeds() {
     let container = single_instance_debug_container();
     let path = container.path().to_string_lossy().into_owned();
 
@@ -205,7 +205,7 @@ fn ironplcdap_when_initialize_launch_disconnect_then_handshake_succeeds() {
 }
 
 #[test]
-fn ironplcdap_when_launch_container_without_debug_then_no_debug_info() {
+fn ironplcvmd_when_launch_container_without_debug_then_no_debug_info() {
     let container = no_debug_container();
     let path = container.path().to_string_lossy().into_owned();
 
@@ -222,7 +222,7 @@ fn ironplcdap_when_launch_container_without_debug_then_no_debug_info() {
 }
 
 #[test]
-fn ironplcdap_when_launch_multi_instance_then_multi_instance_unsupported() {
+fn ironplcvmd_when_launch_multi_instance_then_multi_instance_unsupported() {
     let container = multi_instance_container();
     let path = container.path().to_string_lossy().into_owned();
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,11 +184,6 @@ ironplc_redirects = {
     "vscode/overview.html": "reference/editor/overview.html",
     "vscode/settings.html": "reference/editor/settings.html",
     "vscode/troubleshooting.html": "how-to-guides/troubleshoot-editor.html",
-
-    # The debug server was renamed ironplcdap -> ironplcvmd, so it is named for
-    # the program (the VM's debug daemon) rather than for the Debug Adapter
-    # Protocol it speaks.
-    "reference/runtime/ironplcdap.html": "reference/runtime/ironplcvmd.html",
 }
 
 # -- Open Graph configuration --------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,6 +184,11 @@ ironplc_redirects = {
     "vscode/overview.html": "reference/editor/overview.html",
     "vscode/settings.html": "reference/editor/settings.html",
     "vscode/troubleshooting.html": "how-to-guides/troubleshoot-editor.html",
+
+    # The debug server was renamed ironplcdap -> ironplcvmd, so it is named for
+    # the program (the VM's debug daemon) rather than for the Debug Adapter
+    # Protocol it speaks.
+    "reference/runtime/ironplcdap.html": "reference/runtime/ironplcvmd.html",
 }
 
 # -- Open Graph configuration --------------------------------------------------

--- a/docs/explanation/ironplc-ecosystem.rst
+++ b/docs/explanation/ironplc-ecosystem.rst
@@ -34,7 +34,7 @@ Structured Text code. Today it provides:
   and real-time error checking as you type.
 - **A runtime** (:program:`ironplcvm`) that can execute compiled programs.
 - **An MCP server** (:program:`ironplcmcp`) that AI agents can use to understand and run programs.
-- **A debug server** (:program:`ironplcdap`) that the extension uses to set
+- **A debug server** (:program:`ironplcvmd`) that the extension uses to set
   breakpoints, step through code, and inspect variables while a program runs.
   Debugging is early and in development.
 

--- a/docs/how-to-guides/getting-started/debug-a-program.rst
+++ b/docs/how-to-guides/getting-started/debug-a-program.rst
@@ -147,8 +147,8 @@ When the Debugger Does Not Start
      - The file did not compile. Check the :guilabel:`IronPLC Debug` output
        channel. See :doc:`/reference/editor/problems/E0006`.
    * - "Debug server not found"
-     - :program:`ironplcdap` was not found next to the compiler. Set
-       ``ironplc.dapServerPath``. See
+     - :program:`ironplcvmd` was not found next to the compiler. Set
+       ``ironplc.debugServerPath``. See
        :doc:`/reference/editor/problems/E0007`.
    * - "Compile with debug info enabled"
      - The container has no debug information. Recompile it with

--- a/docs/how-to-guides/troubleshoot-editor.rst
+++ b/docs/how-to-guides/troubleshoot-editor.rst
@@ -72,9 +72,9 @@ immediately.
    :doc:`/how-to-guides/getting-started/debug-a-program` lists the symptoms
    and what each one means.
 
-3. **Check the debug server is installed**: :program:`ironplcdap` installs
+3. **Check the debug server is installed**: :program:`ironplcvmd` installs
    beside :program:`ironplcc`. If it is somewhere else, set
-   ``ironplc.dapServerPath``. See :doc:`/reference/editor/problems/E0007`.
+   ``ironplc.debugServerPath``. See :doc:`/reference/editor/problems/E0007`.
 
 4. **Compile the project first**: The debugger compiles the single file you
    point it at. A file that uses POUs or types from other files does not

--- a/docs/reference/editor/debugging.rst
+++ b/docs/reference/editor/debugging.rst
@@ -8,9 +8,9 @@ The IronPLC extension debugs Structured Text programs: set breakpoints on
 source lines, step through the code, and inspect variables while the program
 is paused.
 
-Debugging is driven by :program:`ironplcdap`, which installs alongside the
+Debugging is driven by :program:`ironplcvmd`, which installs alongside the
 :program:`ironplcc` compiler. There is no separate debug extension to install.
-See :doc:`/reference/runtime/ironplcdap` for the server itself.
+See :doc:`/reference/runtime/ironplcvmd` for the server itself.
 
 Before You Start
 ================
@@ -18,7 +18,7 @@ Before You Start
 Debugging needs two things:
 
 * **The IronPLC compiler.** The extension discovers :program:`ironplcc` and
-  finds :program:`ironplcdap` beside it. See :doc:`problems/E0007` if the
+  finds :program:`ironplcvmd` beside it. See :doc:`problems/E0007` if the
   server cannot be found.
 * **A single program instance.** The configuration must declare exactly one
   ``PROGRAM ... WITH ...`` instance. A program that declares more is refused
@@ -37,7 +37,7 @@ No :file:`launch.json` is required. When you press :kbd:`F5` with no debug
 configuration, the extension debugs the active file.
 
 The extension compiles the file to a temporary ``.iplc`` container, starts
-:program:`ironplcdap`, and runs the program. Compiler output appears in the
+:program:`ironplcvmd`, and runs the program. Compiler output appears in the
 :guilabel:`IronPLC Debug` output channel
 (:menuselection:`View --> Output --> IronPLC Debug`).
 
@@ -258,7 +258,7 @@ runtime reports.
 Settings
 ========
 
-``ironplc.dapServerPath`` overrides the discovery of the debug server. See
+``ironplc.debugServerPath`` overrides the discovery of the debug server. See
 :doc:`settings`.
 
 Supported Languages
@@ -272,5 +272,5 @@ See Also
 
 * :doc:`/quickstart/debugging` --- debug a program for the first time
 * :doc:`/how-to-guides/getting-started/debug-a-program` --- task recipes
-* :doc:`/reference/runtime/ironplcdap` --- the debug server
+* :doc:`/reference/runtime/ironplcvmd` --- the debug server
 * :doc:`problems/index` --- extension problem codes

--- a/docs/reference/editor/problems/E0007.rst
+++ b/docs/reference/editor/problems/E0007.rst
@@ -4,28 +4,41 @@ E0007
 
 .. problem-summary:: E0007
 
-The IronPLC debug server (:program:`ironplcdap`) could not be found.
+The IronPLC debug server (:program:`ironplcvmd`) could not be found.
 
-Debugging is driven by the :program:`ironplcdap` server, a separate executable
+Debugging is driven by the :program:`ironplcvmd` server, a separate executable
 that speaks the Debug Adapter Protocol and is distributed alongside the
 :program:`ironplcc` compiler. This error appears when the extension cannot
 locate that executable, so it has no debug server to launch.
 
-The extension looks for the server in this order: the ``IRONPLCDAP``
-environment variable, then the ``ironplc.dapServerPath`` setting, and finally
+The extension looks for the server in this order: the ``IRONPLCVMD``
+environment variable, then the ``ironplc.debugServerPath`` setting, and finally
 next to the discovered :program:`ironplcc` compiler. The first location that
 contains the executable wins; if none do, you see this error.
 
 **Solutions**:
 
-1. **Install alongside the compiler**: Ensure :program:`ironplcdap`
-   (:program:`ironplcdap.exe` on Windows) sits in the same directory as
+1. **Install alongside the compiler**: Ensure :program:`ironplcvmd`
+   (:program:`ironplcvmd.exe` on Windows) sits in the same directory as
    :program:`ironplcc`. Official installers place both together.
 
-2. **Set the path manually**: Set the ``ironplc.dapServerPath`` setting to the
-   full path of the :program:`ironplcdap` executable if it lives in a
+2. **Set the path manually**: Set the ``ironplc.debugServerPath`` setting to the
+   full path of the :program:`ironplcvmd` executable if it lives in a
    non-standard location.
 
-3. **Use the environment variable**: Set ``IRONPLCDAP`` to the full path of the
+3. **Use the environment variable**: Set ``IRONPLCVMD`` to the full path of the
    executable, for example when running a locally built server from a
    :file:`target/debug` directory.
+
+Renamed in a recent release
+===========================
+
+The debug server was previously named :program:`ironplcdap`, and its override
+was the ``ironplc.dapServerPath`` setting and the ``IRONPLCDAP`` environment
+variable. Both were renamed and the old names are no longer read.
+
+If this error appeared after an upgrade, an override left over from the old
+names is the likely cause: move its value to ``ironplc.debugServerPath`` (or
+``IRONPLCVMD``), or remove it and let the extension discover the server next to
+:program:`ironplcc`.
+

--- a/docs/reference/editor/problems/E0007.rst
+++ b/docs/reference/editor/problems/E0007.rst
@@ -29,16 +29,3 @@ contains the executable wins; if none do, you see this error.
 3. **Use the environment variable**: Set ``IRONPLCVMD`` to the full path of the
    executable, for example when running a locally built server from a
    :file:`target/debug` directory.
-
-Renamed in a recent release
-===========================
-
-The debug server was previously named :program:`ironplcdap`, and its override
-was the ``ironplc.dapServerPath`` setting and the ``IRONPLCDAP`` environment
-variable. Both were renamed and the old names are no longer read.
-
-If this error appeared after an upgrade, an override left over from the old
-names is the likely cause: move its value to ``ironplc.debugServerPath`` (or
-``IRONPLCVMD``), or remove it and let the extension discover the server next to
-:program:`ironplcc`.
-

--- a/docs/reference/editor/settings.rst
+++ b/docs/reference/editor/settings.rst
@@ -61,12 +61,6 @@ Example values:
 
 See :doc:`debugging` for what the debug server does.
 
-.. note::
-
-   This setting was named ``ironplc.dapServerPath`` in earlier releases, when
-   the debug server was named :program:`ironplcdap`. The old name is no longer
-   read; move any existing value to ``ironplc.debugServerPath``.
-
 ironplc.logLevel
 ----------------
 

--- a/docs/reference/editor/settings.rst
+++ b/docs/reference/editor/settings.rst
@@ -40,13 +40,13 @@ Example values:
 * macOS: ``/usr/local/bin/ironplcc``
 * Linux: ``/home/username/ironplc/ironplcc``
 
-ironplc.dapServerPath
----------------------
+ironplc.debugServerPath
+-----------------------
 
 :Type: String
 :Default: Empty (auto-discovery)
 
-Specifies the path to the :program:`ironplcdap` debug server. When empty (the
+Specifies the path to the :program:`ironplcvmd` debug server. When empty (the
 default), the extension looks for the server next to the :program:`ironplcc`
 compiler it discovered.
 
@@ -55,11 +55,17 @@ or when :doc:`problems/E0007` reports that the server was not found.
 
 Example values:
 
-* Windows: ``C:\Program Files\IronPLC\bin\ironplcdap.exe``
-* macOS: ``/usr/local/bin/ironplcdap``
-* Linux: ``/home/username/ironplc/ironplcdap``
+* Windows: ``C:\Program Files\IronPLC\bin\ironplcvmd.exe``
+* macOS: ``/usr/local/bin/ironplcvmd``
+* Linux: ``/home/username/ironplc/ironplcvmd``
 
 See :doc:`debugging` for what the debug server does.
+
+.. note::
+
+   This setting was named ``ironplc.dapServerPath`` in earlier releases, when
+   the debug server was named :program:`ironplcdap`. The old name is no longer
+   read; move any existing value to ``ironplc.debugServerPath``.
 
 ironplc.logLevel
 ----------------
@@ -139,7 +145,7 @@ You can also configure these settings directly in your :file:`settings.json` fil
 
    {
      "ironplc.path": "/custom/path/to/ironplcc",
-     "ironplc.dapServerPath": "/custom/path/to/ironplcdap",
+     "ironplc.debugServerPath": "/custom/path/to/ironplcvmd",
      "ironplc.logLevel": "DEBUG",
      "ironplc.logFile": "/tmp/ironplc-debug.log",
      "ironplc.dialect": "rusty"

--- a/docs/reference/runtime/index.rst
+++ b/docs/reference/runtime/index.rst
@@ -6,7 +6,7 @@ The program :program:`ironplcvm` (:program:`ironplcvm.exe` on Windows) is the
 IronPLC virtual machine runtime. It loads and executes compiled bytecode
 container (``.iplc``) files produced by the :doc:`compiler </reference/compiler/index>`.
 
-The program :program:`ironplcdap` (:program:`ironplcdap.exe` on Windows) runs
+The program :program:`ironplcvmd` (:program:`ironplcvmd.exe` on Windows) runs
 the same programs under a debugger, and installs beside it.
 
 .. toctree::
@@ -14,5 +14,5 @@ the same programs under a debugger, and installs beside it.
 
    Overview <overview>
    Command Reference <ironplcvm>
-   Debug Server <ironplcdap>
+   Debug Server <ironplcvmd>
    Problem Code Index <problems/index>

--- a/docs/reference/runtime/ironplcvmd.rst
+++ b/docs/reference/runtime/ironplcvmd.rst
@@ -1,5 +1,5 @@
 ===========
-ironplcdap
+ironplcvmd
 ===========
 
 .. include:: /includes/debugging-in-development.rst
@@ -7,17 +7,17 @@ ironplcdap
 Name
 ====
 
-ironplcdap --- IronPLC debug server
+ironplcvmd --- IronPLC debug server
 
 Synopsis
 ========
 
-| :program:`ironplcdap`
+| :program:`ironplcvmd`
 
 Description
 ===========
 
-:program:`ironplcdap` is the IronPLC debug server. It speaks the
+:program:`ironplcvmd` is the IronPLC debug server. It speaks the
 `Debug Adapter Protocol <https://microsoft.github.io/debug-adapter-protocol/>`_
 (DAP) on standard input and output, so any DAP-capable editor can debug an
 IEC 61131-3 program with it.
@@ -26,7 +26,7 @@ The server takes no command-line arguments. The program to debug arrives in
 the DAP ``launch`` request as a path to a compiled bytecode container
 (``.iplc``) file.
 
-:program:`ironplcdap` installs alongside :program:`ironplcc` and
+:program:`ironplcvmd` installs alongside :program:`ironplcc` and
 :program:`ironplcvm`. Most developers never run it directly --- the
 :doc:`extension </reference/editor/debugging>` starts it for you.
 
@@ -122,7 +122,7 @@ control is not: a trapped program cannot resume.
 Using Another Editor
 ====================
 
-Any DAP client can drive :program:`ironplcdap`. Configure the client to launch
+Any DAP client can drive :program:`ironplcvmd`. Configure the client to launch
 the executable and speak DAP over its standard input and output, then send a
 ``launch`` request naming a container:
 

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -100,8 +100,8 @@
           "default": "",
           "editPresentation": "singlelineText"
         },
-        "ironplc.dapServerPath": {
-          "markdownDescription": "Overrides the path to the IronPLC debug server (ironplcdap, ironplcdap.exe on Windows). If empty, then discovers the server next to the ironplcc compiler.",
+        "ironplc.debugServerPath": {
+          "markdownDescription": "Overrides the path to the IronPLC debug server (ironplcvmd, ironplcvmd.exe on Windows). If empty, then discovers the server next to the ironplcc compiler.",
           "type": "string",
           "default": "",
           "editPresentation": "singlelineText"

--- a/integrations/vscode/resources/problem-codes.csv
+++ b/integrations/vscode/resources/problem-codes.csv
@@ -5,4 +5,4 @@ E0003,DisassemblyFailed,Failed to disassemble .iplc bytecode file
 E0004,DebugNoProgram,No program specified to debug
 E0005,DebugProgramNotDebuggable,Program is not a Structured Text source or compiled .iplc container
 E0006,DebugCompileFailed,Failed to compile the program for debugging
-E0007,DebugServerNotFound,IronPLC debug server (ironplcdap) not found
+E0007,DebugServerNotFound,IronPLC debug server (ironplcvmd) not found

--- a/integrations/vscode/src/debugAdapter.ts
+++ b/integrations/vscode/src/debugAdapter.ts
@@ -3,9 +3,11 @@ import * as os from 'os';
 import { existsSync } from 'fs';
 import { execFile } from 'child_process';
 import {
+  CONFIG_SECTION,
   DapEnvironment,
   DapDiscoveryResult,
   containerOutputPath,
+  debugServerNotFoundHint,
   findDapServerPath,
   firstLine,
   isDebuggableProgram,
@@ -147,9 +149,9 @@ implements vscode.DebugConfigurationProvider {
 }
 
 /**
- * Produces the DAP adapter executable. The `ironplcdap` binary speaks DAP over
- * stdin/stdout and takes no arguments — the program under debug is delivered by
- * the `launch` request, not the command line.
+ * Produces the DAP adapter executable. The debug server speaks DAP over
+ * stdin/stdout and takes no arguments — the program under debug is delivered
+ * by the `launch` request, not the command line.
  */
 export class IronplcDebugAdapterDescriptorFactory
 implements vscode.DebugAdapterDescriptorFactory {
@@ -163,7 +165,7 @@ implements vscode.DebugAdapterDescriptorFactory {
   ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
     const server = this.resolveServer();
     if (!server) {
-      this.reportProblem(ProblemCode.DebugServerNotFound, 'Set "ironplc.dapServerPath" or install the IronPLC compiler alongside ironplcdap.');
+      this.reportProblem(ProblemCode.DebugServerNotFound, debugServerNotFoundHint());
       return undefined;
     }
     return new vscode.DebugAdapterExecutable(server.path, []);
@@ -174,7 +176,7 @@ implements vscode.DebugAdapterDescriptorFactory {
       platform: process.platform,
       existsSync: existsSync,
       getEnv: name => process.env[name],
-      getConfig: key => vscode.workspace.getConfiguration('ironplc').get<string>(key),
+      getConfig: key => vscode.workspace.getConfiguration(CONFIG_SECTION).get<string>(key),
     };
     return findDapServerPath(env, this.compilerDir);
   }

--- a/integrations/vscode/src/debugAdapterLogic.ts
+++ b/integrations/vscode/src/debugAdapterLogic.ts
@@ -26,8 +26,51 @@ export interface DapDiscoveryResult {
   source: string;
 }
 
-/** The compiled-container extension the DAP server's `launch` expects. */
+/** The compiled-container extension the debug server's `launch` expects. */
 export const CONTAINER_EXTENSION = '.iplc';
+
+/*
+ * The names of the things the debug integration talks to, in one place.
+ *
+ * Each of these strings also exists outside this file — the binary in the
+ * compiler's `[[bin]]` target, the setting id in `package.json`, the binary
+ * again in the E0007 message in `resources/problem-codes.csv` — and none of
+ * those can import a TypeScript constant. Every copy the extension *can*
+ * reach reads these constants instead of retyping the string, and the copies
+ * it cannot reach are pinned to them by the guards in
+ * `test/unit/debugAdapterLogic.test.ts`. Renaming the server is then a change
+ * here plus whatever those guards report, not a grep.
+ */
+
+/** The debug-server executable, without any platform extension. */
+export const DEBUG_SERVER_BINARY = 'ironplcvmd';
+
+/** Environment variable that points directly at the debug-server binary. */
+export const DEBUG_SERVER_ENV_VAR = 'IRONPLCVMD';
+
+/** The configuration section every IronPLC setting lives under. */
+export const CONFIG_SECTION = 'ironplc';
+
+/** Setting key, within [`CONFIG_SECTION`], that points at the binary. */
+export const DEBUG_SERVER_PATH_SETTING = 'debugServerPath';
+
+/** The setting as users and `package.json` spell it. */
+export const DEBUG_SERVER_PATH_SETTING_ID = `${CONFIG_SECTION}.${DEBUG_SERVER_PATH_SETTING}`;
+
+/** The debug-server file name on `platform` (`.exe` on Windows). */
+export function debugServerFileName(platform: string): string {
+  return platform === 'win32' ? DEBUG_SERVER_BINARY + '.exe' : DEBUG_SERVER_BINARY;
+}
+
+/**
+ * The E0007 context line: what to do when the debug server is not found.
+ * Lives here so the setting id and binary name in the user-facing text come
+ * from the constants above rather than from a hand-typed literal.
+ */
+export function debugServerNotFoundHint(): string {
+  return `Set "${DEBUG_SERVER_PATH_SETTING_ID}" or install the IronPLC compiler `
+    + `alongside ${DEBUG_SERVER_BINARY}.`;
+}
 
 /** A subset of a VS Code `contributes.languages` entry. */
 export interface LanguageContribution {
@@ -107,7 +150,7 @@ export function containerOutputPath(program: string, tmpDir: string): string {
 }
 
 /**
- * Resolves the `ironplcdap` DAP-server binary. The resolution order is
+ * Resolves the [`DEBUG_SERVER_BINARY`] executable. The resolution order is
  * environment variable, then setting, then bundled (alongside the discovered
  * `ironplcc` compiler, whose directory is `compilerDir`), matching
  * `specs/design/debugger-support.md` §"Phase 5". Returns the first candidate
@@ -117,17 +160,16 @@ export function findDapServerPath(
   env: DapEnvironment,
   compilerDir?: string,
 ): DapDiscoveryResult | undefined {
-  const ext = env.platform === 'win32' ? '.exe' : '';
-  const exe = 'ironplcdap' + ext;
+  const exe = debugServerFileName(env.platform);
 
   const trials: (() => [string | undefined, string])[] = [
     () => {
       // Environment variable pointing directly at the binary. Not generally set.
-      return [env.getEnv('IRONPLCDAP'), 'environment'];
+      return [env.getEnv(DEBUG_SERVER_ENV_VAR), 'environment'];
     },
     () => {
       // Setting pointing directly at the binary.
-      return [env.getConfig('dapServerPath'), 'configuration'];
+      return [env.getConfig(DEBUG_SERVER_PATH_SETTING), 'configuration'];
     },
     () => {
       // Bundled next to the compiler discovered by `findCompilerPath`.

--- a/integrations/vscode/src/extension.ts
+++ b/integrations/vscode/src/extension.ts
@@ -293,7 +293,8 @@ function registerRunSupport(context: vscode.ExtensionContext) {
 /**
  * Registers the DAP debug adapter: a configuration provider that compiles a
  * source program to an `.iplc` container before launch, and an adapter factory
- * that spawns the `ironplcdap` server (resolved from the compiler's directory).
+ * that spawns the `ironplcvmd` debug server (resolved from the compiler's
+ * directory).
  */
 function registerDebugSupport(context: vscode.ExtensionContext, compilerPath: string) {
   const compilerDir = path.dirname(compilerPath);

--- a/integrations/vscode/src/test/unit/debugAdapterLogic.test.ts
+++ b/integrations/vscode/src/test/unit/debugAdapterLogic.test.ts
@@ -1,8 +1,16 @@
 import * as assert from 'assert';
 import * as path from 'path';
+import * as fs from 'fs';
 import {
+  CONFIG_SECTION,
   DapEnvironment,
+  DEBUG_SERVER_BINARY,
+  DEBUG_SERVER_ENV_VAR,
+  DEBUG_SERVER_PATH_SETTING,
+  DEBUG_SERVER_PATH_SETTING_ID,
   containerOutputPath,
+  debugServerFileName,
+  debugServerNotFoundHint,
   findDapServerPath,
   firstLine,
   isDebuggableProgram,
@@ -121,30 +129,30 @@ suite('containerOutputPath', () => {
 suite('findDapServerPath', () => {
   test('findDapServerPath_when_env_var_set_then_returns_environment_source', () => {
     const env = createDapEnv({
-      getEnv: name => name === 'IRONPLCDAP' ? '/env/ironplcdap' : undefined,
-      existsSync: p => p === '/env/ironplcdap',
+      getEnv: name => name === DEBUG_SERVER_ENV_VAR ? `/env/${DEBUG_SERVER_BINARY}` : undefined,
+      existsSync: p => p === `/env/${DEBUG_SERVER_BINARY}`,
     });
     const result = findDapServerPath(env, '/bundled');
     assert.ok(result);
-    assert.strictEqual(result.path, '/env/ironplcdap');
+    assert.strictEqual(result.path, `/env/${DEBUG_SERVER_BINARY}`);
     assert.strictEqual(result.source, 'environment');
   });
 
   test('findDapServerPath_when_only_setting_then_returns_configuration_source', () => {
     const env = createDapEnv({
-      getConfig: key => key === 'dapServerPath' ? '/cfg/ironplcdap' : undefined,
-      existsSync: p => p === '/cfg/ironplcdap',
+      getConfig: key => key === DEBUG_SERVER_PATH_SETTING ? `/cfg/${DEBUG_SERVER_BINARY}` : undefined,
+      existsSync: p => p === `/cfg/${DEBUG_SERVER_BINARY}`,
     });
     const result = findDapServerPath(env, '/bundled');
     assert.ok(result);
-    assert.strictEqual(result.path, '/cfg/ironplcdap');
+    assert.strictEqual(result.path, `/cfg/${DEBUG_SERVER_BINARY}`);
     assert.strictEqual(result.source, 'configuration');
   });
 
   test('findDapServerPath_when_env_and_setting_set_then_env_wins', () => {
     const env = createDapEnv({
-      getEnv: name => name === 'IRONPLCDAP' ? '/env/ironplcdap' : undefined,
-      getConfig: key => key === 'dapServerPath' ? '/cfg/ironplcdap' : undefined,
+      getEnv: name => name === DEBUG_SERVER_ENV_VAR ? `/env/${DEBUG_SERVER_BINARY}` : undefined,
+      getConfig: key => key === DEBUG_SERVER_PATH_SETTING ? `/cfg/${DEBUG_SERVER_BINARY}` : undefined,
       existsSync: () => true,
     });
     const result = findDapServerPath(env, '/bundled');
@@ -153,7 +161,7 @@ suite('findDapServerPath', () => {
   });
 
   test('findDapServerPath_when_only_bundled_then_returns_bundled_source', () => {
-    const expected = path.join('/bundled', 'ironplcdap');
+    const expected = path.join('/bundled', DEBUG_SERVER_BINARY);
     const env = createDapEnv({
       existsSync: p => p === expected,
     });
@@ -164,14 +172,14 @@ suite('findDapServerPath', () => {
   });
 
   test('findDapServerPath_when_win32_then_uses_exe_extension', () => {
-    const expected = path.join('/bundled', 'ironplcdap.exe');
+    const expected = path.join('/bundled', DEBUG_SERVER_BINARY + '.exe');
     const env = createDapEnv({
       platform: 'win32',
       existsSync: p => p === expected,
     });
     const result = findDapServerPath(env, '/bundled');
     assert.ok(result);
-    assert.ok(result.path.endsWith('ironplcdap.exe'));
+    assert.ok(result.path.endsWith(DEBUG_SERVER_BINARY + '.exe'));
   });
 
   test('findDapServerPath_when_no_compiler_dir_and_nothing_set_then_undefined', () => {
@@ -183,9 +191,9 @@ suite('findDapServerPath', () => {
   test('findDapServerPath_when_candidate_missing_on_disk_then_falls_through', () => {
     // The env var points somewhere that does not exist; discovery falls back
     // to the bundled binary.
-    const bundled = path.join('/bundled', 'ironplcdap');
+    const bundled = path.join('/bundled', DEBUG_SERVER_BINARY);
     const env = createDapEnv({
-      getEnv: name => name === 'IRONPLCDAP' ? '/env/missing' : undefined,
+      getEnv: name => name === DEBUG_SERVER_ENV_VAR ? '/env/missing' : undefined,
       existsSync: p => p === bundled,
     });
     const result = findDapServerPath(env, '/bundled');
@@ -233,3 +241,97 @@ suite('customRequestFailedMessage', () => {
     assert.ok(message.includes('not supported'));
   });
 });
+
+suite('debugServerFileName', () => {
+  test('debugServerFileName_when_posix_then_returns_bare_binary', () => {
+    assert.strictEqual(debugServerFileName('linux'), DEBUG_SERVER_BINARY);
+    assert.strictEqual(debugServerFileName('darwin'), DEBUG_SERVER_BINARY);
+  });
+
+  test('debugServerFileName_when_win32_then_appends_exe', () => {
+    assert.strictEqual(debugServerFileName('win32'), DEBUG_SERVER_BINARY + '.exe');
+  });
+});
+
+suite('debugServerNotFoundHint', () => {
+  test('debugServerNotFoundHint_when_called_then_names_setting_and_binary', () => {
+    // The hint is the only place the E0007 remedy is spelled out, so it must
+    // name both things the user can act on.
+    const hint = debugServerNotFoundHint();
+    assert.ok(hint.includes(DEBUG_SERVER_PATH_SETTING_ID), hint);
+    assert.ok(hint.includes(DEBUG_SERVER_BINARY), hint);
+  });
+});
+
+/**
+ * Guards for the copies of the debug-server names that live outside
+ * TypeScript and so cannot import the constants in `debugAdapterLogic.ts`:
+ * the extension manifest and the compiler's `[[bin]]` target. Without these,
+ * renaming the server leaves the extension compiling and its tests green while
+ * discovery fails at runtime as E0007 on a user's machine.
+ */
+suite('debug server name consistency', () => {
+  // From out/test/unit/: the extension root is 3 levels up, the repo root 5.
+  const extensionRoot = path.resolve(__dirname, '..', '..', '..');
+  const repoRoot = path.resolve(extensionRoot, '..', '..');
+
+  test('packageJson_when_read_then_declares_the_debug_server_path_setting', () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(extensionRoot, 'package.json'), 'utf-8'),
+    );
+    const properties = manifest.contributes.configuration.properties;
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(properties, DEBUG_SERVER_PATH_SETTING_ID),
+      `package.json has no "${DEBUG_SERVER_PATH_SETTING_ID}" setting; `
+      + `it declares ${JSON.stringify(Object.keys(properties))}`,
+    );
+    assert.ok(
+      Object.keys(properties).every(key => key.startsWith(`${CONFIG_SECTION}.`)),
+      `every setting must live under "${CONFIG_SECTION}."`,
+    );
+  });
+
+  test('packageJson_when_setting_described_then_description_names_the_binary', () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(extensionRoot, 'package.json'), 'utf-8'),
+    );
+    const setting = manifest.contributes.configuration.properties[DEBUG_SERVER_PATH_SETTING_ID];
+    assert.ok(
+      setting.markdownDescription.includes(DEBUG_SERVER_BINARY),
+      `the "${DEBUG_SERVER_PATH_SETTING_ID}" description must name ${DEBUG_SERVER_BINARY}, `
+      + `but says: ${setting.markdownDescription}`,
+    );
+  });
+
+  test('cargoManifest_when_read_then_declares_the_debug_server_binary', () => {
+    // The extension launches a binary the compiler builds. Nothing else ties
+    // the two names together, so a rename on either side must fail here.
+    const cargoToml = fs.readFileSync(
+      path.join(repoRoot, 'compiler', 'vm-cli', 'Cargo.toml'),
+      'utf-8',
+    );
+    // Only `[[bin]]` blocks — the `[package]` name is not a binary.
+    const binNames: string[] = [];
+    let inBin = false;
+    for (const line of cargoToml.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('#')) {
+        continue;
+      }
+      if (trimmed.startsWith('[')) {
+        inBin = trimmed === '[[bin]]';
+        continue;
+      }
+      const name = inBin ? /^name\s*=\s*"([^"]+)"/.exec(trimmed) : null;
+      if (name) {
+        binNames.push(name[1]);
+      }
+    }
+    assert.ok(
+      binNames.includes(DEBUG_SERVER_BINARY),
+      `compiler/vm-cli/Cargo.toml declares no target named ${DEBUG_SERVER_BINARY}; `
+      + `it declares ${JSON.stringify(binNames)}`,
+    );
+  });
+});
+

--- a/integrations/vscode/src/test/unit/problems.test.ts
+++ b/integrations/vscode/src/test/unit/problems.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
 import { ProblemCode, PROBLEM_MESSAGES, formatProblem } from '../../problems';
+import { DEBUG_SERVER_BINARY } from '../../debugAdapterLogic';
 
 suite('ProblemCode', () => {
   test('ProblemCode_when_accessed_then_returns_expected_codes', () => {
@@ -15,6 +16,16 @@ suite('ProblemCode', () => {
     assert.strictEqual(ProblemCode.DebugProgramNotDebuggable, 'E0005');
     assert.strictEqual(ProblemCode.DebugCompileFailed, 'E0006');
     assert.strictEqual(ProblemCode.DebugServerNotFound, 'E0007');
+  });
+
+  test('PROBLEM_MESSAGES_when_debug_server_not_found_then_names_the_binary', () => {
+    // problem-codes.csv is not TypeScript and cannot import the constant, so
+    // this is what keeps the generated message in step with the binary name.
+    assert.ok(
+      PROBLEM_MESSAGES[ProblemCode.DebugServerNotFound].includes(DEBUG_SERVER_BINARY),
+      `E0007 must name ${DEBUG_SERVER_BINARY}, but says: `
+      + PROBLEM_MESSAGES[ProblemCode.DebugServerNotFound],
+    );
   });
 
   test('PROBLEM_MESSAGES_when_accessed_then_has_entry_for_each_code', () => {
@@ -63,6 +74,6 @@ suite('formatProblem', () => {
 
   test('formatProblem_when_debug_server_not_found_then_includes_code', () => {
     const result = formatProblem(ProblemCode.DebugServerNotFound);
-    assert.strictEqual(result, 'E0007 - IronPLC debug server (ironplcdap) not found');
+    assert.strictEqual(result, `E0007 - IronPLC debug server (${DEBUG_SERVER_BINARY}) not found`);
   });
 });

--- a/specs/design/debugger-support.md
+++ b/specs/design/debugger-support.md
@@ -94,9 +94,7 @@ The debugger is four layers:
 
 ### Why a separate DAP binary?
 
-The DAP server is its own binary, `ironplcvmd`, built from `dap_main.rs` in the `vm-cli` crate. An earlier draft made it an `ironplcvm debug` subcommand to avoid duplicating the VM embedding code; sharing the crate achieves that without coupling the two entry points, and keeps the DAP protocol loop out of the production VM's argument parsing and lifecycle.
-
-**Naming (revised 2026-08-22).** The binary was originally `ironplcdap`, after the protocol it speaks. It is now `ironplcvmd` — `ironplcvm` plus the daemon `d` — so the name describes the program rather than one of its interfaces, and survives a protocol change. The `ironplc.dapServerPath` setting and `IRONPLCDAP` environment variable became `ironplc.debugServerPath` and `IRONPLCVMD` at the same time, with no compatibility fallback. See `specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md`.
+The DAP server is its own binary, `ironplcvmd`, built from `dap_main.rs` in the `vm-cli` crate. Sharing the crate with `ironplcvm` reuses the VM embedding code without coupling the two entry points, and keeps the DAP protocol loop out of the production VM's argument parsing and lifecycle.
 
 `ironplcvmd` takes **no command-line arguments**. It speaks DAP on stdin/stdout, and the program under debug arrives in the `launch` request's `arguments.program` field as a path to a compiled `.iplc` container.
 

--- a/specs/design/debugger-support.md
+++ b/specs/design/debugger-support.md
@@ -94,9 +94,11 @@ The debugger is four layers:
 
 ### Why a separate DAP binary?
 
-The DAP server is its own binary, `ironplcdap`, built from `dap_main.rs` in the `vm-cli` crate. An earlier draft made it an `ironplcvm debug` subcommand to avoid duplicating the VM embedding code; sharing the crate achieves that without coupling the two entry points, and keeps the DAP protocol loop out of the production VM's argument parsing and lifecycle.
+The DAP server is its own binary, `ironplcvmd`, built from `dap_main.rs` in the `vm-cli` crate. An earlier draft made it an `ironplcvm debug` subcommand to avoid duplicating the VM embedding code; sharing the crate achieves that without coupling the two entry points, and keeps the DAP protocol loop out of the production VM's argument parsing and lifecycle.
 
-`ironplcdap` takes **no command-line arguments**. It speaks DAP on stdin/stdout, and the program under debug arrives in the `launch` request's `arguments.program` field as a path to a compiled `.iplc` container.
+**Naming (revised 2026-08-22).** The binary was originally `ironplcdap`, after the protocol it speaks. It is now `ironplcvmd` — `ironplcvm` plus the daemon `d` — so the name describes the program rather than one of its interfaces, and survives a protocol change. The `ironplc.dapServerPath` setting and `IRONPLCDAP` environment variable became `ironplc.debugServerPath` and `IRONPLCVMD` at the same time, with no compatibility fallback. See `specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md`.
+
+`ironplcvmd` takes **no command-line arguments**. It speaks DAP on stdin/stdout, and the program under debug arrives in the `launch` request's `arguments.program` field as a path to a compiled `.iplc` container.
 
 ## Layer 1: Debug Info
 
@@ -1060,10 +1062,10 @@ The DAP server speaks the [Debug Adapter Protocol](https://microsoft.github.io/d
 The DAP server is launched as a subprocess by the VS Code extension:
 
 ```
-ironplcdap
+ironplcvmd
 ```
 
-`ironplcdap` is always in DAP mode: it reads Content-Length-framed JSON on stdin and writes responses and events on stdout. It takes no arguments — the container to debug arrives in the `launch` request.
+`ironplcvmd` is always in DAP mode: it reads Content-Length-framed JSON on stdin and writes responses and events on stdout. It takes no arguments — the container to debug arrives in the `launch` request.
 
 ### DAP Request Mapping
 
@@ -1262,7 +1264,7 @@ The VS Code extension registers a debug adapter in `package.json`:
 The extension implements a `DebugAdapterDescriptorFactory` that:
 
 1. If `compileFirst` is true and `program` ends with `.st`, compiles the source to a temp `.iplc` file using the IronPLC compiler (same binary used for LSP)
-2. Launches `ironplcdap` as a child process, passing the `.iplc` path in the `launch` request
+2. Launches `ironplcvmd` as a child process, passing the `.iplc` path in the `launch` request
 3. Connects stdin/stdout to VS Code's DAP client
 
 ### Scan Cycle Toolbar
@@ -1367,16 +1369,16 @@ The phasing is reorganized so that the iterative-dispatch rewrite (the prerequis
 
 **Goal:** Launch `ironplcvm debug --dap <file.iplc>` and debug from VS Code using standard DAP.
 
-**Packaging decision (revised 2026-08-16).** DAP support is a **second, always-built binary** in the `vm-cli` crate: `ironplcdap`, whose entry point is `dap_main.rs`. Distribution ships it alongside `ironplcc`, `ironplcvm`, and `ironplcmcp` in every installer, because the VS Code extension resolves the debug adapter from the directory holding the discovered `ironplcc`.
+**Packaging decision (revised 2026-08-16).** DAP support is a **second, always-built binary** in the `vm-cli` crate: `ironplcvmd`, whose entry point is `dap_main.rs`. Distribution ships it alongside `ironplcc`, `ironplcvm`, and `ironplcmcp` in every installer, because the VS Code extension resolves the debug adapter from the directory holding the discovered `ironplcc`.
 
-This supersedes the original decision to feature-gate DAP behind `--features dap`. The gate did not do what it claimed: `mod dap` is declared only in `dap_main.rs`, and separate `[[bin]]` targets are separate compilation units, so `ironplcvm` never compiled the DAP layer either way. What the gate did do was exclude `ironplcdap` from `cargo build` entirely, so local builds silently kept a stale binary and no release ever shipped one. The `shipped_binaries_guard` test (`compiler/test/tests/`) now asserts that every `[[bin]]` target appears in every packaging manifest. See `specs/plans/2026-08-16-always-build-ship-dap-server.md`.
+This supersedes the original decision to feature-gate DAP behind `--features dap`. The gate did not do what it claimed: `mod dap` is declared only in `dap_main.rs`, and separate `[[bin]]` targets are separate compilation units, so `ironplcvm` never compiled the DAP layer either way. What the gate did do was exclude `ironplcvmd` from `cargo build` entirely, so local builds silently kept a stale binary and no release ever shipped one. The `shipped_binaries_guard` test (`compiler/test/tests/`) now asserts that every `[[bin]]` target appears in every packaging manifest. See `specs/plans/2026-08-16-always-build-ship-dap-server.md`.
 
 **Changes:**
 
 | Crate | Files | Changes |
 |-------|-------|---------|
-| `vm-cli` | `Cargo.toml` | Second `[[bin]]` target, `ironplcdap`, built unconditionally |
-| `vm-cli` | new `dap_main.rs` | Entry point for `ironplcdap`; speaks DAP on stdin/stdout and takes no arguments (the program under debug arrives in the `launch` request). `main.rs`/`ironplcvm` is untouched. |
+| `vm-cli` | `Cargo.toml` | Second `[[bin]]` target, `ironplcvmd`, built unconditionally |
+| `vm-cli` | new `dap_main.rs` | Entry point for `ironplcvmd`; speaks DAP on stdin/stdout and takes no arguments (the program under debug arrives in the `launch` request). `main.rs`/`ironplcvm` is untouched. |
 | `vm-cli` | new `dap/framing.rs` | Content-Length framing reader/writer |
 | `vm-cli` | new `dap/types.rs` | DAP protocol types (Request, Response, Event, Capabilities). Prefer the `dap-types` crate if it's a fit; otherwise hand-rolled with `serde`. |
 | `vm-cli` | new `dap/server.rs` | **Single-threaded** event loop: alternate between draining queued DAP requests at natural stop points and running the VM under `run_round_debug` (see §Single-threaded DAP loop). No I/O thread, no `Send`/`Sync`, no `Arc`, no `AtomicBool`. |
@@ -1399,23 +1401,23 @@ This supersedes the original decision to feature-gate DAP behind `--features dap
 Implemented in `specs/plans/2026-08-02-dap-vscode-integration.md`.
 
 **Adapter invocation (as shipped).** Phase 4 shipped the DAP server as a
-**separate binary, `ironplcdap`** (feature-gated on `vm-cli`), that speaks DAP
+**separate binary, `ironplcvmd`** (feature-gated on `vm-cli`), that speaks DAP
 over stdin/stdout and takes **no CLI arguments**; the program under debug is
 delivered by the `launch` request's `arguments.program` field (a path to a
 compiled `.iplc` container). Phase 5 matches that: the adapter spawns
-`ironplcdap` with no arguments and, when `program` is a source file, compiles it
+`ironplcvmd` with no arguments and, when `program` is a source file, compiles it
 to a temp `.iplc` first so the `launch` sees a debug-enabled container.
 
 | Location | Files | Changes |
 |----------|-------|---------|
-| `integrations/vscode` | `package.json` | Add `debuggers` (type `ironplc`) and `breakpoints` contributions; **`commands` and `menus.debug/toolBar` entries for `ironplc.stepScan` and `ironplc.scanCount`** (otherwise custom DAP requests are unreachable); `ironplc.dapServerPath` setting |
-| `integrations/vscode/src` | new `debugAdapterLogic.ts` | Pure, unit-tested decision logic: source-vs-container detection, temp container path, `ironplcdap` discovery (env → setting → bundled), program-path fallback, compile args |
-| `integrations/vscode/src` | new `debugAdapter.ts` | `DebugConfigurationProvider` (fills defaults; if `program` is a source file, runs the compiler with debug info to emit a temp `.iplc`) and `DebugAdapterDescriptorFactory` (spawns `ironplcdap`, resolved via `debugAdapterLogic`) |
+| `integrations/vscode` | `package.json` | Add `debuggers` (type `ironplc`) and `breakpoints` contributions; **`commands` and `menus.debug/toolBar` entries for `ironplc.stepScan` and `ironplc.scanCount`** (otherwise custom DAP requests are unreachable); `ironplc.debugServerPath` setting |
+| `integrations/vscode/src` | new `debugAdapterLogic.ts` | Pure, unit-tested decision logic: source-vs-container detection, temp container path, `ironplcvmd` discovery (env → setting → bundled), program-path fallback, compile args |
+| `integrations/vscode/src` | new `debugAdapter.ts` | `DebugConfigurationProvider` (fills defaults; if `program` is a source file, runs the compiler with debug info to emit a temp `.iplc`) and `DebugAdapterDescriptorFactory` (spawns `ironplcvmd`, resolved via `debugAdapterLogic`) |
 | `integrations/vscode/src` | new `customRequests.ts` | Wraps `ironplc/stepScan` as a VS Code command forwarding to the active session. (Scan count is a scope, not a command — see §Scopes. No force/unforce — those are out of v1 scope.) |
 | `integrations/vscode/src` | `extension.ts` | Register debug config provider, adapter factory, and custom-request commands |
 
 **Tests:**
-- Unit: `debugAdapterLogic` — `ironplcdap` path resolution (env var, setting,
+- Unit: `debugAdapterLogic` — `ironplcvmd` path resolution (env var, setting,
   then bundled), source-vs-container detection, temp container path, program
   fallback, compile args, scan-count formatting.
 - Extension (functional): `ironplc.stepScan` / `ironplc.scanCount` commands
@@ -1518,7 +1520,7 @@ For reviewers familiar with the prior version of this document:
 5. **Optimizer contract** spelled out: post-optimization line map, snap-forward, instruction-boundary invariant, breakpoint-resolution feedback.
 6. **State machine documented** with a Phase enum and a per-DAP-request legality column.
 7. **Tag registry reconciled** with the existing `Tag 9 = ENUM_DEF` implementation.
-8. **DAP packaging** is a second always-built `[[bin]]` on `vm-cli`, `ironplcdap`, shipped by every installer beside `ironplcc` (revised 2026-08-16; it was previously `--features dap`, which meant the binary was never built or shipped at all).
+8. **DAP packaging** is a second always-built `[[bin]]` on `vm-cli`, `ironplcvmd`, shipped by every installer beside `ironplcc` (revised 2026-08-16; it was previously `--features dap`, which meant the binary was never built or shipped at all).
 
 ### v1 scope cuts (changes vs. earlier drafts)
 

--- a/specs/plans/2026-06-25-dap-server-scaffold.md
+++ b/specs/plans/2026-06-25-dap-server-scaffold.md
@@ -1,5 +1,10 @@
 # Phase 4: DAP Server Scaffold (minimal v1)
 
+> **Renamed 2026-08-22.** This plan was written when the debug server was
+> named `ironplcdap`. The name below has been updated to `ironplcvmd` so it
+> matches the shipped binary; see
+> [the rename plan](2026-08-22-rename-ironplcdap-to-ironplcvmd.md).
+
 ## Status (2026-08-02)
 
 Commits 1–3 have landed (PR #1205 merged commit 3: the `initialize → launch →
@@ -14,7 +19,7 @@ implements the stepping primitives, so wiring them later is cheap.
 
 ## Goal
 
-Stand up `ironplcdap <file.iplc>` — a single-threaded Debug Adapter Protocol
+Stand up `ironplcvmd <file.iplc>` — a single-threaded Debug Adapter Protocol
 server that VS Code (or any DAP client) can connect to, drive through the
 `initialize → launch → setBreakpoints → configurationDone → continue →
 disconnect` lifecycle, pause on a **line breakpoint**, walk the stack, and
@@ -76,25 +81,25 @@ expression-subset evaluator. See `2026-06-25-vm-debug-engine.md`.
 defines the CLI error type with `exit_code()`. `serde_json` is already a
 dependency. No `dap` feature, no DAP binary, no DAP modules.
 
-## Binary: `ironplcdap` (not `ironplcvm-debug`)
+## Binary: `ironplcvmd` (not `ironplcvm-debug`)
 
-Ship the DAP server as a dedicated, feature-gated binary named **`ironplcdap`**.
+Ship the DAP server as a dedicated, feature-gated binary named **`ironplcvmd`**.
 
 Rationale: `ironplcvm-debug` reads as "a build of the VM for debugging the VM
-itself," which is confusing. `ironplcdap` names what it is — the DAP server.
+itself," which is confusing. `ironplcvmd` names what it is — the DAP server.
 
 The design spec's §"Why not a separate DAP binary?" argued for a subcommand
 to avoid duplicating the VM-embedding code. We honour that concern *without*
-the confusing name: `ironplcdap` is a **second `[[bin]]` target in the same
+the confusing name: `ironplcvmd` is a **second `[[bin]]` target in the same
 `vm-cli` crate**, gated behind the `dap` feature, reusing the crate's VM
 embedding (buffer sizing, container load) — a few lines of `main`, no
 duplicated embedding logic. The VS Code extension (Phase 5) launches
-`ironplcdap <file.iplc>`, which speaks DAP on stdin/stdout.
+`ironplcvmd <file.iplc>`, which speaks DAP on stdin/stdout.
 
 ```toml
 # vm-cli/Cargo.toml
 [[bin]]
-name = "ironplcdap"
+name = "ironplcvmd"
 path = "src/dap_main.rs"
 required-features = ["dap"]
 
@@ -225,7 +230,7 @@ before Layer 1 finishes; swap in real lookups behind the same signatures.
   `requestNotApplicable`.
 - **Unit — launch**: multi-instance → `MultiInstanceUnsupported`;
   no-debug-section → `NoDebugInfo`.
-- **Integration — handshake**: spawn `ironplcdap`, send `initialize` +
+- **Integration — handshake**: spawn `ironplcvmd`, send `initialize` +
   `launch` + `setBreakpoints` + `configurationDone`, expect `stopped` at the
   breakpoint. (Offset-based breakpoint until Layer 1 line maps land.)
 - **Integration — inspection**: from `stopped`, request `stackTrace`,
@@ -247,9 +252,9 @@ Deferred to Phase 4b (see below):
 ## Commit order
 
 Each commit compiles and passes `cd compiler && just` (DAP code behind the
-`dap` feature; CI builds the `ironplcdap` bin with `--features dap`).
+`dap` feature; CI builds the `ironplcvmd` bin with `--features dap`).
 
-1. `dap` feature + `ironplcdap` bin target (`dap_main.rs`, no-op handler) +
+1. `dap` feature + `ironplcvmd` bin target (`dap_main.rs`, no-op handler) +
    `dap/framing.rs` with its roundtrip unit test.
 2. Hand-rolled `dap/types.rs` (v1 messages only) + `dap/state.rs` legality
    table + tests. Still no VM.
@@ -295,9 +300,9 @@ each is a thin server-side addition:
 
 - New optional dep under the `dap` feature: `serde` (derive). `serde_json` is
   already present. **No `dap` / `dap-types` crate dependency** (see above).
-- One extra binary, `ironplcdap`, feature-gated in the `vm-cli` crate; the
+- One extra binary, `ironplcvmd`, feature-gated in the `vm-cli` crate; the
   production `ironplcvm` binary is unaffected. The VS Code extension (Phase
-  5) launches `ironplcdap <file.iplc>`.
+  5) launches `ironplcvmd <file.iplc>`.
 
 ## Risks
 

--- a/specs/plans/2026-07-19-dap-launch-error-vcodes.md
+++ b/specs/plans/2026-07-19-dap-launch-error-vcodes.md
@@ -1,8 +1,13 @@
 # DAP launch errors carry V-codes
 
+> **Renamed 2026-08-22.** This plan was written when the debug server was
+> named `ironplcdap`. The name below has been updated to `ironplcvmd` so it
+> matches the shipped binary; see
+> [the rename plan](2026-08-22-rename-ironplcdap-to-ironplcvmd.md).
+
 ## Goal
 
-Make every `ironplcdap` `launch` failure carry a stable IronPLC **V-code**, so a
+Make every `ironplcvmd` `launch` failure carry a stable IronPLC **V-code**, so a
 DAP client sees the same `V#### - message` surface the `ironplcvm` CLI already
 emits (and can link to the runtime problem-code docs). Chosen approach:
 `LaunchError` owns its own `v_code()` and renders `"V#### - message"` via
@@ -14,7 +19,7 @@ exiting the process).
 
 `compiler/vm-cli/src/dap/launch.rs` defines `LaunchError` with a `message()`
 that returns bare human text (`"NoDebugInfo: …"`, `"MultiInstanceUnsupported:
-…"`). The `ironplcdap` binary (`dap_main.rs`) does not compile `error.rs`, so it
+…"`). The `ironplcvmd` binary (`dap_main.rs`) does not compile `error.rs`, so it
 has no access to the generated V-code constants. V-codes come from
 `vm-cli/resources/problem-codes.csv` → `build.rs` → `io_codes.rs`
 (`pub const NAME: &str = "V6xxx"`). Runtime traps already expose `Trap::v_code()`.

--- a/specs/plans/2026-08-02-dap-vscode-integration.md
+++ b/specs/plans/2026-08-02-dap-vscode-integration.md
@@ -1,10 +1,15 @@
 # Plan: DAP Phase 5 — VS Code Integration
 
+> **Renamed 2026-08-22.** This plan was written when the debug server was
+> named `ironplcdap`. The name below has been updated to `ironplcvmd` so it
+> matches the shipped binary; see
+> [the rename plan](2026-08-22-rename-ironplcdap-to-ironplcvmd.md).
+
 ## Context
 
 Phases 1–4 of the debugger (`specs/design/debugger-support.md`) delivered debug
 info in the container, the iterative VM, the VM debug engine, and a
-single-threaded DAP server binary (`ironplcdap`, feature-gated on the `vm-cli`
+single-threaded DAP server binary (`ironplcvmd`, feature-gated on the `vm-cli`
 crate). The server speaks DAP over stdin/stdout and drives
 `initialize → launch → setBreakpoints → configurationDone → (run) → stopped →
 inspect → continue → terminated → disconnect`.
@@ -18,7 +23,7 @@ variables, and drive scan-cycle stepping.
 The design's Phase 5 table sketched the adapter as launching
 `ironplcvm-debug --dap <file.iplc>`. The **actual** Phase 4 implementation is:
 
-- binary name is **`ironplcdap`** (see `compiler/vm-cli/Cargo.toml`), not
+- binary name is **`ironplcvmd`** (see `compiler/vm-cli/Cargo.toml`), not
   `ironplcvm-debug`;
 - it takes **no CLI arguments** — it reads/writes DAP on stdin/stdout
   (`compiler/vm-cli/src/dap_main.rs`);
@@ -34,9 +39,9 @@ Phase 5 matches the shipped server, not the older sketch.
 1. A `debuggers` contribution of type `ironplc` so VS Code offers the debugger
    for Structured Text files.
 2. Pressing F5 on a `.st`/`.iec`/TwinCAT source: compile it (with debug info)
-   to a temporary `.iplc` and launch `ironplcdap` against it. Pressing F5 on an
+   to a temporary `.iplc` and launch `ironplcvmd` against it. Pressing F5 on an
    already-compiled `.iplc`: launch directly.
-3. A `DebugAdapterDescriptorFactory` that resolves the `ironplcdap` binary via
+3. A `DebugAdapterDescriptorFactory` that resolves the `ironplcvmd` binary via
    **env var → setting → bundled** (alongside the discovered `ironplcc`).
 4. Custom-request commands `ironplc.stepScan` and `ironplc.scanCount` on the
    debug toolbar, forwarding `ironplc/stepScan` / `ironplc/scanCount` to the
@@ -65,7 +70,7 @@ files do not dilute the 80% line threshold.
 | File | Kind | Responsibility |
 |------|------|----------------|
 | `src/debugAdapterLogic.ts` | pure | `isSourceProgram`, `containerOutputPath`, `findDapServerPath`, `resolveProgramPath`, `buildDebugCompileArgs`, `scanCountMessage` |
-| `src/debugAdapter.ts` | vscode | `IronplcDebugConfigurationProvider` (fill defaults, compile source→`.iplc`), `IronplcDebugAdapterDescriptorFactory` (spawn `ironplcdap`) |
+| `src/debugAdapter.ts` | vscode | `IronplcDebugConfigurationProvider` (fill defaults, compile source→`.iplc`), `IronplcDebugAdapterDescriptorFactory` (spawn `ironplcvmd`) |
 | `src/customRequests.ts` | vscode | register `ironplc.stepScan` / `ironplc.scanCount` commands forwarding to `vscode.debug.activeDebugSession.customRequest` |
 | `src/test/unit/debugAdapterLogic.test.ts` | test | BDD-style tests for every pure function |
 
@@ -76,8 +81,8 @@ files do not dilute the 80% line threshold.
 - `containerOutputPath(program, tmpDir): string` — deterministic temp `.iplc`
   path derived from the source basename.
 - `findDapServerPath(env, compilerDir?): DapDiscoveryResult | undefined` —
-  resolves `ironplcdap[.exe]` in order **env `IRONPLCDAP` → setting
-  `ironplc.dapServerPath` → bundled (compilerDir)**, mirroring
+  resolves `ironplcvmd[.exe]` in order **env `IRONPLCVMD` → setting
+  `ironplc.debugServerPath` → bundled (compilerDir)**, mirroring
   `CompilerEnvironment` injection so it is testable without a filesystem.
 - `resolveProgramPath(configProgram, activeEditorPath): string | undefined` —
   default the program to the active editor when the launch config omits it.
@@ -92,7 +97,7 @@ files do not dilute the 80% line threshold.
 - `breakpoints`: `[{ language: '61131-3-st' }, { language: 'twincat-pou' }]`.
 - `commands`: `ironplc.stepScan`, `ironplc.scanCount`.
 - `menus.debug/toolBar`: both commands, gated `when: debugType == 'ironplc'`.
-- `configuration`: `ironplc.dapServerPath` (override for the DAP binary).
+- `configuration`: `ironplc.debugServerPath` (override for the DAP binary).
 - `activationEvents`: `onDebugResolve:ironplc`.
 
 ### `extension.ts`

--- a/specs/plans/2026-08-03-dap-continuous-run-loop.md
+++ b/specs/plans/2026-08-03-dap-continuous-run-loop.md
@@ -1,10 +1,15 @@
 # Plan: DAP Phase 4c — Continuous Run Loop
 
+> **Renamed 2026-08-22.** This plan was written when the debug server was
+> named `ironplcdap`. The name below has been updated to `ironplcvmd` so it
+> matches the shipped binary; see
+> [the rename plan](2026-08-22-rename-ironplcdap-to-ironplcvmd.md).
+
 ## Context
 
 Phases 1–5 of the debugger (`specs/design/debugger-support.md`) delivered debug
 info, the iterative VM, the VM debug engine, the single-threaded DAP server
-(`ironplcdap`), and the VS Code integration. The DAP server's post-launch
+(`ironplcvmd`), and the VS Code integration. The DAP server's post-launch
 run/stop loop (`compiler/vm-cli/src/dap/server.rs`, `launched_session`) is still
 the Phase 4 **single-scan** minimal loop: on `RoundOutcome::Completed` it emits
 `terminated` after exactly one scan cycle.

--- a/specs/plans/2026-08-16-always-build-ship-dap-server.md
+++ b/specs/plans/2026-08-16-always-build-ship-dap-server.md
@@ -1,16 +1,21 @@
 # Plan: Always build and ship the DAP server
 
+> **Renamed 2026-08-22.** This plan was written when the debug server was
+> named `ironplcdap`. The name below has been updated to `ironplcvmd` so it
+> matches the shipped binary; see
+> [the rename plan](2026-08-22-rename-ironplcdap-to-ironplcvmd.md).
+
 ## Context
 
-`ironplcdap` was declared with `required-features = ["dap"]`, and the `dap`
+`ironplcvmd` was declared with `required-features = ["dap"]`, and the `dap`
 feature is off by default. `just compile` is a bare `cargo build`, so every
 local and release build silently skipped the binary. A developer who pointed
 the VS Code extension at `compiler/target/debug` (via `ironplc.path`, which the
 extension also uses as the DAP-server directory — `extension.ts:299`) got
-whatever `ironplcdap` happened to be left in that directory from the last time
+whatever `ironplcvmd` happened to be left in that directory from the last time
 someone explicitly passed `--features ironplc-vm-cli/dap`.
 
-Observed: `target/debug/ironplcdap` two weeks older than `ironplcc`/`ironplcvm`
+Observed: `target/debug/ironplcvmd` two weeks older than `ironplcc`/`ironplcvm`
 in the same directory, predating the continuous run loop (#1304), single
 stepping (#1305), and the Layer-1 debug-info swap (#1364). The debugger
 appeared broken; the code was fine.
@@ -32,7 +37,7 @@ plain `cargo test` skipped them).
 ### The second half of the bug
 
 Removing the gate fixes "not built". It does not fix "not shipped": no release
-path ever produced `ironplcdap`, and the binary set is hardcoded in four places
+path ever produced `ironplcvmd`, and the binary set is hardcoded in four places
 that nothing cross-checks.
 
 | Location | Lists |
@@ -49,8 +54,8 @@ The extension's last-resort DAP discovery looks next to the installed
 
 ## Goals
 
-1. `cargo build` produces `ironplcdap` on every platform, with no feature flag.
-2. Every installer and package ships `ironplcdap` alongside the other binaries.
+1. `cargo build` produces `ironplcvmd` on every platform, with no feature flag.
+2. Every installer and package ships `ironplcvmd` alongside the other binaries.
 3. A binary that is built but not shipped fails CI, so this class of drift
    cannot recur silently.
 
@@ -69,7 +74,7 @@ The extension's last-resort DAP discovery looks next to the installed
 
 | File | Change |
 |------|--------|
-| `vm-cli/Cargo.toml` | Drop `required-features` from the `ironplcdap` bin, drop the `[features]` block, make `serde` non-optional. Replace the stale comment with why the binary is unconditional. |
+| `vm-cli/Cargo.toml` | Drop `required-features` from the `ironplcvmd` bin, drop the `[features]` block, make `serde` non-optional. Replace the stale comment with why the binary is unconditional. |
 | `justfile` | Drop `--features ironplc-vm-cli/dap` from `test`, `coverage`, `format`, `lint`. |
 | `vm-cli/tests/dap.rs` | Drop `#![cfg(feature = "dap")]` so the DAP integration tests run under a plain `cargo test`. |
 | `vm-cli/src/dap_main.rs` | Drop the "Feature-gated behind `dap`" sentence. |
@@ -79,7 +84,7 @@ The extension's last-resort DAP discovery looks next to the installed
 `justfile` gains a single `binaries` variable used by both tar recipes, so the
 two Unix lists become one. `setup.nsi` gains a `DAPFILE` define and its `File`
 line. The Homebrew formula gains the install entry and the symlink. Each of the
-four now lists `ironplcdap`.
+four now lists `ironplcvmd`.
 
 The NSIS uninstall section is `RMDir /r $INSTDIR`, so there is no per-file
 delete list to update.
@@ -110,13 +115,13 @@ names per manifest.
 
 - `compiler/test`: the new guard, plus fixture tests for each parser.
 - `vm-cli/tests/dap.rs` now runs unconditionally — it is the regression test for
-  Part 1, since it can only build if `ironplcdap` is built by default.
-- Manual: confirm `cargo build` alone produces `target/debug/ironplcdap`.
+  Part 1, since it can only build if `ironplcvmd` is built by default.
+- Manual: confirm `cargo build` alone produces `target/debug/ironplcvmd`.
 - `cd compiler && just` must pass (compile, coverage ≥ 85%, lint, dupes).
 
 ## Out of scope / follow-ups
 
-- Smoke-testing the packaged `ironplcdap` in `verify-package` (it currently
+- Smoke-testing the packaged `ironplcvmd` in `verify-package` (it currently
   execs only `ironplcc` and `ironplcvm` via `tests/e2e/library/verify.sh`,
   whose contract is library verification and takes exactly two binaries).
   Presence is guarded here; executing the shipped DAP bytes is a follow-up.

--- a/specs/plans/2026-08-16-debugger-documentation.md
+++ b/specs/plans/2026-08-16-debugger-documentation.md
@@ -1,5 +1,10 @@
 # Plan: Documenting Debugger Support on the Docs Website
 
+> **Renamed 2026-08-22.** This plan was written when the debug server was
+> named `ironplcdap`. The name below has been updated to `ironplcvmd` so it
+> matches the shipped binary; see
+> [the rename plan](2026-08-22-rename-ironplcdap-to-ironplcvmd.md).
+
 ## Goal
 
 Add debugger documentation to the docs website (`docs/`), covering all four
@@ -9,7 +14,7 @@ and limit, and understand why debugging a scan cycle is not like debugging an
 ordinary program.
 
 The debugger shipped across #1364 (Layer-1 debug-info swap), #1385 (always
-build and ship `ironplcdap`), and #1388 (scan count in the `Runtime` scope).
+build and ship `ironplcvmd`), and #1388 (scan count in the `Runtime` scope).
 The docs website says nothing about it — and the landing page actively says the
 opposite.
 
@@ -28,7 +33,7 @@ opposite.
 
 | Surface | Detail |
 |---------|--------|
-| DAP server | `ironplcdap` (`compiler/vm-cli/src/dap_main.rs`), no CLI arguments, speaks DAP on stdin/stdout, built and shipped unconditionally |
+| DAP server | `ironplcvmd` (`compiler/vm-cli/src/dap_main.rs`), no CLI arguments, speaks DAP on stdin/stdout, built and shipped unconditionally |
 | Editor debug type | `ironplc`, registered for the `61131-3-st` and `twincat-pou` languages |
 | Launch attributes | `program` (an `.st`/`.TcPOU` source **or** a compiled `.iplc`), `stopOnEntry`, `scanLimit` |
 | Breakpoints | Source-line, snapped to the nearest executable line; the editor's dot moves to the bound line |
@@ -36,7 +41,7 @@ opposite.
 | Variables | Two scopes — `Program` (named, typed, `counter : DINT = 42`, STRING rendered as a quoted literal) and `Runtime` (`scanCount : ULINT`) |
 | Execution control | `continue`, `next`, `stepIn`, `stepOut`, `configurationDone`, `disconnect` |
 | Source-to-container | The extension compiles a source `program` to a container before launching |
-| Setting | `ironplc.dapServerPath` overrides DAP-server discovery |
+| Setting | `ironplc.debugServerPath` overrides DAP-server discovery |
 | Debug info | Always emitted by `ironplcc compile`; there is no `--debug` flag and no strip flag |
 
 ### What is explicitly *not* in v1
@@ -67,11 +72,11 @@ item is a documented cut, not a bug:
 |----------|---------|
 | `docs/index.rst:23` | "doesn't yet provide I/O mapping or debugging capabilities" — **factually wrong now** |
 | `docs/reference/editor/overview.rst` | Lists Commands, Build Tasks, Bytecode Viewer, Diagnostics, Run Program — no Debugging section |
-| `docs/reference/editor/settings.rst` | Documents `ironplc.path`, `logLevel`, `logFile`, `dialect` — omits `ironplc.dapServerPath` |
+| `docs/reference/editor/settings.rst` | Documents `ironplc.path`, `logLevel`, `logFile`, `dialect` — omits `ironplc.debugServerPath` |
 | `docs/how-to-guides/troubleshoot-editor.rst` | No debugger section |
 | `docs/quickstart/` | No debug chapter |
 | `docs/explanation/` | Nothing on debugging; `execution-cycle.rst:33` points at `ironplcvm` for "test and debug" |
-| `docs/reference/runtime/index.rst` | Describes `ironplcvm` only; `ironplcdap` ships beside it and is unmentioned |
+| `docs/reference/runtime/index.rst` | Describes `ironplcvm` only; `ironplcvmd` ships beside it and is unmentioned |
 
 The **only** debugger documentation that exists is the problem-code reference:
 `V6008`, `V6009`, `V6010` (runtime) and `E0004`–`E0007` (editor). Those pages
@@ -214,7 +219,7 @@ Task-shaped, no narrative, for someone who already knows what a debugger is:
 **New: `docs/how-to-guides/getting-started/debug-without-vs-code.rst` —
 "Debug from Another Editor"** *(second priority; ship if capacity allows)*
 
-`ironplcdap` is a plain DAP server over stdio, so Neovim (`nvim-dap`), Emacs
+`ironplcvmd` is a plain DAP server over stdio, so Neovim (`nvim-dap`), Emacs
 (`dap-mode`), and other DAP clients can drive it. This guide gives the adapter
 definition and the launch-request JSON, and states the one thing those clients
 do not get for free: they must compile the source to `.iplc` themselves,
@@ -224,7 +229,7 @@ because that step lives in the VS Code extension, not in the server.
 
 Add a "The debugger does not start" section keyed to the existing problem codes,
 so symptoms route to `E0004`–`E0007`, `V6008`–`V6010` rather than duplicating
-them: server not found → `E0007` and `ironplc.dapServerPath`; wrong file type →
+them: server not found → `E0007` and `ironplc.debugServerPath`; wrong file type →
 `E0005`; compile failed → `E0006` and the "IronPLC Debug" output channel;
 multi-instance → `V6010`.
 
@@ -253,12 +258,12 @@ The editor-facing contract:
 This page carries the most inline limitations of the four, because it is where a
 user looks when something they expected is not there.
 
-**New: `docs/reference/runtime/ironplcdap.rst`**
+**New: `docs/reference/runtime/ironplcvmd.rst`**
 
 The server-facing contract, mirroring the shape of the existing
 `reference/runtime/ironplcvm.rst`:
 
-- What `ironplcdap` is, that it takes no arguments, and that it is installed
+- What `ironplcvmd` is, that it takes no arguments, and that it is installed
   beside `ironplcc`/`ironplcvm`.
 - The supported DAP request set, and the requests that answer
   `requestNotApplicable`.
@@ -266,7 +271,7 @@ The server-facing contract, mirroring the shape of the existing
   instance) and the codes they raise.
 - Links to `V6008`–`V6010`.
 
-**Edit: `docs/reference/editor/settings.rst`** — add an `ironplc.dapServerPath`
+**Edit: `docs/reference/editor/settings.rst`** — add an `ironplc.debugServerPath`
 subsection matching the existing per-setting format, and add it to the combined
 example block.
 
@@ -275,7 +280,7 @@ example block.
 `Run Program` executes; the debugger pauses.
 
 **Edit: `docs/reference/runtime/index.rst`** — the section intro currently
-describes `ironplcvm` alone; name `ironplcdap` as the second binary and add it
+describes `ironplcvm` alone; name `ironplcvmd` as the second binary and add it
 to the toctree.
 
 **Edit: `docs/reference/compiler/ironplcc.rst`** — one line stating that
@@ -346,7 +351,7 @@ Every `.. figure::` needs an `:alt:`, as the existing pages do.
 Small, no new pages, removes an actively false statement.
 
 **Phase 1 — Reference.** `reference/editor/debugging.rst`,
-`reference/runtime/ironplcdap.rst`, the
+`reference/runtime/ironplcvmd.rst`, the
 `settings.rst`/`overview.rst`/`runtime/index.rst`/`ironplcc.rst` edits. Reference
 first because the other three quadrants link into it.
 
@@ -372,7 +377,7 @@ Phases 1–4 are each independently shippable.
 - `docs/how-to-guides/getting-started/debug-a-program.rst`
 - `docs/how-to-guides/getting-started/debug-without-vs-code.rst` *(Phase 5)*
 - `docs/reference/editor/debugging.rst`
-- `docs/reference/runtime/ironplcdap.rst`
+- `docs/reference/runtime/ironplcvmd.rst`
 - `docs/explanation/debugging-a-scan-cycle.rst`
 - `docs/images/screenshots/debug-*.png` (4 files)
 

--- a/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
+++ b/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
@@ -92,13 +92,16 @@ catches the one prose copy that is actually addressable (the slug).
 
 ### Docs URL stability
 
-`docs/reference/runtime/ironplcdap.rst` shipped with #1392, which is already on
-`main`. Per the URL-stability policy the old path must keep resolving, so the
-page is renamed to `ironplcvmd.rst` and `conf.py` gains an `ironplc_redirects`
-entry `reference/runtime/ironplcdap.html` → `reference/runtime/ironplcvmd.html`.
-That is the mechanism `conf.py` already documents for a renamed page, and it
-beats a stub file: no second page to keep alive, and the stub carries
-`noindex` + `canonical` so search consolidates on the new URL.
+`docs/reference/runtime/ironplcdap.rst` arrived with #1392. It is on `main` but
+the site has not been published since, so the old slug has never been a live
+URL: nothing links to it and nothing has indexed it. The page is renamed to
+`ironplcvmd.rst` with **no redirect** — the URL-stability policy protects
+*published* URLs, and adding an `ironplc_redirects` entry here would mean
+maintaining a permanent stub for an address that never existed.
+
+This holds only as long as the rename lands before the next docs publish. If it
+slips past one, the old slug becomes a shipped URL and the redirect entry has to
+go in after all.
 
 ## File map
 
@@ -122,7 +125,6 @@ beats a stub file: no second page to keep alive, and the stub carries
 
 **Docs**
 - `docs/reference/runtime/ironplcdap.rst` → `docs/reference/runtime/ironplcvmd.rst`
-- `docs/conf.py` — redirect entry
 - `docs/reference/runtime/index.rst`, `docs/reference/editor/debugging.rst`,
   `docs/reference/editor/settings.rst`, `docs/reference/editor/problems/E0007.rst`,
   `docs/how-to-guides/getting-started/debug-a-program.rst`,
@@ -136,7 +138,7 @@ beats a stub file: no second page to keep alive, and the stub carries
 
 - [x] Commit this plan
 - [x] Rename the binary across the compiler and packaging manifests
-- [x] Rename the docs page, add the redirect, update the referring pages
+- [x] Rename the docs page and update the referring pages
 - [x] Introduce the extension name constants and route all uses through them
 - [x] Add the manifest / CSV / Cargo-target guards
 - [x] Add the docs-page guard to `shipped_binaries_guard.rs`

--- a/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
+++ b/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
@@ -19,9 +19,9 @@ the VM under a debugger. `ironplcvmd` sits beside `ironplcvm` the way a daemon
 sits beside its command, and it survives a protocol change.
 
 Per the issue, there is **no compatibility fallback**: the old setting and
-environment variable stop being read. Anyone who set `ironplc.dapServerPath`
-loses the override and gets E0007 until they update it. This needs a release
-note.
+environment variable stop being read. The setting shipped in v0.235.0-v0.239.0,
+but nobody has set it, so this is a clean rename with no upgraders to carry: the
+docs describe only the new names.
 
 ### The duplication problem
 
@@ -130,5 +130,4 @@ catches the one prose copy that is actually addressable (the slug).
 - [x] Add the manifest / CSV / Cargo-target guards
 - [x] Add the docs-page guard to `shipped_binaries_guard.rs`
 - [x] Update the design doc and DAP plans
-- [x] Add the release note for the setting rename
 - [x] `cd compiler && just`; extension `npm run pretest && npm run test:unit`

--- a/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
+++ b/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
@@ -134,12 +134,12 @@ beats a stub file: no second page to keep alive, and the stub carries
 
 ## Tasks
 
-- [ ] Commit this plan
-- [ ] Rename the binary across the compiler and packaging manifests
-- [ ] Rename the docs page, add the redirect, update the referring pages
-- [ ] Introduce the extension name constants and route all uses through them
-- [ ] Add the manifest / CSV / Cargo-target guards
-- [ ] Add the docs-page guard to `shipped_binaries_guard.rs`
-- [ ] Update the design doc and DAP plans
-- [ ] Add the release note for the setting rename
-- [ ] `cd compiler && just`; extension `npm run pretest && npm run test:unit`
+- [x] Commit this plan
+- [x] Rename the binary across the compiler and packaging manifests
+- [x] Rename the docs page, add the redirect, update the referring pages
+- [x] Introduce the extension name constants and route all uses through them
+- [x] Add the manifest / CSV / Cargo-target guards
+- [x] Add the docs-page guard to `shipped_binaries_guard.rs`
+- [x] Update the design doc and DAP plans
+- [x] Add the release note for the setting rename
+- [x] `cd compiler && just`; extension `npm run pretest && npm run test:unit`

--- a/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
+++ b/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
@@ -90,19 +90,6 @@ text. Substituting them would cost readability for no safety — a stale word in
 a sentence is a documentation bug, not a broken install, and the doc-page guard
 catches the one prose copy that is actually addressable (the slug).
 
-### Docs URL stability
-
-`docs/reference/runtime/ironplcdap.rst` arrived with #1392. It is on `main` but
-the site has not been published since, so the old slug has never been a live
-URL: nothing links to it and nothing has indexed it. The page is renamed to
-`ironplcvmd.rst` with **no redirect** — the URL-stability policy protects
-*published* URLs, and adding an `ironplc_redirects` entry here would mean
-maintaining a permanent stub for an address that never existed.
-
-This holds only as long as the rename lands before the next docs publish. If it
-slips past one, the old slug becomes a shipped URL and the redirect entry has to
-go in after all.
-
 ## File map
 
 **Compiler**

--- a/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
+++ b/specs/plans/2026-08-22-rename-ironplcdap-to-ironplcvmd.md
@@ -1,0 +1,145 @@
+# Plan: Rename `ironplcdap` to `ironplcvmd`
+
+Issue: [#1399](https://github.com/ironplc/ironplc/issues/1399)
+Design doc: [Debugger Support](../design/debugger-support.md)
+
+## Goal
+
+Rename the debug server binary from `ironplcdap` to `ironplcvmd`, so the name
+describes what the program *is* — the virtual machine's debug daemon — rather
+than the protocol it happens to speak. Rename the override setting and
+environment variable with it, and remove the duplication that made the rename a
+30-file edit in the first place.
+
+## Context
+
+`ironplcdap` names the Debug Adapter Protocol. The protocol is an
+implementation detail of how the extension talks to the server; the program is
+the VM under a debugger. `ironplcvmd` sits beside `ironplcvm` the way a daemon
+sits beside its command, and it survives a protocol change.
+
+Per the issue, there is **no compatibility fallback**: the old setting and
+environment variable stop being read. Anyone who set `ironplc.dapServerPath`
+loses the override and gets E0007 until they update it. This needs a release
+note.
+
+### The duplication problem
+
+The name appears 154 times across 32 files. Most of that is prose and is
+harmless. What matters is the set of places where a *load-bearing* copy of the
+string lives, because each one is a place a future rename can silently miss:
+
+| Layer | Load-bearing copies | Cross-checked today? |
+|-------|--------------------|----------------------|
+| `compiler/vm-cli/Cargo.toml` `[[bin]]` | 1 (canonical) | — |
+| `compiler/justfile` `binaries` | 1 | Yes — `shipped_binaries_guard.rs` |
+| `compiler/setup.nsi` | 1 | Yes — same guard |
+| `compiler/homebrew/Formula/ironplc.rb` | 2 | Yes — same guard |
+| `compiler/vm-cli/tests/dap.rs` `cargo_bin!` | 1 | No, but fails loudly at test time |
+| `docs/reference/runtime/<name>.rst` | 1 (the slug) | **No** |
+| VS Code extension source | 3 (binary, env var, setting key) | **No** |
+| VS Code `package.json` setting id | 1 | **No** |
+| VS Code `problem-codes.csv` E0007 text | 1 | **No** |
+| VS Code unit tests | ~8 hand-typed literals | **No** |
+
+The packaging row is already solved: `shipped_binaries_guard.rs` recovers the
+binary set from each manifest and asserts all four agree, so a rename that
+misses an installer fails CI. That is the pattern to extend, not replace.
+
+The genuinely delicate coupling is the one nothing checks: **the extension
+hand-types the compiler's binary name.** Rename the `[[bin]]` target and the
+extension still compiles, still passes its tests, and fails only at runtime as
+E0007 on a user's machine.
+
+## Architecture
+
+Two moves, in addition to the rename itself.
+
+**1. One constant per name in the extension.** `debugAdapterLogic.ts` already
+holds `CONTAINER_EXTENSION` as an exported single source of truth for a string
+the extension shares with the server. The three debug-server names join it:
+
+```ts
+export const DEBUG_SERVER_BINARY = 'ironplcvmd';
+export const DEBUG_SERVER_ENV_VAR = 'IRONPLCVMD';
+export const DEBUG_SERVER_PATH_SETTING = 'debugServerPath';
+export const DEBUG_SERVER_PATH_SETTING_ID = `${CONFIG_SECTION}.${DEBUG_SERVER_PATH_SETTING}`;
+```
+
+`debugAdapter.ts`, `findDapServerPath`, the E0007 hint text, and every unit
+test read the constants instead of retyping the string. The hint text itself
+becomes `debugServerNotFoundHint()` — pure logic in the logic module, so it is
+testable and has exactly one copy.
+
+**2. Guards for the copies that cannot import a constant.** A manifest, a CSV,
+and a Cargo target are not TypeScript, so they get tests that compare them to
+the constant rather than derive from it:
+
+- `package.json` declares exactly `DEBUG_SERVER_PATH_SETTING_ID`, and its
+  description names `DEBUG_SERVER_BINARY`.
+- The E0007 message names `DEBUG_SERVER_BINARY`.
+- **`compiler/vm-cli/Cargo.toml` declares a `[[bin]]` named
+  `DEBUG_SERVER_BINARY`.** This is the weld that does not exist today. It turns
+  a silent runtime break into a failing unit test in the same repo.
+- `shipped_binaries_guard.rs` gains: every built binary has a reference page at
+  `docs/reference/**/<name>.rst`. All four binaries already do; the guard keeps
+  the docs slug from drifting from the binary it documents.
+
+Prose copies (`.rst` body text, doc comments, spec history) are left as plain
+text. Substituting them would cost readability for no safety — a stale word in
+a sentence is a documentation bug, not a broken install, and the doc-page guard
+catches the one prose copy that is actually addressable (the slug).
+
+### Docs URL stability
+
+`docs/reference/runtime/ironplcdap.rst` shipped with #1392, which is already on
+`main`. Per the URL-stability policy the old path must keep resolving, so the
+page is renamed to `ironplcvmd.rst` and `conf.py` gains an `ironplc_redirects`
+entry `reference/runtime/ironplcdap.html` → `reference/runtime/ironplcvmd.html`.
+That is the mechanism `conf.py` already documents for a renamed page, and it
+beats a stub file: no second page to keep alive, and the stub carries
+`noindex` + `canonical` so search consolidates on the new URL.
+
+## File map
+
+**Compiler**
+- `compiler/vm-cli/Cargo.toml` — `[[bin]]` name and its comment
+- `compiler/vm-cli/src/dap_main.rs`, `src/dap/mod.rs`, `src/dap/problem_codes.rs`, `src/error.rs`
+- `compiler/vm-cli/tests/dap.rs` — `cargo_bin!` target and test names
+- `compiler/justfile` — `binaries`
+- `compiler/setup.nsi` — `DAPFILE` → `VMDFILE`
+- `compiler/homebrew/Formula/ironplc.rb`
+- `compiler/test/tests/shipped_binaries_guard.rs` — fixtures, plus the new
+  docs-page guard
+
+**Extension**
+- `integrations/vscode/src/debugAdapterLogic.ts` — new constants, `debugServerNotFoundHint`
+- `integrations/vscode/src/debugAdapter.ts`, `src/extension.ts`
+- `integrations/vscode/package.json` — setting id and description
+- `integrations/vscode/resources/problem-codes.csv` — E0007 text
+- `integrations/vscode/src/test/unit/debugAdapterLogic.test.ts` — use constants; new name guards
+- `integrations/vscode/src/test/unit/problems.test.ts`
+
+**Docs**
+- `docs/reference/runtime/ironplcdap.rst` → `docs/reference/runtime/ironplcvmd.rst`
+- `docs/conf.py` — redirect entry
+- `docs/reference/runtime/index.rst`, `docs/reference/editor/debugging.rst`,
+  `docs/reference/editor/settings.rst`, `docs/reference/editor/problems/E0007.rst`,
+  `docs/how-to-guides/getting-started/debug-a-program.rst`,
+  `docs/how-to-guides/troubleshoot-editor.rst`,
+  `docs/explanation/ironplc-ecosystem.rst`
+
+**Specs**
+- `specs/design/debugger-support.md` and the DAP plans under `specs/plans/`
+
+## Tasks
+
+- [ ] Commit this plan
+- [ ] Rename the binary across the compiler and packaging manifests
+- [ ] Rename the docs page, add the redirect, update the referring pages
+- [ ] Introduce the extension name constants and route all uses through them
+- [ ] Add the manifest / CSV / Cargo-target guards
+- [ ] Add the docs-page guard to `shipped_binaries_guard.rs`
+- [ ] Update the design doc and DAP plans
+- [ ] Add the release note for the setting rename
+- [ ] `cd compiler && just`; extension `npm run pretest && npm run test:unit`


### PR DESCRIPTION
Records the rename and the deduplication that goes with it: one constant
per name in the extension, and guards for the copies that live in a
manifest, a CSV, or a Cargo target and so cannot import one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EKmSJBfmtx77QhqwLVtW3U