### PR TITLE
Fix dereference operator spacing to enable round-trip parsing

### DIFF
--- a/compiler/plc2plc/resources/test/adr_rendered.st
+++ b/compiler/plc2plc/resources/test/adr_rendered.st
@@ -12,6 +12,6 @@ VAR
    value : INT;
 END_VAR
 p := ADR ( counter ) ;
-value := p ^ ;
+value := p^ ;
 p^ := 99 ;
 END_PROGRAM

--- a/compiler/plc2plc/resources/test/pointer_to_rendered.st
+++ b/compiler/plc2plc/resources/test/pointer_to_rendered.st
@@ -19,7 +19,7 @@ VAR
    value : INT;
 END_VAR
 p := REF( counter ) ;
-value := p ^ ;
+value := p^ ;
 p^ := 99 ;
 p := NULL ;
 END_PROGRAM

--- a/compiler/plc2plc/resources/test/ref_rendered.st
+++ b/compiler/plc2plc/resources/test/ref_rendered.st
@@ -9,7 +9,7 @@ FUNCTION read_ref : INT
       pt : REF_TO INT;
    END_VAR
 
-   read_ref := pt ^ ;
+   read_ref := pt^ ;
 END_FUNCTION
 PROGRAM main
 
@@ -40,11 +40,11 @@ END_VAR
 VAR
    value : INT;
 END_VAR
-value := r ^ ;
+value := r^ ;
 r^ := 99 ;
 r := REF( counter ) ;
 IF ( r <> NULL ) THEN
-   value := r ^ ;
+   value := r^ ;
 END_IF ;
 
 value := read_ref ( pt := REF( counter ) ) ;

--- a/compiler/plc2plc/resources/test/reference_to_rendered.st
+++ b/compiler/plc2plc/resources/test/reference_to_rendered.st
@@ -19,8 +19,8 @@ VAR
    value : INT;
 END_VAR
 r REF= counter ;
-value := r ^ ;
+value := r^ ;
 r^ := 99 ;
 refs [ 0 ] REF= counter ;
-value := refs [ 0 ] ^ ;
+value := refs [ 0 ]^ ;
 END_PROGRAM

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -1678,7 +1678,10 @@ impl Visitor<Diagnostic> for LibraryRenderer {
             }
             dsl::textual::ExprKind::Deref(expr) => {
                 self.visit_expr(expr)?;
-                self.write_ws("^");
+                // No separating space: the parser's `unary_expression`
+                // rule allows no whitespace between the operand and the
+                // `^`, so `myRef ^` would not re-parse.
+                self.write("^");
                 Ok(())
             }
             dsl::textual::ExprKind::Null(_) => {

--- a/compiler/plc2plc/src/tests/common.rs
+++ b/compiler/plc2plc/src/tests/common.rs
@@ -55,3 +55,21 @@ pub(crate) fn parse_and_render_resource_empty_var_blocks(name: &'static str) -> 
     let library = parse_program(&source, &FileId::default(), &options).unwrap();
     write_to_string(&library).unwrap()
 }
+
+/// Asserts that `source` survives a parse -> render -> re-parse round trip
+/// with the AST unchanged.
+///
+/// Rendering alone does not prove the output is valid input: a stray space
+/// can produce text the parser rejects (see the `^` and `[` spacing bugs).
+/// Re-parsing here is what catches that.
+pub(crate) fn assert_round_trips(source: &str, options: &CompilerOptions) {
+    let library_original = parse_program(source, &FileId::default(), options).unwrap();
+    let rendered = write_to_string(&library_original).unwrap();
+
+    let library_rendered = parse_program(&rendered, &FileId::default(), options)
+        .unwrap_or_else(|e| panic!("Rendered output did not re-parse: {e:?}\n{rendered}"));
+    assert_eq!(
+        library_original, library_rendered,
+        "Round trip changed the AST. Rendered:\n{rendered}"
+    );
+}

--- a/compiler/plc2plc/src/tests/reference_to.rs
+++ b/compiler/plc2plc/src/tests/reference_to.rs
@@ -80,7 +80,7 @@ VAR
 END_VAR
     value := myRef^;
 END_PROGRAM",
-    "myRef ^"
+    "myRef^"
 )]
 #[case::ref_expression(
     "PROGRAM main
@@ -137,4 +137,31 @@ fn write_to_string_when_ref_to_type_decl_then_preserves() {
     let rendered = parse_and_render_edition3("TYPE IntRef : REF_TO INT; END_TYPE");
     let expected = "TYPE\n   IntRef : REF_TO INT ;\nEND_TYPE\n";
     assert_eq!(rendered, expected);
+}
+
+/// Renders and then *re-parses* a dereference in expression position.
+///
+/// The renderer used to emit `myRef ^` with a separating space, which the
+/// parser's `unary_expression` rule rejects, so the rendered text did not
+/// re-parse. Re-parsing here means a future stray space fails this test
+/// rather than passing silently.
+///
+/// Limited to a plain dereference: a subscripted one (`refs[0]^`) renders
+/// as `refs [ 0 ]^`, which the parser also rejects -- a separate,
+/// pre-existing spacing bug in the subscript rendering, not this one.
+#[test]
+fn write_to_string_when_deref_expression_then_round_trips() {
+    let source = "PROGRAM main
+VAR
+    myRef : REF_TO INT;
+    value : INT;
+END_VAR
+    value := myRef^;
+END_PROGRAM";
+    let options = CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3);
+    let library_original = parse_program(source, &FileId::default(), &options).unwrap();
+    let rendered = write_to_string(&library_original).unwrap();
+
+    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
+    assert_eq!(library_original, library_rendered);
 }

--- a/compiler/plc2plc/src/tests/reference_to.rs
+++ b/compiler/plc2plc/src/tests/reference_to.rs
@@ -148,20 +148,18 @@ fn write_to_string_when_ref_to_type_decl_then_preserves() {
 ///
 /// Limited to a plain dereference: a subscripted one (`refs[0]^`) renders
 /// as `refs [ 0 ]^`, which the parser also rejects -- a separate,
-/// pre-existing spacing bug in the subscript rendering, not this one.
+/// pre-existing spacing bug in the subscript rendering (#1407), not this
+/// one.
 #[test]
 fn write_to_string_when_deref_expression_then_round_trips() {
-    let source = "PROGRAM main
+    assert_round_trips(
+        "PROGRAM main
 VAR
     myRef : REF_TO INT;
     value : INT;
 END_VAR
     value := myRef^;
-END_PROGRAM";
-    let options = CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3);
-    let library_original = parse_program(source, &FileId::default(), &options).unwrap();
-    let rendered = write_to_string(&library_original).unwrap();
-
-    let library_rendered = parse_program(&rendered, &FileId::default(), &options).unwrap();
-    assert_eq!(library_original, library_rendered);
+END_PROGRAM",
+        &CompilerOptions::from_dialect(Dialect::Iec61131_3Ed3),
+    );
 }


### PR DESCRIPTION
## Summary

Fixes the renderer to emit dereference operators (`^`) without a separating space from their operand. The parser's `unary_expression` rule does not allow whitespace between the operand and `^`, so the previous output (`myRef ^`) would fail to re-parse.

## Changes

- **renderer.rs**: Changed `self.write_ws("^")` to `self.write("^")` in the `Deref` expression handler, with a comment explaining the parser constraint
- **Test expectations**: Updated all reference test files to expect `myRef^` instead of `myRef ^`:
  - `ref_rendered.st`
  - `reference_to_rendered.st`
  - `adr_rendered.st`
  - `pointer_to_rendered.st`
- **New round-trip test**: Added `write_to_string_when_deref_expression_then_round_trips()` in `reference_to.rs` that verifies rendered dereference expressions can be re-parsed successfully, preventing future regressions

## Implementation Details

The fix ensures that the plc2plc renderer produces syntactically valid output that can be re-parsed. The new test explicitly validates round-trip parsing (render → parse → compare ASTs) for dereference expressions, catching any future spacing regressions at the parser boundary.

https://claude.ai/code/session_01PmzDHbWkF8vqJ9uXqxLE1s