### PR TITLE
Support top-level ARRAY OF <struct> variables (issue #1383)

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -762,6 +762,7 @@ fn compile_program_with_functions(
         ctx.string_vars = saved_scope.string_vars;
         ctx.array_vars = saved_scope.array_vars;
         ctx.struct_vars = saved_scope.struct_vars;
+        ctx.struct_array_vars = saved_scope.struct_array_vars;
         ctx.fb_instances = saved_scope.fb_instances;
     }
 
@@ -1037,6 +1038,7 @@ pub(crate) struct SavedFbScope {
     pub(crate) string_vars: HashMap<Id, StringVarInfo>,
     pub(crate) array_vars: HashMap<Id, crate::compile_array::ArrayVarInfo>,
     pub(crate) struct_vars: HashMap<Id, crate::compile_struct::StructVarInfo>,
+    pub(crate) struct_array_vars: HashMap<Id, crate::compile_array_struct::StructArrayVarInfo>,
     pub(crate) fb_instances: HashMap<Id, FbInstanceInfo>,
 }
 
@@ -1121,6 +1123,9 @@ pub(crate) struct CompileContext {
     pub(crate) array_vars: HashMap<Id, crate::compile_array::ArrayVarInfo>,
     /// Maps structure variable identifiers to their metadata.
     pub(crate) struct_vars: HashMap<Id, crate::compile_struct::StructVarInfo>,
+    /// Maps top-level `ARRAY OF <struct>` variable identifiers to their metadata.
+    /// Kept apart from `array_vars`, whose elements occupy a single slot each.
+    pub(crate) struct_array_vars: HashMap<Id, crate::compile_array_struct::StructArrayVarInfo>,
     /// Pre-computed ordinal mappings for named enumeration types.
     pub(crate) enum_map: crate::compile_enum::EnumOrdinalMap,
     /// Next available byte offset in the data region.
@@ -1192,6 +1197,7 @@ impl CompileContext {
             fb_instances: HashMap::new(),
             array_vars: HashMap::new(),
             struct_vars: HashMap::new(),
+            struct_array_vars: HashMap::new(),
             data_region_offset: 0,
             max_string_capacity: 0,
             has_wide_string: false,

--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -411,7 +411,12 @@ pub(crate) fn array_spec_for_declaration(
                 dimensions,
             } = array_type
             else {
-                unreachable!("resolve_array_type guarantees Array variant");
+                // `resolve_array_type` returns only the Array variant, so this
+                // is a compiler invariant rather than anything the program did.
+                return Err(Diagnostic::internal_error_at(Label::span(
+                    type_name.span(),
+                    "Array type resolved to a non-array representation",
+                )));
             };
             array_spec_from_named(element_type, dimensions)
         }

--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -208,6 +208,17 @@ pub(crate) fn resolve_access<'ctx, 'ast>(
                     SymbolicVariableKind::Structured(structured) => {
                         levels.reverse();
                         let all_subscripts: Vec<&Expr> = levels.into_iter().flatten().collect();
+                        // `a[i].values[j]` -- the record is itself an array
+                        // element, so the subscripts collected here index the
+                        // *field*, and the element index is still inside the
+                        // record. The array-of-struct path combines the two.
+                        if matches!(structured.record.as_ref(), SymbolicVariableKind::Array(_)) {
+                            return crate::compile_array_struct::resolve_struct_array_element_field(
+                                ctx,
+                                structured,
+                                all_subscripts,
+                            );
+                        }
                         return resolve_struct_field_array(ctx, structured, all_subscripts);
                     }
                     other => {
@@ -222,7 +233,11 @@ pub(crate) fn resolve_access<'ctx, 'ast>(
         Variable::Symbolic(SymbolicVariableKind::Structured(structured))
             if matches!(structured.record.as_ref(), SymbolicVariableKind::Array(_)) =>
         {
-            crate::compile_array_struct::resolve_struct_array_element_field(ctx, structured)
+            crate::compile_array_struct::resolve_struct_array_element_field(
+                ctx,
+                structured,
+                Vec::new(),
+            )
         }
         _ => {
             // Fall through to existing resolve_variable() for scalars.
@@ -403,8 +418,14 @@ pub(crate) fn array_spec_for_declaration(
             array_spec_from_inline(subranges, span)
         }
         ironplc_dsl::common::SpecificationKind::Named(type_name) => {
+            // The caller reaches this arm only for a declaration the type
+            // environment already resolved to an array, so a miss here is a
+            // compiler invariant rather than anything the program did.
             let array_type = types.resolve_array_type(type_name).ok_or_else(|| {
-                Diagnostic::not_implemented(Label::span(type_name.span(), "Unknown array type"))
+                Diagnostic::internal_error_at(Label::span(
+                    type_name.span(),
+                    "Array type is absent from the type environment",
+                ))
             })?;
             let IntermediateType::Array {
                 element_type,

--- a/compiler/codegen/src/compile_array.rs
+++ b/compiler/codegen/src/compile_array.rs
@@ -158,10 +158,22 @@ pub(crate) fn resolve_access<'ctx, 'ast>(
                     SymbolicVariableKind::Named(named) => {
                         levels.reverse();
                         let all_subscripts: Vec<&Expr> = levels.into_iter().flatten().collect();
-                        let info = ctx
-                            .array_vars
-                            .get(&named.name)
-                            .ok_or_else(|| Diagnostic::todo_with_span(named.name.span()))?;
+                        let info = ctx.array_vars.get(&named.name).ok_or_else(|| {
+                            // An element of an array of structures spans
+                            // several slots, so it has no single-value load or
+                            // store; only its fields are addressable.
+                            if ctx.struct_array_vars.contains_key(&named.name) {
+                                Diagnostic::not_implemented(Label::span(
+                                    named.name.span(),
+                                    format!(
+                                        "Whole-element access of '{}' -- select a field of the element instead",
+                                        named.name
+                                    ),
+                                ))
+                            } else {
+                                Diagnostic::todo_with_span(named.name.span())
+                            }
+                        })?;
                         return Ok(ResolvedAccess::ArrayElement {
                             info,
                             subscripts: all_subscripts,
@@ -210,7 +222,7 @@ pub(crate) fn resolve_access<'ctx, 'ast>(
         Variable::Symbolic(SymbolicVariableKind::Structured(structured))
             if matches!(structured.record.as_ref(), SymbolicVariableKind::Array(_)) =>
         {
-            resolve_struct_array_element_field(ctx, structured)
+            crate::compile_array_struct::resolve_struct_array_element_field(ctx, structured)
         }
         _ => {
             // Fall through to existing resolve_variable() for scalars.
@@ -306,158 +318,11 @@ pub(crate) fn resolve_struct_field_array<'ctx, 'ast>(
     })
 }
 
-/// Resolves a field selected from an element of an array-of-struct, e.g. the
-/// `Trigger` in `MyBay.Devices.MeterQRScanner[i].Trigger`.
-///
-/// Structures occupy a contiguous run of slots, so element `k` of an
-/// array-of-struct field starts at `field_offset + k * element_slots` and the
-/// leaf field sits a further compile-time `leaf_offset` into it:
-///
-/// ```text
-/// slot = field_offset + leaf_offset          (compile-time constant)
-///      + flat_index * element_slots          (runtime)
-/// ```
-///
-/// `emit_flat_index` already multiplies each subscript by its dimension
-/// stride, so scaling every stride by `element_slots` makes the emitted flat
-/// index a slot offset directly. That lets this reuse
-/// [`ResolvedAccess::StructFieldArrayElement`] unchanged -- no new opcode and
-/// no new emission path. Bounds checks are unaffected because they validate
-/// against the unscaled `lower_bound`/`size`.
-pub(crate) fn resolve_struct_array_element_field<'ctx, 'ast>(
-    ctx: &'ctx CompileContext,
-    structured: &'ast ironplc_dsl::textual::StructuredVariable,
-) -> Result<ResolvedAccess<'ctx, 'ast>, Diagnostic> {
-    let SymbolicVariableKind::Array(array_var) = structured.record.as_ref() else {
-        return Err(Diagnostic::todo_with_span(structured.span()));
-    };
-
-    // Collect subscript groups innermost-first, then reverse -- the same
-    // walk `resolve_access` performs for plain array chains.
-    let mut levels: Vec<&[Expr]> = Vec::new();
-    let mut current = array_var;
-    let base = loop {
-        levels.push(&current.subscripts);
-        match current.subscripted_variable.as_ref() {
-            SymbolicVariableKind::Array(inner) => current = inner,
-            SymbolicVariableKind::Structured(base) => break base,
-            other => {
-                // A top-level `ARRAY OF <struct>` variable reaches here. Those
-                // are rejected earlier, at declaration time, because
-                // `resolve_type_name` resolves only elementary element types.
-                return Err(Diagnostic::todo_with_span(other.span()));
-            }
-        }
-    };
-    levels.reverse();
-    let subscripts: Vec<&Expr> = levels.into_iter().flatten().collect();
-
-    let (root_name, field_slot_offset, field_type) =
-        crate::compile_struct::walk_struct_chain(ctx, &base.record, &base.field, 0)?;
-
-    let IntermediateType::Array {
-        element_type,
-        dimensions: array_dims,
-    } = &field_type
-    else {
-        return Err(Diagnostic::not_implemented(Label::span(
-            base.field.span(),
-            format!("Field '{}' is not an array type", base.field),
-        )));
-    };
-
-    let IntermediateType::Structure {
-        fields: element_fields,
-    } = element_type.as_ref()
-    else {
-        return Err(Diagnostic::not_implemented(Label::span(
-            structured.field.span(),
-            format!(
-                "Cannot select field '{}' -- array elements are not a structure type",
-                structured.field
-            ),
-        )));
-    };
-
-    let element_slots = element_type.slot_count().map_err(|_| {
-        Diagnostic::not_implemented(Label::span(
-            base.field.span(),
-            format!(
-                "Array element type of field '{}' is unsupported",
-                base.field
-            ),
-        ))
-    })?;
-
-    let (leaf_slot_offset, leaf_type) = crate::compile_struct::find_field_in_type(
-        element_fields,
-        &structured.field,
-        &structured.field.span(),
-    )?;
-
-    // A STRING leaf needs an element stride of `element_slots * 8`, which the
-    // 8-byte ArrayDescriptor cannot express (the VM derives a string array's
-    // stride from `element_extra`). Tracked separately; reject explicitly
-    // rather than emitting a wrong address.
-    if matches!(leaf_type, IntermediateType::String { .. }) {
-        return Err(Diagnostic::not_implemented(Label::span(
-            structured.field.span(),
-            format!(
-                "STRING field '{}' of an array-of-struct element is not yet supported",
-                structured.field
-            ),
-        )));
-    }
-
-    let element_op_type =
-        crate::compile_struct::resolve_field_op_type(&leaf_type).ok_or_else(|| {
-            Diagnostic::not_implemented(Label::span(
-                structured.field.span(),
-                format!(
-                    "Field '{}' of an array-of-struct element is composite (nested struct or array)",
-                    structured.field
-                ),
-            ))
-        })?;
-
-    let struct_info = ctx.struct_vars.get(&root_name).ok_or_else(|| {
-        Diagnostic::not_implemented(Label::span(
-            structured.span(),
-            format!("Variable '{}' is not a structure", root_name),
-        ))
-    })?;
-
-    // Scale strides so the emitted flat index counts slots, not elements.
-    let mut dimensions = dimensions_from_intermediate(array_dims);
-    for dim in &mut dimensions {
-        dim.stride = dim.stride.checked_mul(element_slots).ok_or_else(|| {
-            Diagnostic::not_implemented(Label::span(base.field.span(), "Array too large"))
-        })?;
-    }
-
-    let combined_offset = field_slot_offset
-        .raw()
-        .checked_add(leaf_slot_offset.raw())
-        .ok_or_else(|| {
-            Diagnostic::not_implemented(Label::span(base.field.span(), "Array too large"))
-        })?;
-
-    Ok(ResolvedAccess::StructFieldArrayElement {
-        var_index: struct_info.var_index,
-        desc_index: struct_info.desc_index,
-        field_slot_offset: SlotIndex::new(combined_offset),
-        dimensions,
-        subscripts,
-        element_op_type,
-        element_type: leaf_type,
-    })
-}
-
 /// Converts `ArrayDimension` bounds into `DimensionInfo` with computed strides.
 ///
 /// Strides follow row-major order: the last dimension has stride 1, each
 /// preceding dimension's stride is the product of all subsequent dimension sizes.
-fn dimensions_from_intermediate(dims: &[ArrayDimension]) -> Vec<DimensionInfo> {
+pub(crate) fn dimensions_from_intermediate(dims: &[ArrayDimension]) -> Vec<DimensionInfo> {
     let sizes: Vec<u32> = dims
         .iter()
         .map(|d| (d.upper as i64 - d.lower as i64 + 1).max(0) as u32)
@@ -521,6 +386,36 @@ pub(crate) fn array_spec_from_inline(
         string_max_len,
         string_char_width,
     })
+}
+
+/// Normalizes an array variable declaration -- inline or by named type -- into
+/// an [`ArraySpec`].
+///
+/// Element types that are structures are laid out differently and register
+/// through `compile_array_struct` instead; callers route those away first.
+pub(crate) fn array_spec_for_declaration(
+    types: &ironplc_analyzer::TypeEnvironment,
+    spec: &ironplc_dsl::common::SpecificationKind<ironplc_dsl::common::ArraySubranges>,
+    span: &SourceSpan,
+) -> Result<ArraySpec, Diagnostic> {
+    match spec {
+        ironplc_dsl::common::SpecificationKind::Inline(subranges) => {
+            array_spec_from_inline(subranges, span)
+        }
+        ironplc_dsl::common::SpecificationKind::Named(type_name) => {
+            let array_type = types.resolve_array_type(type_name).ok_or_else(|| {
+                Diagnostic::not_implemented(Label::span(type_name.span(), "Unknown array type"))
+            })?;
+            let IntermediateType::Array {
+                element_type,
+                dimensions,
+            } = array_type
+            else {
+                unreachable!("resolve_array_type guarantees Array variant");
+            };
+            array_spec_from_named(element_type, dimensions)
+        }
+    }
 }
 
 /// Converts a named array type (from the TypeEnvironment) to a normalized ArraySpec.

--- a/compiler/codegen/src/compile_array_struct.rs
+++ b/compiler/codegen/src/compile_array_struct.rs
@@ -51,9 +51,14 @@ pub(crate) struct StructArrayVarInfo {
 ///
 /// The array itself is either a field of a structure or a variable in its own
 /// right; [`struct_array_element_field`] handles both once the base is known.
+///
+/// `field_subscripts` carries the subscripts applied to the selected field, so
+/// that `a[i].values[j]` -- an array inside the element structure -- resolves
+/// here too. It is empty for a plain `a[i].field`.
 pub(crate) fn resolve_struct_array_element_field<'ctx, 'ast>(
     ctx: &'ctx CompileContext,
     structured: &'ast ironplc_dsl::textual::StructuredVariable,
+    field_subscripts: Vec<&'ast Expr>,
 ) -> Result<ResolvedAccess<'ctx, 'ast>, Diagnostic> {
     let SymbolicVariableKind::Array(array_var) = structured.record.as_ref() else {
         return Err(Diagnostic::todo_with_span(structured.span()));
@@ -108,6 +113,7 @@ pub(crate) fn resolve_struct_array_element_field<'ctx, 'ast>(
                 array_dims,
                 &structured.field,
                 subscripts,
+                field_subscripts,
                 &base.field.span(),
             )
         }
@@ -127,6 +133,7 @@ pub(crate) fn resolve_struct_array_element_field<'ctx, 'ast>(
                 &info.dimensions,
                 &structured.field,
                 subscripts,
+                field_subscripts,
                 &name.span(),
             )
         }
@@ -171,7 +178,8 @@ fn struct_array_element_field<'ctx, 'ast>(
     element_type: &IntermediateType,
     array_dims: &[ArrayDimension],
     field: &Id,
-    subscripts: Vec<&'ast Expr>,
+    element_subscripts: Vec<&'ast Expr>,
+    field_subscripts: Vec<&'ast Expr>,
     array_span: &SourceSpan,
 ) -> Result<ResolvedAccess<'ctx, 'ast>, Diagnostic> {
     let IntermediateType::Structure {
@@ -197,11 +205,44 @@ fn struct_array_element_field<'ctx, 'ast>(
     let (leaf_slot_offset, leaf_type) =
         crate::compile_struct::find_field_in_type(element_fields, field, &field.span())?;
 
-    // A STRING leaf needs an element stride of `element_slots * 8`, which the
+    // Scale strides so the emitted flat index counts slots, not elements.
+    let mut dimensions = dimensions_from_intermediate(array_dims);
+    for dim in &mut dimensions {
+        dim.stride = dim.stride.checked_mul(element_slots).ok_or_else(|| {
+            Diagnostic::not_supported(Label::span(array_span.clone(), "Array too large"))
+        })?;
+    }
+    let mut subscripts = element_subscripts;
+
+    // `a[i].values[j]` -- the selected field is itself an array, so its own
+    // dimensions extend the index computation. Its elements are single slots
+    // sitting side by side inside the element structure, so their strides need
+    // no scaling: appending them after the (scaled) element dimensions makes
+    // `emit_flat_index` produce `i * element_slots + j` in one pass, and the
+    // field's own offset is still the compile-time part.
+    let value_type = if field_subscripts.is_empty() {
+        leaf_type
+    } else {
+        let IntermediateType::Array {
+            element_type: inner_element_type,
+            dimensions: inner_dims,
+        } = &leaf_type
+        else {
+            return Err(Diagnostic::not_implemented(Label::span(
+                field.span(),
+                format!("Field '{}' is not an array type", field),
+            )));
+        };
+        dimensions.extend(dimensions_from_intermediate(inner_dims));
+        subscripts.extend(field_subscripts);
+        inner_element_type.as_ref().clone()
+    };
+
+    // A STRING value needs an element stride of `element_slots * 8`, which the
     // 8-byte ArrayDescriptor cannot express (the VM derives a string array's
     // stride from `element_extra`). Tracked separately; reject explicitly
     // rather than emitting a wrong address.
-    if matches!(leaf_type, IntermediateType::String { .. }) {
+    if matches!(value_type, IntermediateType::String { .. }) {
         return Err(Diagnostic::not_implemented(Label::span(
             field.span(),
             format!(
@@ -211,8 +252,10 @@ fn struct_array_element_field<'ctx, 'ast>(
         )));
     }
 
+    // A composite value has no single-slot load or store, and the appended
+    // strides above assume one slot per innermost element.
     let element_op_type =
-        crate::compile_struct::resolve_field_op_type(&leaf_type).ok_or_else(|| {
+        crate::compile_struct::resolve_field_op_type(&value_type).ok_or_else(|| {
             Diagnostic::not_implemented(Label::span(
                 field.span(),
                 format!(
@@ -221,14 +264,6 @@ fn struct_array_element_field<'ctx, 'ast>(
                 ),
             ))
         })?;
-
-    // Scale strides so the emitted flat index counts slots, not elements.
-    let mut dimensions = dimensions_from_intermediate(array_dims);
-    for dim in &mut dimensions {
-        dim.stride = dim.stride.checked_mul(element_slots).ok_or_else(|| {
-            Diagnostic::not_supported(Label::span(array_span.clone(), "Array too large"))
-        })?;
-    }
 
     let combined_offset = base_slot_offset
         .checked_add(leaf_slot_offset.raw())
@@ -243,7 +278,7 @@ fn struct_array_element_field<'ctx, 'ast>(
         dimensions,
         subscripts,
         element_op_type,
-        element_type: leaf_type,
+        element_type: value_type,
     })
 }
 

--- a/compiler/codegen/src/compile_array_struct.rs
+++ b/compiler/codegen/src/compile_array_struct.rs
@@ -293,8 +293,10 @@ pub(crate) fn struct_array_declaration(
             if !matches!(element_type.as_ref(), IntermediateType::Structure { .. }) {
                 return Ok(None);
             }
-            // The type environment records the element's shape but not its
-            // name, so the debug entry carries the array type's own name.
+            // Named array specifications are expanded to inline ones before
+            // codegen, so this arm is defensive. It cannot name the element:
+            // `IntermediateType::Structure` is structural and carries no
+            // declared name, so the debug entry falls back to the array type's.
             Ok(Some((
                 element_type.as_ref().clone(),
                 type_name.to_string().to_uppercase(),

--- a/compiler/codegen/src/compile_array_struct.rs
+++ b/compiler/codegen/src/compile_array_struct.rs
@@ -1,0 +1,412 @@
+//! Code generation for arrays whose element type is a user-defined structure.
+//!
+//! Structures occupy a contiguous run of slots, so an array of them is a flat
+//! slot array rather than one slot per element. That layout is shared by the
+//! two places such an array can appear -- as a field of a structure
+//! (`holder.items[i].a`) and as a variable in its own right
+//! (`items[i].a`) -- so both the declaration and the access paths live here.
+//!
+//! Separated from `compile_array.rs`, whose arrays hold one value per slot, to
+//! keep module sizes within the 1000-line guideline.
+
+use ironplc_dsl::core::{Id, Located, SourceSpan};
+use ironplc_dsl::diagnostic::{Diagnostic, Label};
+use ironplc_dsl::textual::{Expr, SymbolicVariableKind};
+
+use ironplc_analyzer::intermediate_type::{ArrayDimension, IntermediateType};
+use ironplc_container::{ContainerBuilder, SlotIndex, VarIndex};
+
+use ironplc_analyzer::TypeEnvironment;
+use ironplc_dsl::common::SpecificationKind;
+
+use super::compile::CompileContext;
+use super::compile_array::{dimensions_from_intermediate, ResolvedAccess};
+
+/// Metadata for a top-level `ARRAY OF <struct>` variable.
+///
+/// A structure occupies a contiguous run of slots, so an array of them is a
+/// flat slot array — the same shape a structure variable has. The variable
+/// slot holds the data-region byte offset and `desc_index` is a slot-typed
+/// descriptor over the whole region, which lets `arr[i].field` reuse
+/// [`ResolvedAccess::StructFieldArrayElement`].
+///
+/// Kept apart from [`ArrayVarInfo`], whose elements occupy exactly one slot
+/// each and are loaded and stored as single values.
+#[derive(Clone)]
+pub(crate) struct StructArrayVarInfo {
+    /// Variable table index holding the data region byte offset.
+    pub var_index: VarIndex,
+    /// Slot-typed array descriptor covering the whole array.
+    pub desc_index: u16,
+    /// Data region byte offset where element 0 starts.
+    pub data_offset: u32,
+    /// The element structure type.
+    pub element_type: IntermediateType,
+    /// Array bounds, in element (not slot) units.
+    pub dimensions: Vec<ArrayDimension>,
+}
+
+/// Resolves a field selected from an element of an array-of-struct, e.g. the
+/// `Trigger` in `MyBay.Devices.MeterQRScanner[i].Trigger` or in `Scanners[i].Trigger`.
+///
+/// The array itself is either a field of a structure or a variable in its own
+/// right; [`struct_array_element_field`] handles both once the base is known.
+pub(crate) fn resolve_struct_array_element_field<'ctx, 'ast>(
+    ctx: &'ctx CompileContext,
+    structured: &'ast ironplc_dsl::textual::StructuredVariable,
+) -> Result<ResolvedAccess<'ctx, 'ast>, Diagnostic> {
+    let SymbolicVariableKind::Array(array_var) = structured.record.as_ref() else {
+        return Err(Diagnostic::todo_with_span(structured.span()));
+    };
+
+    // Collect subscript groups innermost-first, then reverse -- the same
+    // walk `resolve_access` performs for plain array chains.
+    let mut levels: Vec<&[Expr]> = Vec::new();
+    let mut current = array_var;
+    let base = loop {
+        levels.push(&current.subscripts);
+        match current.subscripted_variable.as_ref() {
+            SymbolicVariableKind::Array(inner) => current = inner,
+            SymbolicVariableKind::Structured(base) => break ArrayOfStructBase::Field(base),
+            SymbolicVariableKind::Named(named) => break ArrayOfStructBase::Variable(&named.name),
+            other => {
+                return Err(Diagnostic::todo_with_span(other.span()));
+            }
+        }
+    };
+    levels.reverse();
+    let subscripts: Vec<&Expr> = levels.into_iter().flatten().collect();
+
+    match base {
+        ArrayOfStructBase::Field(base) => {
+            let (root_name, field_slot_offset, field_type) =
+                crate::compile_struct::walk_struct_chain(ctx, &base.record, &base.field, 0)?;
+
+            let IntermediateType::Array {
+                element_type,
+                dimensions: array_dims,
+            } = &field_type
+            else {
+                return Err(Diagnostic::not_implemented(Label::span(
+                    base.field.span(),
+                    format!("Field '{}' is not an array type", base.field),
+                )));
+            };
+
+            let struct_info = ctx.struct_vars.get(&root_name).ok_or_else(|| {
+                Diagnostic::not_implemented(Label::span(
+                    structured.span(),
+                    format!("Variable '{}' is not a structure", root_name),
+                ))
+            })?;
+
+            struct_array_element_field(
+                struct_info.var_index,
+                struct_info.desc_index,
+                field_slot_offset.raw(),
+                element_type,
+                array_dims,
+                &structured.field,
+                subscripts,
+                &base.field.span(),
+            )
+        }
+        ArrayOfStructBase::Variable(name) => {
+            let info = ctx.struct_array_vars.get(name).ok_or_else(|| {
+                Diagnostic::not_implemented(Label::span(
+                    name.span(),
+                    format!("Variable '{}' is not an array of structures", name),
+                ))
+            })?;
+
+            struct_array_element_field(
+                info.var_index,
+                info.desc_index,
+                0,
+                &info.element_type,
+                &info.dimensions,
+                &structured.field,
+                subscripts,
+                &name.span(),
+            )
+        }
+    }
+}
+
+/// What an array-of-struct subscript chain bottoms out in.
+enum ArrayOfStructBase<'ast> {
+    /// An array field of a structure, as in `holder.items[i]`.
+    Field(&'ast ironplc_dsl::textual::StructuredVariable),
+    /// A variable that is itself an array of structures, as in `items[i]`.
+    Variable(&'ast Id),
+}
+
+/// Builds the access for `<array-of-struct>[i].field`.
+///
+/// Structures occupy a contiguous run of slots, so element `k` starts at
+/// `base_slot_offset + k * element_slots` and the leaf field sits a further
+/// compile-time `leaf_offset` into it:
+///
+/// ```text
+/// slot = base_slot_offset + leaf_offset      (compile-time constant)
+///      + flat_index * element_slots          (runtime)
+/// ```
+///
+/// `emit_flat_index` already multiplies each subscript by its dimension
+/// stride, so scaling every stride by `element_slots` makes the emitted flat
+/// index a slot offset directly. That lets this reuse
+/// [`ResolvedAccess::StructFieldArrayElement`] unchanged -- no new opcode and
+/// no new emission path. Bounds checks are unaffected because they validate
+/// against the unscaled `lower_bound`/`size`.
+///
+/// `base_slot_offset` is the slot offset of element 0 within the region
+/// `desc_index` addresses: the array field's own offset when the array is a
+/// struct field, and zero when the variable *is* the array (the region holds
+/// nothing else).
+#[allow(clippy::too_many_arguments)]
+fn struct_array_element_field<'ctx, 'ast>(
+    var_index: VarIndex,
+    desc_index: u16,
+    base_slot_offset: u32,
+    element_type: &IntermediateType,
+    array_dims: &[ArrayDimension],
+    field: &Id,
+    subscripts: Vec<&'ast Expr>,
+    array_span: &SourceSpan,
+) -> Result<ResolvedAccess<'ctx, 'ast>, Diagnostic> {
+    let IntermediateType::Structure {
+        fields: element_fields,
+    } = element_type
+    else {
+        return Err(Diagnostic::not_implemented(Label::span(
+            field.span(),
+            format!(
+                "Cannot select field '{}' -- array elements are not a structure type",
+                field
+            ),
+        )));
+    };
+
+    let element_slots = element_type.slot_count().map_err(|_| {
+        Diagnostic::not_implemented(Label::span(
+            array_span.clone(),
+            "Array element type is unsupported",
+        ))
+    })?;
+
+    let (leaf_slot_offset, leaf_type) =
+        crate::compile_struct::find_field_in_type(element_fields, field, &field.span())?;
+
+    // A STRING leaf needs an element stride of `element_slots * 8`, which the
+    // 8-byte ArrayDescriptor cannot express (the VM derives a string array's
+    // stride from `element_extra`). Tracked separately; reject explicitly
+    // rather than emitting a wrong address.
+    if matches!(leaf_type, IntermediateType::String { .. }) {
+        return Err(Diagnostic::not_implemented(Label::span(
+            field.span(),
+            format!(
+                "STRING field '{}' of an array-of-struct element is not yet supported",
+                field
+            ),
+        )));
+    }
+
+    let element_op_type =
+        crate::compile_struct::resolve_field_op_type(&leaf_type).ok_or_else(|| {
+            Diagnostic::not_implemented(Label::span(
+                field.span(),
+                format!(
+                    "Field '{}' of an array-of-struct element is composite (nested struct or array)",
+                    field
+                ),
+            ))
+        })?;
+
+    // Scale strides so the emitted flat index counts slots, not elements.
+    let mut dimensions = dimensions_from_intermediate(array_dims);
+    for dim in &mut dimensions {
+        dim.stride = dim.stride.checked_mul(element_slots).ok_or_else(|| {
+            Diagnostic::not_implemented(Label::span(array_span.clone(), "Array too large"))
+        })?;
+    }
+
+    let combined_offset = base_slot_offset
+        .checked_add(leaf_slot_offset.raw())
+        .ok_or_else(|| {
+            Diagnostic::not_implemented(Label::span(array_span.clone(), "Array too large"))
+        })?;
+
+    Ok(ResolvedAccess::StructFieldArrayElement {
+        var_index,
+        desc_index,
+        field_slot_offset: SlotIndex::new(combined_offset),
+        dimensions,
+        subscripts,
+        element_op_type,
+        element_type: leaf_type,
+    })
+}
+
+/// Detects an array declaration whose element type is a user-defined
+/// structure, returning the element type, the debug type name to record for
+/// the variable, and the array bounds.
+///
+/// Returns `None` for every other array — including `ARRAY[..] OF REF_TO
+/// <struct>`, whose elements are one-slot references and so belong on the
+/// ordinary array path.
+#[allow(clippy::type_complexity)]
+pub(crate) fn struct_array_declaration(
+    types: &TypeEnvironment,
+    spec: &SpecificationKind<ironplc_dsl::common::ArraySubranges>,
+    span: &ironplc_dsl::core::SourceSpan,
+) -> Result<Option<(IntermediateType, String, Vec<ArrayDimension>)>, Diagnostic> {
+    match spec {
+        SpecificationKind::Inline(subranges) => {
+            if subranges.ref_to.is_some() {
+                return Ok(None);
+            }
+            let element_name = subranges.type_name.to_type_name();
+            let Some(element_type) = types.resolve_struct_type(&element_name) else {
+                return Ok(None);
+            };
+            // Reuse the inline bounds parsing rather than repeating it.
+            let array_spec = super::compile_array::array_spec_from_inline(subranges, span)?;
+            let dimensions = array_spec
+                .dimensions
+                .iter()
+                .map(|&(lower, upper)| ArrayDimension { lower, upper })
+                .collect();
+            Ok(Some((
+                element_type.clone(),
+                format!("ARRAY OF {}", element_name.to_string().to_uppercase()),
+                dimensions,
+            )))
+        }
+        SpecificationKind::Named(type_name) => {
+            let Some(IntermediateType::Array {
+                element_type,
+                dimensions,
+            }) = types.resolve_array_type(type_name)
+            else {
+                return Ok(None);
+            };
+            if !matches!(element_type.as_ref(), IntermediateType::Structure { .. }) {
+                return Ok(None);
+            }
+            // The type environment records the element's shape but not its
+            // name, so the debug entry carries the array type's own name.
+            Ok(Some((
+                element_type.as_ref().clone(),
+                type_name.to_string().to_uppercase(),
+                dimensions.clone(),
+            )))
+        }
+    }
+}
+
+/// Registers a top-level `ARRAY OF <struct>` variable.
+///
+/// Allocates one contiguous data region run of `total_elements *
+/// element_slots` slots and a slot-typed descriptor over it, mirroring how
+/// [`crate::compile_struct::allocate_struct_variable`] lays out a single
+/// structure. Element fields are not initialized here: the data region starts
+/// zeroed, which matches what an array-of-struct *field* of a structure gets
+/// today.
+///
+/// Returns the debug type tag and type name, like
+/// [`register_array_variable`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn register_struct_array_variable(
+    ctx: &mut CompileContext,
+    builder: &mut ContainerBuilder,
+    id: &Id,
+    var_index: VarIndex,
+    element_type: &IntermediateType,
+    debug_type_name: &str,
+    dimensions: &[ArrayDimension],
+    span: &SourceSpan,
+) -> Result<(u8, String), Diagnostic> {
+    let element_slots = element_type.slot_count().map_err(|_| {
+        Diagnostic::not_implemented(Label::span(
+            span.clone(),
+            "Array element structure is unsupported",
+        ))
+    })?;
+
+    // Reject an element type the field walker cannot describe (for example a
+    // duplicate field name) at declaration time rather than at first access.
+    crate::compile_struct::build_struct_fields(struct_fields(element_type, span)?, span)?;
+
+    let mut total_elements: u32 = 1;
+    for dim in dimensions {
+        let size = (dim.upper as i64 - dim.lower as i64 + 1).max(0) as u32;
+        total_elements = total_elements.checked_mul(size).ok_or_else(|| {
+            Diagnostic::not_implemented(Label::span(span.clone(), "Array too large"))
+        })?;
+    }
+
+    let total_slots = total_elements
+        .checked_mul(element_slots)
+        .ok_or_else(|| Diagnostic::not_implemented(Label::span(span.clone(), "Array too large")))?;
+
+    // The flat index is computed in slots, so the slot count -- not the
+    // element count -- is what must stay within i32 arithmetic.
+    if total_slots > super::compile::MAX_DATA_REGION_SLOTS {
+        return Err(Diagnostic::not_implemented(Label::span(
+            span.clone(),
+            "Array exceeds maximum 32768 slots",
+        )));
+    }
+
+    let data_offset = ctx.data_region_offset;
+    let total_bytes = total_slots.checked_mul(8).ok_or_else(|| {
+        Diagnostic::not_implemented(Label::span(span.clone(), "Data region overflow"))
+    })?;
+    ctx.data_region_offset = ctx
+        .data_region_offset
+        .checked_add(total_bytes)
+        .ok_or_else(|| {
+            Diagnostic::not_implemented(Label::span(span.clone(), "Data region overflow"))
+        })?;
+
+    // The offset is stored in the variable slot via LOAD_CONST_I32.
+    if ctx.data_region_offset > i32::MAX as u32 {
+        return Err(Diagnostic::not_implemented(Label::span(
+            span.clone(),
+            "Data region exceeds 2 GiB limit",
+        )));
+    }
+
+    let desc_index =
+        builder.add_array_descriptor(ironplc_container::FieldType::Slot as u8, total_slots, 0);
+
+    ctx.struct_array_vars.insert(
+        id.clone(),
+        StructArrayVarInfo {
+            var_index,
+            desc_index,
+            data_offset,
+            element_type: element_type.clone(),
+            dimensions: dimensions.to_vec(),
+        },
+    );
+
+    Ok((
+        ironplc_container::debug_section::iec_type_tag::OTHER,
+        debug_type_name.to_string(),
+    ))
+}
+
+/// Returns the field list of a structure `IntermediateType`.
+fn struct_fields<'a>(
+    element_type: &'a IntermediateType,
+    span: &SourceSpan,
+) -> Result<&'a [ironplc_analyzer::intermediate_type::IntermediateStructField], Diagnostic> {
+    match element_type {
+        IntermediateType::Structure { fields } => Ok(fields),
+        _ => Err(Diagnostic::not_implemented(Label::span(
+            span.clone(),
+            "Array element type is not a structure",
+        ))),
+    }
+}

--- a/compiler/codegen/src/compile_array_struct.rs
+++ b/compiler/codegen/src/compile_array_struct.rs
@@ -226,14 +226,14 @@ fn struct_array_element_field<'ctx, 'ast>(
     let mut dimensions = dimensions_from_intermediate(array_dims);
     for dim in &mut dimensions {
         dim.stride = dim.stride.checked_mul(element_slots).ok_or_else(|| {
-            Diagnostic::not_implemented(Label::span(array_span.clone(), "Array too large"))
+            Diagnostic::not_supported(Label::span(array_span.clone(), "Array too large"))
         })?;
     }
 
     let combined_offset = base_slot_offset
         .checked_add(leaf_slot_offset.raw())
         .ok_or_else(|| {
-            Diagnostic::not_implemented(Label::span(array_span.clone(), "Array too large"))
+            Diagnostic::not_supported(Label::span(array_span.clone(), "Array too large"))
         })?;
 
     Ok(ResolvedAccess::StructFieldArrayElement {
@@ -343,18 +343,18 @@ pub(crate) fn register_struct_array_variable(
     for dim in dimensions {
         let size = (dim.upper as i64 - dim.lower as i64 + 1).max(0) as u32;
         total_elements = total_elements.checked_mul(size).ok_or_else(|| {
-            Diagnostic::not_implemented(Label::span(span.clone(), "Array too large"))
+            Diagnostic::not_supported(Label::span(span.clone(), "Array too large"))
         })?;
     }
 
     let total_slots = total_elements
         .checked_mul(element_slots)
-        .ok_or_else(|| Diagnostic::not_implemented(Label::span(span.clone(), "Array too large")))?;
+        .ok_or_else(|| Diagnostic::not_supported(Label::span(span.clone(), "Array too large")))?;
 
     // The flat index is computed in slots, so the slot count -- not the
     // element count -- is what must stay within i32 arithmetic.
     if total_slots > super::compile::MAX_DATA_REGION_SLOTS {
-        return Err(Diagnostic::not_implemented(Label::span(
+        return Err(Diagnostic::not_supported(Label::span(
             span.clone(),
             "Array exceeds maximum 32768 slots",
         )));
@@ -362,18 +362,18 @@ pub(crate) fn register_struct_array_variable(
 
     let data_offset = ctx.data_region_offset;
     let total_bytes = total_slots.checked_mul(8).ok_or_else(|| {
-        Diagnostic::not_implemented(Label::span(span.clone(), "Data region overflow"))
+        Diagnostic::not_supported(Label::span(span.clone(), "Data region overflow"))
     })?;
     ctx.data_region_offset = ctx
         .data_region_offset
         .checked_add(total_bytes)
         .ok_or_else(|| {
-            Diagnostic::not_implemented(Label::span(span.clone(), "Data region overflow"))
+            Diagnostic::not_supported(Label::span(span.clone(), "Data region overflow"))
         })?;
 
     // The offset is stored in the variable slot via LOAD_CONST_I32.
     if ctx.data_region_offset > i32::MAX as u32 {
-        return Err(Diagnostic::not_implemented(Label::span(
+        return Err(Diagnostic::not_supported(Label::span(
             span.clone(),
             "Data region exceeds 2 GiB limit",
         )));

--- a/compiler/codegen/src/compile_fn.rs
+++ b/compiler/codegen/src/compile_fn.rs
@@ -80,6 +80,7 @@ pub(crate) fn compile_user_function(
     let saved_string_vars = std::mem::take(&mut ctx.string_vars);
     let saved_array_vars = std::mem::take(&mut ctx.array_vars);
     let saved_struct_vars = std::mem::take(&mut ctx.struct_vars);
+    let saved_struct_array_vars = std::mem::take(&mut ctx.struct_array_vars);
 
     // Re-insert global variable mappings so the function body can access them.
     for (id, index) in &saved_variables {
@@ -109,6 +110,14 @@ pub(crate) fn compile_user_function(
             .is_some_and(|i| i.raw() < num_globals)
         {
             ctx.struct_vars.insert(id.clone(), info.clone());
+        }
+    }
+    for (id, info) in &saved_struct_array_vars {
+        if saved_variables
+            .get(id)
+            .is_some_and(|i| i.raw() < num_globals)
+        {
+            ctx.struct_array_vars.insert(id.clone(), info.clone());
         }
     }
 
@@ -469,6 +478,7 @@ pub(crate) fn compile_user_function(
     ctx.string_vars = saved_string_vars;
     ctx.array_vars = saved_array_vars;
     ctx.struct_vars = saved_struct_vars;
+    ctx.struct_array_vars = saved_struct_array_vars;
 
     Ok(CompiledFunction {
         function_id,
@@ -525,6 +535,7 @@ pub(crate) fn compile_user_function_block(
     let saved_string_vars = std::mem::take(&mut ctx.string_vars);
     let saved_array_vars = std::mem::take(&mut ctx.array_vars);
     let saved_struct_vars = std::mem::take(&mut ctx.struct_vars);
+    let saved_struct_array_vars = std::mem::take(&mut ctx.struct_array_vars);
     let saved_fb_instances = std::mem::take(&mut ctx.fb_instances);
 
     // Re-insert global variable mappings so the FB body can access them.
@@ -555,6 +566,14 @@ pub(crate) fn compile_user_function_block(
             .is_some_and(|i| i.raw() < num_globals)
         {
             ctx.struct_vars.insert(id.clone(), info.clone());
+        }
+    }
+    for (id, info) in &saved_struct_array_vars {
+        if saved_variables
+            .get(id)
+            .is_some_and(|i| i.raw() < num_globals)
+        {
+            ctx.struct_array_vars.insert(id.clone(), info.clone());
         }
     }
 
@@ -652,6 +671,7 @@ pub(crate) fn compile_user_function_block(
         string_vars: saved_string_vars,
         array_vars: saved_array_vars,
         struct_vars: saved_struct_vars,
+        struct_array_vars: saved_struct_array_vars,
         fb_instances: saved_fb_instances,
     };
 

--- a/compiler/codegen/src/compile_setup.rs
+++ b/compiler/codegen/src/compile_setup.rs
@@ -171,39 +171,41 @@ pub(crate) fn assign_variables(
                     (iec_type_tag::OTHER, fb_name)
                 }
                 InitialValueAssignmentKind::Array(array_init) => {
-                    let spec = match &array_init.spec {
-                        SpecificationKind::Inline(array_subranges) => {
-                            crate::compile_array::array_spec_from_inline(
-                                array_subranges,
-                                &decl.identifier.span(),
-                            )?
-                        }
-                        SpecificationKind::Named(type_name) => {
-                            let array_type =
-                                types.resolve_array_type(type_name).ok_or_else(|| {
-                                    Diagnostic::not_implemented(Label::span(
-                                        type_name.span(),
-                                        "Unknown array type",
-                                    ))
-                                })?;
-                            let IntermediateType::Array {
-                                element_type,
-                                dimensions,
-                            } = array_type
-                            else {
-                                unreachable!("resolve_array_type guarantees Array variant");
-                            };
-                            crate::compile_array::array_spec_from_named(element_type, dimensions)?
-                        }
-                    };
-                    crate::compile_array::register_array_variable(
-                        ctx,
-                        builder,
-                        id,
-                        index,
-                        &spec,
-                        &decl.identifier.span(),
-                    )?
+                    // An array whose elements are structures is laid out as
+                    // one flat run of slots rather than one slot per element,
+                    // so it registers through its own path.
+                    if let Some((element_type, debug_type_name, dimensions)) =
+                        crate::compile_array_struct::struct_array_declaration(
+                            types,
+                            &array_init.spec,
+                            &decl.identifier.span(),
+                        )?
+                    {
+                        crate::compile_array_struct::register_struct_array_variable(
+                            ctx,
+                            builder,
+                            id,
+                            index,
+                            &element_type,
+                            &debug_type_name,
+                            &dimensions,
+                            &decl.identifier.span(),
+                        )?
+                    } else {
+                        let spec = crate::compile_array::array_spec_for_declaration(
+                            types,
+                            &array_init.spec,
+                            &decl.identifier.span(),
+                        )?;
+                        crate::compile_array::register_array_variable(
+                            ctx,
+                            builder,
+                            id,
+                            index,
+                            &spec,
+                            &decl.identifier.span(),
+                        )?
+                    }
                 }
                 InitialValueAssignmentKind::Reference(ref_init) => {
                     // References are stored as 64-bit variable-table indices (unsigned).
@@ -480,7 +482,23 @@ pub(crate) fn emit_initial_values(
                     }
                 }
                 InitialValueAssignmentKind::Array(array_init) => {
-                    if let Some(array_info) = ctx.array_vars.get(id) {
+                    // An array of structures holds the data region offset in
+                    // its variable slot, like a structure variable does. Its
+                    // element fields are left zeroed, matching what an
+                    // array-of-struct field of a structure gets today.
+                    if let Some(struct_array_info) = ctx.struct_array_vars.get(id) {
+                        if !array_init.initial_values.is_empty() {
+                            return Err(Diagnostic::not_implemented(Label::span(
+                                decl.identifier.span(),
+                                "Initial values for an array of structures",
+                            )));
+                        }
+                        let data_offset = struct_array_info.data_offset;
+                        let var_index = struct_array_info.var_index;
+                        let offset_const = ctx.add_i32_constant(data_offset as i32);
+                        emitter.emit_load_const_i32(offset_const);
+                        emitter.emit_store_var_i32(var_index);
+                    } else if let Some(array_info) = ctx.array_vars.get(id) {
                         let data_offset = array_info.data_offset;
                         let var_index = array_info.var_index;
                         let desc_index = array_info.desc_index;

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -31,6 +31,7 @@
 mod call_graph;
 mod compile;
 mod compile_array;
+mod compile_array_struct;
 mod compile_call;
 mod compile_enum;
 mod compile_expr;

--- a/compiler/codegen/tests/it/compile_array.rs
+++ b/compiler/codegen/tests/it/compile_array.rs
@@ -432,3 +432,144 @@ END_PROGRAM
     assert_eq!(desc.total_elements, 3);
     assert_eq!(desc.element_extra, 10);
 }
+
+// --- Top-level ARRAY OF <struct> (issue #1383) ---
+
+#[test]
+fn compile_when_var_top_level_array_of_struct_then_descriptor_covers_all_slots() {
+    // FieldType::Slot = 10 per container/src/type_section.rs. A structure
+    // occupies a contiguous run of slots, so the descriptor spans
+    // total_elements * element_slots rather than one entry per element.
+    let source = "
+TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..4] OF Item;
+  END_VAR
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let type_section = container.type_section.as_ref().unwrap();
+    let desc = type_section
+        .array_descriptors
+        .iter()
+        .find(|d| d.element_type == 10)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a slot-typed descriptor, got: {:?}",
+                type_section.array_descriptors
+            )
+        });
+    // 4 elements * 2 slots each.
+    assert_eq!(desc.total_elements, 8);
+    assert_eq!(desc.element_extra, 0);
+}
+
+#[test]
+fn compile_when_top_level_array_of_struct_field_stored_then_index_is_element_stride_plus_leaf() {
+    // `arr[3].b` addresses slot (3 - 1) * 2 + 1 of the array's region: the
+    // element index is folded to a constant scaled by the element slot count,
+    // then the leaf field's offset is added.
+    let source = "
+TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..4] OF Item;
+  END_VAR
+  arr[3].b := 42;
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let bytecode = container
+        .code
+        .get_function_bytecode(ironplc_container::FunctionId::new(1))
+        .unwrap();
+    let store_pos = bytecode
+        .iter()
+        .position(|&b| b == opcode::STORE_ARRAY)
+        .unwrap();
+
+    // ... LOAD_CONST_I32 <flat index> LOAD_CONST_I64 <leaf offset> ADD_I64 STORE_ARRAY
+    let add_pos = store_pos - 1;
+    assert_eq!(bytecode[add_pos], opcode::ADD_I64);
+    assert_eq!(bytecode[add_pos - 3], opcode::LOAD_CONST_I64);
+    let leaf_const = u16::from_le_bytes([bytecode[add_pos - 2], bytecode[add_pos - 1]]);
+    assert_eq!(
+        container
+            .constant_pool
+            .get_i64(ironplc_container::ConstantIndex::new(leaf_const))
+            .unwrap(),
+        1,
+        "leaf field 'b' sits one slot into the element"
+    );
+    assert_eq!(bytecode[add_pos - 6], opcode::LOAD_CONST_I32);
+    let index_const = u16::from_le_bytes([bytecode[add_pos - 5], bytecode[add_pos - 4]]);
+    assert_eq!(
+        container
+            .constant_pool
+            .get_i32(ironplc_container::ConstantIndex::new(index_const))
+            .unwrap(),
+        4,
+        "element 3 of a 2-slot element type starts at slot 4"
+    );
+}
+
+#[test]
+fn compile_when_top_level_array_of_struct_then_data_offset_stored_in_variable_slot() {
+    // The variable slot holds the data region byte offset, the same protocol a
+    // structure variable uses. Without it every element access addresses
+    // offset 0.
+    let source = "
+TYPE Item : STRUCT a : DINT; END_STRUCT; END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..4] OF Item;
+  END_VAR
+END_PROGRAM
+";
+    let container = parse_and_compile(source, &CompilerOptions::default());
+    let bytecode = container
+        .code
+        .get_function_bytecode(ironplc_container::FunctionId::new(0))
+        .unwrap();
+    assert!(
+        bytecode.contains(&opcode::STORE_VAR_I32),
+        "init function must store the array's data offset into its variable slot"
+    );
+}
+
+#[test]
+fn compile_when_top_level_array_of_ref_to_struct_then_stays_on_reference_path() {
+    // `ARRAY[..] OF REF_TO <struct>` elements are one-slot references, so the
+    // array keeps the ordinary (U64) descriptor rather than the slot-typed one.
+    // FieldType::U64 = 3 per container/src/type_section.rs.
+    let source = "
+TYPE Item : STRUCT a : DINT; END_STRUCT; END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..4] OF REF_TO Item;
+  END_VAR
+END_PROGRAM
+";
+    let options = CompilerOptions {
+        allow_ref_to: true,
+        ..CompilerOptions::default()
+    };
+    let container = try_parse_and_compile(source, &options).unwrap();
+    let type_section = container.type_section.as_ref().unwrap();
+    let desc = type_section
+        .array_descriptors
+        .iter()
+        .find(|d| d.total_elements == 4)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a 4-element descriptor, got: {:?}",
+                type_section.array_descriptors
+            )
+        });
+    assert_eq!(desc.element_type, 3);
+}

--- a/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
+++ b/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
@@ -558,11 +558,45 @@ END_PROGRAM
 // the assertion is on the compile result rather than on run values.
 
 /// Compiles `source` with default options and asserts codegen rejects it
-/// with the not-implemented problem code.
+/// with the not-implemented problem code (P9999) -- a capability we intend to
+/// support but have not built yet.
 fn assert_codegen_rejects(source: &str, what: &str) {
+    assert_codegen_rejects_with(source, what, "P9999");
+}
+
+/// Compiles `source` with default options and asserts codegen rejects it with
+/// `expected_code`.
+fn assert_codegen_rejects_with(source: &str, what: &str, expected_code: &str) {
     let result = try_parse_and_compile(source, &CompilerOptions::default());
     assert!(result.is_err(), "expected compilation to fail for {}", what);
-    assert_eq!(result.unwrap_err().code, "P9999", "for {}", what);
+    assert_eq!(result.unwrap_err().code, expected_code, "for {}", what);
+}
+
+// A fixed limit of the bytecode format, not a missing feature, so it reports
+// P9997 (NotSupported) rather than P9999 (NotImplemented) -- P9999 promises
+// "not yet", and this limit is not going to be lifted by a later release.
+//
+// This is the example in docs/reference/compiler/problems/P9997.rst; keep the
+// two in step.
+#[test]
+fn compile_when_top_level_array_of_struct_exceeds_slot_limit_then_not_supported() {
+    assert_codegen_rejects_with(
+        "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    readings : ARRAY[1..40000] OF Item;
+  END_VAR
+END_PROGRAM
+",
+        "an array of structures over the slot limit",
+        "P9997",
+    );
 }
 
 #[test]

--- a/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
+++ b/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
@@ -6,70 +6,224 @@
 //! Field access through an array-of-struct *field* (`h.items[i].a`) is covered
 //! by `end_to_end_struct.rs`; these tests own the case where the variable
 //! itself is the array.
+//!
+//! Assertion indices are variable-table slots, assigned in declaration order
+//! starting at 0. Each test notes its mapping.
 
 use crate::common::try_parse_and_compile;
 use ironplc_parser::options::CompilerOptions;
 
 // --- Nominal read and write ---
 
-// arr is var 0, result is var 1.
+// arr 0, result 1.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_written_with_literal_index_then_reads_back,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : DINT; END_VAR arr[2].b := 42; result := arr[2].b; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    result : DINT;
+  END_VAR
+  arr[2].b := 42;
+  result := arr[2].b;
+END_PROGRAM
+",
     &[(1, 42)],
 );
 
 // The reported repro: a BOOL field written through a literal index. Exercises
 // the narrow-width truncation path on store.
+//
+// Arr 0, result 1.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_bool_field_written_then_reads_back,
-    "TYPE Item : STRUCT Flag : BOOL; END_STRUCT; END_TYPE PROGRAM main VAR Arr : ARRAY[1..6] OF Item; result : DINT; END_VAR Arr[1].Flag := TRUE; result := BOOL_TO_DINT(Arr[1].Flag); END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  Flag : BOOL;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    Arr : ARRAY[1..6] OF Item;
+    result : DINT;
+  END_VAR
+  Arr[1].Flag := TRUE;
+  result := BOOL_TO_DINT(Arr[1].Flag);
+END_PROGRAM
+",
     &[(1, 1)],
 );
 
 // Writing one element must not disturb its neighbours -- this is what a wrong
 // element stride would break.
+//
+// arr 0, r1 1, r2 2, r3 3.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_elements_written_then_each_element_distinct,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; r1 : DINT; r2 : DINT; r3 : DINT; END_VAR arr[1].a := 11; arr[2].a := 22; arr[3].a := 33; r1 := arr[1].a; r2 := arr[2].a; r3 := arr[3].a; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    r1 : DINT;
+    r2 : DINT;
+    r3 : DINT;
+  END_VAR
+  arr[1].a := 11;
+  arr[2].a := 22;
+  arr[3].a := 33;
+  r1 := arr[1].a;
+  r2 := arr[2].a;
+  r3 := arr[3].a;
+END_PROGRAM
+",
     &[(1, 11), (2, 22), (3, 33)],
 );
 
 // Distinct fields within one element must not alias -- this is what a wrong
 // leaf offset would break.
+//
+// arr 0, ra 1, rb 2.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_sibling_fields_written_then_do_not_alias,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; ra : DINT; rb : DINT; END_VAR arr[2].a := 7; arr[2].b := 9; ra := arr[2].a; rb := arr[2].b; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    ra : DINT;
+    rb : DINT;
+  END_VAR
+  arr[2].a := 7;
+  arr[2].b := 9;
+  ra := arr[2].a;
+  rb := arr[2].b;
+END_PROGRAM
+",
     &[(1, 7), (2, 9)],
 );
 
 // Variable subscript exercises the runtime flat-index path rather than the
 // compile-time constant-folded one.
+//
+// arr 0, i 1, result 2.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_indexed_by_variable_then_correct_element,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; i : INT; result : DINT; END_VAR i := 3; arr[i].b := 55; result := arr[i].b; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    i : INT;
+    result : DINT;
+  END_VAR
+  i := 3;
+  arr[i].b := 55;
+  result := arr[i].b;
+END_PROGRAM
+",
     &[(2, 55)],
 );
 
 // A FOR loop over the array, the shape the issue's users actually write.
+//
+// arr 0, i 1, total 2. total = 1 + 2 + 3.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_written_in_for_loop_then_all_elements_set,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; i : INT; total : DINT; END_VAR FOR i := 1 TO 3 DO arr[i].a := i; END_FOR; total := arr[1].a + arr[2].a + arr[3].a; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    i : INT;
+    total : DINT;
+  END_VAR
+  FOR i := 1 TO 3 DO
+    arr[i].a := i;
+  END_FOR;
+  total := arr[1].a + arr[2].a + arr[3].a;
+END_PROGRAM
+",
     &[(2, 6)],
 );
 
 // Several element reads combined in one expression.
+//
+// arr 0, total 1. total = 1 + 2 + 3.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_elements_summed_then_correct_total,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; total : DINT; END_VAR arr[1].a := 1; arr[2].a := 2; arr[3].a := 3; total := arr[1].a + arr[2].a + arr[3].a; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    total : DINT;
+  END_VAR
+  arr[1].a := 1;
+  arr[2].a := 2;
+  arr[3].a := 3;
+  total := arr[1].a + arr[2].a + arr[3].a;
+END_PROGRAM
+",
     &[(1, 6)],
 );
 
 // Unwritten elements read as zero: the data region starts zeroed and nothing
 // else is allowed to land on top of the array.
+//
+// arr 0, r1 1, r2 2.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_not_written_then_fields_read_zero,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[1].a := 5; r1 := arr[2].a; r2 := arr[3].b; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    r1 : DINT;
+    r2 : DINT;
+  END_VAR
+  arr[1].a := 5;
+  r1 := arr[2].a;
+  r2 := arr[3].b;
+END_PROGRAM
+",
     &[(1, 0), (2, 0)],
 );
 
@@ -77,23 +231,86 @@ e2e_i32!(
 
 // A zero lower bound: the subtracted lower bound is 0 so the emitted index is
 // the subscript itself.
+//
+// arr 0, r1 1, r2 2.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_zero_based_then_correct_element,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[0..2] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[0].a := 4; arr[2].a := 6; r1 := arr[0].a; r2 := arr[2].a; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[0..2] OF Item;
+    r1 : DINT;
+    r2 : DINT;
+  END_VAR
+  arr[0].a := 4;
+  arr[2].a := 6;
+  r1 := arr[0].a;
+  r2 := arr[2].a;
+END_PROGRAM
+",
     &[(1, 4), (2, 6)],
 );
 
-// A negative lower bound must be subtracted, not ignored.
+// A negative lower bound must be subtracted, not ignored. The constant and
+// variable subscript paths both have to do it, so this uses one of each.
+//
+// arr 0, i 1, r1 2, r2 3.
 e2e_i32!(
     end_to_end_when_top_level_array_of_struct_negative_lower_bound_then_correct_element,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[-1..1] OF Item; i : INT; r1 : DINT; r2 : DINT; END_VAR i := 1; arr[-1].a := 8; arr[i].a := 9; r1 := arr[-1].a; r2 := arr[1].a; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[-1..1] OF Item;
+    i : INT;
+    r1 : DINT;
+    r2 : DINT;
+  END_VAR
+  i := 1;
+  arr[-1].a := 8;
+  arr[i].a := 9;
+  r1 := arr[-1].a;
+  r2 := arr[1].a;
+END_PROGRAM
+",
     &[(2, 8), (3, 9)],
 );
 
 // Two-dimensional: both strides must be scaled by the element slot count.
+//
+// arr 0, r1 1, r2 2.
 e2e_i32!(
     end_to_end_when_two_dimensional_top_level_array_of_struct_then_correct_element,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..2, 1..3] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[1,1].a := 1; arr[2,3].a := 6; r1 := arr[1,1].a; r2 := arr[2,3].a; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..2, 1..3] OF Item;
+    r1 : DINT;
+    r2 : DINT;
+  END_VAR
+  arr[1,1].a := 1;
+  arr[2,3].a := 6;
+  r1 := arr[1,1].a;
+  r2 := arr[2,3].a;
+END_PROGRAM
+",
     &[(1, 1), (2, 6)],
 );
 
@@ -102,7 +319,23 @@ e2e_i32!(
 // neighbouring variable's region.
 #[test]
 fn end_to_end_when_top_level_array_of_struct_index_out_of_range_then_traps() {
-    let source = "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; i : INT; r : DINT; END_VAR i := 9; r := arr[i].a; END_PROGRAM";
+    let source = "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    i : INT;
+    r : DINT;
+  END_VAR
+  i := 9;
+  r := arr[i].a;
+END_PROGRAM
+";
     let result = crate::common::parse_and_try_run(source, &CompilerOptions::default());
     assert!(
         result.is_err(),
@@ -113,28 +346,91 @@ fn end_to_end_when_top_level_array_of_struct_index_out_of_range_then_traps() {
 // --- Element shapes ---
 
 // A structure with a nested structure: the element stride is the *total* slot
-// count, so a wrong count here shifts every element after the first.
+// count (3 slots per Item), so a wrong count here shifts every element after
+// the first.
+//
+// arr 0, r1 1, r2 2.
 e2e_i32!(
     end_to_end_when_top_level_array_of_nested_struct_then_element_stride_correct,
-    "TYPE Inner : STRUCT x : DINT; y : DINT; END_STRUCT; END_TYPE TYPE Item : STRUCT lead : DINT; inner : Inner; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[1].lead := 1; arr[2].lead := 2; r1 := arr[1].lead; r2 := arr[2].lead; END_PROGRAM",
+    "
+TYPE Inner : STRUCT
+  x : DINT;
+  y : DINT;
+END_STRUCT;
+END_TYPE
+
+TYPE Item : STRUCT
+  lead : DINT;
+  inner : Inner;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    r1 : DINT;
+    r2 : DINT;
+  END_VAR
+  arr[1].lead := 1;
+  arr[2].lead := 2;
+  r1 := arr[1].lead;
+  r2 := arr[2].lead;
+END_PROGRAM
+",
     &[(1, 1), (2, 2)],
 );
 
-// A LINT field is a 64-bit leaf, so the load and store must be emitted at
-// W64 rather than the default width.
+// A LINT field is a 64-bit leaf, so the load and store must be emitted at W64
+// rather than the default width. 4294967296 does not fit in 32 bits.
+//
+// arr 0, result 1.
 e2e_i64!(
     end_to_end_when_top_level_array_of_struct_lint_field_then_full_width_preserved,
-    "TYPE Item : STRUCT big : LINT; small : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..2] OF Item; result : LINT; END_VAR arr[2].big := 4294967296; result := arr[2].big; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  big : LINT;
+  small : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..2] OF Item;
+    result : LINT;
+  END_VAR
+  arr[2].big := 4294967296;
+  result := arr[2].big;
+END_PROGRAM
+",
     &[(1, 4294967296)],
 );
 
 // --- Named array type ---
 
-// `arr : Items` where `Items` is a named ARRAY OF <struct> type resolves
-// through the type environment rather than an inline specification.
+// `arr : Items` where `Items` is a named ARRAY OF <struct> type, rather than
+// an inline array specification on the declaration.
+//
+// arr 0, result 1.
 e2e_i32!(
     end_to_end_when_top_level_named_array_of_struct_type_then_reads_back,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE TYPE Items : ARRAY[1..3] OF Item; END_TYPE PROGRAM main VAR arr : Items; result : DINT; END_VAR arr[3].a := 21; result := arr[3].a; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+TYPE Items : ARRAY[1..3] OF Item; END_TYPE
+
+PROGRAM main
+  VAR
+    arr : Items;
+    result : DINT;
+  END_VAR
+  arr[3].a := 21;
+  result := arr[3].a;
+END_PROGRAM
+",
     &[(1, 21)],
 );
 
@@ -142,9 +438,34 @@ e2e_i32!(
 
 // A second array-of-struct and a plain array declared alongside must each get
 // their own data region run.
+//
+// first 0, second 1, plain 2, r1 3, r2 4, r3 5.
 e2e_i32!(
     end_to_end_when_two_top_level_arrays_of_struct_then_regions_do_not_overlap,
-    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR first : ARRAY[1..2] OF Item; second : ARRAY[1..2] OF Item; plain : ARRAY[1..2] OF DINT; r1 : DINT; r2 : DINT; r3 : DINT; END_VAR first[1].a := 1; second[1].a := 2; plain[1] := 3; r1 := first[1].a; r2 := second[1].a; r3 := plain[1]; END_PROGRAM",
+    "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    first : ARRAY[1..2] OF Item;
+    second : ARRAY[1..2] OF Item;
+    plain : ARRAY[1..2] OF DINT;
+    r1 : DINT;
+    r2 : DINT;
+    r3 : DINT;
+  END_VAR
+  first[1].a := 1;
+  second[1].a := 2;
+  plain[1] := 3;
+  r1 := first[1].a;
+  r2 := second[1].a;
+  r3 := plain[1];
+END_PROGRAM
+",
     &[(3, 1), (4, 2), (5, 3)],
 );
 
@@ -152,10 +473,16 @@ e2e_i32!(
 
 // A global array-of-struct is registered before program locals and aliased
 // into the program through VAR_EXTERNAL.
+//
+// devices 0 (global), result 1. result = 100 + 200.
 e2e_i32!(
     end_to_end_when_global_array_of_struct_then_external_can_read_and_write,
     "
-TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
 
 CONFIGURATION config
   VAR_GLOBAL
@@ -186,10 +513,16 @@ END_PROGRAM
 // without it the array resolves as a plain scalar and the field access fails.
 // Functions reach globals by name (VAR_EXTERNAL is a POU-level construct the
 // parser accepts only on programs and function blocks).
+//
+// devices 0 (global), result 1.
 e2e_i32!(
     end_to_end_when_function_reads_global_array_of_struct_then_correct_value,
     "
-TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
 
 CONFIGURATION config
   VAR_GLOBAL
@@ -235,7 +568,21 @@ fn assert_codegen_rejects(source: &str, what: &str) {
 #[test]
 fn compile_when_top_level_array_of_struct_element_assigned_whole_then_not_implemented() {
     assert_codegen_rejects(
-        "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; one : Item; END_VAR arr[1] := one; END_PROGRAM",
+        "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    one : Item;
+  END_VAR
+  arr[1] := one;
+END_PROGRAM
+",
         "a whole-element assignment",
     );
 }
@@ -245,7 +592,20 @@ fn compile_when_top_level_array_of_struct_has_initial_values_then_not_implemente
     // Element fields are left zeroed, so an explicit initializer must be
     // rejected rather than silently dropped.
     assert_codegen_rejects(
-        "TYPE Item : STRUCT a : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..2] OF Item := [1, 2]; result : DINT; END_VAR result := arr[1].a; END_PROGRAM",
+        "
+TYPE Item : STRUCT
+  a : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..2] OF Item := [1, 2];
+    result : DINT;
+  END_VAR
+  result := arr[1].a;
+END_PROGRAM
+",
         "an array-of-struct with initial values",
     );
 }
@@ -253,7 +613,20 @@ fn compile_when_top_level_array_of_struct_has_initial_values_then_not_implemente
 #[test]
 fn compile_when_top_level_array_of_struct_string_field_read_then_not_implemented() {
     assert_codegen_rejects(
-        "TYPE Item : STRUCT name : STRING[8]; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : STRING[8]; END_VAR result := arr[1].name; END_PROGRAM",
+        "
+TYPE Item : STRUCT
+  name : STRING[8];
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    result : STRING[8];
+  END_VAR
+  result := arr[1].name;
+END_PROGRAM
+",
         "a STRING field of an element",
     );
 }
@@ -261,7 +634,25 @@ fn compile_when_top_level_array_of_struct_string_field_read_then_not_implemented
 #[test]
 fn compile_when_top_level_array_of_struct_composite_field_read_then_not_implemented() {
     assert_codegen_rejects(
-        "TYPE Inner : STRUCT x : DINT; END_STRUCT; END_TYPE TYPE Item : STRUCT inner : Inner; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : DINT; END_VAR result := arr[1].inner.x; END_PROGRAM",
+        "
+TYPE Inner : STRUCT
+  x : DINT;
+END_STRUCT;
+END_TYPE
+
+TYPE Item : STRUCT
+  inner : Inner;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    result : DINT;
+  END_VAR
+  result := arr[1].inner.x;
+END_PROGRAM
+",
         "a composite field of an element",
     );
 }
@@ -269,7 +660,21 @@ fn compile_when_top_level_array_of_struct_composite_field_read_then_not_implemen
 #[test]
 fn compile_when_top_level_array_of_struct_unknown_field_then_not_implemented() {
     assert_codegen_rejects(
-        "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : DINT; END_VAR result := arr[1].missing; END_PROGRAM",
+        "
+TYPE Item : STRUCT
+  a : DINT;
+  b : DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    arr : ARRAY[1..3] OF Item;
+    result : DINT;
+  END_VAR
+  result := arr[1].missing;
+END_PROGRAM
+",
         "an unknown field of an element",
     );
 }

--- a/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
+++ b/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
@@ -405,6 +405,156 @@ END_PROGRAM
     &[(1, 4294967296)],
 );
 
+// --- Array field inside the element ---
+//
+// `a[i].values[j]` needs both indices in one flat-index computation: the
+// element index scaled by the element's slot count, then the field's own
+// index at stride 1. The field's offset within the element stays the
+// compile-time part.
+
+// a 0, r1 1, r2 2, r3 3.
+e2e_i32!(
+    end_to_end_when_array_of_struct_element_has_array_field_then_reads_back,
+    "
+TYPE Item : STRUCT
+  values : ARRAY[1..4] OF DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    a : ARRAY[1..3] OF Item;
+    r1 : DINT;
+    r2 : DINT;
+    r3 : DINT;
+  END_VAR
+  a[1].values[1] := 11;
+  a[1].values[4] := 14;
+  a[3].values[2] := 32;
+  r1 := a[1].values[1];
+  r2 := a[1].values[4];
+  r3 := a[3].values[2];
+END_PROGRAM
+",
+    &[(1, 11), (2, 14), (3, 32)],
+);
+
+// Both subscripts variable, so the whole index is computed at runtime rather
+// than folded to a constant.
+//
+// a 0, i 1, j 2, r 3.
+e2e_i32!(
+    end_to_end_when_array_of_struct_array_field_indexed_by_variables_then_correct_element,
+    "
+TYPE Item : STRUCT
+  values : ARRAY[1..4] OF DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    a : ARRAY[1..3] OF Item;
+    i : INT;
+    j : INT;
+    r : DINT;
+  END_VAR
+  i := 2;
+  j := 3;
+  a[i].values[j] := 55;
+  r := a[i].values[j];
+END_PROGRAM
+",
+    &[(3, 55)],
+);
+
+// A scalar ahead of the array field, so the field's own offset has to be added
+// on top of the element stride. A wrong offset would alias `lead` with
+// `values[1]`.
+//
+// a 0, rl 1, rv 2.
+e2e_i32!(
+    end_to_end_when_array_of_struct_array_field_preceded_by_scalar_then_no_alias,
+    "
+TYPE Item : STRUCT
+  lead : DINT;
+  values : ARRAY[1..3] OF DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    a : ARRAY[1..3] OF Item;
+    rl : DINT;
+    rv : DINT;
+  END_VAR
+  a[2].lead := 9;
+  a[2].values[1] := 21;
+  rl := a[2].lead;
+  rv := a[2].values[1];
+END_PROGRAM
+",
+    &[(1, 9), (2, 21)],
+);
+
+// Nested FOR loops over both indices, the shape that would expose a wrong
+// stride on either axis. a[3].values[2] is 3 * 10 + 2.
+//
+// a 0, i 1, j 2, r 3.
+e2e_i32!(
+    end_to_end_when_array_of_struct_array_field_written_in_nested_loops_then_all_set,
+    "
+TYPE Item : STRUCT
+  values : ARRAY[1..2] OF DINT;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    a : ARRAY[1..3] OF Item;
+    i : INT;
+    j : INT;
+    r : DINT;
+  END_VAR
+  FOR i := 1 TO 3 DO
+    FOR j := 1 TO 2 DO
+      a[i].values[j] := i * 10 + j;
+    END_FOR;
+  END_FOR;
+  r := a[3].values[2];
+END_PROGRAM
+",
+    &[(3, 32)],
+);
+
+// The same shape reached through a struct field rather than a top-level
+// variable: `h.items[i].values[j]`.
+//
+// h 0, r 1.
+e2e_i32!(
+    end_to_end_when_struct_field_array_of_struct_has_array_field_then_reads_back,
+    "
+TYPE Item : STRUCT
+  values : ARRAY[1..3] OF DINT;
+END_STRUCT;
+END_TYPE
+
+TYPE Holder : STRUCT
+  items : ARRAY[1..2] OF Item;
+END_STRUCT;
+END_TYPE
+
+PROGRAM main
+  VAR
+    h : Holder;
+    r : DINT;
+  END_VAR
+  h.items[2].values[3] := 77;
+  r := h.items[2].values[3];
+END_PROGRAM
+",
+    &[(1, 77)],
+);
+
 // --- Named array type ---
 
 // `arr : Items` where `Items` is a named ARRAY OF <struct> type, rather than

--- a/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
+++ b/compiler/codegen/tests/it/end_to_end_array_of_struct.rs
@@ -1,0 +1,275 @@
+//! End-to-end tests for a *top-level* `ARRAY OF <struct>` variable — an array
+//! whose element type is a user-defined structure and which is not reached
+//! through an enclosing structure. See issue #1383 and
+//! `specs/plans/2026-08-22-top-level-array-of-struct.md`.
+//!
+//! Field access through an array-of-struct *field* (`h.items[i].a`) is covered
+//! by `end_to_end_struct.rs`; these tests own the case where the variable
+//! itself is the array.
+
+use crate::common::try_parse_and_compile;
+use ironplc_parser::options::CompilerOptions;
+
+// --- Nominal read and write ---
+
+// arr is var 0, result is var 1.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_written_with_literal_index_then_reads_back,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : DINT; END_VAR arr[2].b := 42; result := arr[2].b; END_PROGRAM",
+    &[(1, 42)],
+);
+
+// The reported repro: a BOOL field written through a literal index. Exercises
+// the narrow-width truncation path on store.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_bool_field_written_then_reads_back,
+    "TYPE Item : STRUCT Flag : BOOL; END_STRUCT; END_TYPE PROGRAM main VAR Arr : ARRAY[1..6] OF Item; result : DINT; END_VAR Arr[1].Flag := TRUE; result := BOOL_TO_DINT(Arr[1].Flag); END_PROGRAM",
+    &[(1, 1)],
+);
+
+// Writing one element must not disturb its neighbours -- this is what a wrong
+// element stride would break.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_elements_written_then_each_element_distinct,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; r1 : DINT; r2 : DINT; r3 : DINT; END_VAR arr[1].a := 11; arr[2].a := 22; arr[3].a := 33; r1 := arr[1].a; r2 := arr[2].a; r3 := arr[3].a; END_PROGRAM",
+    &[(1, 11), (2, 22), (3, 33)],
+);
+
+// Distinct fields within one element must not alias -- this is what a wrong
+// leaf offset would break.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_sibling_fields_written_then_do_not_alias,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; ra : DINT; rb : DINT; END_VAR arr[2].a := 7; arr[2].b := 9; ra := arr[2].a; rb := arr[2].b; END_PROGRAM",
+    &[(1, 7), (2, 9)],
+);
+
+// Variable subscript exercises the runtime flat-index path rather than the
+// compile-time constant-folded one.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_indexed_by_variable_then_correct_element,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; i : INT; result : DINT; END_VAR i := 3; arr[i].b := 55; result := arr[i].b; END_PROGRAM",
+    &[(2, 55)],
+);
+
+// A FOR loop over the array, the shape the issue's users actually write.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_written_in_for_loop_then_all_elements_set,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; i : INT; total : DINT; END_VAR FOR i := 1 TO 3 DO arr[i].a := i; END_FOR; total := arr[1].a + arr[2].a + arr[3].a; END_PROGRAM",
+    &[(2, 6)],
+);
+
+// Several element reads combined in one expression.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_elements_summed_then_correct_total,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; total : DINT; END_VAR arr[1].a := 1; arr[2].a := 2; arr[3].a := 3; total := arr[1].a + arr[2].a + arr[3].a; END_PROGRAM",
+    &[(1, 6)],
+);
+
+// Unwritten elements read as zero: the data region starts zeroed and nothing
+// else is allowed to land on top of the array.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_not_written_then_fields_read_zero,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[1].a := 5; r1 := arr[2].a; r2 := arr[3].b; END_PROGRAM",
+    &[(1, 0), (2, 0)],
+);
+
+// --- Bounds shapes ---
+
+// A zero lower bound: the subtracted lower bound is 0 so the emitted index is
+// the subscript itself.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_zero_based_then_correct_element,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[0..2] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[0].a := 4; arr[2].a := 6; r1 := arr[0].a; r2 := arr[2].a; END_PROGRAM",
+    &[(1, 4), (2, 6)],
+);
+
+// A negative lower bound must be subtracted, not ignored.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_struct_negative_lower_bound_then_correct_element,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[-1..1] OF Item; i : INT; r1 : DINT; r2 : DINT; END_VAR i := 1; arr[-1].a := 8; arr[i].a := 9; r1 := arr[-1].a; r2 := arr[1].a; END_PROGRAM",
+    &[(2, 8), (3, 9)],
+);
+
+// Two-dimensional: both strides must be scaled by the element slot count.
+e2e_i32!(
+    end_to_end_when_two_dimensional_top_level_array_of_struct_then_correct_element,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..2, 1..3] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[1,1].a := 1; arr[2,3].a := 6; r1 := arr[1,1].a; r2 := arr[2,3].a; END_PROGRAM",
+    &[(1, 1), (2, 6)],
+);
+
+// The descriptor spans `total_elements * element_slots`, so an out-of-range
+// subscript still trips the VM's array bounds check rather than reading a
+// neighbouring variable's region.
+#[test]
+fn end_to_end_when_top_level_array_of_struct_index_out_of_range_then_traps() {
+    let source = "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; i : INT; r : DINT; END_VAR i := 9; r := arr[i].a; END_PROGRAM";
+    let result = crate::common::parse_and_try_run(source, &CompilerOptions::default());
+    assert!(
+        result.is_err(),
+        "expected a trap for an out-of-bounds element"
+    );
+}
+
+// --- Element shapes ---
+
+// A structure with a nested structure: the element stride is the *total* slot
+// count, so a wrong count here shifts every element after the first.
+e2e_i32!(
+    end_to_end_when_top_level_array_of_nested_struct_then_element_stride_correct,
+    "TYPE Inner : STRUCT x : DINT; y : DINT; END_STRUCT; END_TYPE TYPE Item : STRUCT lead : DINT; inner : Inner; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; r1 : DINT; r2 : DINT; END_VAR arr[1].lead := 1; arr[2].lead := 2; r1 := arr[1].lead; r2 := arr[2].lead; END_PROGRAM",
+    &[(1, 1), (2, 2)],
+);
+
+// A LINT field is a 64-bit leaf, so the load and store must be emitted at
+// W64 rather than the default width.
+e2e_i64!(
+    end_to_end_when_top_level_array_of_struct_lint_field_then_full_width_preserved,
+    "TYPE Item : STRUCT big : LINT; small : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..2] OF Item; result : LINT; END_VAR arr[2].big := 4294967296; result := arr[2].big; END_PROGRAM",
+    &[(1, 4294967296)],
+);
+
+// --- Named array type ---
+
+// `arr : Items` where `Items` is a named ARRAY OF <struct> type resolves
+// through the type environment rather than an inline specification.
+e2e_i32!(
+    end_to_end_when_top_level_named_array_of_struct_type_then_reads_back,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE TYPE Items : ARRAY[1..3] OF Item; END_TYPE PROGRAM main VAR arr : Items; result : DINT; END_VAR arr[3].a := 21; result := arr[3].a; END_PROGRAM",
+    &[(1, 21)],
+);
+
+// --- Neighbouring variables ---
+
+// A second array-of-struct and a plain array declared alongside must each get
+// their own data region run.
+e2e_i32!(
+    end_to_end_when_two_top_level_arrays_of_struct_then_regions_do_not_overlap,
+    "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR first : ARRAY[1..2] OF Item; second : ARRAY[1..2] OF Item; plain : ARRAY[1..2] OF DINT; r1 : DINT; r2 : DINT; r3 : DINT; END_VAR first[1].a := 1; second[1].a := 2; plain[1] := 3; r1 := first[1].a; r2 := second[1].a; r3 := plain[1]; END_PROGRAM",
+    &[(3, 1), (4, 2), (5, 3)],
+);
+
+// --- Global declaration ---
+
+// A global array-of-struct is registered before program locals and aliased
+// into the program through VAR_EXTERNAL.
+e2e_i32!(
+    end_to_end_when_global_array_of_struct_then_external_can_read_and_write,
+    "
+TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE
+
+CONFIGURATION config
+  VAR_GLOBAL
+    devices : ARRAY[1..3] OF Item;
+  END_VAR
+  RESOURCE resource1 ON PLC
+    TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+    PROGRAM plc_task_instance WITH plc_task : main;
+  END_RESOURCE
+END_CONFIGURATION
+
+PROGRAM main
+  VAR_EXTERNAL
+    devices : ARRAY[1..3] OF Item;
+  END_VAR
+  VAR
+    result : DINT;
+  END_VAR
+  devices[1].a := 100;
+  devices[3].b := 200;
+  result := devices[1].a + devices[3].b;
+END_PROGRAM
+",
+    &[(1, 300)],
+);
+
+// A function body sees the global through the re-inserted global metadata;
+// without it the array resolves as a plain scalar and the field access fails.
+// Functions reach globals by name (VAR_EXTERNAL is a POU-level construct the
+// parser accepts only on programs and function blocks).
+e2e_i32!(
+    end_to_end_when_function_reads_global_array_of_struct_then_correct_value,
+    "
+TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE
+
+CONFIGURATION config
+  VAR_GLOBAL
+    devices : ARRAY[1..3] OF Item;
+  END_VAR
+  RESOURCE resource1 ON PLC
+    TASK plc_task(INTERVAL := T#100ms, PRIORITY := 1);
+    PROGRAM plc_task_instance WITH plc_task : main;
+  END_RESOURCE
+END_CONFIGURATION
+
+FUNCTION second_a : DINT
+  second_a := devices[2].a;
+END_FUNCTION
+
+PROGRAM main
+  VAR_EXTERNAL
+    devices : ARRAY[1..3] OF Item;
+  END_VAR
+  VAR
+    result : DINT;
+  END_VAR
+  devices[2].a := 17;
+  result := second_a();
+END_PROGRAM
+",
+    &[(1, 17)],
+);
+
+// --- Rejected shapes ---
+//
+// Each of these is accepted by `ironplcc check` and rejected by codegen, so
+// the assertion is on the compile result rather than on run values.
+
+/// Compiles `source` with default options and asserts codegen rejects it
+/// with the not-implemented problem code.
+fn assert_codegen_rejects(source: &str, what: &str) {
+    let result = try_parse_and_compile(source, &CompilerOptions::default());
+    assert!(result.is_err(), "expected compilation to fail for {}", what);
+    assert_eq!(result.unwrap_err().code, "P9999", "for {}", what);
+}
+
+#[test]
+fn compile_when_top_level_array_of_struct_element_assigned_whole_then_not_implemented() {
+    assert_codegen_rejects(
+        "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; one : Item; END_VAR arr[1] := one; END_PROGRAM",
+        "a whole-element assignment",
+    );
+}
+
+#[test]
+fn compile_when_top_level_array_of_struct_has_initial_values_then_not_implemented() {
+    // Element fields are left zeroed, so an explicit initializer must be
+    // rejected rather than silently dropped.
+    assert_codegen_rejects(
+        "TYPE Item : STRUCT a : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..2] OF Item := [1, 2]; result : DINT; END_VAR result := arr[1].a; END_PROGRAM",
+        "an array-of-struct with initial values",
+    );
+}
+
+#[test]
+fn compile_when_top_level_array_of_struct_string_field_read_then_not_implemented() {
+    assert_codegen_rejects(
+        "TYPE Item : STRUCT name : STRING[8]; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : STRING[8]; END_VAR result := arr[1].name; END_PROGRAM",
+        "a STRING field of an element",
+    );
+}
+
+#[test]
+fn compile_when_top_level_array_of_struct_composite_field_read_then_not_implemented() {
+    assert_codegen_rejects(
+        "TYPE Inner : STRUCT x : DINT; END_STRUCT; END_TYPE TYPE Item : STRUCT inner : Inner; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : DINT; END_VAR result := arr[1].inner.x; END_PROGRAM",
+        "a composite field of an element",
+    );
+}
+
+#[test]
+fn compile_when_top_level_array_of_struct_unknown_field_then_not_implemented() {
+    assert_codegen_rejects(
+        "TYPE Item : STRUCT a : DINT; b : DINT; END_STRUCT; END_TYPE PROGRAM main VAR arr : ARRAY[1..3] OF Item; result : DINT; END_VAR result := arr[1].missing; END_PROGRAM",
+        "an unknown field of an element",
+    );
+}

--- a/compiler/codegen/tests/it/main.rs
+++ b/compiler/codegen/tests/it/main.rs
@@ -35,6 +35,7 @@ mod end_to_end_add;
 mod end_to_end_adr;
 mod end_to_end_any_int_literals;
 mod end_to_end_array;
+mod end_to_end_array_of_struct;
 mod end_to_end_array_ref_to;
 mod end_to_end_array_string;
 mod end_to_end_atan2;

--- a/compiler/dsl/src/diagnostic.rs
+++ b/compiler/dsl/src/diagnostic.rs
@@ -262,6 +262,25 @@ impl Diagnostic {
             .with_source(caller.file(), caller.line())
     }
 
+    /// Creates a P9997 (NotSupported) diagnostic that automatically records
+    /// the compiler `file#Lline` of the call site as its source location.
+    ///
+    /// Use this — rather than [`Diagnostic::not_implemented`] — for a capability
+    /// the compiler deliberately does not offer: a fixed limit of the bytecode
+    /// format, or a construct that is not planned. P9999 promises "not yet";
+    /// P9997 does not, so a program that hits it needs to change rather than
+    /// wait for a later release.
+    ///
+    /// The location is captured via `#[track_caller]`, so no `file!()`/`line!()`
+    /// need to be passed.
+    #[track_caller]
+    #[allow(deprecated)]
+    pub fn not_supported(primary: Label) -> Self {
+        let caller = std::panic::Location::caller();
+        Diagnostic::problem(Problem::NotSupported, primary)
+            .with_source(caller.file(), caller.line())
+    }
+
     /// Creates an "internal error" diagnostic associated with a file and line in the Rust
     /// source code.
     ///

--- a/compiler/problems/build.rs
+++ b/compiler/problems/build.rs
@@ -70,6 +70,10 @@ fn create_problems() -> Result<(), Box<dyn Error>> {
     // `Diagnostic::problem(Problem::NotImplemented, …)` fails to compile.
     let compiler_located: &[(&str, &str)] = &[
         (
+            "NotSupported",
+            "construct via Diagnostic::not_supported so the compiler file/line is recorded for the P9xxx dashboards",
+        ),
+        (
             "NotImplemented",
             "construct via Diagnostic::not_implemented (or todo*) so the compiler file/line is recorded for the P9xxx dashboards",
         ),

--- a/compiler/problems/resources/problem-codes.csv
+++ b/compiler/problems/resources/problem-codes.csv
@@ -109,5 +109,6 @@ P8001,McpInputValidation,MCP tool input validation error
 P9001,UnsupportedStdLibType,Referenced type is valid but not implemented
 P9002,NoContent,Set of valid source files has no content
 P9003,XmlBodyTypeNotSupported,POU body language is not supported
+P9997,NotSupported,Capability is not supported
 P9998,InternalError,Internal error indicating a bug in the compiler
 P9999,NotImplemented,Capability is not implemented (yet!)

--- a/docs/reference/compiler/problems/P9997.rst
+++ b/docs/reference/compiler/problems/P9997.rst
@@ -1,0 +1,71 @@
+=====
+P9997
+=====
+
+.. problem-summary:: P9997
+
+Compiling the IEC 61131-3 source failed because the program needs a capability
+that the IronPLC compiler does not offer and does not plan to offer. This is
+usually a fixed limit of the bytecode format rather than a missing feature.
+
+This differs from :doc:`P9999 <P9999>`, which reports a capability that is not
+implemented *yet*. A later release is expected to accept a program that
+produces P9999. A program that produces P9997 has to change, because the limit
+it reached is part of the design.
+
+Example
+-------
+
+Each variable occupies a run of 8-byte slots in the data region, and the
+compiler addresses a slot with a 32-bit index. A single variable may therefore
+occupy at most 32768 slots. The following declaration asks for far more, so it
+produces error P9997:
+
+.. code-block::
+
+   TYPE Item : STRUCT
+     a : DINT;
+     b : DINT;
+   END_STRUCT;
+   END_TYPE
+
+   PROGRAM main
+     VAR
+       readings : ARRAY[1..40000] OF Item;
+     END_VAR
+   END_PROGRAM
+
+Each ``Item`` occupies 2 slots, so the array needs 80000 slots — more than
+twice the limit.
+
+To fix this error, reduce the amount of data the variable holds. Splitting the
+data across several variables works because the limit applies to each variable
+separately:
+
+.. code-block::
+
+   TYPE Item : STRUCT
+     a : DINT;
+     b : DINT;
+   END_STRUCT;
+   END_TYPE
+
+   PROGRAM main
+     VAR
+       readings : ARRAY[1..8000] OF Item;
+     END_VAR
+   END_PROGRAM
+
+Limits that produce this error
+------------------------------
+
+* a single variable occupying more than 32768 slots
+* a data region larger than 2 GiB
+* an array whose element count, slot count, or byte size overflows the
+  compiler's internal arithmetic
+
+If your program needs more than one of these limits allows, please describe
+what you are building in a `GitHub issue`_ — the limits are design choices, and
+a concrete use case is what would prompt revisiting one.
+
+.. _GitHub issue: https://github.com/ironplc/ironplc/issues/new?template=bug_report.md

--- a/specs/plans/2026-08-22-top-level-array-of-struct.md
+++ b/specs/plans/2026-08-22-top-level-array-of-struct.md
@@ -63,28 +63,33 @@ addressing added for #1376.
 
 | File | Change |
 |------|--------|
+| `compiler/codegen/src/compile_array_struct.rs` | New module: `StructArrayVarInfo`, declaration detection, registration, and `arr[i].field` resolution for both the top-level and struct-field forms |
 | `compiler/codegen/src/compile.rs` | `CompileContext::struct_array_vars` map |
-| `compiler/codegen/src/compile_array.rs` | `StructArrayVarInfo`, `register_struct_array_variable`, top-level base in `resolve_struct_array_element_field`, shared element-field access helper |
+| `compiler/codegen/src/compile_array.rs` | Moved the array-of-struct access path into the new module; extracted `array_spec_for_declaration`; explanatory diagnostic for whole-element access |
 | `compiler/codegen/src/compile_setup.rs` | Route struct element types to the new registration; store the data offset into the variable slot in `emit_initial_values` |
 | `compiler/codegen/src/compile_fn.rs` | Save/restore `struct_array_vars` and re-expose globals to function and FB bodies |
+| `compiler/codegen/src/lib.rs` | Register the new module |
 | `compiler/codegen/tests/it/end_to_end_array_of_struct.rs` | New end-to-end file (registered in `tests/it/main.rs`) |
+| `compiler/codegen/tests/it/compile_array.rs` | Container-shape and emitted-index tests |
 
 ## Tasks
 
-- [ ] Add `StructArrayVarInfo` and `CompileContext::struct_array_vars`
-- [ ] Add `register_struct_array_variable` (slot accounting, limits, descriptor)
-- [ ] Route inline (`ARRAY[..] OF Item`) and named array types with a
+- [x] Add `StructArrayVarInfo` and `CompileContext::struct_array_vars`
+- [x] Add `register_struct_array_variable` (slot accounting, limits, descriptor)
+- [x] Route inline (`ARRAY[..] OF Item`) and named array types with a
       structure element type to the new registration in `assign_variables`
-- [ ] Emit the data-region offset into the variable slot in
+- [x] Emit the data-region offset into the variable slot in
       `emit_initial_values`; reject explicit initial values
-- [ ] Resolve `Arr[i].field` for a top-level base in
+- [x] Resolve `Arr[i].field` for a top-level base in
       `resolve_struct_array_element_field`, factoring the tail shared with the
       struct-field base into one helper
-- [ ] Give whole-element access (`Arr[i]` without a field) an explanatory
+- [x] Move the array-of-struct paths into `compile_array_struct.rs` so no
+      module crosses the 1000-line guideline
+- [x] Give whole-element access (`Arr[i]` without a field) an explanatory
       diagnostic instead of the bare `todo`
-- [ ] Save/restore `struct_array_vars` across function and FB body compilation
-- [ ] End-to-end tests: literal and variable subscript, distinct elements,
+- [x] Save/restore `struct_array_vars` across function and FB body compilation
+- [x] End-to-end tests: literal and variable subscript, distinct elements,
       sibling fields, multi-dimensional, FOR loop, BOOL leaf, read-back in an
       expression, named array type, and a global declaration
-- [ ] Unit tests for the registration and resolution error paths
-- [ ] `cd compiler && just`
+- [x] Unit tests for the registration and resolution error paths
+- [x] `cd compiler && just`

--- a/specs/plans/2026-08-22-top-level-array-of-struct.md
+++ b/specs/plans/2026-08-22-top-level-array-of-struct.md
@@ -1,0 +1,90 @@
+# Plan: Top-Level `ARRAY OF <struct>` Variables
+
+Fixes [#1383](https://github.com/ironplc/ironplc/issues/1383).
+
+## Goal
+
+Allow a variable whose type is an array of a user-defined structure to be
+declared and accessed at the top level of a POU, so that
+
+```st
+TYPE Item : STRUCT Flag : BOOL; END_STRUCT; END_TYPE
+
+PROGRAM main
+VAR
+    Arr : ARRAY[1..6] OF Item;
+END_VAR
+    Arr[1].Flag := TRUE;
+END_PROGRAM
+```
+
+compiles and runs. Today `ironplcc check` accepts the program but codegen
+rejects it at *declaration* time with P9999 "Unsupported array element type",
+so neither reads nor writes are reachable.
+
+## Architecture
+
+`register_array_variable` resolves the element type through
+`compile_setup::resolve_type_name`, which maps only elementary and generic
+type names to a `VarTypeInfo`. A structure type name yields `None`, hence the
+diagnostic.
+
+The array-of-struct layout is already solved for the *struct field* case
+(`holder.items[i].field`, issue #1376): structures occupy a contiguous run of
+slots, so an array of them is a flat slot array, and
+`ResolvedAccess::StructFieldArrayElement` addresses it as
+
+```text
+slot = base_slot_offset + leaf_offset      (compile time)
+     + flat_index * element_slots          (runtime)
+```
+
+A top-level array-of-struct has no enclosing struct whose descriptor and data
+region it can borrow, so it needs its own allocation path. Once it has one,
+the *access* path is identical: register the variable exactly the way a
+structure variable is registered — variable slot holds the data-region byte
+offset, plus a slot-typed array descriptor sized `total_elements *
+element_slots` — and `Arr[i].field` reuses `StructFieldArrayElement` with a
+`base_slot_offset` of 0. No new opcode and no new emission path.
+
+Element field *initialization* is deliberately not emitted, matching the
+existing array-of-struct-through-a-field behavior
+(`initialize_struct_fields` emits nothing for an array-of-struct field): the
+data region starts zeroed. Explicit array initializers on an array-of-struct
+are rejected with a clear diagnostic rather than silently ignored.
+
+## Design doc reference
+
+None. Extends the layout established in
+`specs/plans/struct-array-field-subscript.md` and the array-of-struct element
+addressing added for #1376.
+
+## File map
+
+| File | Change |
+|------|--------|
+| `compiler/codegen/src/compile.rs` | `CompileContext::struct_array_vars` map |
+| `compiler/codegen/src/compile_array.rs` | `StructArrayVarInfo`, `register_struct_array_variable`, top-level base in `resolve_struct_array_element_field`, shared element-field access helper |
+| `compiler/codegen/src/compile_setup.rs` | Route struct element types to the new registration; store the data offset into the variable slot in `emit_initial_values` |
+| `compiler/codegen/src/compile_fn.rs` | Save/restore `struct_array_vars` and re-expose globals to function and FB bodies |
+| `compiler/codegen/tests/it/end_to_end_array_of_struct.rs` | New end-to-end file (registered in `tests/it/main.rs`) |
+
+## Tasks
+
+- [ ] Add `StructArrayVarInfo` and `CompileContext::struct_array_vars`
+- [ ] Add `register_struct_array_variable` (slot accounting, limits, descriptor)
+- [ ] Route inline (`ARRAY[..] OF Item`) and named array types with a
+      structure element type to the new registration in `assign_variables`
+- [ ] Emit the data-region offset into the variable slot in
+      `emit_initial_values`; reject explicit initial values
+- [ ] Resolve `Arr[i].field` for a top-level base in
+      `resolve_struct_array_element_field`, factoring the tail shared with the
+      struct-field base into one helper
+- [ ] Give whole-element access (`Arr[i]` without a field) an explanatory
+      diagnostic instead of the bare `todo`
+- [ ] Save/restore `struct_array_vars` across function and FB body compilation
+- [ ] End-to-end tests: literal and variable subscript, distinct elements,
+      sibling fields, multi-dimensional, FOR loop, BOOL leaf, read-back in an
+      expression, named array type, and a global declaration
+- [ ] Unit tests for the registration and resolution error paths
+- [ ] `cd compiler && just`


### PR DESCRIPTION
## Summary

Implements support for declaring and accessing top-level `ARRAY OF <struct>` variables, allowing code like `Arr[i].field` where `Arr` is an array whose elements are user-defined structures. Previously, `ironplcc check` accepted such declarations but codegen rejected them at declaration time.

## Key Changes

- **New module `compile_array_struct.rs`**: Handles declaration detection, registration, and field access resolution for arrays of structures. Structures occupy contiguous slot runs, so an array of them is a flat slot array rather than one slot per element.

- **Registration path**: Top-level array-of-struct variables are allocated like structure variables—one contiguous data region run of `total_elements * element_slots` slots, plus a slot-typed array descriptor covering the entire region. The variable slot holds the data-region byte offset.

- **Access path reuse**: Field access (`arr[i].field`) reuses the existing `ResolvedAccess::StructFieldArrayElement` variant by scaling array dimension strides by the element slot count, making the emitted flat index count slots directly. No new opcodes or emission paths required.

- **Moved code**: The array-of-struct element field resolution logic previously in `compile_array.rs` is now in the new module, shared between struct-field arrays (`holder.items[i].field`) and top-level arrays (`items[i].field`).

- **Declaration detection**: `struct_array_declaration()` identifies arrays with structure element types (both inline `ARRAY[..] OF Item` and named array types), distinguishing them from `ARRAY OF REF_TO <struct>` which remains on the reference path.

- **Global support**: Functions and function blocks can access global array-of-struct variables through re-inserted global metadata, matching the existing pattern for structure and array globals.

- **Validation**: Rejects unsupported shapes (whole-element access, STRING fields, composite fields) with clear diagnostics at declaration or first access time.

## Implementation Details

- Element initialization is deliberately not emitted, matching existing array-of-struct-field behavior; the data region starts zeroed.
- Bounds checks validate against unscaled element counts, not slot counts.
- Data region byte offsets are stored in variable slots via `LOAD_CONST_I32`, with overflow checks for the 2 GiB limit and 32768-slot maximum.
- Comprehensive end-to-end tests cover nominal reads/writes, bounds shapes (zero-based, negative lower bounds, multidimensional), element shapes (nested structures, 64-bit fields), named array types, global declarations, and rejected shapes.

## Testing

- 20+ end-to-end tests in new `end_to_end_array_of_struct.rs` covering read/write, bounds, element types, globals, and error cases
- Container-shape and bytecode-emission tests in `compile_array.rs`
- All existing tests continue to pass

https://claude.ai/code/session_01Phh6cZqjqR7tSVpe2UUCX2