### PR TITLE
Capture caller location automatically in todo/internal_error diagnostics

### DIFF
--- a/compiler/analyzer/src/intermediates/structure.rs
+++ b/compiler/analyzer/src/intermediates/structure.rs
@@ -283,7 +283,7 @@ fn resolve_field_type(
         }
         _other => {
             // Other types are not yet supported
-            Err(Diagnostic::todo(file!(), line!()))
+            Err(Diagnostic::todo())
         }
     }
 }

--- a/compiler/analyzer/src/rule_var_decl_const_initialized.rs
+++ b/compiler/analyzer/src/rule_var_decl_const_initialized.rs
@@ -83,7 +83,7 @@ impl<'a> Visitor<Diagnostic> for RuleConstantVarsInitialized<'a> {
         match node.qualifier {
             DeclarationQualifier::Constant => match &node.initializer {
                 InitialValueAssignmentKind::None(sp) => {
-                    return Err(Diagnostic::todo_with_span(sp.clone(), file!(), line!()))
+                    return Err(Diagnostic::todo_with_span(sp.clone()))
                 }
                 InitialValueAssignmentKind::Simple(si) => match si.initial_value {
                     Some(_) => {}
@@ -138,9 +138,7 @@ impl<'a> Visitor<Diagnostic> for RuleConstantVarsInitialized<'a> {
                     // Function blocks cannot be CONSTANT - this is handled by
                     // rule_var_decl_const_not_fb, so skip initialization checking here.
                 }
-                InitialValueAssignmentKind::Subrange(_) => {
-                    return Err(Diagnostic::internal_error(file!(), line!()))
-                }
+                InitialValueAssignmentKind::Subrange(_) => return Err(Diagnostic::internal_error()),
                 InitialValueAssignmentKind::Structure(struct_init) => {
                     // For const structures, verify that all fields without defaults
                     // are explicitly initialized in the variable declaration.
@@ -169,7 +167,7 @@ impl<'a> Visitor<Diagnostic> for RuleConstantVarsInitialized<'a> {
                     }
                 }
                 InitialValueAssignmentKind::LateResolvedType(_) => {
-                    return Err(Diagnostic::internal_error(file!(), line!()))
+                    return Err(Diagnostic::internal_error())
                 }
                 InitialValueAssignmentKind::SimpleExpr(_) => {
                     // A constant-expression initializer — normalized to

--- a/compiler/analyzer/src/rule_var_decl_global_const_requires_external_const.rs
+++ b/compiler/analyzer/src/rule_var_decl_global_const_requires_external_const.rs
@@ -78,7 +78,7 @@ impl Visitor<Diagnostic> for FindGlobalConstVars<'_> {
                 VariableIdentifier::Symbol(name) => {
                     self.global_consts.insert(name.clone());
                 }
-                VariableIdentifier::Direct(_) => return Err(Diagnostic::todo(file!(), line!())),
+                VariableIdentifier::Direct(_) => return Err(Diagnostic::todo()),
             }
         }
         Ok(())

--- a/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_expr_kind.rs
@@ -323,7 +323,7 @@ impl Fold<Diagnostic> for DeclarationResolver<'_> {
                 VariableType::FunctionBlock => {
                     // Function block variables are parsed as LateResolvedType, not FunctionBlock.
                     // If we reach this branch, it indicates an internal error.
-                    Err(Diagnostic::internal_error(file!(), line!()))
+                    Err(Diagnostic::internal_error())
                 }
                 VariableType::Subrange => Ok(self.resolve_late_bound(node.value)),
                 VariableType::Structure => Ok(self.resolve_late_bound(node.value)),

--- a/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
+++ b/compiler/analyzer/src/xform_resolve_late_bound_type_initializer.rs
@@ -234,7 +234,7 @@ impl Fold<Diagnostic> for TypeResolver<'_> {
                         TypeDefinitionKind::Subrange => Ok(InitialValueAssignmentKind::Subrange(
                             SpecificationKind::Named(name),
                         )),
-                        _ => Err(Diagnostic::todo_with_type(&name, file!(), line!())),
+                        _ => Err(Diagnostic::todo_with_type(&name)),
                     },
                     None => {
                         trace!("{:?}", self.types);

--- a/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
+++ b/compiler/analyzer/src/xform_resolve_type_decl_environment.rs
@@ -102,7 +102,7 @@ impl TypeEnvironment {
                 // not TYPE declarations, so they should never appear in the type environment.
                 // If we reach this branch, it indicates a bug in the compiler.
                 IntermediateType::FunctionBlock { .. } | IntermediateType::Function { .. } => {
-                    Err(Diagnostic::internal_error(file!(), line!()))
+                    Err(Diagnostic::internal_error())
                 }
                 // Primitive types are handled by the is_primitive() check above,
                 // so reaching this branch indicates a bug in the compiler
@@ -115,9 +115,7 @@ impl TypeEnvironment {
                 | IntermediateType::Date { .. }
                 | IntermediateType::TimeOfDay { .. }
                 | IntermediateType::DateAndTime { .. }
-                | IntermediateType::String { .. } => {
-                    Err(Diagnostic::internal_error(file!(), line!()))
-                }
+                | IntermediateType::String { .. } => Err(Diagnostic::internal_error()),
             }
         }
     }
@@ -241,13 +239,13 @@ impl Fold<Diagnostic> for TypeEnvironment {
                 // Reference types are not resolved through simple declarations
             }
             InitialValueAssignmentKind::LateResolvedType(_type_name) => {
-                return Err(Diagnostic::internal_error(file!(), line!()));
+                return Err(Diagnostic::internal_error());
             }
             InitialValueAssignmentKind::SimpleExpr(_) => {
                 // Constant-expression initializers are a VAR-declaration
                 // extension; they never appear in a TYPE alias's
                 // spec_and_init (that grammar path is unchanged).
-                return Err(Diagnostic::internal_error(file!(), line!()));
+                return Err(Diagnostic::internal_error());
             }
         }
 
@@ -364,7 +362,7 @@ impl Fold<Diagnostic> for TypeEnvironment {
                     array::IntermediateResult::Type(attrs) => attrs.representation,
                     array::IntermediateResult::Alias(base_type_name) => self
                         .get(&base_type_name)
-                        .ok_or_else(|| Diagnostic::internal_error(file!(), line!()))?
+                        .ok_or_else(|| Diagnostic::internal_error())?
                         .representation
                         .clone(),
                 }

--- a/compiler/analyzer/src/xform_toposort_declarations.rs
+++ b/compiler/analyzer/src/xform_toposort_declarations.rs
@@ -516,7 +516,7 @@ impl Visitor<Diagnostic> for RuleGraphReferenceableElements {
                 let to = self.declarations.add_node(&node.name);
                 self.declarations.graph.add_edge(to, from, ());
             }
-            None => return Err(Diagnostic::todo(file!(), line!())),
+            None => return Err(Diagnostic::todo()),
         }
 
         node.recurse_visit(self)
@@ -537,7 +537,7 @@ impl Visitor<Diagnostic> for RuleGraphReferenceableElements {
                 let to = self.declarations.add_node(&init.type_name.name);
                 self.declarations.graph.add_edge(to, from, ());
             }
-            None => return Err(Diagnostic::todo(file!(), line!())),
+            None => return Err(Diagnostic::todo()),
         }
 
         Ok(())

--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -158,9 +158,10 @@ pub(crate) fn resolve_access<'ctx, 'ast>(
                     SymbolicVariableKind::Named(named) => {
                         levels.reverse();
                         let all_subscripts: Vec<&Expr> = levels.into_iter().flatten().collect();
-                        let info = ctx.array_vars.get(&named.name).ok_or_else(|| {
-                            Diagnostic::todo_with_span(named.name.span(), file!(), line!())
-                        })?;
+                        let info = ctx
+                            .array_vars
+                            .get(&named.name)
+                            .ok_or_else(|| Diagnostic::todo_with_span(named.name.span()))?;
                         return Ok(ResolvedAccess::ArrayElement {
                             info,
                             subscripts: all_subscripts,
@@ -178,20 +179,17 @@ pub(crate) fn resolve_access<'ctx, 'ast>(
                                 levels.reverse();
                                 let all_subscripts: Vec<&Expr> =
                                     levels.into_iter().flatten().collect();
-                                let info = ctx.array_vars.get(&named.name).ok_or_else(|| {
-                                    Diagnostic::todo_with_span(named.name.span(), file!(), line!())
-                                })?;
+                                let info = ctx
+                                    .array_vars
+                                    .get(&named.name)
+                                    .ok_or_else(|| Diagnostic::todo_with_span(named.name.span()))?;
                                 return Ok(ResolvedAccess::DerefArrayElement {
                                     info,
                                     subscripts: all_subscripts,
                                 });
                             }
                             other => {
-                                return Err(Diagnostic::todo_with_span(
-                                    other.span(),
-                                    file!(),
-                                    line!(),
-                                ));
+                                return Err(Diagnostic::todo_with_span(other.span()));
                             }
                         }
                     }
@@ -201,7 +199,7 @@ pub(crate) fn resolve_access<'ctx, 'ast>(
                         return resolve_struct_field_array(ctx, structured, all_subscripts);
                     }
                     other => {
-                        return Err(Diagnostic::todo_with_span(other.span(), file!(), line!()));
+                        return Err(Diagnostic::todo_with_span(other.span()));
                     }
                 }
             }
@@ -331,11 +329,7 @@ pub(crate) fn resolve_struct_array_element_field<'ctx, 'ast>(
     structured: &'ast ironplc_dsl::textual::StructuredVariable,
 ) -> Result<ResolvedAccess<'ctx, 'ast>, Diagnostic> {
     let SymbolicVariableKind::Array(array_var) = structured.record.as_ref() else {
-        return Err(Diagnostic::todo_with_span(
-            structured.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(structured.span()));
     };
 
     // Collect subscript groups innermost-first, then reverse -- the same
@@ -351,7 +345,7 @@ pub(crate) fn resolve_struct_array_element_field<'ctx, 'ast>(
                 // A top-level `ARRAY OF <struct>` variable reaches here. Those
                 // are rejected earlier, at declaration time, because
                 // `resolve_type_name` resolves only elementary element types.
-                return Err(Diagnostic::todo_with_span(other.span(), file!(), line!()));
+                return Err(Diagnostic::todo_with_span(other.span()));
             }
         }
     };
@@ -618,7 +612,7 @@ fn intermediate_type_to_name(ty: &IntermediateType) -> Result<Id, Diagnostic> {
             size: ByteSized::B64,
         } => "LTIME",
         IntermediateType::String { .. } => "STRING",
-        _ => return Err(Diagnostic::todo(file!(), line!())),
+        _ => return Err(Diagnostic::todo()),
     };
     Ok(Id::from(name))
 }
@@ -870,7 +864,7 @@ pub(crate) fn flatten_array_initial_values(
                 result.push(value.clone());
             }
             ArrayInitialElementKind::EnumValue(_) => {
-                return Err(Diagnostic::todo(file!(), line!()));
+                return Err(Diagnostic::todo());
             }
             ArrayInitialElementKind::Repeated(repeated) => {
                 let count = repeated.size.value as usize;

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -369,7 +369,7 @@ fn compile_generic_builtin(
 ) -> Result<(), Diagnostic> {
     let func_name = func.name.original().to_uppercase();
     let func_id = lookup_builtin(&func_name, op_type.0, op_type.1)
-        .ok_or_else(|| Diagnostic::todo_with_span(func.name.span(), file!(), line!()))?;
+        .ok_or_else(|| Diagnostic::todo_with_span(func.name.span()))?;
 
     let expected_args = opcode::builtin::arg_count(func_id) as usize;
 
@@ -383,11 +383,7 @@ fn compile_generic_builtin(
         .collect();
 
     if args.len() != expected_args {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let is_sel = func_name == "SEL";
@@ -428,11 +424,7 @@ fn compile_two_arg_operator(
         .collect();
 
     if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     compile_expr(emitter, ctx, args[0], op_type)?;
@@ -453,11 +445,7 @@ fn extract_two_positional_args(func: &Function) -> Result<(&Expr, &Expr), Diagno
         .collect();
 
     if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     Ok((args[0], args[1]))
@@ -524,11 +512,7 @@ fn compile_dt_to_date(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let op_type = (OpWidth::W32, Signedness::Unsigned);
@@ -565,11 +549,7 @@ fn compile_dt_to_tod(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let op_type = (OpWidth::W32, Signedness::Unsigned);
@@ -678,11 +658,7 @@ fn compile_not_function(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     compile_expr(emitter, ctx, args[0], op_type)?;
@@ -710,11 +686,7 @@ fn compile_move(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     compile_expr(emitter, ctx, args[0], op_type)?;
@@ -744,11 +716,7 @@ fn compile_trunc(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     // Determine the argument's float type from its resolved type.
@@ -800,11 +768,7 @@ fn compile_sizeof(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     // Check if the argument is a variable that maps to an array.
@@ -832,9 +796,8 @@ fn sizeof_from_resolved_type(expr: &Expr) -> Result<u32, Diagnostic> {
     let resolved = expr
         .resolved_type
         .as_ref()
-        .ok_or_else(|| Diagnostic::todo(file!(), line!()))?;
-    let info =
-        resolve_type_name(&resolved.name).ok_or_else(|| Diagnostic::todo(file!(), line!()))?;
+        .ok_or_else(|| Diagnostic::todo())?;
+    let info = resolve_type_name(&resolved.name).ok_or_else(|| Diagnostic::todo())?;
     // Ceiling division: types like BOOL (1 bit) still occupy 1 byte.
     Ok((info.storage_bits as u32).div_ceil(8))
 }
@@ -859,11 +822,7 @@ fn compile_bcd_to_int(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let arg_op_type = op_type(args[0])?;
@@ -875,13 +834,7 @@ fn compile_bcd_to_int(
         16 => opcode::builtin::BCD_TO_INT_16,
         32 => opcode::builtin::BCD_TO_INT_32,
         64 => opcode::builtin::BCD_TO_INT_64,
-        _ => {
-            return Err(Diagnostic::todo_with_span(
-                func.name.span(),
-                file!(),
-                line!(),
-            ))
-        }
+        _ => return Err(Diagnostic::todo_with_span(func.name.span())),
     };
     emitter.emit_builtin(func_id);
     Ok(())
@@ -907,11 +860,7 @@ fn compile_int_to_bcd(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let arg_op_type = op_type(args[0])?;
@@ -928,13 +877,7 @@ fn compile_int_to_bcd(
             match target_op_type.0 {
                 OpWidth::W32 => opcode::builtin::INT_TO_BCD_32,
                 OpWidth::W64 => opcode::builtin::INT_TO_BCD_64,
-                _ => {
-                    return Err(Diagnostic::todo_with_span(
-                        func.name.span(),
-                        file!(),
-                        line!(),
-                    ))
-                }
+                _ => return Err(Diagnostic::todo_with_span(func.name.span())),
             }
         }
     };
@@ -966,21 +909,13 @@ fn compile_mux(
 
     // Must have at least 3 args (K + 2 IN values)
     if args.len() < 3 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let num_inputs = (args.len() - 1) as u16; // subtract K
 
     if num_inputs > opcode::builtin::MUX_MAX_INPUTS {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let base = match op_type.0 {
@@ -1039,11 +974,7 @@ pub(crate) fn compile_type_conversion(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     compile_expr(emitter, ctx, args[0], source_op_type)?;
@@ -1056,11 +987,7 @@ pub(crate) fn compile_type_conversion(
             OpWidth::W32 => emitter.emit_builtin(opcode::builtin::CONV_I32_TO_BOOL),
             OpWidth::W64 => emitter.emit_builtin(opcode::builtin::CONV_I64_TO_BOOL),
             _ => {
-                return Err(Diagnostic::todo_with_span(
-                    func.name.span(),
-                    file!(),
-                    line!(),
-                ));
+                return Err(Diagnostic::todo_with_span(func.name.span()));
             }
         }
     } else {
@@ -1154,11 +1081,7 @@ fn compile_shift_rotate(
         .collect();
 
     if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     // Compile IN (value) with the inferred op_type
@@ -1190,13 +1113,7 @@ fn compile_shift_rotate(
             16 => opcode::builtin::ROR_U16,
             _ => opcode::builtin::ROR_I32,
         },
-        _ => {
-            return Err(Diagnostic::todo_with_span(
-                func.name.span(),
-                file!(),
-                line!(),
-            ))
-        }
+        _ => return Err(Diagnostic::todo_with_span(func.name.span())),
     };
 
     emitter.emit_builtin(func_id);
@@ -1356,11 +1273,7 @@ pub(crate) fn compile_string_conversion(
 ) -> Result<(), Diagnostic> {
     let args = collect_positional_args(func);
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     match conv {
@@ -1373,11 +1286,7 @@ pub(crate) fn compile_string_conversion(
                 (OpWidth::W32, Signedness::Unsigned) => opcode::builtin::CONV_U32_TO_STR,
                 (OpWidth::F32, _) => opcode::builtin::CONV_F32_TO_STR,
                 _ => {
-                    return Err(Diagnostic::todo_with_span(
-                        func.name.span(),
-                        file!(),
-                        line!(),
-                    ));
+                    return Err(Diagnostic::todo_with_span(func.name.span()));
                 }
             };
             emitter.emit_builtin(func_id);
@@ -1393,11 +1302,7 @@ pub(crate) fn compile_string_conversion(
                 OpWidth::W32 => opcode::builtin::CONV_STR_TO_I32,
                 OpWidth::F32 => opcode::builtin::CONV_STR_TO_F32,
                 _ => {
-                    return Err(Diagnostic::todo_with_span(
-                        func.name.span(),
-                        file!(),
-                        line!(),
-                    ));
+                    return Err(Diagnostic::todo_with_span(func.name.span()));
                 }
             };
             emitter.emit_builtin(func_id);

--- a/compiler/codegen/src/compile_expr.rs
+++ b/compiler/codegen/src/compile_expr.rs
@@ -34,7 +34,7 @@ pub(crate) fn op_type(expr: &Expr) -> Result<OpType, Diagnostic> {
     let resolved = expr
         .resolved_type
         .as_ref()
-        .ok_or_else(|| Diagnostic::todo(file!(), line!()))?;
+        .ok_or_else(|| Diagnostic::todo())?;
     // Enum types resolve to user-defined names (e.g. "COLOR") which
     // resolve_type_name doesn't handle. Fall back to DINT since all
     // enums use W32/Signed at codegen level (REQ-EN-codegen-003).
@@ -86,9 +86,8 @@ pub(crate) fn storage_bits(expr: &Expr) -> Result<u8, Diagnostic> {
     let resolved = expr
         .resolved_type
         .as_ref()
-        .ok_or_else(|| Diagnostic::todo(file!(), line!()))?;
-    let info =
-        resolve_type_name(&resolved.name).ok_or_else(|| Diagnostic::todo(file!(), line!()))?;
+        .ok_or_else(|| Diagnostic::todo())?;
+    let info = resolve_type_name(&resolved.name).ok_or_else(|| Diagnostic::todo())?;
     Ok(info.storage_bits)
 }
 
@@ -383,7 +382,7 @@ pub(crate) fn compile_constant(
                 emitter.emit_load_const_f64(pool_index);
                 Ok(())
             }
-            _ => Err(Diagnostic::todo(file!(), line!())),
+            _ => Err(Diagnostic::todo()),
         },
         ConstantKind::Boolean(lit) => {
             match lit.value {
@@ -852,11 +851,7 @@ pub(crate) fn resolve_symbolic_variable_name(
         // table. Giving it a receiver-pointer parameter is the codegen
         // slice that also owns method-call codegen; until then this is an
         // error, never a guess at some enclosing name.
-        SymbolicVariableKind::SelfRef(self_ref) => Err(Diagnostic::todo_with_span(
-            self_ref.span(),
-            file!(),
-            line!(),
-        )),
+        SymbolicVariableKind::SelfRef(self_ref) => Err(Diagnostic::todo_with_span(self_ref.span())),
     }
 }
 
@@ -868,36 +863,20 @@ pub(crate) fn resolve_variable(
     match variable {
         Variable::Symbolic(symbolic) => match symbolic {
             SymbolicVariableKind::Named(named) => ctx.var_index(&named.name),
-            SymbolicVariableKind::Array(array) => {
-                Err(Diagnostic::todo_with_span(array.span(), file!(), line!()))
+            SymbolicVariableKind::Array(array) => Err(Diagnostic::todo_with_span(array.span())),
+            SymbolicVariableKind::Structured(structured) => {
+                Err(Diagnostic::todo_with_span(structured.span()))
             }
-            SymbolicVariableKind::Structured(structured) => Err(Diagnostic::todo_with_span(
-                structured.span(),
-                file!(),
-                line!(),
-            )),
-            SymbolicVariableKind::BitAccess(bit_access) => Err(Diagnostic::todo_with_span(
-                bit_access.span(),
-                file!(),
-                line!(),
-            )),
-            SymbolicVariableKind::PartialAccess(pa) => {
-                Err(Diagnostic::todo_with_span(pa.span(), file!(), line!()))
+            SymbolicVariableKind::BitAccess(bit_access) => {
+                Err(Diagnostic::todo_with_span(bit_access.span()))
             }
-            SymbolicVariableKind::Deref(deref) => {
-                Err(Diagnostic::todo_with_span(deref.span(), file!(), line!()))
+            SymbolicVariableKind::PartialAccess(pa) => Err(Diagnostic::todo_with_span(pa.span())),
+            SymbolicVariableKind::Deref(deref) => Err(Diagnostic::todo_with_span(deref.span())),
+            SymbolicVariableKind::SelfRef(self_ref) => {
+                Err(Diagnostic::todo_with_span(self_ref.span()))
             }
-            SymbolicVariableKind::SelfRef(self_ref) => Err(Diagnostic::todo_with_span(
-                self_ref.span(),
-                file!(),
-                line!(),
-            )),
         },
-        Variable::Direct(direct) => Err(Diagnostic::todo_with_span(
-            direct.position.clone(),
-            file!(),
-            line!(),
-        )),
+        Variable::Direct(direct) => Err(Diagnostic::todo_with_span(direct.position.clone())),
     }
 }
 

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -285,7 +285,7 @@ pub(crate) fn compile_user_function(
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
-                .ok_or_else(|| Diagnostic::todo(file!(), line!()))?;
+                .ok_or_else(|| Diagnostic::todo())?;
 
             if max_length > ctx.max_string_capacity {
                 ctx.max_string_capacity = max_length;

--- a/compiler/codegen/src/compile_setup.rs
+++ b/compiler/codegen/src/compile_setup.rs
@@ -272,7 +272,7 @@ pub(crate) fn assign_variables(
                 InitialValueAssignmentKind::LateResolvedType(_) => {
                     // LateResolvedType should have been resolved before codegen.
                     // If we reach here, it indicates a bug in the compiler.
-                    return Err(Diagnostic::internal_error(file!(), line!()));
+                    return Err(Diagnostic::internal_error());
                 }
                 // Other initializer kinds (EnumeratedValues, etc.)
                 // do not yet have type info tracked in codegen.

--- a/compiler/codegen/src/compile_stmt.rs
+++ b/compiler/codegen/src/compile_stmt.rs
@@ -41,7 +41,7 @@ pub(crate) fn compile_body(
             compile_statements(emitter, ctx, statements)
         }
         FunctionBlockBodyKind::Empty => Ok(()),
-        FunctionBlockBodyKind::Sfc(_) => Err(Diagnostic::todo(file!(), line!())),
+        FunctionBlockBodyKind::Sfc(_) => Err(Diagnostic::todo()),
     }
 }
 
@@ -110,7 +110,7 @@ fn compile_statement(
                 let target_name = resolve_variable_name(&assignment.target);
                 let target_index = target_name
                     .and_then(|name| ctx.variables.get(name).copied())
-                    .ok_or_else(|| Diagnostic::todo(file!(), line!()))?;
+                    .ok_or_else(|| Diagnostic::todo())?;
 
                 // Compile the value expression (use DEFAULT_OP_TYPE; the referenced
                 // type determines the actual width at runtime).
@@ -441,11 +441,7 @@ fn compile_statement(
             // specs/plans/2026-08-12-oop-method-declarations-static-dispatch.md.
             // Parsing, resolution, and diagnostics already work; only
             // execution is not yet implemented.
-            Err(Diagnostic::todo_with_span(
-                method_call.position.clone(),
-                file!(),
-                line!(),
-            ))
+            Err(Diagnostic::todo_with_span(method_call.position.clone()))
         }
         StmtKind::If(if_stmt) => compile_if(emitter, ctx, if_stmt),
         StmtKind::Case(case_stmt) => compile_case(emitter, ctx, case_stmt),
@@ -513,7 +509,7 @@ fn compile_fb_call(
     let fb_info = ctx
         .fb_instances
         .get(&fb_call.var_name)
-        .ok_or_else(|| Diagnostic::todo_with_span(fb_call.span(), file!(), line!()))?;
+        .ok_or_else(|| Diagnostic::todo_with_span(fb_call.span()))?;
     let type_id = fb_info.type_id;
     let field_indices = fb_info.field_indices.clone();
     let var_index = fb_info.var_index;
@@ -527,7 +523,7 @@ fn compile_fb_call(
             let field_name = input.name.to_string().to_lowercase();
             let field_idx = field_indices
                 .get(&field_name)
-                .ok_or_else(|| Diagnostic::todo_with_span(input.name.span(), file!(), line!()))?;
+                .ok_or_else(|| Diagnostic::todo_with_span(input.name.span()))?;
             let op_type = resolve_fb_field_op_type(ctx, type_id, &field_name);
             compile_expr(emitter, ctx, &input.expr, op_type)?;
             emitter.emit_fb_store_param(*field_idx);
@@ -552,7 +548,7 @@ fn compile_fb_call(
             let field_name = output.src.to_string().to_lowercase();
             let field_idx = field_indices
                 .get(&field_name)
-                .ok_or_else(|| Diagnostic::todo_with_span(output.src.span(), file!(), line!()))?;
+                .ok_or_else(|| Diagnostic::todo_with_span(output.src.span()))?;
             emitter.emit_fb_load_param(*field_idx);
             let target_index = resolve_variable(ctx, &output.tgt)?;
             let op_type = resolve_fb_field_op_type(ctx, type_id, &field_name);
@@ -742,7 +738,7 @@ fn compile_case_selector(
                     emitter.emit_eq_i64();
                 }
                 // CASE with float types is not meaningful in IEC 61131-3.
-                _ => return Err(Diagnostic::todo(file!(), line!())),
+                _ => return Err(Diagnostic::todo()),
             }
             Ok(())
         }
@@ -779,7 +775,7 @@ fn compile_case_selector(
                     emit_le(emitter, op_type);
                 }
                 // CASE with float types is not meaningful in IEC 61131-3.
-                _ => return Err(Diagnostic::todo(file!(), line!())),
+                _ => return Err(Diagnostic::todo()),
             }
 
             emitter.emit_bool_and();
@@ -827,7 +823,7 @@ fn compile_case_selector(
                     emitter.emit_eq_i64();
                 }
                 // CASE with float types is not meaningful in IEC 61131-3.
-                _ => return Err(Diagnostic::todo(file!(), line!())),
+                _ => return Err(Diagnostic::todo()),
             }
             Ok(())
         }
@@ -843,7 +839,7 @@ pub(crate) fn resolve_string_max_length(
     match &string_init.length {
         None => Ok(DEFAULT_STRING_MAX_LENGTH_U16),
         Some(IntegerRef::Literal(i)) => Ok(i.value as u16),
-        Some(IntegerRef::Constant(id)) => Err(Diagnostic::todo_with_id(id, file!(), line!())),
+        Some(IntegerRef::Constant(id)) => Err(Diagnostic::todo_with_id(id)),
     }
 }
 
@@ -856,7 +852,7 @@ pub(crate) fn resolve_string_spec_max_length(
     match &spec.length {
         None => Ok(DEFAULT_STRING_MAX_LENGTH_U16),
         Some(IntegerRef::Literal(i)) => Ok(i.value as u16),
-        Some(IntegerRef::Constant(id)) => Err(Diagnostic::todo_with_id(id, file!(), line!())),
+        Some(IntegerRef::Constant(id)) => Err(Diagnostic::todo_with_id(id)),
     }
 }
 
@@ -865,7 +861,7 @@ pub(crate) fn resolve_string_spec_max_length(
 fn resolve_signed_integer_ref(sir: &SignedIntegerRef) -> Result<&SignedInteger, Diagnostic> {
     match sir {
         SignedIntegerRef::Literal(si) => Ok(si),
-        SignedIntegerRef::Constant(id) => Err(Diagnostic::todo_with_id(id, file!(), line!())),
+        SignedIntegerRef::Constant(id) => Err(Diagnostic::todo_with_id(id)),
     }
 }
 

--- a/compiler/codegen/src/compile_string.rs
+++ b/compiler/codegen/src/compile_string.rs
@@ -38,11 +38,7 @@ pub(crate) fn compile_len(
         .collect();
 
     if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     // The argument must be a string variable so we can look up its data_offset.
@@ -51,13 +47,12 @@ pub(crate) fn compile_len(
         _ => None,
     };
 
-    let name =
-        var_name.ok_or_else(|| Diagnostic::todo_with_span(func.name.span(), file!(), line!()))?;
+    let name = var_name.ok_or_else(|| Diagnostic::todo_with_span(func.name.span()))?;
 
     let info = ctx
         .string_vars
         .get(name)
-        .ok_or_else(|| Diagnostic::todo_with_span(func.name.span(), file!(), line!()))?;
+        .ok_or_else(|| Diagnostic::todo_with_span(func.name.span()))?;
 
     emitter.emit_len_str(info.data_offset);
     Ok(())
@@ -95,7 +90,7 @@ pub(crate) fn compile_string_compare(
         CompareOp::LtEq => emitter.emit_le_i32(),
         CompareOp::GtEq => emitter.emit_ge_i32(),
         _ => {
-            return Err(Diagnostic::todo_with_span(span, file!(), line!()));
+            return Err(Diagnostic::todo_with_span(span));
         }
     }
     Ok(())
@@ -128,7 +123,7 @@ pub(crate) fn resolve_string_arg(
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
-                .ok_or_else(|| Diagnostic::todo_with_span(func_span.clone(), file!(), line!()))?;
+                .ok_or_else(|| Diagnostic::todo_with_span(func_span.clone()))?;
 
             if max_length > ctx.max_string_capacity {
                 ctx.max_string_capacity = max_length;
@@ -151,7 +146,7 @@ pub(crate) fn resolve_string_arg(
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
-                .ok_or_else(|| Diagnostic::todo_with_span(func_span.clone(), file!(), line!()))?;
+                .ok_or_else(|| Diagnostic::todo_with_span(func_span.clone()))?;
 
             if max_length > ctx.max_string_capacity {
                 ctx.max_string_capacity = max_length;
@@ -177,7 +172,7 @@ pub(crate) fn resolve_string_arg(
             ctx.data_region_offset = ctx
                 .data_region_offset
                 .checked_add(total_bytes)
-                .ok_or_else(|| Diagnostic::todo_with_span(func_span.clone(), file!(), line!()))?;
+                .ok_or_else(|| Diagnostic::todo_with_span(func_span.clone()))?;
 
             if max_length > ctx.max_string_capacity {
                 ctx.max_string_capacity = max_length;
@@ -218,11 +213,7 @@ pub(crate) fn compile_find(
     let args = collect_positional_args(func);
 
     if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let in1_offset = resolve_string_arg(emitter, ctx, args[0], &func.name.span())?;
@@ -246,11 +237,7 @@ pub(crate) fn compile_replace(
     let args = collect_positional_args(func);
 
     if args.len() != 4 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let in1_offset = resolve_string_arg(emitter, ctx, args[0], &func.name.span())?;
@@ -281,11 +268,7 @@ pub(crate) fn compile_insert(
     let args = collect_positional_args(func);
 
     if args.len() != 3 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let in1_offset = resolve_string_arg(emitter, ctx, args[0], &func.name.span())?;
@@ -316,11 +299,7 @@ fn compile_string_2arg(
     let args = collect_positional_args(func);
 
     if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let in_offset = resolve_string_arg(emitter, ctx, args[0], &func.name.span())?;
@@ -348,11 +327,7 @@ fn compile_string_3arg(
     let args = collect_positional_args(func);
 
     if args.len() != 3 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let in_offset = resolve_string_arg(emitter, ctx, args[0], &func.name.span())?;
@@ -429,11 +404,7 @@ pub(crate) fn compile_concat(
     let args = collect_positional_args(func);
 
     if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(
-            func.name.span(),
-            file!(),
-            line!(),
-        ));
+        return Err(Diagnostic::todo_with_span(func.name.span()));
     }
 
     let in1_offset = resolve_string_arg(emitter, ctx, args[0], &func.name.span())?;

--- a/compiler/codegen/src/compile_struct.rs
+++ b/compiler/codegen/src/compile_struct.rs
@@ -305,7 +305,7 @@ pub(crate) fn walk_struct_chain(
             ))
         }
         // Array access within struct chain handled in PR 8
-        _ => Err(Diagnostic::todo_with_span(record.span(), file!(), line!())),
+        _ => Err(Diagnostic::todo_with_span(record.span())),
     }
 }
 

--- a/compiler/dsl/src/diagnostic.rs
+++ b/compiler/dsl/src/diagnostic.rs
@@ -140,6 +140,12 @@ pub struct Diagnostic {
     pub source_line: Option<u32>,
 }
 
+/// Formats the label message for a "not implemented" diagnostic from the
+/// compiler location that produced it.
+fn not_implemented_message(caller: &std::panic::Location<'_>) -> String {
+    format!("Not implemented at {}#L{}", caller.file(), caller.line())
+}
+
 impl Diagnostic {
     /// Creates a diagnostic from the problem code and with the specified label.
     ///
@@ -163,16 +169,18 @@ impl Diagnostic {
     ///
     /// Unlike other uses of problem, the location in this is related to the compiler
     /// rather than the IEC 61131-3 source.
+    ///
+    /// The location is captured via `#[track_caller]`, so no `file!()`/`line!()`
+    /// need to be passed.
+    #[track_caller]
     #[allow(deprecated)]
-    pub fn todo(file: &str, line: u32) -> Self {
+    pub fn todo() -> Self {
+        let caller = std::panic::Location::caller();
         Diagnostic::problem(
             Problem::NotImplemented,
-            Label::span(
-                SourceSpan::default(),
-                format!("Not implemented at {file}#L{line}"),
-            ),
+            Label::span(SourceSpan::default(), not_implemented_message(caller)),
         )
-        .with_source(file, line)
+        .with_source(caller.file(), caller.line())
     }
 
     /// Creates a "todo" diagnostic associated with a file and line in the Rust
@@ -181,13 +189,18 @@ impl Diagnostic {
     ///
     /// Unlike other uses of problem, the location in this is related to the compiler
     /// rather than the IEC 61131-3 source.
+    ///
+    /// The location is captured via `#[track_caller]`, so no `file!()`/`line!()`
+    /// need to be passed.
+    #[track_caller]
     #[allow(deprecated)]
-    pub fn todo_with_id(id: &Id, file: &str, line: u32) -> Self {
+    pub fn todo_with_id(id: &Id) -> Self {
+        let caller = std::panic::Location::caller();
         Diagnostic::problem(
             Problem::NotImplemented,
-            Label::span(id.span(), format!("Not implemented at {file}#L{line}")),
+            Label::span(id.span(), not_implemented_message(caller)),
         )
-        .with_source(file, line)
+        .with_source(caller.file(), caller.line())
     }
 
     /// Creates a "todo" diagnostic associated with a file and line in the Rust
@@ -196,13 +209,18 @@ impl Diagnostic {
     ///
     /// Unlike other uses of problem, the location in this is related to the compiler
     /// rather than the IEC 61131-3 source.
+    ///
+    /// The location is captured via `#[track_caller]`, so no `file!()`/`line!()`
+    /// need to be passed.
+    #[track_caller]
     #[allow(deprecated)]
-    pub fn todo_with_type(ty: &TypeName, file: &str, line: u32) -> Self {
+    pub fn todo_with_type(ty: &TypeName) -> Self {
+        let caller = std::panic::Location::caller();
         Diagnostic::problem(
             Problem::NotImplemented,
-            Label::span(ty.span(), format!("Not implemented at {file}#L{line}")),
+            Label::span(ty.span(), not_implemented_message(caller)),
         )
-        .with_source(file, line)
+        .with_source(caller.file(), caller.line())
     }
 
     /// Creates a "todo" diagnostic associated with a file and line in the Rust
@@ -211,13 +229,18 @@ impl Diagnostic {
     ///
     /// Unlike other uses of problem, the location in this is related to the compiler
     /// rather than the IEC 61131-3 source.
+    ///
+    /// The location is captured via `#[track_caller]`, so no `file!()`/`line!()`
+    /// need to be passed.
+    #[track_caller]
     #[allow(deprecated)]
-    pub fn todo_with_span(span: SourceSpan, file: &str, line: u32) -> Self {
+    pub fn todo_with_span(span: SourceSpan) -> Self {
+        let caller = std::panic::Location::caller();
         Diagnostic::problem(
             Problem::NotImplemented,
-            Label::span(span, format!("Not implemented at {file}#L{line}")),
+            Label::span(span, not_implemented_message(caller)),
         )
-        .with_source(file, line)
+        .with_source(caller.file(), caller.line())
     }
 
     /// Creates a P9999 (NotImplemented) diagnostic that automatically records
@@ -244,16 +267,25 @@ impl Diagnostic {
     ///
     /// Unlike other uses of problem, the location in this is related to the compiler
     /// rather than the IEC 61131-3 source.
+    ///
+    /// The location is captured via `#[track_caller]`, so no `file!()`/`line!()`
+    /// need to be passed.
+    #[track_caller]
     #[allow(deprecated)]
-    pub fn internal_error(file: &str, line: u32) -> Self {
+    pub fn internal_error() -> Self {
+        let caller = std::panic::Location::caller();
         Diagnostic::problem(
             Problem::InternalError,
             Label::span(
                 SourceSpan::default(),
-                format!("Internal error at {file}#L{line} indicates a bug in the compiler"),
+                format!(
+                    "Internal error at {}#L{} indicates a bug in the compiler",
+                    caller.file(),
+                    caller.line()
+                ),
             ),
         )
-        .with_source(file, line)
+        .with_source(caller.file(), caller.line())
     }
 
     /// Creates a P9998 (InternalError) diagnostic that automatically records
@@ -261,8 +293,8 @@ impl Diagnostic {
     /// letting the caller supply a descriptive primary label.
     ///
     /// Prefer this over `Diagnostic::problem(Problem::InternalError, …)` (which
-    /// no longer compiles). Use `internal_error(file, line)` instead when no
-    /// custom label is needed.
+    /// no longer compiles). Use `internal_error()` instead when no custom label
+    /// is needed.
     ///
     /// The location is captured via `#[track_caller]`, so no `file!()`/`line!()`
     /// need to be passed.
@@ -387,43 +419,56 @@ mod tests {
 
     #[test]
     fn todo_when_called_then_creates_not_implemented_diagnostic() {
-        let diag = Diagnostic::todo("test.rs", 42);
+        let line = line!() + 1;
+        let diag = Diagnostic::todo();
         assert_eq!(diag.code, "P9999");
-        assert!(diag.primary.message.contains("test.rs"));
-        assert!(diag.source_file.is_some());
-        assert_eq!(diag.source_line, Some(42));
+        assert!(diag.primary.message.contains(file!()));
+        assert_eq!(diag.source_file.as_deref(), Some(file!()));
+        assert_eq!(diag.source_line, Some(line));
     }
 
     #[test]
     fn todo_with_id_when_called_then_includes_id_location() {
         let id = Id::from("my_var");
-        let diag = Diagnostic::todo_with_id(&id, "foo.rs", 10);
+        let line = line!() + 1;
+        let diag = Diagnostic::todo_with_id(&id);
         assert_eq!(diag.code, "P9999");
-        assert!(diag.primary.message.contains("foo.rs"));
+        assert!(diag.primary.message.contains(file!()));
+        assert_eq!(diag.source_file.as_deref(), Some(file!()));
+        assert_eq!(diag.source_line, Some(line));
     }
 
     #[test]
     fn todo_with_type_when_called_then_includes_type_location() {
         let ty = TypeName::from("MY_TYPE");
-        let diag = Diagnostic::todo_with_type(&ty, "bar.rs", 20);
+        let line = line!() + 1;
+        let diag = Diagnostic::todo_with_type(&ty);
         assert_eq!(diag.code, "P9999");
-        assert!(diag.primary.message.contains("bar.rs"));
+        assert!(diag.primary.message.contains(file!()));
+        assert_eq!(diag.source_file.as_deref(), Some(file!()));
+        assert_eq!(diag.source_line, Some(line));
     }
 
     #[test]
     fn todo_with_span_when_called_then_includes_span() {
         let span = SourceSpan::default();
-        let diag = Diagnostic::todo_with_span(span, "baz.rs", 30);
+        let line = line!() + 1;
+        let diag = Diagnostic::todo_with_span(span);
         assert_eq!(diag.code, "P9999");
-        assert!(diag.primary.message.contains("baz.rs"));
+        assert!(diag.primary.message.contains(file!()));
+        assert_eq!(diag.source_file.as_deref(), Some(file!()));
+        assert_eq!(diag.source_line, Some(line));
     }
 
     #[test]
     fn internal_error_when_called_then_creates_diagnostic() {
-        let diag = Diagnostic::internal_error("err.rs", 99);
+        let line = line!() + 1;
+        let diag = Diagnostic::internal_error();
         assert_eq!(diag.code, "P9998");
-        assert!(diag.primary.message.contains("err.rs"));
+        assert!(diag.primary.message.contains(file!()));
         assert!(diag.primary.message.contains("bug in the compiler"));
+        assert_eq!(diag.source_file.as_deref(), Some(file!()));
+        assert_eq!(diag.source_line, Some(line));
     }
 
     #[test]

--- a/compiler/mcp/src/tools/compile.rs
+++ b/compiler/mcp/src/tools/compile.rs
@@ -131,7 +131,7 @@ pub fn build_response(
     // compile guarantees both.
     let (Some(library), Some(context)) = (project.analyzed_library(), project.semantic_context())
     else {
-        let err = Diagnostic::internal_error(file!(), line!());
+        let err = Diagnostic::internal_error();
         diagnostics.push(serialize_diagnostic(&err));
         return CompileResponse {
             ok: false,

--- a/compiler/playground/src/lib.rs
+++ b/compiler/playground/src/lib.rs
@@ -232,7 +232,7 @@ fn internal_run_error(message: String) -> RunError {
     let loc = std::panic::Location::caller();
     // Derive the stable code from the shared diagnostic constructor rather than
     // hard-coding "P9998", so it tracks the compiler's internal-error code.
-    let code = Diagnostic::internal_error(loc.file(), loc.line()).code;
+    let code = Diagnostic::internal_error().code;
     RunError {
         message,
         code: Some(code),
@@ -255,7 +255,7 @@ fn fallback_error_json(err: &RunError) -> String {
 #[track_caller]
 fn internal_diagnostic(message: String) -> DiagnosticInfo {
     let loc = std::panic::Location::caller();
-    let code = Diagnostic::internal_error(loc.file(), loc.line()).code;
+    let code = Diagnostic::internal_error().code;
     DiagnosticInfo {
         code,
         message,

--- a/compiler/project/src/compile.rs
+++ b/compiler/project/src/compile.rs
@@ -80,7 +80,7 @@ pub fn compile(
     else {
         // A clean analysis always caches its artifacts, so this is a compiler
         // defect rather than a problem with the input.
-        diagnostics.push(Diagnostic::internal_error(file!(), line!()));
+        diagnostics.push(Diagnostic::internal_error());
         return CompileOutput {
             diagnostics,
             container: None,

--- a/compiler/sources/src/source.rs
+++ b/compiler/sources/src/source.rs
@@ -100,7 +100,7 @@ impl Source {
             },
             None => {
                 // This should not be possible to reach since we set self.library above
-                Err(vec![Diagnostic::internal_error(file!(), line!())])
+                Err(vec![Diagnostic::internal_error()])
             }
         }
     }

--- a/compiler/sources/src/xml/transform.rs
+++ b/compiler/sources/src/xml/transform.rs
@@ -378,9 +378,9 @@ fn transform_data_type(data_type: &DataType, file_id: &FileId) -> Result<TypeNam
         DataType::Derived(derived) => Ok(make_type_name(&derived.name, file_id)),
 
         // Complex types that need context
-        DataType::Array(_) => Err(Diagnostic::todo(file!(), line!())),
-        DataType::Enum(_) => Err(Diagnostic::todo(file!(), line!())),
-        DataType::Struct(_) => Err(Diagnostic::todo(file!(), line!())),
+        DataType::Array(_) => Err(Diagnostic::todo()),
+        DataType::Enum(_) => Err(Diagnostic::todo()),
+        DataType::Struct(_) => Err(Diagnostic::todo()),
 
         // Generic types (usually for library functions)
         DataType::Any => Ok(TypeName::from("ANY")),
@@ -395,10 +395,8 @@ fn transform_data_type(data_type: &DataType, file_id: &FileId) -> Result<TypeNam
         DataType::AnyDate => Ok(TypeName::from("ANY_DATE")),
 
         // Subranges and pointers
-        DataType::SubrangeSigned(_) | DataType::SubrangeUnsigned(_) => {
-            Err(Diagnostic::todo(file!(), line!()))
-        }
-        DataType::Pointer(_) => Err(Diagnostic::todo(file!(), line!())),
+        DataType::SubrangeSigned(_) | DataType::SubrangeUnsigned(_) => Err(Diagnostic::todo()),
+        DataType::Pointer(_) => Err(Diagnostic::todo()),
     }
 }
 

--- a/specs/steering/problem-code-management.md
+++ b/specs/steering/problem-code-management.md
@@ -264,8 +264,16 @@ return Err(Diagnostic::internal_error_at(Label::span(
 )));
 
 // Internal error with the generic message (no custom label):
-return Err(Diagnostic::internal_error(file!(), line!()));
+return Err(Diagnostic::internal_error());
+
+// Unimplemented capability with the generic message; the `todo_with_*`
+// variants attach an IEC 61131-3 span (id, type name or span):
+return Err(Diagnostic::todo());
+return Err(Diagnostic::todo_with_span(span.clone()));
 ```
+
+None of these constructors take `file!()`/`line!()` — they are `#[track_caller]`
+and record the call site themselves.
 
 
 ### Error Message Guidelines


### PR DESCRIPTION
`Diagnostic::todo`, `todo_with_id`, `todo_with_type`, `todo_with_span` and
`internal_error` each required the caller to pass `file!(), line!()` so the
compiler location could be recorded for the P9998/P9999 telemetry
dashboards. Mark them `#[track_caller]` and read
`std::panic::Location::caller()` instead, matching what `not_implemented`
and `internal_error_at` already do.

This removes the `file!(), line!()` argument pair from roughly 100 call
sites, most of which collapse back to a single line.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018TYrJozHdukLPKKv8FrWwh