### PR TITLE
Implement ironplc/stepScan custom DAP request for scan-cycle stepping

### DIFF
--- a/compiler/vm-cli/src/dap/server.rs
+++ b/compiler/vm-cli/src/dap/server.rs
@@ -185,9 +185,12 @@ fn load_and_check(request: &Request) -> Result<(Container, LaunchRequestArgument
 /// — the session terminates once `scan_count` reaches it — and `stopOnEntry`
 /// pauses before the first instruction of the first scan.
 ///
-/// Execution control is `continue` plus single-stepping (`next`/`stepIn`/
-/// `stepOut`); a step is armed on the next round's hook, seeded from the paused
-/// frames so it measures from the real pause point.
+/// Execution control is `continue`, single-stepping (`next`/`stepIn`/
+/// `stepOut`), and scan stepping (`ironplc/stepScan`); a step is armed on the
+/// next round's hook, seeded from the paused frames so it measures from the
+/// real pause point. A scan step spans two rounds: the first runs the cycle out
+/// to `RoundOutcome::PausedAfterScan`, the second stops at the first
+/// instruction of the new scan so the stop has a frame to show.
 ///
 /// Current limitations: trap→`exception` is not yet implemented. A free-running
 /// program with no breakpoint and no `scanLimit` scans until the client
@@ -240,8 +243,13 @@ fn launched_session<R: BufRead, W: Write>(
     let scan_limit = args.scan_limit;
     // Armed once, before the first scan, when the launch requested `stopOnEntry`.
     let mut pending_stop_on_entry = args.stop_on_entry;
-    // Set by a `next`/`stepIn`/`stepOut` request; armed on the next round's hook.
+    // Set by a `next`/`stepIn`/`stepOut`/`ironplc/stepScan` request; armed on
+    // the next round's hook.
     let mut pending_step: Option<StepMode> = None;
+    // Set when a scan step ran its cycle out: the next round stops before its
+    // first instruction, so the scan step lands at the start of the new scan
+    // rather than at the frame-less boundary between the two.
+    let mut pending_scan_landing = false;
 
     loop {
         if phase == Phase::Running {
@@ -255,6 +263,10 @@ fn launched_session<R: BufRead, W: Write>(
                     hook.stop_on_entry();
                     pending_stop_on_entry = false;
                 }
+                if pending_scan_landing {
+                    hook.land_scan_step();
+                    pending_scan_landing = false;
+                }
                 if let Some(mode) = pending_step.take() {
                     // Seed the hook to the paused position so the step's origin
                     // is where the VM actually stopped, not scan entry. Frames
@@ -267,6 +279,7 @@ fn launched_session<R: BufRead, W: Write>(
                         StepMode::Over => hook.step_over(),
                         StepMode::In => hook.step_in(),
                         StepMode::Out => hook.step_out(),
+                        StepMode::Scan => hook.step_scan(),
                         StepMode::None => {}
                     }
                 }
@@ -277,12 +290,25 @@ fn launched_session<R: BufRead, W: Write>(
             match outcome {
                 // A completed scan keeps the debugger scanning: run the next
                 // cycle unless a `scanLimit` bound has been reached.
-                Ok(RoundOutcome::Completed) | Ok(RoundOutcome::PausedAfterScan) => {
-                    if scan_limit.is_some_and(|limit| running.scan_count() >= limit) {
+                Ok(RoundOutcome::Completed) => {
+                    if scan_limit_reached(scan_limit, &running) {
                         send(writer, &Event::new(take_seq(seq), "terminated", None))?;
                         phase = Phase::Terminated;
                     }
                     // Otherwise stay in `Running`: the loop drives the next scan.
+                }
+                // A scan step ran its cycle out. The boundary itself has no
+                // frames to inspect, so run one more round with the landing
+                // armed and stop at the first instruction of the new scan --
+                // unless the finished cycle reached the `scanLimit`, in which
+                // case there is no next scan to land in.
+                Ok(RoundOutcome::PausedAfterScan) => {
+                    if scan_limit_reached(scan_limit, &running) {
+                        send(writer, &Event::new(take_seq(seq), "terminated", None))?;
+                        phase = Phase::Terminated;
+                    } else {
+                        pending_scan_landing = true;
+                    }
                 }
                 Ok(RoundOutcome::Paused(reason)) => {
                     let dap_reason = match reason {
@@ -291,8 +317,8 @@ fn launched_session<R: BufRead, W: Write>(
                             suppress_bp = true;
                             "breakpoint"
                         }
-                        // Neither is produced yet (no stepping, no
-                        // stop-on-entry), but map them so the loop is total.
+                        // A step landing, whether from `next`/`stepIn`/
+                        // `stepOut` or from a scan step's landing round.
                         PauseReason::Step => {
                             suppress_bp = true;
                             "step"
@@ -418,6 +444,11 @@ fn launched_session<R: BufRead, W: Write>(
                 pending_step = Some(StepMode::Out);
                 phase = Phase::Running;
             }
+            Some(Command::StepScan) if legal_here => {
+                send(writer, &Response::success(take_seq(seq), &request, None))?;
+                pending_step = Some(StepMode::Scan);
+                phase = Phase::Running;
+            }
             _ => {
                 // Illegal in this phase or an unknown command.
                 send(
@@ -427,6 +458,12 @@ fn launched_session<R: BufRead, W: Write>(
             }
         }
     }
+}
+
+/// Whether the launch's `scanLimit` bound (if any) has been reached, so the
+/// session should terminate rather than start another cycle.
+fn scan_limit_reached(scan_limit: Option<u64>, running: &VmRunning) -> bool {
+    scan_limit.is_some_and(|limit| running.scan_count() >= limit)
 }
 
 /// Builds the `stopped` event for `reason`, scoped to the single thread.
@@ -871,10 +908,26 @@ mod tests {
 
     #[test]
     fn serve_when_unknown_command_then_request_not_applicable() {
+        // A custom request in IronPLC's namespace that the server does not
+        // implement (unlike `ironplc/stepScan`, which it does).
         let out = run_server(&[json!({"seq": 1, "type": "request",
-                                      "command": "ironplc/stepScan"})]);
+                                      "command": "ironplc/forceVariable"})]);
         assert_eq!(out[0]["success"], false);
         assert_eq!(out[0]["message"], "requestNotApplicable");
+    }
+
+    #[test]
+    fn serve_when_step_scan_before_a_pause_then_request_not_applicable() {
+        // Scan stepping is execution control: it needs a live pause to step
+        // from, the same as `continue` or `next`.
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "ironplc/stepScan"}),
+        ]);
+        let step_scan = out.last().unwrap();
+        assert_eq!(step_scan["command"], "ironplc/stepScan");
+        assert_eq!(step_scan["success"], false);
+        assert_eq!(step_scan["message"], "requestNotApplicable");
     }
 
     #[test]
@@ -1412,5 +1465,174 @@ mod tests {
         assert_eq!(events(&out, "terminated").len(), 1);
         assert_eq!(responses(&out, "stepIn")[0]["success"], true);
         assert_eq!(responses(&out, "stepOut")[0]["success"], true);
+    }
+
+    // -- scan stepping (`ironplc/stepScan`) ---------------------------------
+
+    #[test]
+    fn serve_when_step_scan_then_stops_at_start_of_next_scan_with_cycle_complete() {
+        // The whole point of the command: one press runs the rest of the
+        // current cycle and stops at the top of the next, with the finished
+        // cycle's values on screen.
+        let (_file, path) = incrementing_scan_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path, "stopOnEntry": true}}),
+            json!({"seq": 3, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 4, "type": "request", "command": "ironplc/stepScan",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 5, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 6, "type": "request", "command": "variables",
+                   "arguments": {"variablesReference": 1}}),
+            json!({"seq": 7, "type": "request", "command": "variables",
+                   "arguments": {"variablesReference": 2}}),
+            json!({"seq": 8, "type": "request", "command": "disconnect"}),
+        ]);
+
+        assert_eq!(responses(&out, "ironplc/stepScan")[0]["success"], true);
+
+        // The entry stop, then the scan step's landing -- reported as a step.
+        let stopped = events(&out, "stopped");
+        assert_eq!(stopped.len(), 2);
+        assert_eq!(stopped[0]["body"]["reason"], "entry");
+        assert_eq!(stopped[1]["body"]["reason"], "step");
+        assert!(events(&out, "terminated").is_empty());
+
+        // The stop has a live frame at the first statement of the new scan --
+        // not the frame-less scan boundary, where a client would show no call
+        // stack and no variables.
+        let st = responses(&out, "stackTrace");
+        assert_eq!(st[0]["body"]["stackFrames"].as_array().unwrap().len(), 1);
+        assert_eq!(st[0]["body"]["stackFrames"][0]["name"], "MAIN");
+        assert_eq!(st[0]["body"]["stackFrames"][0]["line"], 10);
+
+        // One full cycle ran: the increment landed and the count advanced.
+        let vars = responses(&out, "variables");
+        assert_eq!(vars[0]["body"]["variables"][0]["name"], "x");
+        assert_eq!(vars[0]["body"]["variables"][0]["value"], "1");
+        assert_eq!(vars[1]["body"]["variables"][0]["name"], "scanCount");
+        assert_eq!(vars[1]["body"]["variables"][0]["value"], "1");
+    }
+
+    #[test]
+    fn serve_when_step_scan_repeatedly_then_advances_exactly_one_cycle_each_time() {
+        let (_file, path) = incrementing_scan_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path, "stopOnEntry": true}}),
+            json!({"seq": 3, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 4, "type": "request", "command": "ironplc/stepScan",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 5, "type": "request", "command": "variables",
+                   "arguments": {"variablesReference": 2}}),
+            json!({"seq": 6, "type": "request", "command": "ironplc/stepScan",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 7, "type": "request", "command": "variables",
+                   "arguments": {"variablesReference": 2}}),
+            json!({"seq": 8, "type": "request", "command": "ironplc/stepScan",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 9, "type": "request", "command": "variables",
+                   "arguments": {"variablesReference": 2}}),
+            json!({"seq": 10, "type": "request", "command": "disconnect"}),
+        ]);
+
+        // Entry stop plus one landing per press.
+        assert_eq!(events(&out, "stopped").len(), 4);
+        let counts: Vec<&str> = responses(&out, "variables")
+            .iter()
+            .map(|v| v["body"]["variables"][0]["value"].as_str().unwrap())
+            .collect();
+        assert_eq!(counts, ["1", "2", "3"], "one cycle per press, never two");
+    }
+
+    #[test]
+    fn serve_when_step_scan_lands_then_a_following_step_advances_one_statement() {
+        // The landing must leave a usable pause position. Stopping at the
+        // frame-less scan boundary instead would seed the next step from
+        // `(depth 0, offset 0)` -- the first statement -- so `next` would skip
+        // it and land on the second.
+        let (_file, path) = scan_container_file(&MULTI_STATEMENT_SCAN, 1, &MULTI_STATEMENT_LINES);
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path, "stopOnEntry": true}}),
+            json!({"seq": 3, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 4, "type": "request", "command": "ironplc/stepScan",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 5, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 6, "type": "request", "command": "next",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 7, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 8, "type": "request", "command": "disconnect"}),
+        ]);
+
+        let st = responses(&out, "stackTrace");
+        assert_eq!(st[0]["body"]["stackFrames"][0]["line"], 10);
+        assert_eq!(st[1]["body"]["stackFrames"][0]["line"], 11);
+    }
+
+    #[test]
+    fn serve_when_breakpoint_inside_stepped_scan_then_stops_at_the_breakpoint() {
+        // A breakpoint reached while running the cycle out wins and abandons
+        // the scan step, the same way one reached mid-`next` does.
+        let (_file, path) = incrementing_scan_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path, "stopOnEntry": true}}),
+            // Line 11 is the RET_VOID, after the increment statement.
+            json!({"seq": 3, "type": "request", "command": "setBreakpoints",
+                   "arguments": {"source": {"path": "demo.st"},
+                                 "breakpoints": [{"line": 11}]}}),
+            json!({"seq": 4, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 5, "type": "request", "command": "ironplc/stepScan",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 6, "type": "request", "command": "stackTrace",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 7, "type": "request", "command": "variables",
+                   "arguments": {"variablesReference": 2}}),
+            json!({"seq": 8, "type": "request", "command": "disconnect"}),
+        ]);
+
+        let stopped = events(&out, "stopped");
+        assert_eq!(stopped.len(), 2);
+        assert_eq!(stopped[1]["body"]["reason"], "breakpoint");
+        assert_eq!(
+            responses(&out, "stackTrace")[0]["body"]["stackFrames"][0]["line"],
+            11
+        );
+        // The cycle never finished, so no scan has completed.
+        assert_eq!(
+            responses(&out, "variables")[0]["body"]["variables"][0]["value"],
+            "0"
+        );
+    }
+
+    #[test]
+    fn serve_when_step_scan_reaches_scan_limit_then_terminates_instead_of_landing() {
+        // With one scan left in the bound, the stepped cycle is the last one:
+        // there is no next scan to land in, so the session ends.
+        let (_file, path) = incrementing_scan_container_file();
+        let out = run_server(&[
+            json!({"seq": 1, "type": "request", "command": "initialize"}),
+            json!({"seq": 2, "type": "request", "command": "launch",
+                   "arguments": {"program": path, "stopOnEntry": true,
+                                 "scanLimit": 1}}),
+            json!({"seq": 3, "type": "request", "command": "configurationDone"}),
+            json!({"seq": 4, "type": "request", "command": "ironplc/stepScan",
+                   "arguments": {"threadId": 1}}),
+            json!({"seq": 5, "type": "request", "command": "disconnect"}),
+        ]);
+
+        // Only the entry stop: the scan step terminated rather than landing.
+        let stopped = events(&out, "stopped");
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(stopped[0]["body"]["reason"], "entry");
+        assert_eq!(events(&out, "terminated").len(), 1);
     }
 }

--- a/compiler/vm-cli/src/dap/state.rs
+++ b/compiler/vm-cli/src/dap/state.rs
@@ -59,6 +59,9 @@ pub enum Command {
     Next,
     StepIn,
     StepOut,
+    /// The `ironplc/stepScan` custom request: run the rest of the current scan
+    /// cycle and stop at the start of the next.
+    StepScan,
     Disconnect,
     // Known DAP requests deliberately unsupported in v1: always illegal.
     Pause,
@@ -86,6 +89,7 @@ impl Command {
             "next" => Command::Next,
             "stepIn" => Command::StepIn,
             "stepOut" => Command::StepOut,
+            "ironplc/stepScan" => Command::StepScan,
             "disconnect" => Command::Disconnect,
             "pause" => Command::Pause,
             "setVariable" => Command::SetVariable,
@@ -112,8 +116,9 @@ pub fn legal(phase: Phase, command: Command) -> bool {
         // count is inspected through the `Runtime` scope, so it needs no
         // request of its own — `scopes`/`variables` already carry it.
         Threads | StackTrace | Scopes | Variables => matches!(phase, Paused | Faulted),
-        // Execution control: only at a non-terminal pause.
-        Continue | Next | StepIn | StepOut => phase == Paused,
+        // Execution control: only at a non-terminal pause. Scan stepping is
+        // execution control like the rest — it just measures in cycles.
+        Continue | Next | StepIn | StepOut | StepScan => phase == Paused,
         // Teardown is always accepted.
         Disconnect => true,
         // Cut from v1: refused in every phase.
@@ -134,7 +139,7 @@ mod tests {
         Phase::Faulted,
     ];
 
-    const ALL_COMMANDS: [Command; 17] = [
+    const ALL_COMMANDS: [Command; 18] = [
         Command::Initialize,
         Command::Launch,
         Command::SetBreakpoints,
@@ -147,6 +152,7 @@ mod tests {
         Command::Next,
         Command::StepIn,
         Command::StepOut,
+        Command::StepScan,
         Command::Disconnect,
         Command::Pause,
         Command::SetVariable,
@@ -166,7 +172,7 @@ mod tests {
             ConfigurationDone => &[Configuring],
             SetBreakpoints => &[Configuring, Paused],
             Threads | StackTrace | Scopes | Variables => &[Paused, Faulted],
-            Continue | Next | StepIn | StepOut => &[Paused],
+            Continue | Next | StepIn | StepOut | StepScan => &[Paused],
             Disconnect => &[
                 Initialized,
                 Configuring,
@@ -243,6 +249,7 @@ mod tests {
             Command::Next,
             Command::StepIn,
             Command::StepOut,
+            Command::StepScan,
         ] {
             assert!(!legal(Phase::Faulted, command));
         }
@@ -255,6 +262,11 @@ mod tests {
             Some(Command::ConfigurationDone)
         );
         assert_eq!(Command::from_request("stepIn"), Some(Command::StepIn));
+        // The one custom (non-DAP-standard) request the server models.
+        assert_eq!(
+            Command::from_request("ironplc/stepScan"),
+            Some(Command::StepScan)
+        );
         // Known-but-cut requests still map, so the caller can answer
         // requestNotApplicable rather than "unknown command".
         assert_eq!(Command::from_request("pause"), Some(Command::Pause));
@@ -262,7 +274,10 @@ mod tests {
 
     #[test]
     fn from_request_when_unknown_command_then_none() {
-        assert_eq!(Command::from_request("ironplc/stepScan"), None);
+        // A custom request in IronPLC's namespace that the server does not
+        // implement is as unknown as any other.
+        assert_eq!(Command::from_request("ironplc/forceVariable"), None);
+        assert_eq!(Command::from_request("stepScan"), None);
         assert_eq!(Command::from_request(""), None);
     }
 }

--- a/compiler/vm/src/debug.rs
+++ b/compiler/vm/src/debug.rs
@@ -155,6 +155,16 @@ pub enum StepMode {
     In,
     /// Run until the current function returns, then stop in the caller.
     Out,
+    /// Run to the end of the current scan cycle, then stop at the start of the
+    /// next one.
+    ///
+    /// Unlike the other modes this one has no *intra*-scan landing: the stop is
+    /// a round boundary, not an instruction, so the driver decides it. The
+    /// [`DebuggerHook`] only reports that a scan step is in flight (see
+    /// [`DebugHook::stepping_scan`](crate::debug_hook::DebugHook::stepping_scan))
+    /// and `run_round_debug` turns a completed scan into
+    /// [`RoundOutcome::PausedAfterScan`](crate::RoundOutcome::PausedAfterScan).
+    Scan,
 }
 
 /// Remembers where a step started so the hook can tell when it has "landed".
@@ -192,6 +202,9 @@ impl StepController {
             StepMode::In => !at_origin,
             // Only once control has unwound past the origin frame.
             StepMode::Out => depth < self.origin_depth,
+            // A scan step never lands inside the scan: it runs to the scan
+            // boundary, which only the round driver can observe.
+            StepMode::Scan => false,
         }
     }
 }
@@ -213,6 +226,12 @@ pub struct DebuggerHook<'a> {
     /// exactly once, before any breakpoint or step check. The single-threaded
     /// driver arms this only on the first round of a `stopOnEntry` launch.
     stop_on_entry: bool,
+    /// When set, the next instruction pauses with [`PauseReason::Step`] exactly
+    /// once — the landing half of a scan step, armed by the driver on the round
+    /// that follows the scan the step ran out. See [`land_scan_step`].
+    ///
+    /// [`land_scan_step`]: DebuggerHook::land_scan_step
+    scan_landing: bool,
     /// Call depth relative to scan entry: `+1` per call, `-1` per return.
     /// Self-heals to 0 at each scan boundary (the entry-frame return uses a
     /// saturating decrement).
@@ -230,6 +249,7 @@ impl<'a> DebuggerHook<'a> {
             breakpoints,
             skip_breakpoint_once: false,
             stop_on_entry: false,
+            scan_landing: false,
             depth: 0,
             last_offset: 0,
             step: StepController::idle(),
@@ -263,6 +283,36 @@ impl<'a> DebuggerHook<'a> {
     /// current function returns, then stop in the caller.
     pub fn step_out(&mut self) {
         self.arm(StepMode::Out);
+    }
+
+    /// Arm the *run* half of a scan step: finish the current scan cycle without
+    /// stopping at any step landing, so the driver reports
+    /// [`RoundOutcome::PausedAfterScan`](crate::RoundOutcome::PausedAfterScan)
+    /// at the scan boundary.
+    ///
+    /// Breakpoints still fire during that scan, and abandon the step where they
+    /// stop — the same way a breakpoint reached mid-`step_over` abandons that
+    /// step. Because a scan step's stop is the *next* scan's first instruction
+    /// (the frame stack has drained at the boundary itself, leaving nothing to
+    /// inspect), the driver completes it with [`land_scan_step`] on the
+    /// following round.
+    ///
+    /// [`land_scan_step`]: Self::land_scan_step
+    pub fn step_scan(&mut self) {
+        self.arm(StepMode::Scan);
+    }
+
+    /// Arm the *landing* half of a scan step: pause before this round's first
+    /// instruction, reported as [`PauseReason::Step`].
+    ///
+    /// The driver arms this on the round that follows a
+    /// [`RoundOutcome::PausedAfterScan`](crate::RoundOutcome::PausedAfterScan),
+    /// so the user lands at the start of the new scan with the entry frame
+    /// live: a call stack to show, a line to highlight, and freshly flushed
+    /// outputs to read. A breakpoint on that same instruction takes precedence
+    /// and is reported instead.
+    pub fn land_scan_step(&mut self) {
+        self.scan_landing = true;
     }
 
     fn arm(&mut self, mode: StepMode) {
@@ -317,9 +367,10 @@ impl DebugHook for DebuggerHook<'_> {
                 return HookAction::Pause(PauseReason::Breakpoint(id));
             }
         }
-        if self.step.landed(self.depth, pc) {
+        if self.scan_landing || self.step.landed(self.depth, pc) {
             // A step lands only once; disarm and suppress a co-located
             // breakpoint on the resume instruction.
+            self.scan_landing = false;
             self.step.mode = StepMode::None;
             self.skip_breakpoint_once = true;
             return HookAction::Pause(PauseReason::Step);
@@ -333,6 +384,10 @@ impl DebugHook for DebuggerHook<'_> {
 
     fn after_return(&mut self, _returning_to: Option<FunctionId>) {
         self.depth = self.depth.saturating_sub(1);
+    }
+
+    fn stepping_scan(&self) -> bool {
+        self.step.mode == StepMode::Scan
     }
 }
 
@@ -522,6 +577,87 @@ mod tests {
             hook.before_instruction(FunctionId::SCAN, 8, 0),
             HookAction::Pause(PauseReason::Step)
         ));
+    }
+
+    #[test]
+    fn debugger_hook_when_step_scan_then_never_lands_inside_the_scan() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let table = BreakpointTable::new();
+        let mut hook = DebuggerHook::new(&table);
+        hook.seed_resume_position(0, 0);
+        hook.step_scan();
+        // A scan step's landing is the scan boundary, which the driver
+        // observes -- so no instruction, at any depth, is a landing.
+        assert!(hook.stepping_scan());
+        for (depth_change, function_id, pc) in [
+            (0, FunctionId::SCAN, 3),
+            (1, FunctionId::new(2), 0),
+            (-1, FunctionId::SCAN, 6),
+        ] {
+            match depth_change {
+                1 => hook.before_call(FunctionId::new(2)),
+                -1 => hook.after_return(Some(FunctionId::SCAN)),
+                _ => {}
+            }
+            assert!(matches!(
+                hook.before_instruction(function_id, pc, 0),
+                HookAction::Continue
+            ));
+        }
+        // Still armed at the end of the scan: that is what the driver reads.
+        assert!(hook.stepping_scan());
+    }
+
+    #[test]
+    fn debugger_hook_when_step_scan_and_breakpoint_then_breakpoint_wins() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let mut table = BreakpointTable::new();
+        let id = table.add(FunctionId::SCAN, 6);
+        let mut hook = DebuggerHook::new(&table);
+        hook.step_scan();
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 3, 0),
+            HookAction::Continue
+        ));
+        // A breakpoint inside the stepped-over scan still stops there, the way
+        // one inside a step-over does.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 6, 0),
+            HookAction::Pause(PauseReason::Breakpoint(bp)) if bp == id
+        ));
+    }
+
+    #[test]
+    fn debugger_hook_when_scan_step_landing_then_pauses_at_first_instruction() {
+        use crate::debug_hook::{DebugHook, HookAction};
+        let table = BreakpointTable::new();
+        let mut hook = DebuggerHook::new(&table);
+        hook.land_scan_step();
+        // The landing half is a step stop at the very first instruction of the
+        // new scan -- and it is not itself a scan step, so the driver does not
+        // run another cycle out.
+        assert!(!hook.stepping_scan());
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 0, 0),
+            HookAction::Pause(PauseReason::Step)
+        ));
+        // One-shot: the following instruction runs.
+        assert!(matches!(
+            hook.before_instruction(FunctionId::SCAN, 3, 0),
+            HookAction::Continue
+        ));
+    }
+
+    #[test]
+    fn debugger_hook_when_not_stepping_scan_then_driver_sees_no_scan_step() {
+        use crate::debug_hook::DebugHook;
+        let table = BreakpointTable::new();
+        let mut hook = DebuggerHook::new(&table);
+        assert!(!hook.stepping_scan());
+        hook.step_over();
+        assert!(!hook.stepping_scan());
+        // The default trait impl keeps a non-debugger hook out of the way.
+        assert!(!crate::debug_hook::NoopDebugHook.stepping_scan());
     }
 
     #[test]

--- a/compiler/vm/src/debug_hook.rs
+++ b/compiler/vm/src/debug_hook.rs
@@ -74,6 +74,20 @@ pub trait DebugHook {
     /// resuming in, or `None` if the outermost frame just returned.
     /// Default: no-op.
     fn after_return(&mut self, _returning_to: Option<FunctionId>) {}
+
+    /// Whether a *scan step* is in flight: the user asked to run out the
+    /// current scan cycle and stop when it ends.
+    ///
+    /// A scan step is the one stop a hook cannot report on its own, because
+    /// its landing is a scan boundary rather than an instruction. The driver
+    /// ([`run_round_debug`](crate::VmRunning::run_round_debug)) asks this once
+    /// per completed scan and reports
+    /// [`RoundOutcome::PausedAfterScan`](crate::RoundOutcome::PausedAfterScan)
+    /// when it holds. Default: `false`, so a hook that does not step never
+    /// interrupts the run loop.
+    fn stepping_scan(&self) -> bool {
+        false
+    }
 }
 
 /// A no-op [`DebugHook`] used by default. Zero-sized; the empty

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -298,9 +298,15 @@ pub enum Phase {
 pub enum RoundOutcome {
     /// The scan completed; call again to run the next scan.
     Completed,
-    /// A step spanned the scan boundary and stopped at the start of the
-    /// next scan. Reserved for scan-stepping; not produced in the first
-    /// debug phase (intra-scan steps report [`RoundOutcome::Paused`]).
+    /// A scan step ran the cycle out: the scan completed (outputs flushed,
+    /// `scan_count` advanced) and stopped there because the hook reported
+    /// [`DebugHook::stepping_scan`](crate::debug_hook::DebugHook::stepping_scan).
+    ///
+    /// The frame stack has drained at this boundary, so there is nothing to
+    /// inspect *at* it; a driver presenting a scan step to a user runs one more
+    /// round with the landing armed (`DebuggerHook::land_scan_step`) to stop at
+    /// the first instruction of the new scan. Intra-scan stops report
+    /// [`RoundOutcome::Paused`] instead.
     PausedAfterScan,
     /// The VM paused mid-scan; the frame stack is preserved for inspection
     /// and a later resume.
@@ -513,7 +519,16 @@ impl<'a> VmRunning<'a> {
             ExecuteOutcome::Completed => {
                 self.scan_count += 1;
                 self.phase = Phase::CompletedScan;
-                Ok(RoundOutcome::Completed)
+                // A scan step's landing is this boundary, which no
+                // per-instruction hook can see; ask the hook whether one is in
+                // flight and report it here. The phase stays `CompletedScan`
+                // either way: the cycle really did finish, so the next call
+                // starts a fresh scan rather than resuming this one.
+                if hook.stepping_scan() {
+                    Ok(RoundOutcome::PausedAfterScan)
+                } else {
+                    Ok(RoundOutcome::Completed)
+                }
             }
         }
     }

--- a/compiler/vm/tests/it/debug_engine.rs
+++ b/compiler/vm/tests/it/debug_engine.rs
@@ -429,3 +429,153 @@ fn run_round_debug_when_step_out_of_callee_then_lands_in_caller_after_call() {
     assert_eq!(frames[0].function_id, FunctionId::SCAN);
     assert_eq!(frames[0].pc, 8);
 }
+
+/// A scan that increments `var[0]` by one and returns: `LOAD_VAR\@0,
+/// LOAD_CONST\@3, ADD\@6, STORE\@7, RET_VOID\@10`. Running the cycle out is
+/// observable as `var[0]` advancing by one.
+fn incrementing_scan_container() -> ironplc_container::Container {
+    #[rustfmt::skip]
+    let scan_bytecode: Vec<u8> = vec![
+        opcode::LOAD_VAR_I32, 0x00, 0x00,   // @0
+        opcode::LOAD_CONST_I32, 0x00, 0x00, // @3
+        opcode::ADD_I32,                    // @6
+        opcode::STORE_VAR_I32, 0x00, 0x00,  // @7
+        opcode::RET_VOID,                   // @10
+    ];
+    call_container(&scan_bytecode, &[], 1, &[1])
+}
+
+#[test]
+fn run_round_debug_when_step_scan_then_runs_the_cycle_out_and_pauses_after_scan() {
+    let c = incrementing_scan_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let mut table = BreakpointTable::new();
+    table.add(FunctionId::SCAN, 7); // the STORE, before the increment lands
+
+    // Pause mid-scan: the increment has not been stored yet.
+    let mut hook = DebuggerHook::new(&table);
+    assert!(matches!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Breakpoint(_))
+    ));
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 0);
+    assert_eq!(vm.scan_count(), 0);
+
+    // A scan step finishes the cycle rather than stopping at an instruction.
+    hook.step_scan();
+    assert_eq!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::PausedAfterScan
+    );
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 1);
+    assert_eq!(vm.scan_count(), 1, "the cycle completed, outputs and all");
+    assert!(
+        vm.debug_frames().is_empty(),
+        "the frame stack drains at a scan boundary -- which is why the DAP \
+         server lands the step on the next scan's first instruction instead"
+    );
+}
+
+#[test]
+fn run_round_debug_when_scan_step_landing_then_stops_at_next_scan_first_instruction() {
+    let c = incrementing_scan_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    // Run one cycle out with a scan step armed from the top of the scan.
+    let table = BreakpointTable::new();
+    let mut hook = DebuggerHook::new(&table);
+    hook.step_scan();
+    assert_eq!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::PausedAfterScan
+    );
+
+    // The landing round: a fresh hook (the DAP loop rebuilds one per round)
+    // stops before the first instruction of the *new* scan.
+    let mut hook = DebuggerHook::new(&table);
+    hook.land_scan_step();
+    assert_eq!(
+        vm.run_round_debug(1000, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Step)
+    );
+    let frames = vm.debug_frames();
+    assert_eq!(frames.len(), 1, "the entry frame is live for inspection");
+    assert_eq!(frames[0].function_id, FunctionId::SCAN);
+    assert_eq!(frames[0].pc, 0);
+    // Nothing of the new scan has run yet, so the stop shows the finished
+    // cycle's values.
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 1);
+    assert_eq!(vm.scan_count(), 1);
+}
+
+#[test]
+fn run_round_debug_when_step_scan_spans_a_call_then_does_not_stop_on_return() {
+    // A scan step is not a step-out: returning to a shallower frame mid-scan
+    // is not a landing, so the cycle runs to its end.
+    let c = stepping_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let mut table = BreakpointTable::new();
+    table.add(FunctionId::new(2), 0); // inside the callee
+    let mut hook = DebuggerHook::new(&table);
+    assert!(matches!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Breakpoint(_))
+    ));
+    assert_eq!(vm.debug_frames().len(), 2);
+
+    hook.step_scan();
+    assert_eq!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::PausedAfterScan
+    );
+    // The callee's result was stored: the whole scan ran.
+    assert_eq!(vm.read_variable(VarIndex::new(0)).unwrap(), 42);
+}
+
+#[test]
+fn run_round_debug_when_breakpoint_during_step_scan_then_stops_at_the_breakpoint() {
+    // A breakpoint inside the stepped-over cycle wins, exactly as it does
+    // mid-`step_over`, and the scan does not complete.
+    let c = incrementing_scan_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let mut table = BreakpointTable::new();
+    table.add(FunctionId::SCAN, 0);
+    table.add(FunctionId::SCAN, 7);
+    let mut hook = DebuggerHook::new(&table);
+    assert!(matches!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Breakpoint(_))
+    ));
+    assert_eq!(vm.debug_frames().last().unwrap().pc, 0);
+
+    hook.step_scan();
+    assert!(matches!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Paused(PauseReason::Breakpoint(_))
+    ));
+    assert_eq!(vm.debug_frames().last().unwrap().pc, 7);
+    assert_eq!(vm.scan_count(), 0, "the cycle never finished");
+}
+
+#[test]
+fn run_round_debug_when_no_step_scan_then_completed_scan_is_not_a_pause() {
+    // The `stepping_scan` default must not turn every completed scan into a
+    // stop for hooks that never arm a scan step.
+    let c = incrementing_scan_container();
+    let mut b = VmBuffers::from_container(&c);
+    let mut vm = crate::common::load_and_start(&c, &mut b).unwrap();
+
+    let table = BreakpointTable::new();
+    let mut hook = DebuggerHook::new(&table);
+    assert_eq!(
+        vm.run_round_debug(0, &mut hook).unwrap(),
+        RoundOutcome::Completed
+    );
+}

--- a/docs/reference/editor/debugging.rst
+++ b/docs/reference/editor/debugging.rst
@@ -183,16 +183,34 @@ While the program is paused:
    * - :guilabel:`Step Out`
      - :kbd:`Shift+F11`
      - Run to the end of the current POU and stop in its caller.
+   * - :guilabel:`Step Scan Cycle`
+     - None
+     - Run the rest of the current scan cycle and stop at the start of the
+       next one.
    * - :guilabel:`Stop`
      - :kbd:`Shift+F5`
      - End the session.
 
-.. note::
+Scan Stepping
+-------------
 
-   The :guilabel:`Step Scan Cycle` button on the debug toolbar is not yet
-   implemented. Pressing it reports that the request is not supported. Use
-   :guilabel:`Continue` to advance to the next scan, and watch ``scanCount``
-   in the :guilabel:`Runtime` scope to see the cycles pass.
+:guilabel:`Step Scan Cycle` is on the debug toolbar and in the Command
+Palette. It is the scan-cycle equivalent of :guilabel:`Step Over`: one press
+advances the program by exactly one cycle, no matter how many lines that
+takes.
+
+The stop lands on the first line of the *next* cycle. The cycle you stepped
+has finished --- its outputs are written and ``scanCount`` in the
+:guilabel:`Runtime` scope has gone up by one --- so the values you see are
+that cycle's results.
+
+A breakpoint reached partway through the cycle stops there instead, the same
+way one reached during :guilabel:`Step Over` does. The scan step ends at that
+breakpoint; press :guilabel:`Step Scan Cycle` again to run out the rest of the
+cycle.
+
+If the cycle you step is the last one allowed by ``scanLimit``, the session
+ends rather than stopping again.
 
 Inspecting Variables
 ====================

--- a/integrations/vscode/src/customRequests.ts
+++ b/integrations/vscode/src/customRequests.ts
@@ -9,6 +9,9 @@ import { customRequestFailedMessage } from './debugAdapterLogic';
  * `specs/design/debugger-support.md` §"Phase 5"). The debug toolbar button that
  * invokes it is contributed in `package.json`.
  *
+ * The server runs the rest of the current scan cycle and stops at the start of
+ * the next, so one press advances the program by exactly one cycle.
+ *
  * The scan *count* is deliberately not a command. It is a value you watch while
  * stepping, not one you ask for: the server publishes it in the `Runtime`
  * scope, which the client re-reads at every stop, so it is simply on screen in
@@ -25,9 +28,10 @@ export function registerCustomRequests(context: vscode.ExtensionContext): void {
       try {
         await session.customRequest('ironplc/stepScan');
       } catch {
-        // Server-side `ironplc/stepScan` is not implemented yet, so the request
-        // is refused and the promise rejects. Report it rather than letting the
-        // rejection escape as an unhandled error.
+        // The server refuses the request outside a live pause (a terminated or
+        // faulted session still shows the toolbar), which rejects the promise.
+        // Report it rather than letting the rejection escape as an unhandled
+        // error.
         void vscode.window.showWarningMessage(customRequestFailedMessage('Step Scan Cycle'));
       }
     }),

--- a/integrations/vscode/src/debugAdapterLogic.ts
+++ b/integrations/vscode/src/debugAdapterLogic.ts
@@ -178,12 +178,14 @@ export function firstLine(text: string): string {
  * The message shown when a custom request is refused by the debug server.
  *
  * `DebugSession.customRequest` rejects when the adapter answers with
- * `success: false`, which is what a server that does not implement the request
- * returns (`requestNotApplicable`). Without this, the rejection escapes the
- * command handler as an unhandled error and the user sees no useful
- * explanation. `title` is the command's UI title, so the message names the
- * button that was pressed.
+ * `success: false`, which is what the server returns (`requestNotApplicable`)
+ * for a request that is legal only in another phase. The debug toolbar shows
+ * its buttons for the whole session, so scan stepping can be pressed after the
+ * program has terminated or faulted, when there is no cycle left to step.
+ * Without this, the rejection escapes the command handler as an unhandled error
+ * and the user sees no useful explanation. `title` is the command's UI title, so
+ * the message names the button that was pressed.
  */
 export function customRequestFailedMessage(title: string): string {
-  return `IronPLC: "${title}" is not supported by this debug server.`;
+  return `IronPLC: "${title}" is only available while the program is paused.`;
 }

--- a/integrations/vscode/src/test/unit/debugAdapterLogic.test.ts
+++ b/integrations/vscode/src/test/unit/debugAdapterLogic.test.ts
@@ -230,6 +230,6 @@ suite('customRequestFailedMessage', () => {
   test('customRequestFailedMessage_when_given_title_then_names_the_command', () => {
     const message = customRequestFailedMessage('Step Scan Cycle');
     assert.ok(message.includes('Step Scan Cycle'));
-    assert.ok(message.includes('not supported'));
+    assert.ok(message.includes('paused'));
   });
 });

--- a/specs/design/debugger-support.md
+++ b/specs/design/debugger-support.md
@@ -760,6 +760,9 @@ enum StepMode {
     /// DAP "stepOut".
     StepOut,
     /// Run until the next scan cycle boundary. Custom DAP request.
+    /// (Shipped as `StepMode::Scan`; it has no intra-scan landing, so
+    /// `StepController::check` returns false for it and the round driver
+    /// reports the boundary instead.)
     StepScan,
 }
 ```
@@ -808,7 +811,7 @@ The natural stop points are:
 | Breakpoint | `DebuggerHook` returns `HookAction::Pause(Breakpoint)` |
 | Step landing | `DebuggerHook` returns `HookAction::Pause(Step)` |
 | Scan boundary | `run_round_debug` returns `RoundOutcome::Completed` (one complete scan finished) |
-| Step Scan landing | `run_round_debug` returns `RoundOutcome::PausedAfterScan` |
+| Step Scan landing | `run_round_debug` returns `RoundOutcome::PausedAfterScan`, and the loop stops on the following round's first instruction (frames have drained at the boundary itself) |
 | Trap | `Err(Trap)` from the dispatch loop, with trap-bp enabled |
 | Disconnect timer | `scanLimit` reached (launch-config; runaway prevention) |
 
@@ -845,7 +848,7 @@ For PLC-specific debugging, users need scan-level control:
 
 | Command | Behavior |
 |---------|----------|
-| **Step Scan** | Run one complete scan cycle (INPUT_FREEZE → EXECUTE → OUTPUT_FLUSH), then pause before the next |
+| **Step Scan** | Run one complete scan cycle (INPUT_FREEZE → EXECUTE → OUTPUT_FLUSH), then pause before the next. *Implemented;* the pause is reported at the next scan's first instruction rather than at the frame-less boundary, so the stop has a call stack and variables to show. |
 | **Pause Between Scans** | Always pause after OUTPUT_FLUSH, before the next INPUT_FREEZE |
 | **Run to Scan N** | Continue until `scan_count` reaches a target value |
 
@@ -861,8 +864,8 @@ For PLC-specific debugging, users need scan-level control:
 > `pause`-while-running remains the Phase 6 cut. This continuous-loop work is a
 > tracked server follow-up (Phase 4c) and is **not** part of Phase 5 (VS Code
 > integration). The scan count is now surfaced by the `Runtime` scope rather
-> than a custom request (2026-08-16); `ironplc/stepScan` is still answered
-> `requestNotApplicable` — see §Custom DAP Requests and §Scopes.
+> than a custom request (2026-08-16), and `ironplc/stepScan` landed on
+> 2026-08-22 — see §Custom DAP Requests and §Scopes.
 
 A new `VmRunning::run_round_debug` method drives a single round under a `DebuggerHook`. v1 supports a single program instance only (see §Multi-instance: not supported in v1), so the `instances_for_task` loop is collapsed to "the one instance":
 
@@ -897,7 +900,7 @@ impl<'a> VmRunning<'a> {
         // OUTPUT_FLUSH and scan_count++ run only when the instance completed.
         self.flush_outputs();
         self.scan_count += 1;
-        if hook.took_step_scan_now() {
+        if hook.stepping_scan() {
             return Ok(RoundOutcome::PausedAfterScan);
         }
         Ok(RoundOutcome::Completed)
@@ -1141,7 +1144,7 @@ It does **not** support arithmetic, function calls, or non-constant subscripts. 
 
 | Custom Request | Description | Status |
 |----------------|-------------|--------|
-| `ironplc/stepScan` | Run one complete scan cycle, then pause | Deferred — `RoundOutcome::PausedAfterScan` has no producer and `StepMode` has no scan-level variant, so this needs debug-engine work. Answered `requestNotApplicable`. |
+| `ironplc/stepScan` | Run one complete scan cycle, then pause at the start of the next | **Implemented (2026-08-22).** `StepMode::Scan` + `DebuggerHook::step_scan()` run the cycle out; `run_round_debug` reports `RoundOutcome::PausedAfterScan` at the boundary; the DAP loop then lands the stop on the next scan's first instruction with `DebuggerHook::land_scan_step()` (the boundary itself has no frames to inspect). Legal at a non-terminal pause, like the other execution-control requests. |
 | ~~`ironplc/scanCount`~~ | Return the current scan_count | **Dropped (2026-08-16).** Superseded by the `Runtime` scope (see §Scopes), which carries the same value over standard `scopes`/`variables`. A custom request would be the *less* portable path — every DAP client can read a scope, but only an IronPLC-aware client knows this request — and having both meant two ways to read one counter. |
 
 Removed from v1 (deferred):
@@ -1425,10 +1428,12 @@ to a temp `.iplc` first so the `launch` sees a debug-enabled container.
 
 Single-stepping landed in #1305. The scan count landed on 2026-08-16 as the
 `Runtime` scope rather than a custom request, and its toolbar button was retired
-(see `specs/plans/2026-08-16-dap-scan-count.md`). `ironplc/stepScan` is still
-answered `requestNotApplicable`, so that toolbar button remains inert; a refused
-custom request is now reported to the user rather than escaping the command
-handler as an unhandled rejection.
+(see `specs/plans/2026-08-16-dap-scan-count.md`). `ironplc/stepScan` landed on
+2026-08-22 (see `specs/plans/2026-08-22-dap-step-scan.md`), so the Step Scan
+Cycle toolbar button now works; a refused custom request — the button is on the
+toolbar for the whole session, including after termination — is still reported
+to the user rather than escaping the command handler as an unhandled
+rejection.
 
 ### Phase 6: Beyond v1 (Future)
 

--- a/specs/plans/2026-08-22-dap-step-scan.md
+++ b/specs/plans/2026-08-22-dap-step-scan.md
@@ -1,0 +1,129 @@
+# Plan: Implement `ironplc/stepScan` in the debug server
+
+## Context
+
+The VS Code extension contributes a **Step Scan Cycle** button to the debug
+toolbar (`integrations/vscode/package.json`, `src/customRequests.ts`), but
+`Command::from_request` in `compiler/vm-cli/src/dap/state.rs` does not model
+`ironplc/stepScan`, so the server answers `requestNotApplicable` and the
+extension pops a "not supported by this debug server" warning. A control that is
+always visible during a session always fails — see
+[#1398](https://github.com/ironplc/ironplc/issues/1398).
+
+The issue offers two ways out: implement the request, or hide the button. This
+plan implements it, which is what the design already calls for — the button is
+not the problem, the missing server half is.
+
+### What the design says
+
+`specs/design/debugger-support.md` §"Scan Cycle Control" defines the behavior:
+
+> **Step Scan** — Run one complete scan cycle (INPUT_FREEZE → EXECUTE →
+> OUTPUT_FLUSH), then pause before the next
+
+and §"Single-threaded DAP loop (v1)" lists "Step Scan landing" as a natural stop
+point signalled by `RoundOutcome::PausedAfterScan`. That outcome is declared in
+`compiler/vm/src/vm.rs` but has **no producer**, and `StepMode` has no
+scan-level variant, so the debug engine needs the work first.
+
+### Where the stop lands
+
+`RoundOutcome::PausedAfterScan` is a *scan-boundary* signal: at the boundary the
+frame stack has drained, so a stop reported there would answer `stackTrace` with
+zero frames. A DAP client with no frames requests no scopes, so the Variables
+pane would be empty — for the one command whose entire purpose is watching
+values change from cycle to cycle. It also breaks a following `next`: a step
+armed against an empty frame stack measures its origin from `(depth 0, offset
+0)`, which is the first instruction, so it would land on the *second* statement
+of the new scan.
+
+So the stop lands **at the first instruction of the next scan**, which is also
+what the issue asks for ("run to the end of the current scan and pause at the
+start of the next"). The outputs of the finished cycle are flushed and
+`scanCount` has advanced, exactly as at the boundary, but the client sees a real
+frame, a highlighted line, and a populated Variables pane.
+
+That makes a scan step two halves across two rounds, because the DAP loop
+rebuilds the `DebuggerHook` every round (it mutates the `BreakpointTable`
+between rounds while the hook borrows it):
+
+1. **Run half** — the round runs with `StepMode::Scan` armed. The step never
+   lands intra-scan; when the scan completes, `run_round_debug` reports
+   `RoundOutcome::PausedAfterScan`.
+2. **Landing half** — the server arms the next round's hook to pause before its
+   first instruction, which surfaces as `RoundOutcome::Paused(PauseReason::Step)`
+   and a `stopped{reason:"step"}` event.
+
+The server already carries `pending_step`, `pending_stop_on_entry`, and
+`suppress_bp` across rounds the same way, so this adds one more flag of the same
+kind rather than a new mechanism.
+
+A breakpoint reached during the run half still wins: the hook checks breakpoints
+before step landings, so the scan step is abandoned at the breakpoint stop. That
+matches how `next`/`stepIn` already behave and is what every debugger does.
+
+`scanLimit` still bounds the run: if the completed cycle reaches the bound, the
+session terminates instead of landing the step.
+
+## Goals
+
+1. Pressing **Step Scan Cycle** while paused runs the rest of the current scan
+   cycle and stops at the start of the next, with the call stack and variables
+   inspectable at the stop.
+2. `ironplc/stepScan` is a modelled request, legal exactly where the other
+   execution-control requests are (a non-terminal pause) and refused elsewhere.
+3. The extension no longer reports the command as unsupported.
+4. The design doc and the debugger reference no longer describe it as deferred.
+
+## Non-goals
+
+- **Pause Between Scans** and **Run to Scan N** (the other two rows of §"Scan
+  Cycle Control"). `scanLimit` covers the runaway case today.
+- Multi-instance scan stepping — v1 rejects multi-instance programs at launch.
+
+## Architecture
+
+| Layer | Change |
+|-------|--------|
+| `vm` debug engine | `StepMode::Scan`; `DebuggerHook::step_scan()` (run half) and `land_scan_step()` (landing half); `DebugHook::stepping_scan()` so the driver can ask |
+| `vm` driver | `run_round_debug` reports `RoundOutcome::PausedAfterScan` when a completed scan had a scan step armed — the outcome finally gets its producer |
+| DAP legality | `Command::StepScan`, mapped from `ironplc/stepScan`, legal in `Paused` |
+| DAP loop | `stepScan` arms `StepMode::Scan`; `PausedAfterScan` arms the landing on the next round (or terminates at `scanLimit`) |
+| Extension | Drop the "not supported" catch; report a genuine failure instead |
+
+`StepController::landed` returns `false` for `StepMode::Scan`: a scan step has
+no intra-scan landing, so the decision belongs to the driver at the round
+boundary, not to the per-instruction check.
+
+## Design doc reference
+
+`specs/design/debugger-support.md` — §"Scan Cycle Control", §"Step Modes",
+§"Single-threaded DAP loop (v1)", §"Custom DAP Requests".
+
+## File map
+
+| File | Change |
+|------|--------|
+| `compiler/vm/src/debug.rs` | `StepMode::Scan`, `step_scan()`, `land_scan_step()`, `stepping_scan()`, `landed` arm; unit tests |
+| `compiler/vm/src/debug_hook.rs` | `DebugHook::stepping_scan()` with a `false` default |
+| `compiler/vm/src/vm.rs` | `run_round_debug` produces `RoundOutcome::PausedAfterScan`; doc comment updated |
+| `compiler/vm/tests/it/debug_engine.rs` | Integration tests for both halves |
+| `compiler/vm-cli/src/dap/state.rs` | `Command::StepScan` + legality; unit tests |
+| `compiler/vm-cli/src/dap/server.rs` | `stepScan` handler, landing flag, `PausedAfterScan` arm; server tests |
+| `integrations/vscode/src/customRequests.ts` | Error path no longer says "not supported" |
+| `integrations/vscode/src/debugAdapterLogic.ts` | Rename/retarget `customRequestFailedMessage` |
+| `docs/reference/editor/debugging.rst` | Replace the known-limitation note with the real behavior |
+| `specs/design/debugger-support.md` | Mark `ironplc/stepScan` implemented |
+
+## Tasks
+
+- [ ] Commit this plan
+- [ ] `vm`: `StepMode::Scan` + hook arming/landing + `stepping_scan()`
+- [ ] `vm`: `run_round_debug` produces `PausedAfterScan`
+- [ ] `vm`: unit + integration tests
+- [ ] DAP: model `ironplc/stepScan` and its legality
+- [ ] DAP: server loop handles the request and the two-round landing
+- [ ] DAP: server tests (stop position, scanCount advance, scanLimit, legality)
+- [ ] Extension: fix the failure message and its test
+- [ ] Docs: debugger reference + design doc
+- [ ] `cd compiler && just` passes


### PR DESCRIPTION
## Summary

Implements the `ironplc/stepScan` custom Debug Adapter Protocol request, enabling users to step through PLC programs one scan cycle at a time. This completes the scan-level execution control defined in the debugger design and fixes the "not supported" error that appeared when pressing the Step Scan Cycle button in VS Code.

## Key Changes

**VM Debug Engine** (`compiler/vm/src/debug.rs`, `compiler/vm/src/debug_hook.rs`, `compiler/vm/src/vm.rs`)
- Added `StepMode::Scan` variant for scan-cycle stepping
- Implemented `DebuggerHook::step_scan()` to arm the run half (finish the current cycle without stopping at instructions)
- Implemented `DebuggerHook::land_scan_step()` to arm the landing half (pause at the first instruction of the next scan)
- Added `DebugHook::stepping_scan()` trait method so the driver can detect when a scan step is in flight
- Modified `StepController::landed()` to return `false` for `StepMode::Scan` (scan steps have no intra-scan landing)
- Updated `run_round_debug` to produce `RoundOutcome::PausedAfterScan` when a completed scan had a scan step armed

**DAP Server** (`compiler/vm-cli/src/dap/state.rs`, `compiler/vm-cli/src/dap/server.rs`)
- Added `Command::StepScan` variant and mapped it from the `ironplc/stepScan` request
- Made `StepScan` legal only in the `Paused` phase (same as other execution-control commands)
- Implemented the server-side handler: arms `StepMode::Scan` on the request and transitions to `Running`
- Added `pending_scan_landing` flag to track the landing half across rounds
- Updated the round outcome handler to arm the landing on the next round when `PausedAfterScan` is received (unless `scanLimit` is reached)
- Extracted `scan_limit_reached()` helper for cleaner logic

**Tests**
- Added comprehensive integration tests in `compiler/vm/tests/it/debug_engine.rs`:
  - Scan step runs the cycle out and pauses after scan
  - Landing round stops at the first instruction of the new scan
  - Repeated scan steps advance exactly one cycle each
  - Following step after a scan-step landing advances one statement (not two)
  - Breakpoint during scan step stops at the breakpoint (scan step is abandoned)
  - Completed scan without a scan step armed is not a pause
- Added unit tests in `compiler/vm/src/debug.rs` for hook behavior
- Added DAP server tests for legality, stop position, and scanCount advancement

**Documentation & Extension**
- Updated `docs/reference/editor/debugging.rst` to document scan stepping behavior and remove the "not yet implemented" note
- Updated `specs/design/debugger-support.md` to mark `ironplc/stepScan` as implemented
- Updated VS Code extension error handling in `integrations/vscode/src/debugAdapterLogic.ts` and `customRequests.ts` to provide clearer messaging
- Added plan document `specs/plans/2026-08-22-dap-step-scan.md` describing the design and implementation

## Implementation Details

A scan step spans two rounds because the DAP loop rebuilds the `DebuggerHook` each round:

1. **Run half**: The round executes with `StepMode::Scan` armed. The step never lands at any instruction; when the scan completes, `run_round_debug` reports `RoundOutcome::PausedAfterScan`.

2. **Landing half**: The server arms `land_scan_step()` on the next round's hook. This causes the hook to pause before the first instruction with `PauseReason::Step`, giving the client a live frame to inspect and the finished cycle's values to display.

Breakpoints still take precedence: if one fires during the run half, the scan step is abandoned and the breakpoint is reported instead. The `scanLimit` bound is respected

https://claude.ai/code/session_017tguZ2K91XfkZFzVUTMtxd