### PR TITLE
THIS^ and SUPER^ parsing (ADR-0041 Phase 1)

### DIFF
--- a/compiler/analyzer/src/rule_bit_access_range.rs
+++ b/compiler/analyzer/src/rule_bit_access_range.rs
@@ -246,6 +246,13 @@ fn resolve_variable_type(
         SymbolicVariableKind::PartialAccess(partial) => {
             resolve_variable_type(&partial.variable, var_initializers, type_env)
         }
+        SymbolicVariableKind::SelfRef(_) => {
+            // Typing a member of THIS^/SUPER^ needs function-block member
+            // resolution, which does not exist yet. Unreachable in practice:
+            // `visit_self_ref_variable` below reports the construct before
+            // any range check runs. See issue #1406.
+            None
+        }
         SymbolicVariableKind::Deref(deref) => {
             resolve_variable_type(&deref.variable, var_initializers, type_env)
         }
@@ -296,6 +303,21 @@ impl Visitor<Diagnostic> for RuleBitAccessRange<'_> {
         let ret = node.recurse_visit(self);
         self.var_initializers.clear();
         ret
+    }
+
+    fn visit_self_ref_variable(&mut self, node: &SelfRefVariable) -> Result<(), Diagnostic> {
+        // Report rather than skip: a bit access through THIS^/SUPER^ cannot
+        // be range-checked until member resolution exists, and staying
+        // silent here would keep this rule quietly passing such a program
+        // once the construct is otherwise supported. See issue #1406.
+        self.diagnostics.push(Diagnostic::not_implemented(Label::span(
+            node.span(),
+            format!(
+                "{} is recognized but its members are not yet resolved, so bit and partial access through it is not range-checked",
+                node.kind.spelling()
+            ),
+        )));
+        Ok(())
     }
 
     fn visit_bit_access_variable(&mut self, node: &BitAccessVariable) -> Result<(), Diagnostic> {

--- a/compiler/analyzer/src/rule_method_call_declared.rs
+++ b/compiler/analyzer/src/rule_method_call_declared.rs
@@ -183,14 +183,32 @@ impl Visitor<Diagnostic> for RuleMethodCallDeclared<'_> {
     }
 
     fn visit_method_call(&mut self, call: &MethodCall) -> Result<Self::Value, Diagnostic> {
-        let fb_type = match self.var_to_fb.get(&call.instance) {
+        // `THIS^.M()` / `SUPER^.M()` resolve against the enclosing function
+        // block (and, for SUPER^, its base) rather than a variable's declared
+        // type. That resolution is not implemented yet, so say so rather than
+        // skipping the call: a silent skip would keep quietly passing once
+        // the receiver becomes resolvable. Tracked in issue #1406.
+        let instance = match &call.receiver {
+            MethodReceiver::Instance(id) => id,
+            MethodReceiver::SelfRef(self_ref) => {
+                return Err(Diagnostic::not_implemented(Label::span(
+                    self_ref.span(),
+                    format!(
+                        "{} method invocation is recognized but not yet resolved by IronPLC",
+                        self_ref.kind.spelling()
+                    ),
+                )))
+            }
+        };
+
+        let fb_type = match self.var_to_fb.get(instance) {
             Some(t) => t,
             None => {
                 return Err(Diagnostic::problem(
                     Problem::FunctionBlockNotInScope,
                     Label::span(call.span(), "Method invocation"),
                 )
-                .with_context_id("invocation", &call.instance))
+                .with_context_id("invocation", instance))
             }
         };
 
@@ -199,7 +217,7 @@ impl Visitor<Diagnostic> for RuleMethodCallDeclared<'_> {
                 Problem::FunctionBlockNotInScope,
                 Label::span(call.span(), "Method invocation"),
             )
-            .with_context_id("invocation", &call.instance));
+            .with_context_id("invocation", instance));
         }
 
         match self.resolve_method(fb_type, &call.method) {

--- a/compiler/analyzer/src/rule_unsupported_extension.rs
+++ b/compiler/analyzer/src/rule_unsupported_extension.rs
@@ -97,8 +97,7 @@ impl Visitor<Diagnostic> for RuleUnsupportedExtension {
     ) -> Result<Self::Value, Diagnostic> {
         // A SelfRefVariable only exists when THIS^/SUPER^ was written, so
         // it is always an extension. Parsed and rendered, but neither
-        // analyzed nor executed -- see
-        // specs/plans/2026-08-22-oop-this-super-parsing.md.
+        // analyzed nor executed.
         self.flag(node);
         node.recurse_visit(self)
     }

--- a/compiler/analyzer/src/rule_unsupported_extension.rs
+++ b/compiler/analyzer/src/rule_unsupported_extension.rs
@@ -91,6 +91,18 @@ impl Visitor<Diagnostic> for RuleUnsupportedExtension {
         node.recurse_visit(self)
     }
 
+    fn visit_self_ref_variable(
+        &mut self,
+        node: &ironplc_dsl::textual::SelfRefVariable,
+    ) -> Result<Self::Value, Diagnostic> {
+        // A SelfRefVariable only exists when THIS^/SUPER^ was written, so
+        // it is always an extension. Parsed and rendered, but neither
+        // analyzed nor executed -- see
+        // specs/plans/2026-08-22-oop-this-super-parsing.md.
+        self.flag(node);
+        node.recurse_visit(self)
+    }
+
     fn visit_interface_declaration(
         &mut self,
         node: &InterfaceDeclaration,
@@ -157,6 +169,36 @@ END_FUNCTION_BLOCK";
 
         let (input, _context) =
             parse_and_resolve_types_with_options(program, &opts_with_fb_inheritance());
+        let context = SemanticContextBuilder::new().build().unwrap();
+        let result = apply(&input, &context, &opts_with_fb_inheritance());
+
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        // P9999 == Problem::NotImplemented; the enum variant is #[deprecated]
+        // (must be constructed via Diagnostic::not_implemented), so assert on
+        // the stable code string rather than referencing the variant.
+        assert_eq!("P9999", errors[0].code);
+    }
+
+    #[rstest::rstest]
+    #[case::this("    THIS^.count := 1;")]
+    #[case::super_("    count := SUPER^.count;")]
+    #[case::this_method_call("    THIS^.Start();")]
+    fn apply_when_self_ref_then_p9999(#[case] body: &str) {
+        let program = format!(
+            "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Run
+{body}
+END_METHOD
+END_FUNCTION_BLOCK"
+        );
+
+        let (input, _context) =
+            parse_and_resolve_types_with_options(&program, &opts_with_fb_inheritance());
         let context = SemanticContextBuilder::new().build().unwrap();
         let result = apply(&input, &context, &opts_with_fb_inheritance());
 

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -618,4 +618,80 @@ END_FUNCTION_BLOCK";
             "unexpected spurious P2011: {codes:?}"
         );
     }
+
+    // ---------------------------------------------------------------------
+    // THIS^ / SUPER^ (parsed, not analyzed or executed).
+    // See specs/plans/2026-08-22-oop-this-super-parsing.md.
+    // ---------------------------------------------------------------------
+
+    /// A program using `THIS^` is rejected, and P9999 is among the reasons.
+    ///
+    /// Deliberately asserts presence rather than an exact diagnostic set:
+    /// several passes meet the construct and each says so, and pinning the
+    /// set would turn every later improvement into a test edit. What must
+    /// hold is that no pass quietly accepts it.
+    #[rstest::rstest]
+    #[case::this_field_write("    THIS^.count := 1;")]
+    #[case::super_field_read("    count := SUPER^.count;")]
+    #[case::this_method_call("    THIS^.Start();")]
+    fn analyze_when_self_ref_then_rejected_with_not_implemented(#[case] body: &str) {
+        let options = CompilerOptions {
+            allow_fb_inheritance: true,
+            ..CompilerOptions::default()
+        };
+        let program = format!(
+            "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Start
+    count := 1;
+END_METHOD
+METHOD Run
+{body}
+END_METHOD
+END_FUNCTION_BLOCK"
+        );
+        let lib = parse_program(&program, &FileId::default(), &options).unwrap();
+        let (_library, context) = analyze(&[&lib], &options).unwrap();
+
+        let codes: Vec<&str> = context
+            .diagnostics()
+            .iter()
+            .map(|d| d.code.as_str())
+            .collect();
+        assert!(
+            codes.contains(&"P9999"),
+            "expected P9999 among diagnostics, got: {codes:?}"
+        );
+    }
+
+    /// The same function block without `THIS^` analyzes cleanly -- the new
+    /// arms must not report anything for programs that do not use it.
+    #[test]
+    fn analyze_when_no_self_ref_then_no_not_implemented() {
+        let options = CompilerOptions {
+            allow_fb_inheritance: true,
+            ..CompilerOptions::default()
+        };
+        let program = "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Start
+    count := 1;
+END_METHOD
+END_FUNCTION_BLOCK";
+        let lib = parse_program(program, &FileId::default(), &options).unwrap();
+        let (_library, context) = analyze(&[&lib], &options).unwrap();
+
+        let codes: Vec<&str> = context
+            .diagnostics()
+            .iter()
+            .map(|d| d.code.as_str())
+            .collect();
+        assert!(codes.is_empty(), "expected no diagnostics, got: {codes:?}");
+    }
 }

--- a/compiler/analyzer/src/stages.rs
+++ b/compiler/analyzer/src/stages.rs
@@ -621,7 +621,6 @@ END_FUNCTION_BLOCK";
 
     // ---------------------------------------------------------------------
     // THIS^ / SUPER^ (parsed, not analyzed or executed).
-    // See specs/plans/2026-08-22-oop-this-super-parsing.md.
     // ---------------------------------------------------------------------
 
     /// A program using `THIS^` is rejected, and P9999 is among the reasons.

--- a/compiler/analyzer/src/xform_resolve_expr_types.rs
+++ b/compiler/analyzer/src/xform_resolve_expr_types.rs
@@ -9,8 +9,8 @@
 //! don't match, causing incorrect opcode selection. By resolving aliases to
 //! elementary types here, codegen gets clean type names.
 use ironplc_dsl::common::*;
-use ironplc_dsl::core::Id;
-use ironplc_dsl::diagnostic::Diagnostic;
+use ironplc_dsl::core::{Id, Located};
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::fold::Fold;
 use ironplc_dsl::textual::*;
 use std::collections::HashMap;
@@ -475,6 +475,13 @@ impl ExprTypeResolver<'_> {
                     None
                 }
             }
+            Variable::Symbolic(SymbolicVariableKind::SelfRef(_)) => {
+                // THIS^/SUPER^ has no resolvable type until function-block
+                // member resolution exists. Unreachable in practice:
+                // `fold_self_ref_variable` rejects the construct before any
+                // type resolution runs. See issue #1406.
+                None
+            }
             Variable::Direct(_) => None,
         }
     }
@@ -548,6 +555,23 @@ impl Fold<Diagnostic> for ExprTypeResolver<'_> {
         self.var_types.clear();
         self.array_element_types.clear();
         result
+    }
+
+    fn fold_self_ref_variable(
+        &mut self,
+        node: SelfRefVariable,
+    ) -> Result<SelfRefVariable, Diagnostic> {
+        // Fail rather than resolve to "unknown": every downstream consumer
+        // of this pass treats an unresolved type as a fact about the
+        // program, and silently producing one here would let THIS^/SUPER^
+        // through unnoticed once it is otherwise supported. See issue #1406.
+        Err(Diagnostic::not_implemented(Label::span(
+            node.span(),
+            format!(
+                "{} is recognized but its type cannot be resolved by IronPLC yet",
+                node.kind.spelling()
+            ),
+        )))
     }
 
     fn fold_expr(&mut self, node: Expr) -> Result<Expr, Diagnostic> {

--- a/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
@@ -6,10 +6,13 @@
 //!
 //! The transformation succeeds when all ambiguous expression elements
 //! resolve to a declared type.
-use ironplc_dsl::diagnostic::Diagnostic;
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::fold::Fold;
 use ironplc_dsl::textual::*;
-use ironplc_dsl::{common::*, core::Id};
+use ironplc_dsl::{
+    common::*,
+    core::{Id, Located},
+};
 use std::collections::{HashMap, HashSet};
 
 use crate::type_environment::TypeEnvironment;
@@ -217,6 +220,22 @@ impl Fold<Diagnostic> for DeclarationResolver<'_> {
                         // Determining the field type requires looking up the struct
                         // declaration which isn't available here. Default to None.
                         self.current_type = VariableType::None;
+                    }
+                    SymbolicVariableKind::SelfRef(self_ref) => {
+                        // Assignment through THIS^/SUPER^. The target's type
+                        // comes from the enclosing function block's members,
+                        // which are not resolved yet -- report instead of
+                        // defaulting to None, which would silently bind any
+                        // late-bound value on the right-hand side to the
+                        // wrong type once the construct is supported.
+                        // See issue #1406.
+                        return Err(Diagnostic::not_implemented(Label::span(
+                            self_ref.span(),
+                            format!(
+                                "{} is recognized but its members are not yet resolved by IronPLC",
+                                self_ref.kind.spelling()
+                            ),
+                        )));
                     }
                     SymbolicVariableKind::BitAccess(_ba) => {
                         // Assignment to a bit access like w.0 := value

--- a/compiler/codegen/src/compile_expr.rs
+++ b/compiler/codegen/src/compile_expr.rs
@@ -848,6 +848,15 @@ pub(crate) fn resolve_symbolic_variable_name(
             resolve_symbolic_variable_name(&structured.record)
         }
         SymbolicVariableKind::Deref(deref) => resolve_symbolic_variable_name(&deref.variable),
+        // THIS^/SUPER^ names the executing instance, not a variable in the
+        // table. Giving it a receiver-pointer parameter is the codegen
+        // slice that also owns method-call codegen; until then this is an
+        // error, never a guess at some enclosing name.
+        SymbolicVariableKind::SelfRef(self_ref) => Err(Diagnostic::todo_with_span(
+            self_ref.span(),
+            file!(),
+            line!(),
+        )),
     }
 }
 
@@ -878,6 +887,11 @@ pub(crate) fn resolve_variable(
             SymbolicVariableKind::Deref(deref) => {
                 Err(Diagnostic::todo_with_span(deref.span(), file!(), line!()))
             }
+            SymbolicVariableKind::SelfRef(self_ref) => Err(Diagnostic::todo_with_span(
+                self_ref.span(),
+                file!(),
+                line!(),
+            )),
         },
         Variable::Direct(direct) => Err(Diagnostic::todo_with_span(
             direct.position.clone(),

--- a/compiler/codegen/tests/it/compile_this_super.rs
+++ b/compiler/codegen/tests/it/compile_this_super.rs
@@ -1,7 +1,6 @@
 //! `THIS^` / `SUPER^` reach codegen only if analysis lets them through;
 //! codegen itself has no execution semantics for them and says so rather
-//! than emitting anything. See
-//! specs/plans/2026-08-22-oop-this-super-parsing.md.
+//! than emitting anything.
 //!
 //! The statements under test live in the function block *body*, not in a
 //! `METHOD` body: method bodies are not compiled at all yet (method

--- a/compiler/codegen/tests/it/compile_this_super.rs
+++ b/compiler/codegen/tests/it/compile_this_super.rs
@@ -40,9 +40,6 @@ END_PROGRAM
     };
     let result = try_parse_and_compile(&source, &options);
 
-    assert!(
-        result.is_err(),
-        "expected compilation to fail for THIS^/SUPER^"
-    );
+    assert!(result.is_err());
     assert_eq!(result.unwrap_err().code, "P9999");
 }

--- a/compiler/codegen/tests/it/compile_this_super.rs
+++ b/compiler/codegen/tests/it/compile_this_super.rs
@@ -1,0 +1,48 @@
+//! `THIS^` / `SUPER^` reach codegen only if analysis lets them through;
+//! codegen itself has no execution semantics for them and says so rather
+//! than emitting anything. See
+//! specs/plans/2026-08-22-oop-this-super-parsing.md.
+//!
+//! The statements under test live in the function block *body*, not in a
+//! `METHOD` body: method bodies are not compiled at all yet (method
+//! codegen is its own unstarted slice), so a `THIS^` inside one never
+//! reaches these code paths.
+
+use crate::common::try_parse_and_compile;
+use ironplc_parser::options::CompilerOptions;
+use rstest::rstest;
+
+#[rstest]
+#[case::this_field_write("    THIS^.count := 1;")]
+#[case::super_field_read("    count := SUPER^.count;")]
+
+fn compile_when_self_ref_then_not_implemented(#[case] body: &str) {
+    let source = format!(
+        "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+{body}
+END_FUNCTION_BLOCK
+
+PROGRAM main
+VAR
+    m : FB_Motor;
+END_VAR
+    m();
+END_PROGRAM
+"
+    );
+    let options = CompilerOptions {
+        allow_fb_inheritance: true,
+        ..CompilerOptions::default()
+    };
+    let result = try_parse_and_compile(&source, &options);
+
+    assert!(
+        result.is_err(),
+        "expected compilation to fail for THIS^/SUPER^"
+    );
+    assert_eq!(result.unwrap_err().code, "P9999");
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -25,6 +25,7 @@ mod compile_loops;
 mod compile_mux;
 mod compile_shift;
 mod compile_struct;
+mod compile_this_super;
 mod compile_types;
 mod end_to_end;
 mod end_to_end_abs;

--- a/compiler/dsl/src/fold.rs
+++ b/compiler/dsl/src/fold.rs
@@ -315,6 +315,8 @@ pub trait Fold<E> {
     dispatch!(FbCall);
     dispatch!(MethodCall);
 
+    dispatch!(MethodReceiver);
+
     // 3.2.3
     dispatch!(PositionalInput);
 
@@ -379,4 +381,6 @@ pub trait Fold<E> {
     dispatch!(PartialAccessVariable);
 
     dispatch!(DerefVariable);
+
+    dispatch!(SelfRefVariable);
 }

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -52,6 +52,9 @@ impl From<SymbolicVariableKind> for Variable {
             SymbolicVariableKind::Deref(deref) => {
                 Variable::Symbolic(SymbolicVariableKind::Deref(deref))
             }
+            SymbolicVariableKind::SelfRef(self_ref) => {
+                Variable::Symbolic(SymbolicVariableKind::SelfRef(self_ref))
+            }
         }
     }
 }
@@ -73,6 +76,7 @@ pub enum SymbolicVariableKind {
     BitAccess(BitAccessVariable),
     PartialAccess(PartialAccessVariable),
     Deref(DerefVariable),
+    SelfRef(SelfRefVariable),
 }
 
 impl fmt::Display for SymbolicVariableKind {
@@ -88,6 +92,7 @@ impl fmt::Display for SymbolicVariableKind {
             }
             SymbolicVariableKind::PartialAccess(partial) => f.write_fmt(format_args!("{partial}")),
             SymbolicVariableKind::Deref(deref) => f.write_fmt(format_args!("{deref}")),
+            SymbolicVariableKind::SelfRef(self_ref) => f.write_fmt(format_args!("{self_ref}")),
         }
     }
 }
@@ -101,6 +106,7 @@ impl Located for SymbolicVariableKind {
             SymbolicVariableKind::BitAccess(bit_access) => bit_access.span(),
             SymbolicVariableKind::PartialAccess(partial) => partial.span(),
             SymbolicVariableKind::Deref(deref) => deref.span(),
+            SymbolicVariableKind::SelfRef(self_ref) => self_ref.span(),
         }
     }
 }
@@ -286,6 +292,53 @@ impl fmt::Display for DerefVariable {
     }
 }
 
+/// Which implicit instance a [`SelfRefVariable`] names.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SelfRefKind {
+    /// `THIS^` — the function block instance currently executing.
+    This,
+    /// `SUPER^` — the same instance, viewed as its base type.
+    Super,
+}
+
+impl SelfRefKind {
+    /// The source spelling, including the mandatory dereference caret.
+    pub fn spelling(&self) -> &'static str {
+        match self {
+            SelfRefKind::This => "THIS^",
+            SelfRefKind::Super => "SUPER^",
+        }
+    }
+}
+
+/// `THIS^` or `SUPER^` at the head of a variable reference (OOP extension,
+/// ADR-0041 Phase 1).
+///
+/// This is the head of a symbolic variable rather than an expression
+/// because `THIS^.count := 1;` puts it in assignment-target position,
+/// where the AST is a [`Variable`]. Placing it at the head means the
+/// ordinary element chain — `.field`, `[i]`, `.%X0` — composes with it
+/// for free, in both read and write position.
+///
+/// The dereference caret is part of this node rather than a wrapping
+/// [`DerefVariable`]: `THIS`/`SUPER` have no pointer type to be given,
+/// so an un-dereferenced form would be a node nothing could type, and
+/// folding the caret in makes "the caret is mandatory" structural. See
+/// `specs/plans/2026-08-22-oop-this-super-parsing.md`.
+#[derive(Debug, PartialEq, Clone, Recurse, Located)]
+pub struct SelfRefVariable {
+    #[recurse(ignore)]
+    pub kind: SelfRefKind,
+    /// Spans the keyword through the caret.
+    pub position: SourceSpan,
+}
+
+impl fmt::Display for SelfRefVariable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.kind.spelling())
+    }
+}
+
 /// Function block invocation.
 ///
 /// See section 3.2.3.
@@ -304,11 +357,37 @@ pub struct FbCall {
 /// expression position (e.g. `IF fb.IsMoving() THEN`) are a follow-up
 /// slice — see
 /// `specs/plans/2026-08-12-oop-method-declarations-static-dispatch.md`.
+/// The instance a [`MethodCall`] is invoked on.
+#[derive(Debug, PartialEq, Clone, Recurse)]
+pub enum MethodReceiver {
+    /// A function block instance named by a variable: `instance.M()`.
+    Instance(Id),
+    /// The enclosing instance itself: `THIS^.M()` or `SUPER^.M()`.
+    SelfRef(SelfRefVariable),
+}
+
+impl fmt::Display for MethodReceiver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MethodReceiver::Instance(name) => f.write_fmt(format_args!("{name}")),
+            MethodReceiver::SelfRef(self_ref) => f.write_fmt(format_args!("{self_ref}")),
+        }
+    }
+}
+
+impl Located for MethodReceiver {
+    fn span(&self) -> SourceSpan {
+        match self {
+            MethodReceiver::Instance(name) => name.span(),
+            MethodReceiver::SelfRef(self_ref) => self_ref.span(),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct MethodCall {
-    /// Name of the variable holding the function-block instance the
-    /// method is called on.
-    pub instance: Id,
+    /// The function block instance the method is called on.
+    pub receiver: MethodReceiver,
     /// Name of the method being called.
     pub method: Id,
     pub params: Vec<ParamAssignmentKind>,

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -339,6 +339,19 @@ impl fmt::Display for SelfRefVariable {
     }
 }
 
+impl crate::extension::LanguageExtension for SelfRefVariable {
+    fn extension_name(&self) -> &'static str {
+        match self.kind {
+            SelfRefKind::This => "THIS^ self reference",
+            SelfRefKind::Super => "SUPER^ base reference",
+        }
+    }
+
+    fn extension_span(&self) -> SourceSpan {
+        self.position.clone()
+    }
+}
+
 /// Function block invocation.
 ///
 /// See section 3.2.3.

--- a/compiler/dsl/src/textual.rs
+++ b/compiler/dsl/src/textual.rs
@@ -311,8 +311,7 @@ impl SelfRefKind {
     }
 }
 
-/// `THIS^` or `SUPER^` at the head of a variable reference (OOP extension,
-/// ADR-0041 Phase 1).
+/// `THIS^` or `SUPER^` at the head of a variable reference (OOP extension).
 ///
 /// This is the head of a symbolic variable rather than an expression
 /// because `THIS^.count := 1;` puts it in assignment-target position,
@@ -323,8 +322,7 @@ impl SelfRefKind {
 /// The dereference caret is part of this node rather than a wrapping
 /// [`DerefVariable`]: `THIS`/`SUPER` have no pointer type to be given,
 /// so an un-dereferenced form would be a node nothing could type, and
-/// folding the caret in makes "the caret is mandatory" structural. See
-/// `specs/plans/2026-08-22-oop-this-super-parsing.md`.
+/// folding the caret in makes "the caret is mandatory" structural.
 #[derive(Debug, PartialEq, Clone, Recurse, Located)]
 pub struct SelfRefVariable {
     #[recurse(ignore)]

--- a/compiler/dsl/src/visitor.rs
+++ b/compiler/dsl/src/visitor.rs
@@ -366,6 +366,8 @@ pub trait Visitor<E> {
     dispatch!(FbCall);
     dispatch!(MethodCall);
 
+    dispatch!(MethodReceiver);
+
     // 3.2.3
     dispatch!(PositionalInput);
 
@@ -430,6 +432,8 @@ pub trait Visitor<E> {
     dispatch!(PartialAccessVariable);
 
     dispatch!(DerefVariable);
+
+    dispatch!(SelfRefVariable);
 }
 
 #[cfg(test)]

--- a/compiler/ironplc-cli/src/lsp_project.rs
+++ b/compiler/ironplc-cli/src/lsp_project.rs
@@ -529,6 +529,8 @@ impl From<LspTokenType> for Option<SemanticToken> {
             TokenType::EndInterface => Some(KEYWORD_INDEX),
             TokenType::Abstract => Some(KEYWORD_INDEX),
             TokenType::Method => Some(KEYWORD_INDEX),
+            TokenType::This => Some(KEYWORD_INDEX),
+            TokenType::Super => Some(KEYWORD_INDEX),
             TokenType::EndMethod => Some(KEYWORD_INDEX),
             TokenType::Configuration => Some(KEYWORD_INDEX),
             TokenType::EndConfiguration => Some(KEYWORD_INDEX),

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -849,14 +849,13 @@ parser! {
     //rule symbolic_variable() -> SymbolicVariableKind =
     //  multi_element_variable()
     //  / name:variable_name() { SymbolicVariableKind::Named(NamedVariable{name}) }
-    // OOP extension: `THIS^` / `SUPER^` (ADR-0041 Phase 1). The caret is
-    // mandatory -- `THIS` and `SUPER` are pointers to an instance in the
-    // dialects that define them -- and optional whitespace/comments are
-    // accepted between the keyword and the caret, since nothing in the
-    // grammar joins them into one token. The `This`/`Super` tokens only
-    // reach the parser when `allow_fb_inheritance` is set (they demote to
-    // identifiers otherwise), so this rule is gated at the token level.
-    // See specs/plans/2026-08-22-oop-this-super-parsing.md.
+    // OOP extension: `THIS^` / `SUPER^`. The caret is mandatory -- `THIS`
+    // and `SUPER` are pointers to an instance in the dialects that define
+    // them -- and optional whitespace/comments are accepted between the
+    // keyword and the caret, since nothing in the grammar joins them into
+    // one token. The `This`/`Super` tokens only reach the parser when
+    // `allow_fb_inheritance` is set (they demote to identifiers otherwise),
+    // so this rule is gated at the token level.
     rule self_ref() -> SelfRefVariable =
       t:tok(TokenType::This) _ c:tok(TokenType::Caret) {
         SelfRefVariable { kind: SelfRefKind::This, position: SourceSpan::join(&t.span, &c.span) }

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -849,9 +849,27 @@ parser! {
     //rule symbolic_variable() -> SymbolicVariableKind =
     //  multi_element_variable()
     //  / name:variable_name() { SymbolicVariableKind::Named(NamedVariable{name}) }
-    rule symbolic_variable() -> SymbolicVariableKind = name:variable_identifier() elements:(tok(TokenType::Period) n:integer() { Element::Bit(n) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessBit) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(Element::Bit) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessByte) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::Byte, i)) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessWord) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::Word, i)) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessDWord) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::DWord, i)) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessLWord) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::LWord, i)) } / tok(TokenType::Period) id:identifier() { Element::Struct(id) } / sub:subscript_list() {Element::Array(sub)} / tok(TokenType::Caret) &(tok(TokenType::LeftBracket) / tok(TokenType::Period)) { Element::Deref })* {
-      // Start by assuming that the top is just a named variable
-      let mut head = SymbolicVariableKind::Named(NamedVariable { name });
+    // OOP extension: `THIS^` / `SUPER^` (ADR-0041 Phase 1). The caret is
+    // mandatory -- `THIS` and `SUPER` are pointers to an instance in the
+    // dialects that define them -- and optional whitespace/comments are
+    // accepted between the keyword and the caret, since nothing in the
+    // grammar joins them into one token. The `This`/`Super` tokens only
+    // reach the parser when `allow_fb_inheritance` is set (they demote to
+    // identifiers otherwise), so this rule is gated at the token level.
+    // See specs/plans/2026-08-22-oop-this-super-parsing.md.
+    rule self_ref() -> SelfRefVariable =
+      t:tok(TokenType::This) _ c:tok(TokenType::Caret) {
+        SelfRefVariable { kind: SelfRefKind::This, position: SourceSpan::join(&t.span, &c.span) }
+      }
+      / t:tok(TokenType::Super) _ c:tok(TokenType::Caret) {
+        SelfRefVariable { kind: SelfRefKind::Super, position: SourceSpan::join(&t.span, &c.span) }
+      }
+    rule symbolic_variable_head() -> SymbolicVariableKind =
+      s:self_ref() { SymbolicVariableKind::SelfRef(s) }
+      / name:variable_identifier() { SymbolicVariableKind::Named(NamedVariable { name }) }
+    rule symbolic_variable() -> SymbolicVariableKind = head:symbolic_variable_head() elements:(tok(TokenType::Period) n:integer() { Element::Bit(n) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessBit) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(Element::Bit) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessByte) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::Byte, i)) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessWord) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::Word, i)) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessDWord) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::DWord, i)) } / tok(TokenType::Period) pa:tok(TokenType::PartialAccessLWord) {? Integer::new(&pa.text[2..], SourceSpan::default()).map(|i| Element::PartialAccess(PartialAccessSize::LWord, i)) } / tok(TokenType::Period) id:identifier() { Element::Struct(id) } / sub:subscript_list() {Element::Array(sub)} / tok(TokenType::Caret) &(tok(TokenType::LeftBracket) / tok(TokenType::Period)) { Element::Deref })* {
+      // Start from whatever the head matched (a plain name, or THIS^/SUPER^)
+      let mut head = head;
 
       // Then consume additional items
       for elem in elements {
@@ -1849,10 +1867,13 @@ parser! {
     // is purely additive and needs no dialect gating of its own -- the
     // METHOD declarations that would make such a call resolve are
     // already gated by `allow_fb_inheritance` at the token level.
-    rule method_invocation() -> StmtKind = instance:identifier() _ period() _ method:identifier() _ tok(TokenType::LeftParen) _ params:param_assignment() ** (_ tok(TokenType::Comma) _) _ end:tok(TokenType::RightParen) {
-      let span = SourceSpan::join(&instance.span, &end.span);
+    rule method_receiver() -> MethodReceiver =
+      s:self_ref() { MethodReceiver::SelfRef(s) }
+      / id:identifier() { MethodReceiver::Instance(id) }
+    rule method_invocation() -> StmtKind = receiver:method_receiver() _ period() _ method:identifier() _ tok(TokenType::LeftParen) _ params:param_assignment() ** (_ tok(TokenType::Comma) _) _ end:tok(TokenType::RightParen) {
+      let span = SourceSpan::join(&receiver.span(), &end.span);
       StmtKind::MethodCall(MethodCall {
-        instance,
+        receiver,
         method,
         params,
         position: span,

--- a/compiler/parser/src/tests/mod.rs
+++ b/compiler/parser/src/tests/mod.rs
@@ -24,6 +24,7 @@ mod reference_to;
 mod short_circuit;
 mod struct_init_expressions;
 mod tasks;
+mod this_super;
 mod time_functions;
 mod types_and_returns;
 mod var_declarations;

--- a/compiler/parser/src/tests/this_super.rs
+++ b/compiler/parser/src/tests/this_super.rs
@@ -1,5 +1,4 @@
 //! OOP extension: `THIS^` and `SUPER^` self/base references.
-//! See specs/plans/2026-08-22-oop-this-super-parsing.md.
 
 use super::common::*;
 

--- a/compiler/parser/src/tests/this_super.rs
+++ b/compiler/parser/src/tests/this_super.rs
@@ -21,9 +21,7 @@ METHOD Run
 END_METHOD
 END_FUNCTION_BLOCK"
     );
-    let result = parse_program(&source, &FileId::default(), &opts_with_fb_inheritance());
-    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
-    result.unwrap()
+    parse_program(&source, &FileId::default(), &opts_with_fb_inheritance()).unwrap()
 }
 
 /// Proves THIS/SUPER remain valid identifiers in standard IEC 61131-3
@@ -43,11 +41,7 @@ SUPER := 2;
 END_FUNCTION_BLOCK
 ";
     let result = parse_program(program, &FileId::default(), &CompilerOptions::default());
-    assert!(
-        result.is_ok(),
-        "THIS/SUPER must remain valid identifiers in standard mode: {:?}",
-        result.err()
-    );
+    assert!(result.is_ok());
 }
 
 /// Without the flag, `THIS^.x` keeps its pre-existing meaning: a
@@ -193,8 +187,5 @@ END_METHOD
 END_FUNCTION_BLOCK"
     );
     let result = parse_program(&source, &FileId::default(), &opts_with_fb_inheritance());
-    assert!(
-        result.is_err(),
-        "THIS/SUPER without a dereference caret must be rejected"
-    );
+    assert!(result.is_err());
 }

--- a/compiler/parser/src/tests/this_super.rs
+++ b/compiler/parser/src/tests/this_super.rs
@@ -1,0 +1,200 @@
+//! OOP extension: `THIS^` and `SUPER^` self/base references.
+//! See specs/plans/2026-08-22-oop-this-super-parsing.md.
+
+use super::common::*;
+
+/// Returns the statements of the first method of the first function block.
+fn first_method_body(library: &Library) -> &Vec<StmtKind> {
+    &extract_fb(library).methods[0].body
+}
+
+/// Wraps `body` in a function block with a method, since `THIS^`/`SUPER^`
+/// only make sense inside a method body.
+fn parse_in_method(body: &str) -> Library {
+    let source = format!(
+        "FUNCTION_BLOCK FB_Derived EXTENDS FB_Base
+VAR
+    count : INT;
+END_VAR
+METHOD Run
+{body}
+END_METHOD
+END_FUNCTION_BLOCK"
+    );
+    let result = parse_program(&source, &FileId::default(), &opts_with_fb_inheritance());
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    result.unwrap()
+}
+
+/// Proves THIS/SUPER remain valid identifiers in standard IEC 61131-3
+/// mode, mirroring the prerequisite established for the other OOP
+/// keywords in `fb_inheritance.rs` and `methods.rs`.
+#[test]
+fn parse_when_standard_mode_then_this_super_are_valid_identifiers() {
+    let program = "
+FUNCTION_BLOCK FB_ALL_SELF_REF_KEYWORDS_AS_VARS
+VAR
+    THIS : INT;
+    SUPER : INT;
+END_VAR
+
+THIS := 1;
+SUPER := 2;
+END_FUNCTION_BLOCK
+";
+    let result = parse_program(program, &FileId::default(), &CompilerOptions::default());
+    assert!(
+        result.is_ok(),
+        "THIS/SUPER must remain valid identifiers in standard mode: {:?}",
+        result.err()
+    );
+}
+
+/// Without the flag, `THIS^.x` keeps its pre-existing meaning: a
+/// dereference of an ordinary variable named THIS. This slice must not
+/// change how any program parses in standard mode.
+#[test]
+fn parse_when_standard_mode_then_this_caret_is_ordinary_deref() {
+    let source = "
+FUNCTION_BLOCK FB_Motor
+VAR
+    THIS : INT;
+END_VAR
+THIS^.count := 1;
+END_FUNCTION_BLOCK";
+    let library = parse_text(source);
+    let fb = extract_fb(&library);
+    let body = cast!(&fb.body, FunctionBlockBodyKind::Statements);
+    let assignment = cast!(&body.body[0], StmtKind::Assignment);
+    let symbolic = cast!(&assignment.target, Variable::Symbolic);
+    let structured = cast!(symbolic, SymbolicVariableKind::Structured);
+    // The head is a plain named variable, NOT a self reference.
+    let named = cast!(structured.record.as_ref(), SymbolicVariableKind::Deref);
+    assert!(matches!(
+        named.variable.as_ref(),
+        SymbolicVariableKind::Named(_)
+    ));
+}
+
+#[test]
+fn parse_when_this_caret_field_assigned_then_self_ref_head() {
+    let library = parse_in_method("    THIS^.count := 1;");
+    let assignment = cast!(&first_method_body(&library)[0], StmtKind::Assignment);
+    let symbolic = cast!(&assignment.target, Variable::Symbolic);
+    let structured = cast!(symbolic, SymbolicVariableKind::Structured);
+    assert_eq!(structured.field, Id::from("count"));
+    let self_ref = cast!(structured.record.as_ref(), SymbolicVariableKind::SelfRef);
+    assert_eq!(self_ref.kind, SelfRefKind::This);
+}
+
+#[test]
+fn parse_when_super_caret_field_read_then_self_ref_head() {
+    let library = parse_in_method("    count := SUPER^.count;");
+    let assignment = cast!(&first_method_body(&library)[0], StmtKind::Assignment);
+    let variable = cast!(&assignment.value.kind, ExprKind::Variable);
+    let symbolic = cast!(variable, Variable::Symbolic);
+    let structured = cast!(symbolic, SymbolicVariableKind::Structured);
+    let self_ref = cast!(structured.record.as_ref(), SymbolicVariableKind::SelfRef);
+    assert_eq!(self_ref.kind, SelfRefKind::Super);
+}
+
+/// The element chain composes with a self-reference head the same way it
+/// does with a named head.
+#[test]
+fn parse_when_this_caret_field_subscripted_then_array_of_structured() {
+    let library = parse_in_method("    count := THIS^.values[2];");
+    let assignment = cast!(&first_method_body(&library)[0], StmtKind::Assignment);
+    let variable = cast!(&assignment.value.kind, ExprKind::Variable);
+    let symbolic = cast!(variable, Variable::Symbolic);
+    let array = cast!(symbolic, SymbolicVariableKind::Array);
+    let structured = cast!(
+        array.subscripted_variable.as_ref(),
+        SymbolicVariableKind::Structured
+    );
+    let self_ref = cast!(structured.record.as_ref(), SymbolicVariableKind::SelfRef);
+    assert_eq!(self_ref.kind, SelfRefKind::This);
+}
+
+/// `THIS^` with no element chain is a complete variable reference.
+#[test]
+fn parse_when_bare_this_caret_then_self_ref_alone() {
+    let library = parse_in_method("    count := THIS^;");
+    let assignment = cast!(&first_method_body(&library)[0], StmtKind::Assignment);
+    let variable = cast!(&assignment.value.kind, ExprKind::Variable);
+    let symbolic = cast!(variable, Variable::Symbolic);
+    let self_ref = cast!(symbolic, SymbolicVariableKind::SelfRef);
+    assert_eq!(self_ref.kind, SelfRefKind::This);
+}
+
+#[rstest]
+#[case::this("    THIS^.Start();", SelfRefKind::This)]
+#[case::super_("    SUPER^.Start();", SelfRefKind::Super)]
+fn parse_when_self_ref_method_call_then_self_ref_receiver(
+    #[case] body: &str,
+    #[case] expected: SelfRefKind,
+) {
+    let library = parse_in_method(body);
+    let call = cast!(&first_method_body(&library)[0], StmtKind::MethodCall);
+    assert_eq!(call.method, Id::from("Start"));
+    let self_ref = cast!(&call.receiver, MethodReceiver::SelfRef);
+    assert_eq!(self_ref.kind, expected);
+}
+
+#[test]
+fn parse_when_self_ref_method_call_has_args_then_params_captured() {
+    let library = parse_in_method("    SUPER^.SetSpeed(rNewSpeed := 1.0);");
+    let call = cast!(&first_method_body(&library)[0], StmtKind::MethodCall);
+    assert_eq!(call.params.len(), 1);
+}
+
+/// An ordinary instance receiver still parses -- the receiver rule is
+/// additive, not a replacement.
+#[test]
+fn parse_when_instance_method_call_then_instance_receiver() {
+    let library = parse_in_method("    motor.Start();");
+    let call = cast!(&first_method_body(&library)[0], StmtKind::MethodCall);
+    let instance = cast!(&call.receiver, MethodReceiver::Instance);
+    assert_eq!(instance, &Id::from("motor"));
+}
+
+/// Whitespace between the keyword and its caret is accepted: nothing in
+/// the grammar joins them into a single token. See the plan's
+/// "whitespace question" section.
+#[rstest]
+#[case::no_space("    THIS^.count := 1;")]
+#[case::space("    THIS ^.count := 1;")]
+#[case::comment("    THIS (* self *) ^.count := 1;")]
+fn parse_when_whitespace_before_caret_then_ok(#[case] body: &str) {
+    let library = parse_in_method(body);
+    let assignment = cast!(&first_method_body(&library)[0], StmtKind::Assignment);
+    let symbolic = cast!(&assignment.target, Variable::Symbolic);
+    let structured = cast!(symbolic, SymbolicVariableKind::Structured);
+    let self_ref = cast!(structured.record.as_ref(), SymbolicVariableKind::SelfRef);
+    assert_eq!(self_ref.kind, SelfRefKind::This);
+}
+
+/// The caret is mandatory: THIS/SUPER are pointers in the dialects that
+/// define them, so the un-dereferenced forms are rejected. A dedicated
+/// diagnostic for this shape is tracked in issue #1405.
+#[rstest]
+#[case::bare_this("    THIS := 1;")]
+#[case::this_dot("    THIS.count := 1;")]
+#[case::bare_super("    SUPER := 1;")]
+#[case::super_dot("    SUPER.count := 1;")]
+fn parse_when_self_ref_without_caret_then_err(#[case] body: &str) {
+    let source = format!(
+        "FUNCTION_BLOCK FB_Derived EXTENDS FB_Base
+VAR
+    count : INT;
+END_VAR
+METHOD Run
+{body}
+END_METHOD
+END_FUNCTION_BLOCK"
+    );
+    let result = parse_program(&source, &FileId::default(), &opts_with_fb_inheritance());
+    assert!(
+        result.is_err(),
+        "THIS/SUPER without a dereference caret must be rejected"
+    );
+}

--- a/compiler/parser/src/token.rs
+++ b/compiler/parser/src/token.rs
@@ -220,6 +220,13 @@ pub enum TokenType {
     Method,
     #[token("END_METHOD", ignore(case))]
     EndMethod,
+    // `THIS^` / `SUPER^` -- the self-reference and base-reference forms.
+    // The caret is the ordinary dereference operator; see
+    // specs/plans/2026-08-22-oop-this-super-parsing.md.
+    #[token("THIS", ignore(case))]
+    This,
+    #[token("SUPER", ignore(case))]
+    Super,
 
     #[token("IF", ignore(case))]
     If,
@@ -559,6 +566,8 @@ impl TokenType {
             TokenType::Abstract => "'ABSTRACT'",
             TokenType::Method => "'METHOD'",
             TokenType::EndMethod => "'END_METHOD'",
+            TokenType::This => "'THIS'",
+            TokenType::Super => "'SUPER'",
             TokenType::If => "'IF'",
             TokenType::Then => "'THEN'",
             TokenType::Elsif => "'ELSIF'",
@@ -783,6 +792,8 @@ mod tests {
             (Abstract, "ABSTRACT"),
             (Method, "METHOD"),
             (EndMethod, "END_METHOD"),
+            (This, "THIS"),
+            (Super, "SUPER"),
             (If, "IF"),
             (Then, "THEN"),
             (Elsif, "ELSIF"),

--- a/compiler/parser/src/token.rs
+++ b/compiler/parser/src/token.rs
@@ -221,8 +221,8 @@ pub enum TokenType {
     #[token("END_METHOD", ignore(case))]
     EndMethod,
     // `THIS^` / `SUPER^` -- the self-reference and base-reference forms.
-    // The caret is the ordinary dereference operator; see
-    // specs/plans/2026-08-22-oop-this-super-parsing.md.
+    // The caret is the ordinary dereference operator. Identifiers unless
+    // `allow_fb_inheritance` is set -- see xform_demote_keywords.rs.
     #[token("THIS", ignore(case))]
     This,
     #[token("SUPER", ignore(case))]

--- a/compiler/parser/src/xform_demote_keywords.rs
+++ b/compiler/parser/src/xform_demote_keywords.rs
@@ -35,7 +35,8 @@ use crate::{
 /// * **`POINTER`** — demoted unless `allow_pointer_to` (TwinCAT/CODESYS
 ///   `POINTER TO`).
 /// * **OOP keywords** (`EXTENDS`, `IMPLEMENTS`, `INTERFACE`, `END_INTERFACE`,
-///   `ABSTRACT`, `METHOD`, `END_METHOD`) — demoted unless `allow_fb_inheritance`.
+///   `ABSTRACT`, `METHOD`, `END_METHOD`, `THIS`, `SUPER`) — demoted unless
+///   `allow_fb_inheritance`.
 /// * **`AND_THEN`** — demoted unless `allow_short_circuit_operators`.
 ///
 /// The context-sensitive `TIME` keyword is handled by [`apply_time`].
@@ -62,7 +63,9 @@ pub fn apply(tokens: &mut [Token], options: &CompilerOptions) {
             | TokenType::EndInterface
             | TokenType::Abstract
             | TokenType::Method
-            | TokenType::EndMethod => demote_oop,
+            | TokenType::EndMethod
+            | TokenType::This
+            | TokenType::Super => demote_oop,
             TokenType::AndThen => demote_and_then,
             _ => false,
         };

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -1368,12 +1368,13 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         Ok(())
     }
 
-    // OOP extension: `instance.MethodName(args)` (ADR-0041 Phase 1).
+    // OOP extension: `instance.MethodName(args)`, `THIS^.MethodName(args)`
+    // (ADR-0041 Phase 1).
     fn visit_method_call(
         &mut self,
         node: &dsl::textual::MethodCall,
     ) -> Result<Self::Value, Diagnostic> {
-        self.visit_id(&node.instance)?;
+        self.visit_method_receiver(&node.receiver)?;
         self.write(".");
         self.visit_id(&node.method)?;
 
@@ -1696,6 +1697,30 @@ impl Visitor<Diagnostic> for LibraryRenderer {
         self.visit_symbolic_variable_kind(&node.variable)?;
         self.write("^");
         Ok(())
+    }
+
+    // OOP extension: `THIS^` / `SUPER^`. The caret is part of the node's
+    // spelling, so it can never be split from the keyword, and whatever
+    // element follows (`.field`, `[i]`) is written with no gap -- which is
+    // what the parser requires after a caret.
+    fn visit_self_ref_variable(
+        &mut self,
+        node: &dsl::textual::SelfRefVariable,
+    ) -> Result<Self::Value, Diagnostic> {
+        self.write_ws(node.kind.spelling());
+        Ok(())
+    }
+
+    fn visit_method_receiver(
+        &mut self,
+        node: &dsl::textual::MethodReceiver,
+    ) -> Result<Self::Value, Diagnostic> {
+        match node {
+            dsl::textual::MethodReceiver::Instance(name) => self.visit_id(name),
+            dsl::textual::MethodReceiver::SelfRef(self_ref) => {
+                self.visit_self_ref_variable(self_ref)
+            }
+        }
     }
 
     fn visit_reference_declaration(

--- a/compiler/plc2plc/src/tests/mod.rs
+++ b/compiler/plc2plc/src/tests/mod.rs
@@ -21,4 +21,5 @@ mod short_circuit;
 mod struct_init_expressions;
 mod tc2_math_calls;
 mod tc2_utilities_calls;
+mod this_super;
 mod time_and_sizeof;

--- a/compiler/plc2plc/src/tests/this_super.rs
+++ b/compiler/plc2plc/src/tests/this_super.rs
@@ -73,8 +73,7 @@ fn write_to_string_when_self_ref_source_then_round_trips(#[case] source: &'stati
     };
     let library_original = parse_program(source, &FileId::default(), &options).unwrap();
     let rendered = write_to_string(&library_original).unwrap();
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
-        .unwrap_or_else(|e| panic!("re-parse failed: {e:?}\n--- rendered ---\n{rendered}"));
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
     assert_eq!(library_original, library_rendered);
 }
 

--- a/compiler/plc2plc/src/tests/this_super.rs
+++ b/compiler/plc2plc/src/tests/this_super.rs
@@ -1,0 +1,105 @@
+//! OOP extension: `THIS^` / `SUPER^` round-trip. See
+//! specs/plans/2026-08-22-oop-this-super-parsing.md.
+
+use super::common::*;
+use rstest::rstest;
+
+/// Each case parses source under `allow_fb_inheritance`, renders it back
+/// to text, and re-parses the rendering to confirm it produces the same
+/// AST as the original. The re-parse is what proves the caret is rendered
+/// tight against its keyword and against whatever follows it -- a stray
+/// space either side fails to parse.
+///
+/// No array-subscript case: `THIS^.values[2]` renders as
+/// `THIS^.values [ 2 ]`, which does not re-parse. That is a pre-existing
+/// renderer bug affecting every subscript, `THIS^` or not (issue #1404);
+/// the AST shape for that chain is asserted in the parser tests instead.
+#[rstest]
+#[case::this_field_write(
+    "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Run
+    THIS^.count := 1;
+END_METHOD
+END_FUNCTION_BLOCK
+"
+)]
+#[case::super_field_read(
+    "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Run
+    count := SUPER^.count;
+END_METHOD
+END_FUNCTION_BLOCK
+"
+)]
+#[case::this_method_call(
+    "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Start
+    count := 1;
+END_METHOD
+METHOD Run
+    THIS^.Start();
+END_METHOD
+END_FUNCTION_BLOCK
+"
+)]
+#[case::super_method_call_with_args(
+    "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Run
+    SUPER^.SetSpeed(rNewSpeed := 1.5);
+END_METHOD
+END_FUNCTION_BLOCK
+"
+)]
+fn write_to_string_when_self_ref_source_then_round_trips(#[case] source: &'static str) {
+    let options = CompilerOptions {
+        allow_fb_inheritance: true,
+        ..CompilerOptions::default()
+    };
+    let library_original = parse_program(source, &FileId::default(), &options).unwrap();
+    let rendered = write_to_string(&library_original).unwrap();
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options)
+        .unwrap_or_else(|e| panic!("re-parse failed: {e:?}\n--- rendered ---\n{rendered}"));
+    assert_eq!(library_original, library_rendered);
+}
+
+/// Whitespace written between the keyword and its caret is not preserved:
+/// the caret belongs to the node, so every spelling renders canonically.
+#[test]
+fn write_to_string_when_space_before_caret_then_renders_tight() {
+    let options = CompilerOptions {
+        allow_fb_inheritance: true,
+        ..CompilerOptions::default()
+    };
+    let source = "
+FUNCTION_BLOCK FB_Motor
+VAR
+    count : INT;
+END_VAR
+METHOD Run
+    THIS ^.count := 1;
+END_METHOD
+END_FUNCTION_BLOCK
+";
+    let library = parse_program(source, &FileId::default(), &options).unwrap();
+    let rendered = write_to_string(&library).unwrap();
+    assert!(
+        rendered.contains("THIS^.count"),
+        "Expected THIS^.count in output, got: {rendered}"
+    );
+}

--- a/compiler/plc2plc/src/tests/this_super.rs
+++ b/compiler/plc2plc/src/tests/this_super.rs
@@ -1,5 +1,4 @@
-//! OOP extension: `THIS^` / `SUPER^` round-trip. See
-//! specs/plans/2026-08-22-oop-this-super-parsing.md.
+//! OOP extension: `THIS^` / `SUPER^` round-trip.
 
 use super::common::*;
 use rstest::rstest;

--- a/docs/explanation/object-orientation.rst
+++ b/docs/explanation/object-orientation.rst
@@ -93,6 +93,35 @@ one ``VAR`` block — are a duplicate and are rejected
 *different* scopes, the base type and the derived type, so the name is
 resolved by choosing the nearer declaration rather than reported as an error.
 
+Referring to the instance and to the base type
+----------------------------------------------
+
+Hiding raises a question: once a derived type has hidden an inherited name,
+how does it reach the hidden one? The standard answers with two names for the
+instance a method is running on —
+:doc:`THIS and SUPER </reference/language/object-orientation/this-and-super>`.
+
+``THIS^`` is the instance itself. It is what makes an instance variable
+reachable when a nearer name — a method parameter, say — hides it.
+
+``SUPER^`` is the same instance seen as its base type. A derived type that
+overrides an inherited method uses it to call the implementation it
+overrode, so the derived behavior can add to the base behavior rather than
+replace it:
+
+.. code-block::
+
+   FUNCTION_BLOCK FB_LoggingMotor EXTENDS FB_Motor
+       METHOD Stop
+           SUPER^.Stop();
+       END_METHOD
+   END_FUNCTION_BLOCK
+
+Both are pointers to an instance, which is why each is written with the
+dereference operator ``^``. ``SUPER^`` is resolved when the program is
+compiled, not while it runs: "the base type's implementation" is decided by
+the declaration, not by what the instance turns out to be.
+
 Interfaces
 ==========
 

--- a/docs/reference/language/object-orientation/index.rst
+++ b/docs/reference/language/object-orientation/index.rst
@@ -38,6 +38,8 @@ Keywords
      - Mark a function block type as not directly instantiable
    * - :doc:`interface`
      - Declare an interface — a named set of method signatures
+   * - :doc:`this-and-super`
+     - Refer to the instance a method is running on, or to its base type
 
 .. toctree::
    :maxdepth: 1
@@ -47,3 +49,4 @@ Keywords
    implements
    abstract
    interface
+   this-and-super

--- a/docs/reference/language/object-orientation/this-and-super.rst
+++ b/docs/reference/language/object-orientation/this-and-super.rst
@@ -1,0 +1,79 @@
+==============
+THIS and SUPER
+==============
+
+``THIS`` and ``SUPER`` name the function block instance a method is running
+on. ``THIS^`` is that instance itself; ``SUPER^`` is the same instance seen
+as its :doc:`base type <extends>`, which is how a derived type reaches an
+inherited member it has hidden with one of its own. Both are pointers, so
+both are written with the dereference operator ``^``.
+
+.. |keyword| replace:: ``THIS`` and ``SUPER``
+.. |flag| replace:: ``--allow-fb-inheritance``
+.. include:: /includes/oop-keyword-flag.rst
+
+.. list-table::
+   :widths: 30 70
+
+   * - **IEC 61131-3**
+     - Edition 3 (object-oriented programming)
+   * - **Support**
+     - Parsed only — not yet analyzed or executed
+       (:doc:`P9999 </reference/compiler/problems/P9999>`). Enable with
+       ``--allow-fb-inheritance``; see
+       :doc:`/explanation/enabling-dialects-and-features`.
+
+Syntax
+------
+
+The dereference operator is required — ``THIS`` and ``SUPER`` are pointers,
+so ``THIS.count`` is not valid where ``THIS^.count`` is. Whitespace between
+the keyword and the ``^`` is accepted:
+
+.. code-block:: bnf
+
+   THIS ^ . member
+   SUPER ^ . member
+
+A dereferenced reference is used wherever a variable is: read from, assigned
+to, subscripted, or called.
+
+Example
+-------
+
+.. code-block::
+
+   FUNCTION_BLOCK FB_Motor
+       VAR
+           speed : INT;
+       END_VAR
+
+       METHOD Stop
+           THIS^.speed := 0;
+       END_METHOD
+   END_FUNCTION_BLOCK
+
+   FUNCTION_BLOCK FB_LoggingMotor EXTENDS FB_Motor
+       METHOD Stop
+           SUPER^.Stop();
+       END_METHOD
+   END_FUNCTION_BLOCK
+
+``FB_LoggingMotor`` declares its own ``Stop``, which hides the one it
+inherits. ``SUPER^.Stop()`` calls the hidden base implementation; writing
+``Stop()`` there would call itself.
+
+``THIS^`` is most useful when a local name hides a member of the instance —
+for example a method parameter named after a variable of the function block.
+``THIS^.speed`` then names the function block's variable, and ``speed`` alone
+names the parameter.
+
+See Also
+--------
+
+- :doc:`extends` — derive from a base type
+- :doc:`abstract` — mark a type as not directly instantiable
+- :doc:`interface` — declare an interface
+- :doc:`/explanation/object-orientation` — inheritance, interfaces, and
+  abstract types explained
+- :doc:`/reference/language/pous/function-block` — the ``FUNCTION_BLOCK`` unit

--- a/specs/plans/2026-08-22-oop-this-super-parsing.md
+++ b/specs/plans/2026-08-22-oop-this-super-parsing.md
@@ -30,9 +30,12 @@ In scope:
   - statement-position method call: `THIS^.Start();`, `SUPER^.Start();`
   - bare: `v := THIS^;` (parses; nothing can be done with it yet)
 - plc2plc rendering and round-trip.
-- One clean `P9999` per occurrence from `rule_unsupported_extension`,
-  via a `LanguageExtension` impl — the pattern already used for
-  `IMPLEMENTS`, `ABSTRACT`, and `INTERFACE`.
+- `P9999` per occurrence from `rule_unsupported_extension`, via a
+  `LanguageExtension` impl — the pattern already used for
+  `IMPLEMENTS`, `ABSTRACT`, and `INTERFACE`. Earlier passes will also
+  report the construct as unimplemented, so the diagnostic output is
+  expected to be redundant and blunt at first; see *Analyzer* for why
+  that is preferred to silencing them.
 - Codegen: an explicit not-implemented arm (`Diagnostic::todo`) as a
   backstop, mirroring how `StmtKind::MethodCall` is handled today.
 
@@ -265,31 +268,49 @@ also touches whatever currently walks `instance`.
 
 ### Analyzer
 
+**No quiet arms.** The compiler will force a new match arm at every site
+that matches `SymbolicVariableKind` exhaustively. Every one of those arms
+must be *loud* — return an explicit not-implemented diagnostic
+(`Diagnostic::not_implemented` / `Diagnostic::todo`, naming the pass) —
+never a silent `None`, `Ok(())`, or "skip this node". A quiet arm is
+indistinguishable from a handled case, so when `THIS^`/`SUPER^` later
+grows real semantics, a pass that was silently ignoring it keeps
+ignoring it and miscompiles instead of failing. Being noisy and slightly
+confusing at first is the accepted cost; the diagnostics get refined
+once the construct has semantics worth resolving.
+
 - `impl LanguageExtension for SelfRefVariable` with name
   `"THIS^"` / `"SUPER^"` (from `kind`), plus a
   `visit_self_ref_variable` override in
   `rule_unsupported_extension.rs` → one `P9999` per occurrence.
 - The semantic rules run *after* the resolution transforms
-  (`stages.rs:337` vs `stages.rs:135-300`), so the risk is that
-  `xform_resolve_expr_types` and friends emit their own confused
-  diagnostics before `P9999` is ever reached. Each site that matches
-  `SymbolicVariableKind` needs an arm that returns "no type / not
-  resolvable" *quietly*:
-  `xform_resolve_expr_types.rs` (14 sites, incl. `find_base_variable_name`
-  → `None`), `xform_resolve_late_bound_expr_kind.rs` (7),
+  (`stages.rs:337` vs `stages.rs:135-300`), so the transforms meet the
+  new variant first and will report it before `rule_unsupported_extension`
+  ever runs. That is fine and expected: a program using `THIS^` is
+  rejected either way. The sites the compiler will point at are
+  `xform_resolve_expr_types.rs` (14, incl. `find_base_variable_name`),
+  `xform_resolve_late_bound_expr_kind.rs` (7),
   `rule_bit_access_range.rs` (6), `rule_ref_to.rs` (8),
   `xform_insert_implicit_deref.rs`, `xform_fold_initializer_expressions.rs`,
   `rule_function_call_type_check.rs`, `rule_string_encoding_compat.rs`.
+- Consequence to accept up front: a single `THIS^.count := 1;` may
+  produce several diagnostics — one per pass that meets it — and their
+  wording will be blunt ("`THIS^` is not supported by
+  <pass>"). Do not tune this by suppressing passes; the redundancy is
+  the signal that each pass has an unimplemented case.
+- Existing `_ =>` wildcard arms are not to be *relied on* for the new
+  variant. Where the compiler does not force a change, check whether a
+  wildcard is swallowing `SelfRef` into a wrong-but-plausible path
+  (rather than into a diagnostic); if it is, split the arm out
+  explicitly. Where a wildcard already lands in an error path, leave it.
 - `rule_use_declared_symbolic_var` needs no change *by construction*:
   a `SelfRef` head is not a `NamedVariable`, so `THIS` is never looked
   up as an undeclared symbol. Cover it with a test anyway.
-- `rule_method_call_declared.rs` skips `MethodReceiver::SelfRef`
-  receivers in this slice — resolving them would produce a second
-  diagnostic alongside `P9999`. It already tracks the enclosing
-  function block, so wiring resolution up later is cheap (see
-  *Optional add-ons*).
-- Acceptance test: a program using `THIS^.x` and `SUPER^.M()` produces
-  **exactly** the expected `P9999`s and nothing else.
+- `rule_method_call_declared.rs` reports `MethodReceiver::SelfRef`
+  receivers as not-implemented rather than skipping them — same rule:
+  a silent skip would keep quietly passing once `THIS^.M()` is
+  resolvable. It already tracks the enclosing function block, so
+  wiring real resolution up later is cheap (see *Optional add-ons*).
 
 ### Codegen
 
@@ -317,7 +338,7 @@ not `write_ws("^")`, so no space is introduced. Receiver rendering for
 | `compiler/dsl/src/visitor.rs`, `fold.rs` | `dispatch!` entries; receiver walk |
 | `compiler/dsl/src/extension.rs` consumers | `LanguageExtension` impl for `SelfRefVariable` |
 | `compiler/analyzer/src/rule_unsupported_extension.rs` | `visit_self_ref_variable` → P9999 |
-| `compiler/analyzer/src/xform_resolve_expr_types.rs` and the 7 other listed sites | Quiet "unresolvable" arms |
+| `compiler/analyzer/src/xform_resolve_expr_types.rs` and the 7 other listed sites | Explicit not-implemented arms (no silent skips) |
 | `compiler/analyzer/src/rule_method_call_declared.rs` | Skip `SelfRef` receivers; adapt to `receiver` field |
 | `compiler/codegen/src/compile_expr.rs`, `compile_stmt.rs` | `Diagnostic::todo` arms |
 | `compiler/plc2plc/src/renderer.rs` | Render `THIS^` / `SUPER^`; receiver rendering |
@@ -349,7 +370,12 @@ the others do not.
   including re-parsing the rendered output (as
   `plc2plc/src/tests/case.rs:33` does) so a stray space before `^`
   fails the test.
-- **Analyzer** — exactly the expected `P9999`s and no other diagnostic.
+- **Analyzer** — a program using `THIS^`/`SUPER^` is rejected, and
+  `P9999` is among the diagnostics. Assert *presence*, not an exact
+  diagnostic set: the set is expected to be noisy and to change as
+  passes are taught the construct, and pinning it would make every
+  later improvement a test edit. Do assert that a program *without*
+  `THIS^`/`SUPER^` is unaffected.
 - **Codegen** — `compile` fails with `P9999`, like
   `codegen/tests/it/end_to_end_struct.rs:620`.
 - **No end-to-end execution test** — nothing executes yet; the
@@ -387,7 +413,7 @@ the others do not.
 - [ ] Parser tests (flag on and flag off, including the whitespace case)
 - [ ] plc2plc rendering + re-parsing round-trip tests
 - [ ] `LanguageExtension` impl + `rule_unsupported_extension` override
-- [ ] Quiet arms in the resolution transforms; analyzer test asserting *only* P9999
+- [ ] Explicit not-implemented arms in the resolution transforms (audit `_ =>` wildcards for wrong-but-plausible fallthrough); analyzer test asserting rejection + P9999 present
 - [ ] Codegen `Diagnostic::todo` arms + compile-fails-with-P9999 test
 - [ ] Docs: reference page, `index.rst`, explanation page
 - [ ] Decide the optional add-ons above

--- a/specs/plans/2026-08-22-oop-this-super-parsing.md
+++ b/specs/plans/2026-08-22-oop-this-super-parsing.md
@@ -44,8 +44,7 @@ Out of scope:
 - Any execution semantics or bytecode. `SUPER^`'s base-method dispatch
   and `THIS^`'s receiver pointer belong to the codegen slice.
 - Type-checking / member resolution through `THIS^`/`SUPER^` (no
-  "member does not exist on the enclosing FB" diagnostic yet). See
-  *Optional add-ons*.
+  "member does not exist on the enclosing FB" diagnostic yet).
 - Unqualified self-calls (`Start();` inside a method body).
 - `THIS^` / `SUPER^` in expression-position method calls
   (`IF THIS^.IsMoving() THEN`) — expression-position method calls do
@@ -307,7 +306,7 @@ once the construct has semantics worth resolving.
   receivers as not-implemented rather than skipping them — same rule:
   a silent skip would keep quietly passing once `THIS^.M()` is
   resolvable. It already tracks the enclosing function block, so
-  wiring real resolution up later is cheap (see *Optional add-ons*).
+  wiring real resolution up later is cheap (#1406).
 
 ### Codegen
 
@@ -380,22 +379,14 @@ the others do not.
   that produces executable code.
 - `cd compiler && just` clean before the PR.
 
-## Optional add-ons (call before implementing)
+## Follow-ups (tracked separately, not part of this PR)
 
-1. **A real diagnostic for a missing caret.** With the flag on,
-   `THIS := 1;` or `THIS.count := 1;` currently fails as a generic
-   `P0002` syntax error. A dedicated problem code (next free is
-   `P4047`) saying "THIS must be dereferenced — write `THIS^`" is a
-   meaningful DX win for anyone arriving from a language where `this.x`
-   is the spelling. Costs a grammar path, a problem code, and a docs
-   page. **Recommended.**
-2. **`SUPER^` outside an extending function block.** `SUPER^` in a
-   `PROGRAM`, a `FUNCTION`, or a function block with no `EXTENDS` is
-   always wrong and is cheap to detect (`rule_method_call_declared`
-   already tracks the enclosing FB). It is real analysis on a construct
-   this slice otherwise only parses, and it would be additive to the
-   `P9999` rather than replacing it — so it may read as noise. **Defer
-   to the codegen slice** unless you want the diagnostic sooner.
+- **#1405** — diagnose `THIS` / `SUPER` written without the `^`, instead
+  of the generic `P0002` syntax error.
+- **#1406** — reject `SUPER^` where there is no base type, and
+  `THIS^`/`SUPER^` outside a function block body.
+- **#1404** — pre-existing plc2plc `ExprKind::Deref` rendering bug,
+  unrelated to this feature.
 
 ## Tasks
 
@@ -408,5 +399,4 @@ the others do not.
 - [ ] Explicit not-implemented arms in the resolution transforms (audit `_ =>` wildcards for wrong-but-plausible fallthrough); analyzer test asserting rejection + P9999 present
 - [ ] Codegen `Diagnostic::todo` arms + compile-fails-with-P9999 test
 - [ ] Docs: reference page, `index.rst`, explanation page
-- [ ] Decide the optional add-ons above
 - [ ] `cd compiler && just` clean

--- a/specs/plans/2026-08-22-oop-this-super-parsing.md
+++ b/specs/plans/2026-08-22-oop-this-super-parsing.md
@@ -112,12 +112,9 @@ Two related decisions that follow from the same reasoning:
   Relaxing member access generally is a separate change; this slice
   should not make `THIS^` more permissive than `p^` past the caret.
 
-Also worth fixing near this work (separately — it is a pre-existing bug,
-not part of this feature): `renderer.rs:1679` renders `ExprKind::Deref`
-with `write_ws("^")`, which emits `myRef ^` — output the parser then
-rejects in expression position. `visit_deref_variable` already uses
-`write("^")` correctly. One-word fix, and
-`plc2plc/src/tests/reference_to.rs:83` asserts the buggy spelling.
+(The same inconsistency also produces a pre-existing plc2plc rendering
+bug, tracked separately as issue #1404. It is not part of this feature
+and this slice does not touch it.)
 
 ## Design
 
@@ -399,11 +396,6 @@ the others do not.
    this slice otherwise only parses, and it would be additive to the
    `P9999` rather than replacing it — so it may read as noise. **Defer
    to the codegen slice** unless you want the diagnostic sooner.
-3. **Fix the `ExprKind::Deref` rendering bug** (`renderer.rs:1679`,
-   `write_ws` → `write`) plus its test at
-   `plc2plc/src/tests/reference_to.rs:83`. Unrelated to this feature,
-   two lines, and this is the slice that is looking straight at it.
-   **Recommended as its own commit.**
 
 ## Tasks
 

--- a/specs/plans/2026-08-22-oop-this-super-parsing.md
+++ b/specs/plans/2026-08-22-oop-this-super-parsing.md
@@ -390,13 +390,35 @@ the others do not.
 
 ## Tasks
 
-- [ ] `This` / `Super` tokens + demotion arm + token tests
-- [ ] `SelfRefVariable` / `SelfRefKind` / `MethodReceiver` AST + `dispatch!` entries
-- [ ] `self_ref()` rule; `symbolic_variable()` head; `method_invocation()` receiver
-- [ ] Parser tests (flag on and flag off, including the whitespace case)
-- [ ] plc2plc rendering + re-parsing round-trip tests
-- [ ] `LanguageExtension` impl + `rule_unsupported_extension` override
-- [ ] Explicit not-implemented arms in the resolution transforms (audit `_ =>` wildcards for wrong-but-plausible fallthrough); analyzer test asserting rejection + P9999 present
-- [ ] Codegen `Diagnostic::todo` arms + compile-fails-with-P9999 test
-- [ ] Docs: reference page, `index.rst`, explanation page
-- [ ] `cd compiler && just` clean
+- [x] `This` / `Super` tokens + demotion arm + token tests
+- [x] `SelfRefVariable` / `SelfRefKind` / `MethodReceiver` AST + `dispatch!` entries
+- [x] `self_ref()` rule; `symbolic_variable()` head; `method_invocation()` receiver
+- [x] Parser tests (flag on and flag off, including the whitespace case) — `parser/src/tests/this_super.rs`, 17 tests
+- [x] plc2plc rendering + re-parsing round-trip tests — `plc2plc/src/tests/this_super.rs`, 6 tests
+- [x] `LanguageExtension` impl + `rule_unsupported_extension` override
+- [x] Explicit not-implemented arms in the resolution transforms; analyzer test asserting rejection + P9999 present
+- [x] Codegen `Diagnostic::todo` arms + compile-fails-with-P9999 test
+- [x] Docs: reference page, `index.rst`, explanation page
+- [x] `cd compiler && just` clean
+
+### Notes from implementation (2026-08-22)
+
+- The forced-match-arm count came in lower than the plan estimated: four
+  sites in the analyzer (`rule_method_call_declared`, `rule_bit_access_range`,
+  `xform_resolve_expr_types`, `xform_resolve_late_bound_expr_kind`), two in
+  codegen (`compile_expr`), one in the LSP semantic-token map, and one in
+  the renderer. The rest of the ~50 `SymbolicVariableKind` match sites
+  already had wildcard arms landing in an error or recursion path.
+- Two of the analyzer sites are `Option`-returning type resolvers, where a
+  diagnostic cannot be returned from the helper itself. Those got the arm
+  *plus* a loud guard at the pass's own entry point
+  (`fold_self_ref_variable` / `visit_self_ref_variable`), so the pass
+  reports and stops rather than proceeding on an unresolved type.
+- Method bodies are not compiled at all yet, so a `THIS^` inside a
+  `METHOD` never reaches codegen. The codegen test therefore puts the
+  statement in the function block body; without that it passes
+  vacuously.
+- No array-subscript round-trip case: `THIS^.values[2]` renders as
+  `THIS^.values [ 2 ]`, which does not re-parse. It is a pre-existing
+  renderer bug affecting every subscript (`values [ 2 ]` alone fails the
+  same way, with no dialect flags involved) — reported on issue #1404.

--- a/specs/plans/2026-08-22-oop-this-super-parsing.md
+++ b/specs/plans/2026-08-22-oop-this-super-parsing.md
@@ -1,0 +1,394 @@
+# Plan: `THIS^` and `SUPER^` parsing (ADR-0041 Phase 1, front-end only)
+
+## Goal
+
+Parse `THIS^` and `SUPER^` — the self-reference and base-reference forms
+used by CODESYS/TwinCAT OOP — behind the existing
+`--allow-fb-inheritance` flag, round-trip them through plc2plc, and
+report them as not-yet-implemented (P9999) instead of a syntax error.
+
+This is the next slice named as out-of-scope in
+`specs/plans/2026-08-12-oop-method-declarations-static-dispatch.md`, and
+it is item 2 of Phase 2 in `specs/design/beckhoff-twincat-dialect.md`.
+It is deliberately front-end only: **no code generation**. ADR-0041's
+Phase 1 semantics for `THIS^`/`SUPER^` (a receiver pointer plumbed
+through method codegen; `SUPER^` calling the base's own body) stay
+deferred to the codegen slice that also owns `MethodCall` codegen, which
+is likewise unstarted.
+
+## Scope
+
+In scope:
+
+- `THIS` / `SUPER` keyword tokens, demoted to identifiers unless
+  `allow_fb_inheritance` (same gate and same mechanism as `METHOD`,
+  `EXTENDS`, `IMPLEMENTS`, `ABSTRACT`).
+- `THIS^` / `SUPER^` as the head of a variable reference, in every
+  position an ordinary variable reference is legal:
+  - read: `v := THIS^.count;`, `v := SUPER^.arr[2];`
+  - write: `THIS^.count := 1;`
+  - statement-position method call: `THIS^.Start();`, `SUPER^.Start();`
+  - bare: `v := THIS^;` (parses; nothing can be done with it yet)
+- plc2plc rendering and round-trip.
+- One clean `P9999` per occurrence from `rule_unsupported_extension`,
+  via a `LanguageExtension` impl — the pattern already used for
+  `IMPLEMENTS`, `ABSTRACT`, and `INTERFACE`.
+- Codegen: an explicit not-implemented arm (`Diagnostic::todo`) as a
+  backstop, mirroring how `StmtKind::MethodCall` is handled today.
+
+Out of scope:
+
+- Any execution semantics or bytecode. `SUPER^`'s base-method dispatch
+  and `THIS^`'s receiver pointer belong to the codegen slice.
+- Type-checking / member resolution through `THIS^`/`SUPER^` (no
+  "member does not exist on the enclosing FB" diagnostic yet). See
+  *Optional add-ons*.
+- Unqualified self-calls (`Start();` inside a method body).
+- `THIS^` / `SUPER^` in expression-position method calls
+  (`IF THIS^.IsMoving() THEN`) — expression-position method calls do
+  not exist for any receiver yet.
+- `p^.Method()` — a method call on a dereferenced pointer. It is a
+  syntax error today and stays one; only `THIS^`/`SUPER^` get a
+  receiver form here.
+- Editor syntax highlighting. `integrations/vscode/syntaxes/` does not
+  list `EXTENDS`/`METHOD` either; adding OOP keywords there is its own
+  change.
+
+## The whitespace question: is `SUPER ^` allowed?
+
+**Short answer: nothing makes it illegal, real code never writes it, and
+IronPLC should accept it.**
+
+Neither IEC 61131-3 nor the CODESYS/TwinCAT dialects define `THIS^` as a
+single lexical token. `THIS` and `SUPER` are keywords whose value is a
+pointer to an instance, and `^` is the ordinary dereference operator
+applied to them — the same `^` as in `pMotor^`. Token-based grammars
+separate those two tokens on whitespace like any other pair, so on the
+letter of the grammar `SUPER ^` is a dereference of `SUPER` and is legal.
+This has not been verified against the CODESYS or TwinCAT compilers
+themselves, and their documentation does not state a rule either way.
+
+IronPLC's own parser is currently inconsistent about whitespace before
+`^`, which is worth knowing before picking a rule. Measured against the
+`codesys` dialect on the current `main`:
+
+| Source | Result today |
+|---|---|
+| `v := p^;` | parses |
+| `v := p ^;` | **P0002 syntax error** |
+| `p^ := 1;` | parses |
+| `p ^ := 1;` | parses |
+| `p^.x := 1;` | parses |
+| `p ^.x := 1;` | **P0002 syntax error** |
+| `v := a [1];` | **P0002 syntax error** |
+
+The cause is that `symbolic_variable` (`parser.rs:852`) chains its
+elements — `.field`, `[i]`, `^` — with no `_` (optional
+whitespace/comment) rule between them, while the deref-assignment rule
+at `parser.rs:1817` does have `_` around its caret. So the strictness is
+an accident of two rules, not a decision.
+
+**Recommendation:** put `_` between the keyword and its caret in the new
+rules, i.e. accept `THIS^`, `THIS ^`, and `THIS /* comment */ ^`.
+Reasons:
+
+- It costs one token in one rule.
+- It cannot mis-accept a standard program: with the flag off, `THIS` and
+  `SUPER` are demoted to plain identifiers and none of these rules
+  apply. With the flag on they are keywords, so no program can be using
+  `SUPER` as a variable that `SUPER ^` might have dereferenced.
+- Accepting a shape a vendor might reject is harmless; rejecting one a
+  vendor accepts is a parse failure on real code.
+
+Two related decisions that follow from the same reasoning:
+
+- **The `^` stays mandatory.** `THIS.count` and a bare `THIS` are not
+  accepted. That matches CODESYS/TwinCAT, where these are pointers.
+- **Whitespace *after* the caret keeps today's behavior** — `THIS^.x`
+  parses, `THIS^ . x` does not, exactly as `p^.x` / `p^ . x` behave now.
+  Relaxing member access generally is a separate change; this slice
+  should not make `THIS^` more permissive than `p^` past the caret.
+
+Also worth fixing near this work (separately — it is a pre-existing bug,
+not part of this feature): `renderer.rs:1679` renders `ExprKind::Deref`
+with `write_ws("^")`, which emits `myRef ^` — output the parser then
+rejects in expression position. `visit_deref_variable` already uses
+`write("^")` correctly. One-word fix, and
+`plc2plc/src/tests/reference_to.rs:83` asserts the buggy spelling.
+
+## Design
+
+### Tokens (`compiler/parser/src/token.rs`)
+
+Add next to the other OOP keywords (`token.rs:206`):
+
+```rust
+#[token("THIS", ignore(case))]
+This,
+#[token("SUPER", ignore(case))]
+Super,
+```
+
+Plus their `describe`/display strings (`token.rs:669`) and an entry in
+the keyword round-trip table (`token.rs:884`).
+
+### Gating (`compiler/parser/src/xform_demote_keywords.rs`)
+
+One arm added to the existing OOP group — no new flag, no new gate:
+
+```rust
+TokenType::Extends
+| TokenType::Implements
+| TokenType::Interface
+| TokenType::EndInterface
+| TokenType::Abstract
+| TokenType::Method
+| TokenType::EndMethod
+| TokenType::This
+| TokenType::Super => demote_oop,
+```
+
+With the flag off, `THIS : INT;` and `THIS := 1;` keep working, and
+`THIS^.v := 1;` keeps its current meaning (dereference of a variable
+named `THIS`). That existing behavior must not change — it is a
+regression test, not just a nicety.
+
+### AST (`compiler/dsl/src/textual.rs`)
+
+`THIS^` is not only an expression: `THIS^.count := 1;` puts it in
+assignment-target position, where the AST is `Variable` /
+`SymbolicVariableKind`, not `Expr`. So the new node belongs at the
+**head of a symbolic variable**, not as an `ExprKind` variant. (The
+sketch in `specs/design/beckhoff-twincat-dialect.md:673` proposed
+`ExprKind::ThisRef`/`SuperRef`; that shape cannot express the assignment
+target, so this plan supersedes it.) Putting it at the head means every
+existing element chain — `.field`, `[i]`, `.%X0`, `^` — composes with it
+for free, in both read and write position.
+
+```rust
+pub enum SelfRefKind { This, Super }
+
+pub struct SelfRefVariable {
+    pub kind: SelfRefKind,
+    pub span: SourceSpan,   // spans keyword through caret
+}
+
+pub enum SymbolicVariableKind {
+    // ...existing...
+    SelfRef(SelfRefVariable),
+}
+```
+
+`Display` renders `THIS^` / `SUPER^` (the caret is part of the node —
+see below).
+
+**The caret is folded into the node** rather than modeled as
+`DerefVariable { variable: This }`. `THIS`/`SUPER` are not pointers in
+IronPLC's type system and there is no pointer type to give them, so an
+un-dereferenced form would be a node nothing can type. Folding the caret
+in also makes "the caret is mandatory" a structural property instead of
+a semantic check. The trade-off is that `SelfRefVariable`'s `Display`
+carries a `^` its name does not mention; the alternative (two variants,
+`ThisRef`/`SuperRef`, no `kind` enum) is a reasonable second choice and
+costs a few more match arms.
+
+Adding a `SymbolicVariableKind` variant makes the compiler enumerate the
+work: ~50 match sites across analyzer and codegen, most with existing
+wildcard arms. That is the intended forcing function.
+
+### Method-call receiver (`compiler/dsl/src/textual.rs`)
+
+`MethodCall.instance` is an `Id` today (`textual.rs:308`), which cannot
+hold `THIS^`. Narrowest change that works:
+
+```rust
+pub enum MethodReceiver {
+    Instance(Id),           // instance.M()
+    SelfRef(SelfRefVariable), // THIS^.M() / SUPER^.M()
+}
+
+pub struct MethodCall {
+    pub receiver: MethodReceiver,
+    pub method: Id,
+    pub params: Vec<ParamAssignmentKind>,
+    pub position: SourceSpan,
+}
+```
+
+Not widened to a full `Variable` receiver: that would silently start
+accepting `p^.M()` and `a.b.M()`, which is a separate feature with its
+own resolution rules.
+
+### Parser (`compiler/parser/src/parser.rs`)
+
+One new rule, and one new alternative in each of two existing rules:
+
+```
+rule self_ref() -> SelfRefVariable =
+    t:tok(TokenType::This)  _ c:tok(TokenType::Caret) { /* This  */ }
+  / t:tok(TokenType::Super) _ c:tok(TokenType::Caret) { /* Super */ }
+```
+
+`symbolic_variable()` (`parser.rs:852`) gains a head alternative — the
+element chain after it is untouched:
+
+```
+rule symbolic_variable() -> SymbolicVariableKind =
+    head:( s:self_ref() { SymbolicVariableKind::SelfRef(s) }
+         / name:variable_identifier() { SymbolicVariableKind::Named(..) } )
+    elements:( ...unchanged... )*
+```
+
+`method_invocation()` (`parser.rs:1852`) gains a receiver alternative:
+
+```
+rule method_invocation() -> StmtKind =
+    recv:( s:self_ref() { MethodReceiver::SelfRef(s) }
+         / id:identifier() { MethodReceiver::Instance(id) } )
+    _ period() _ method:identifier() _ tok(LeftParen) ... 
+```
+
+No dialect gating is needed in the grammar itself: without the flag the
+`This`/`Super` tokens never reach the parser, so both alternatives are
+unreachable — the same argument that already justifies ungated
+`method_invocation`.
+
+Ordering note: `statement()` tries `assignment_statement()` first, so
+`THIS^.M();` is attempted as an assignment, fails at the missing `:=`,
+and backtracks into `subprogram_control_statement()`. PEG backtracking
+handles this; no reordering needed.
+
+### Visitor / fold (`compiler/dsl/src/visitor.rs`, `fold.rs`)
+
+`dispatch!(SelfRefVariable);` in both. The `MethodCall` receiver change
+also touches whatever currently walks `instance`.
+
+### Analyzer
+
+- `impl LanguageExtension for SelfRefVariable` with name
+  `"THIS^"` / `"SUPER^"` (from `kind`), plus a
+  `visit_self_ref_variable` override in
+  `rule_unsupported_extension.rs` → one `P9999` per occurrence.
+- The semantic rules run *after* the resolution transforms
+  (`stages.rs:337` vs `stages.rs:135-300`), so the risk is that
+  `xform_resolve_expr_types` and friends emit their own confused
+  diagnostics before `P9999` is ever reached. Each site that matches
+  `SymbolicVariableKind` needs an arm that returns "no type / not
+  resolvable" *quietly*:
+  `xform_resolve_expr_types.rs` (14 sites, incl. `find_base_variable_name`
+  → `None`), `xform_resolve_late_bound_expr_kind.rs` (7),
+  `rule_bit_access_range.rs` (6), `rule_ref_to.rs` (8),
+  `xform_insert_implicit_deref.rs`, `xform_fold_initializer_expressions.rs`,
+  `rule_function_call_type_check.rs`, `rule_string_encoding_compat.rs`.
+- `rule_use_declared_symbolic_var` needs no change *by construction*:
+  a `SelfRef` head is not a `NamedVariable`, so `THIS` is never looked
+  up as an undeclared symbol. Cover it with a test anyway.
+- `rule_method_call_declared.rs` skips `MethodReceiver::SelfRef`
+  receivers in this slice — resolving them would produce a second
+  diagnostic alongside `P9999`. It already tracks the enclosing
+  function block, so wiring resolution up later is cheap (see
+  *Optional add-ons*).
+- Acceptance test: a program using `THIS^.x` and `SUPER^.M()` produces
+  **exactly** the expected `P9999`s and nothing else.
+
+### Codegen
+
+Add the not-implemented arms and stop:
+`compile_expr.rs` (variable lowering), `compile_stmt.rs` (assignment
+target and the `MethodCall` receiver), returning `Diagnostic::todo` the
+way `StmtKind::MethodCall` does today (`compile_stmt.rs:438`). Analysis
+already rejects the program with `P9999`, so these arms are a backstop
+against a future analyzer change silently miscompiling.
+
+### plc2plc (`compiler/plc2plc/src/renderer.rs`)
+
+`visit_self_ref_variable` writes `THIS^` / `SUPER^` — with `write("^")`,
+not `write_ws("^")`, so no space is introduced. Receiver rendering for
+`MethodCall` follows the same split.
+
+## Files
+
+| File | Change |
+|---|---|
+| `compiler/parser/src/token.rs` | `This` / `Super` token types, display strings, keyword table entry |
+| `compiler/parser/src/xform_demote_keywords.rs` | Two token types added to the existing `demote_oop` arm + doc comment |
+| `compiler/parser/src/parser.rs` | `self_ref()` rule; head alternative in `symbolic_variable()`; receiver alternative in `method_invocation()` |
+| `compiler/dsl/src/textual.rs` | `SelfRefKind`, `SelfRefVariable`, `SymbolicVariableKind::SelfRef`, `MethodReceiver`, `MethodCall.receiver` |
+| `compiler/dsl/src/visitor.rs`, `fold.rs` | `dispatch!` entries; receiver walk |
+| `compiler/dsl/src/extension.rs` consumers | `LanguageExtension` impl for `SelfRefVariable` |
+| `compiler/analyzer/src/rule_unsupported_extension.rs` | `visit_self_ref_variable` → P9999 |
+| `compiler/analyzer/src/xform_resolve_expr_types.rs` and the 7 other listed sites | Quiet "unresolvable" arms |
+| `compiler/analyzer/src/rule_method_call_declared.rs` | Skip `SelfRef` receivers; adapt to `receiver` field |
+| `compiler/codegen/src/compile_expr.rs`, `compile_stmt.rs` | `Diagnostic::todo` arms |
+| `compiler/plc2plc/src/renderer.rs` | Render `THIS^` / `SUPER^`; receiver rendering |
+| `compiler/parser/src/tests/this_super.rs` (new) + `tests/mod.rs` | Parser tests |
+| `compiler/plc2plc/src/tests/this_super.rs` (new) + `tests/mod.rs` | Round-trip tests |
+| `compiler/codegen/tests/it/` | P9999-on-compile test |
+| `docs/reference/language/object-orientation/this-and-super.rst` (new), `index.rst` | Reference page |
+| `docs/explanation/object-orientation.rst` | Short section on self/base reference |
+
+No new `--allow-*` flag, so no `options.rs`, no LSP `extract_compiler_options`,
+and no `enabling-dialects-and-features.rst` / `ironplcc.rst` changes.
+
+## Testing
+
+Per `specs/steering/syntax-support-guide.md`, each leg asserts something
+the others do not.
+
+- **Parser** (`parser/src/tests/this_super.rs`) — AST shape:
+  `THIS^.count := 1;` → `Structured{ record: SelfRef(This), field }`;
+  `v := SUPER^.arr[2];`; `THIS^.M();` and `SUPER^.M(a := 1);` →
+  `MethodCall` with a `SelfRef` receiver; `v := THIS^;` bare;
+  `THIS ^.x := 1;` (the whitespace decision, asserted explicitly);
+  `THIS.x := 1;` and bare `THIS := 1;` rejected with the flag on.
+- **Parser, flag off** — `THIS`/`SUPER` usable as variable names
+  (extend the existing keyword-safety test rather than writing a new
+  one), and `THIS^.v := 1;` still parses as a deref of a variable named
+  `THIS` — the no-regression case.
+- **plc2plc** (`plc2plc/src/tests/this_super.rs`) — text → AST → text,
+  including re-parsing the rendered output (as
+  `plc2plc/src/tests/case.rs:33` does) so a stray space before `^`
+  fails the test.
+- **Analyzer** — exactly the expected `P9999`s and no other diagnostic.
+- **Codegen** — `compile` fails with `P9999`, like
+  `codegen/tests/it/end_to_end_struct.rs:620`.
+- **No end-to-end execution test** — nothing executes yet; the
+  syntax-support-guide's execution-test requirement applies to syntax
+  that produces executable code.
+- `cd compiler && just` clean before the PR.
+
+## Optional add-ons (call before implementing)
+
+1. **A real diagnostic for a missing caret.** With the flag on,
+   `THIS := 1;` or `THIS.count := 1;` currently fails as a generic
+   `P0002` syntax error. A dedicated problem code (next free is
+   `P4047`) saying "THIS must be dereferenced — write `THIS^`" is a
+   meaningful DX win for anyone arriving from a language where `this.x`
+   is the spelling. Costs a grammar path, a problem code, and a docs
+   page. **Recommended.**
+2. **`SUPER^` outside an extending function block.** `SUPER^` in a
+   `PROGRAM`, a `FUNCTION`, or a function block with no `EXTENDS` is
+   always wrong and is cheap to detect (`rule_method_call_declared`
+   already tracks the enclosing FB). It is real analysis on a construct
+   this slice otherwise only parses, and it would be additive to the
+   `P9999` rather than replacing it — so it may read as noise. **Defer
+   to the codegen slice** unless you want the diagnostic sooner.
+3. **Fix the `ExprKind::Deref` rendering bug** (`renderer.rs:1679`,
+   `write_ws` → `write`) plus its test at
+   `plc2plc/src/tests/reference_to.rs:83`. Unrelated to this feature,
+   two lines, and this is the slice that is looking straight at it.
+   **Recommended as its own commit.**
+
+## Tasks
+
+- [ ] `This` / `Super` tokens + demotion arm + token tests
+- [ ] `SelfRefVariable` / `SelfRefKind` / `MethodReceiver` AST + `dispatch!` entries
+- [ ] `self_ref()` rule; `symbolic_variable()` head; `method_invocation()` receiver
+- [ ] Parser tests (flag on and flag off, including the whitespace case)
+- [ ] plc2plc rendering + re-parsing round-trip tests
+- [ ] `LanguageExtension` impl + `rule_unsupported_extension` override
+- [ ] Quiet arms in the resolution transforms; analyzer test asserting *only* P9999
+- [ ] Codegen `Diagnostic::todo` arms + compile-fails-with-P9999 test
+- [ ] Docs: reference page, `index.rst`, explanation page
+- [ ] Decide the optional add-ons above
+- [ ] `cd compiler && just` clean


### PR DESCRIPTION
## Summary

This is an implementation plan for parsing `THIS^` and `SUPER^` — the self-reference and base-reference forms used by CODESYS/TwinCAT OOP — behind the existing `--allow-fb-inheritance` flag. The plan covers front-end parsing and round-trip rendering only, with no code generation semantics. Programs using these constructs will be reported as not-yet-implemented (P9999) rather than syntax errors.

This is Phase 1 of ADR-0041 and item 2 of Phase 2 in the Beckhoff TwinCAT dialect design document.

## Key Changes

The plan specifies:

- **Tokens**: Add `THIS` and `SUPER` keyword tokens, demoted to identifiers when `allow_fb_inheritance` is off (same gating as `METHOD`, `EXTENDS`, etc.)

- **AST**: Introduce `SelfRefKind` enum and `SelfRefVariable` struct as a new head variant of `SymbolicVariableKind`, allowing `THIS^` and `SUPER^` to appear in both read and write positions. The caret is folded into the node since these are not pointers in IronPLC's type system.

- **Parser**: Add `self_ref()` rule accepting `THIS _^ ` and `SUPER _^` (with optional whitespace before the caret), integrate as head alternative in `symbolic_variable()`, and add receiver alternative in `method_invocation()` for statement-position method calls.

- **Method calls**: Introduce `MethodReceiver` enum to distinguish `Instance(Id)` from `SelfRef(SelfRefVariable)` receivers, narrowing the change to avoid silently accepting `p^.M()` or `a.b.M()`.

- **Analyzer**: Implement `LanguageExtension` for `SelfRefVariable` and add explicit not-implemented arms (never silent skips) at all match sites. This forces the compiler to enumerate the work and ensures future semantics additions don't silently miscompile.

- **Codegen**: Add `Diagnostic::todo` backstop arms in variable lowering and statement compilation.

- **plc2plc**: Render `THIS^` / `SUPER^` with `write("^")` (no space) and support round-trip parsing.

- **Testing**: Parser tests (flag on/off, whitespace cases), plc2plc round-trip tests, analyzer rejection + P9999 presence assertion, and compile-fails-with-P9999 test.

## Notable Implementation Details

- **Whitespace before caret is accepted** (`THIS ^` is legal) to match vendor behavior and avoid rejecting real code, while whitespace after the caret keeps today's behavior (`THIS^ . x` still fails).

- **The caret is mandatory** — `THIS.count` and bare `THIS` are not accepted, matching CODESYS/TwinCAT semantics where these are pointers.

- **No quiet analyzer arms** — every new match site must return an explicit diagnostic, never a silent skip. This prevents future semantic additions from silently miscompiling if an earlier pass was quietly ignoring the construct.

- **Redundant diagnostics are expected** — multiple passes will report the construct as unimplemented before `rule_unsupported_extension` runs. This is the accepted cost of ensuring no pass silently skips the construct.

- **Optional add-ons** identified for future work: a dedicated diagnostic for missing caret, `SUPER^` outside an extending FB, and fixing an unrelated `ExprKind::Deref` rendering bug.

## Files Modified

The plan details changes to ~20 files across parser, DSL, analyzer, codegen, plc2plc, and documentation, with a comprehensive task checklist for implementation.

https://claude.ai/code/session_01GGyTDF3y1QSec861eiJsj4