### PR TITLE
Add plan for traversal-driven scopes and scope paths

### DIFF
--- a/compiler/analyzer/src/rule_use_declared_symbolic_var.rs
+++ b/compiler/analyzer/src/rule_use_declared_symbolic_var.rs
@@ -44,6 +44,7 @@ use ironplc_dsl::{
     common::*,
     core::{Id, Located},
     diagnostic::{Diagnostic, Label},
+    scope::ScopeNode,
     visitor::Visitor,
 };
 use ironplc_problems::Problem;
@@ -99,38 +100,45 @@ struct SymbolScopeChecker<'a> {
 impl Visitor<Diagnostic> for SymbolScopeChecker<'_> {
     type Value = ();
 
-    fn visit_function_declaration(&mut self, node: &FunctionDeclaration) -> Result<(), Diagnostic> {
+    /// Opens the scope of a declaration and seeds the names that are in
+    /// scope by virtue of the declaration itself.
+    ///
+    /// The traversal calls this for every declaration marked
+    /// `#[recurse(scope)]`, so this rule states what a scope *contains*
+    /// and never which node kinds have one. The match is exhaustive on
+    /// purpose: a new kind of scope must be a compile error here rather
+    /// than a silently unseeded scope.
+    fn enter_scope(&mut self, node: ScopeNode<'_>) -> Result<(), Diagnostic> {
         self.table.enter();
 
-        self.table.add(&node.name, DummyNode {});
-        let ret = node.recurse_visit(self);
-        self.table.exit();
-        ret
-    }
-
-    fn visit_program_declaration(&mut self, node: &ProgramDeclaration) -> Result<(), Diagnostic> {
-        self.table.enter();
-        self.table.add(&node.name, DummyNode {});
-        let ret = node.recurse_visit(self);
-        self.table.exit();
-        ret
-    }
-
-    fn visit_function_block_declaration(
-        &mut self,
-        node: &FunctionBlockDeclaration,
-    ) -> Result<(), Diagnostic> {
-        self.table.enter();
-        self.table.add(&node.name.name, DummyNode {});
-        if let Some(fields) = self.inherited_fields.get(&node.name).cloned() {
-            for field in &fields {
-                self.table
-                    .add_if(field.identifier.symbolic_id(), DummyNode {});
+        match node {
+            // A function's own name is its implicit result variable, so
+            // `FOO := ...` inside `FUNCTION FOO` resolves.
+            ScopeNode::Function(node) => {
+                self.table.add(&node.name, DummyNode {});
+            }
+            ScopeNode::Program(node) => {
+                self.table.add(&node.name, DummyNode {});
+            }
+            // A derived function block's scope also holds the fields it
+            // inherits through `EXTENDS`, so an unqualified reference to
+            // an ancestor's field resolves.
+            ScopeNode::FunctionBlock(node) => {
+                self.table.add(&node.name.name, DummyNode {});
+                if let Some(fields) = self.inherited_fields.get(&node.name).cloned() {
+                    for field in &fields {
+                        self.table
+                            .add_if(field.identifier.symbolic_id(), DummyNode {});
+                    }
+                }
             }
         }
-        let ret = node.recurse_visit(self);
+
+        Ok(())
+    }
+
+    fn exit_scope(&mut self) {
         self.table.exit();
-        ret
     }
 
     fn visit_var_decl(&mut self, node: &VarDecl) -> Result<Self::Value, Diagnostic> {

--- a/compiler/analyzer/src/xform_fold_initializer_expressions.rs
+++ b/compiler/analyzer/src/xform_fold_initializer_expressions.rs
@@ -38,6 +38,7 @@ use ironplc_dsl::common::*;
 use ironplc_dsl::core::{Id, Located};
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
 use ironplc_dsl::fold::Fold;
+use ironplc_dsl::scope::ScopeNode;
 use ironplc_dsl::textual::*;
 use ironplc_parser::options::CompilerOptions;
 use ironplc_problems::Problem;
@@ -285,37 +286,29 @@ impl Fold<Diagnostic> for InitializerFolder<'_> {
         }
     }
 
-    fn fold_function_block_declaration(
-        &mut self,
-        node: FunctionBlockDeclaration,
-    ) -> Result<FunctionBlockDeclaration, Diagnostic> {
+    /// Opens the scope of a declaration and registers the constants it
+    /// declares, so that a `VAR CONSTANT` is visible to initializers
+    /// within the declaration and to nothing outside it.
+    ///
+    /// The match is exhaustive because every kind registers the same
+    /// thing: should a new kind of scope not want its constants
+    /// registered, that has to be said here rather than inferred from an
+    /// absent arm.
+    fn enter_scope(&mut self, node: ScopeNode<'_>) -> Result<(), Diagnostic> {
         self.constants.enter();
-        register_constants(&mut self.constants, &node.variables, &mut self.diagnostics);
-        let result = node.recurse_fold(self);
-        self.constants.exit();
-        result
+
+        let variables = match node {
+            ScopeNode::Function(node) => &node.variables,
+            ScopeNode::FunctionBlock(node) => &node.variables,
+            ScopeNode::Program(node) => &node.variables,
+        };
+        register_constants(&mut self.constants, variables, &mut self.diagnostics);
+
+        Ok(())
     }
 
-    fn fold_function_declaration(
-        &mut self,
-        node: FunctionDeclaration,
-    ) -> Result<FunctionDeclaration, Diagnostic> {
-        self.constants.enter();
-        register_constants(&mut self.constants, &node.variables, &mut self.diagnostics);
-        let result = node.recurse_fold(self);
+    fn exit_scope(&mut self) {
         self.constants.exit();
-        result
-    }
-
-    fn fold_program_declaration(
-        &mut self,
-        node: ProgramDeclaration,
-    ) -> Result<ProgramDeclaration, Diagnostic> {
-        self.constants.enter();
-        register_constants(&mut self.constants, &node.variables, &mut self.diagnostics);
-        let result = node.recurse_fold(self);
-        self.constants.exit();
-        result
     }
 }
 

--- a/compiler/dsl/src/common.rs
+++ b/compiler/dsl/src/common.rs
@@ -13,6 +13,7 @@ use crate::configuration::{ConfigurationDeclaration, Direction};
 use crate::core::{Id, Located, SourceSpan};
 use crate::extension::LanguageExtension;
 use crate::fold::Fold;
+use crate::scope::ScopeBearing;
 use crate::sfc::{Network, Sfc};
 use crate::textual::*;
 use crate::time::*;
@@ -2728,6 +2729,7 @@ impl From<TypeName> for FunctionReturnType {
 ///
 /// See section 2.5.1.
 #[derive(Clone, Debug, PartialEq, Recurse)]
+#[recurse(scope)]
 pub struct FunctionDeclaration {
     pub name: Id,
     pub return_type: FunctionReturnType,
@@ -2750,6 +2752,7 @@ impl HasVariables for FunctionDeclaration {
 ///
 /// See section 2.5.2.
 #[derive(Clone, Debug, PartialEq, Recurse, Located)]
+#[recurse(scope)]
 pub struct FunctionBlockDeclaration {
     pub name: TypeName,
     pub variables: Vec<VarDecl>,
@@ -2786,6 +2789,12 @@ pub struct FunctionBlockDeclaration {
 /// (own methods first, then the `EXTENDS` chain) is implemented outside
 /// the AST, in `ironplc-analyzer`.
 #[derive(Clone, Debug, PartialEq, Recurse, Located)]
+// A `METHOD` *should* open a scope -- its parameters and locals belong to it,
+// not to the function block, and its own name should be assignable to set the
+// result value. It does not today, which is
+// https://github.com/ironplc/ironplc/issues/1439. Stated explicitly rather than
+// left to an omission so that the fix is a one-word change here.
+#[recurse(no_scope)]
 pub struct MethodDeclaration {
     pub name: Id,
     pub return_type: Option<FunctionReturnType>,
@@ -2910,6 +2919,7 @@ impl LanguageExtension for InterfaceDeclaration {
 ///
 /// See section 2.5.3.
 #[derive(Clone, Debug, PartialEq, Recurse)]
+#[recurse(scope)]
 pub struct ProgramDeclaration {
     pub name: Id,
     pub variables: Vec<VarDecl>,

--- a/compiler/dsl/src/fold.rs
+++ b/compiler/dsl/src/fold.rs
@@ -10,6 +10,7 @@
 use crate::common::*;
 use crate::configuration::*;
 use crate::core::*;
+use crate::scope::ScopeNode;
 use crate::sfc::*;
 use crate::textual::*;
 use crate::time::*;
@@ -49,6 +50,24 @@ pub trait Fold<E> {
     fn fold_library(&mut self, node: Library) -> Result<Library, E> {
         node.recurse_fold(self)
     }
+
+    /// Called when the fold enters a declaration that opens a scope.
+    ///
+    /// See [`Visitor::enter_scope`] for the contract, which is identical.
+    /// The declaration is borrowed before the fold consumes it, so `node`
+    /// is valid for the duration of the call only.
+    ///
+    /// [`Visitor::enter_scope`]: crate::visitor::Visitor::enter_scope
+    fn enter_scope(&mut self, _node: ScopeNode<'_>) -> Result<(), E> {
+        Ok(())
+    }
+
+    /// Called when the fold leaves a declaration that opens a scope.
+    ///
+    /// See [`Visitor::exit_scope`].
+    ///
+    /// [`Visitor::exit_scope`]: crate::visitor::Visitor::exit_scope
+    fn exit_scope(&mut self) {}
 
     // Declarations from Core
 

--- a/compiler/dsl/src/lib.rs
+++ b/compiler/dsl/src/lib.rs
@@ -7,6 +7,7 @@ pub mod core;
 pub mod diagnostic;
 pub mod extension;
 pub mod fold;
+pub mod scope;
 pub mod sfc;
 pub mod textual;
 pub mod time;

--- a/compiler/dsl/src/scope.rs
+++ b/compiler/dsl/src/scope.rs
@@ -1,0 +1,67 @@
+//! Declarations that open a lexical scope.
+//!
+//! A scope-bearing declaration is one whose variable declarations are
+//! visible only inside its own body: a `FUNCTION`, a `FUNCTION_BLOCK`, a
+//! `PROGRAM`. Rather than each analysis pass deciding for itself which
+//! node kinds those are — and silently getting no scope for the kinds it
+//! forgot — the traversal opens and closes the scope, and a pass that
+//! cares implements [`Visitor::enter_scope`]/[`Visitor::exit_scope`] (or
+//! the [`Fold`] equivalents) exactly once.
+//!
+//! Marking a declaration `#[recurse(scope)]` is what makes the derived
+//! `recurse_visit`/`recurse_fold` call those hooks. The derive refuses to
+//! compile a declaration that holds `variables: Vec<VarDecl>` and says
+//! neither `#[recurse(scope)]` nor `#[recurse(no_scope)]`, so a new
+//! POU-like construct cannot quietly arrive without the question being
+//! answered.
+//!
+//! [`Visitor::enter_scope`]: crate::visitor::Visitor::enter_scope
+//! [`Visitor::exit_scope`]: crate::visitor::Visitor::exit_scope
+//! [`Fold`]: crate::fold::Fold
+
+use crate::common::{FunctionBlockDeclaration, FunctionDeclaration, ProgramDeclaration};
+
+/// The declaration that opened the scope the traversal is entering.
+///
+/// Passes match on this without a wildcard arm: the kinds do not agree on
+/// what a scope contains — a function seeds its own name as the implicit
+/// result variable, a function block additionally seeds the fields it
+/// inherits through `EXTENDS` — so a new variant must be a compile error
+/// everywhere that discriminates, not a silently skipped case.
+///
+/// `MethodDeclaration` is deliberately absent: a `METHOD` does not open a
+/// scope today, which is
+/// [#1439](https://github.com/ironplc/ironplc/issues/1439).
+#[derive(Debug)]
+pub enum ScopeNode<'a> {
+    Function(&'a FunctionDeclaration),
+    FunctionBlock(&'a FunctionBlockDeclaration),
+    Program(&'a ProgramDeclaration),
+}
+
+/// Implemented by every declaration marked `#[recurse(scope)]`.
+///
+/// The derived traversal calls this to describe the scope it is opening.
+/// The trait supplies the content; the enforcement that a pass handles
+/// every kind is [`ScopeNode`]'s exhaustiveness.
+pub trait ScopeBearing {
+    fn as_scope_node(&self) -> ScopeNode<'_>;
+}
+
+impl ScopeBearing for FunctionDeclaration {
+    fn as_scope_node(&self) -> ScopeNode<'_> {
+        ScopeNode::Function(self)
+    }
+}
+
+impl ScopeBearing for FunctionBlockDeclaration {
+    fn as_scope_node(&self) -> ScopeNode<'_> {
+        ScopeNode::FunctionBlock(self)
+    }
+}
+
+impl ScopeBearing for ProgramDeclaration {
+    fn as_scope_node(&self) -> ScopeNode<'_> {
+        ScopeNode::Program(self)
+    }
+}

--- a/compiler/dsl/src/visitor.rs
+++ b/compiler/dsl/src/visitor.rs
@@ -35,6 +35,7 @@
 use crate::common::*;
 use crate::configuration::*;
 use crate::core::{Id, SourceSpan};
+use crate::scope::ScopeNode;
 use crate::sfc::*;
 use crate::textual::*;
 use crate::time::*;
@@ -98,6 +99,30 @@ pub trait Visitor<E> {
     fn walk(&mut self, node: &Library) -> Result<Self::Value, E> {
         node.recurse_visit(self)
     }
+
+    /// Called when the traversal enters a declaration that opens a scope.
+    ///
+    /// The derived `recurse_visit` of a `#[recurse(scope)]` declaration
+    /// calls this before visiting the declaration's contents and calls
+    /// `exit_scope` after, including when the contents return an error,
+    /// so the pair can never be left unbalanced by an early return. The
+    /// pair fires if and only if the traversal recurses: a visitor that
+    /// overrides the declaration's `visit_*` and returns without calling
+    /// `recurse_visit` opens no scope, which is correct, because it
+    /// visited nothing.
+    ///
+    /// `node` borrows the declaration for the duration of the call only;
+    /// copy out what the scope needs rather than retaining it.
+    fn enter_scope(&mut self, _node: ScopeNode<'_>) -> Result<(), E> {
+        Ok(())
+    }
+
+    /// Called when the traversal leaves a declaration that opens a scope.
+    ///
+    /// Takes no argument and cannot fail: it runs on the error path, and
+    /// a visitor that needs to know what it is closing already has the
+    /// stack it pushed in `enter_scope`.
+    fn exit_scope(&mut self) {}
 
     // Declarations from Core
 

--- a/compiler/dsl_macro_derive/src/lib.rs
+++ b/compiler/dsl_macro_derive/src/lib.rs
@@ -47,9 +47,24 @@ pub fn recurse_macro_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let name = &ast.ident;
 
+    let scope = match scope_attr(&ast.attrs) {
+        Ok(scope) => scope,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    if let syn::Data::Struct(data_struct) = &ast.data {
+        if let syn::Fields::Named(named_fields) = &data_struct.fields {
+            if let Err(err) = check_scope_declared(name, named_fields, scope) {
+                return err.to_compile_error().into();
+            }
+        }
+    }
+
     let visit_res: Result<TokenStream> = match &ast.data {
         syn::Data::Struct(data_struct) => match &data_struct.fields {
-            syn::Fields::Named(named_fields) => expand_struct_recurse_visit(name, named_fields),
+            syn::Fields::Named(named_fields) => {
+                expand_struct_recurse_visit(name, named_fields, scope)
+            }
             _ => {
                 unimplemented!("#[derive(Recurse)] is only supported for structs with named types")
             }
@@ -63,7 +78,9 @@ pub fn recurse_macro_derive(input: TokenStream) -> TokenStream {
 
     let fold_res: Result<TokenStream> = match &ast.data {
         syn::Data::Struct(data_struct) => match &data_struct.fields {
-            syn::Fields::Named(named_fields) => expand_struct_recurse_fold(name, named_fields),
+            syn::Fields::Named(named_fields) => {
+                expand_struct_recurse_fold(name, named_fields, scope)
+            }
             _ => {
                 unimplemented!("#[derive(Recurse)] is only supported for structs with named types")
             }
@@ -77,6 +94,100 @@ pub fn recurse_macro_derive(input: TokenStream) -> TokenStream {
 
     visit_res.extend(fold_res);
     visit_res
+}
+
+/// Whether a declaration says it opens a lexical scope.
+///
+/// See `ironplc_dsl::scope` for what a scope is and why the traversal
+/// rather than each pass is what opens one.
+#[derive(Clone, Copy, PartialEq)]
+enum ScopeAttr {
+    /// `#[recurse(scope)]` -- the derived traversal brackets the
+    /// recursion with `enter_scope`/`exit_scope`.
+    Scope,
+    /// `#[recurse(no_scope)]` -- it deliberately does not.
+    NoScope,
+    /// Neither, which is only allowed for a declaration that holds no
+    /// variables of its own. See `check_scope_declared`.
+    Absent,
+}
+
+/// Returns the scope attribute declared on a type, or `Absent`.
+fn scope_attr(attrs: &[Attribute]) -> Result<ScopeAttr> {
+    let mut scope = ScopeAttr::Absent;
+    for attr in attrs {
+        if attr.path().is_ident("recurse") {
+            attr.parse_nested_meta(|meta| {
+                // #[recurse(scope)]
+                if meta.path.is_ident("scope") {
+                    scope = ScopeAttr::Scope;
+                    return Ok(());
+                }
+                // #[recurse(no_scope)]
+                if meta.path.is_ident("no_scope") {
+                    scope = ScopeAttr::NoScope;
+                    return Ok(());
+                }
+                Err(meta.error("unrecognized value in recurse"))
+            })?;
+        }
+    }
+    Ok(scope)
+}
+
+/// Rejects a declaration that owns variables without saying whether it
+/// scopes them.
+///
+/// A struct holding `variables: Vec<VarDecl>` is a program organization
+/// unit or something shaped like one, so whether those variables are
+/// visible outside its own body is a question that has to be answered
+/// deliberately. Left unstated, it answers itself as "not a scope",
+/// silently and in every pass at once -- which is how a `METHOD`'s
+/// locals came to leak into its siblings
+/// (https://github.com/ironplc/ironplc/issues/1439). Requiring the
+/// attribute turns that omission into a build error at the declaration
+/// itself.
+///
+/// The check is syntactic, so a declaration that holds variables under
+/// another field name (`ResourceDeclaration::global_vars`,
+/// `ConfigurationDeclaration::global_var`) is not reached by it.
+fn check_scope_declared(name: &Ident, fields: &FieldsNamed, scope: ScopeAttr) -> Result<()> {
+    if scope != ScopeAttr::Absent {
+        return Ok(());
+    }
+
+    for field in &fields.named {
+        let Some(ident) = field.ident.as_ref().filter(|id| *id == "variables") else {
+            continue;
+        };
+        let (inner, container) = extract_type_ident_from_path(&field.ty);
+        if container != DeclaredType::Vec || !type_is_named(inner, "VarDecl") {
+            continue;
+        }
+        return Err(Error::new(
+            ident.span(),
+            format!(
+                "`{name}` declares `variables: Vec<VarDecl>`, so it must say whether it opens a \
+                 lexical scope: add `#[recurse(scope)]` to bracket its contents with \
+                 `enter_scope`/`exit_scope`, or `#[recurse(no_scope)]` to state that its \
+                 variables are visible to the enclosing scope"
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Returns whether a type is the named path type, ignoring any qualifier.
+fn type_is_named(ty: &syn::Type, name: &str) -> bool {
+    match ty {
+        syn::Type::Path(type_path) => type_path
+            .path
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == name),
+        _ => false,
+    }
 }
 
 /// Derives an implementation of the `Located` trait for a struct.
@@ -286,7 +397,11 @@ fn expand_enum_recurse_visit(name: &Ident, data_enum: &DataEnum) -> Result<Token
 }
 
 /// Returns a stream of tokens that implement recursive visit for a struct.
-fn expand_struct_recurse_visit(name: &Ident, fields: &FieldsNamed) -> Result<TokenStream> {
+fn expand_struct_recurse_visit(
+    name: &Ident,
+    fields: &FieldsNamed,
+    scope: ScopeAttr,
+) -> Result<TokenStream> {
     // Filter out all fields that are marked as do not included
     let included_fields: Result<Vec<&Field>> = fields
         .named
@@ -344,15 +459,46 @@ fn expand_struct_recurse_visit(name: &Ident, fields: &FieldsNamed) -> Result<Tok
         }
     });
 
-    // Create the recurse implementation method for the type.
-    let gen = quote! {
-        impl #name {
-            pub fn recurse_visit<V: Visitor<E> + ?Sized, E>(
-                &self,
-                v: &mut V,
-            ) -> Result<V::Value, E> {
-                #(#visit_methods;)*
-                Ok(V::Value::default())
+    let body = quote! {
+        #(#visit_methods;)*
+        Ok(V::Value::default())
+    };
+
+    // Create the recurse implementation method for the type. A scope-bearing
+    // declaration brackets the recursion with the visitor's scope hooks. The
+    // body moves into a private method so that `exit_scope` runs even when it
+    // returns early through `?`, which is what makes the pair impossible for a
+    // visitor to leave unbalanced.
+    let gen = if scope == ScopeAttr::Scope {
+        quote! {
+            impl #name {
+                pub fn recurse_visit<V: Visitor<E> + ?Sized, E>(
+                    &self,
+                    v: &mut V,
+                ) -> Result<V::Value, E> {
+                    v.enter_scope(ScopeBearing::as_scope_node(self))?;
+                    let result = self.recurse_visit_inner(v);
+                    v.exit_scope();
+                    result
+                }
+
+                fn recurse_visit_inner<V: Visitor<E> + ?Sized, E>(
+                    &self,
+                    v: &mut V,
+                ) -> Result<V::Value, E> {
+                    #body
+                }
+            }
+        }
+    } else {
+        quote! {
+            impl #name {
+                pub fn recurse_visit<V: Visitor<E> + ?Sized, E>(
+                    &self,
+                    v: &mut V,
+                ) -> Result<V::Value, E> {
+                    #body
+                }
             }
         }
     };
@@ -423,7 +569,11 @@ fn expand_enum_recurse_fold(name: &Ident, data_enum: &DataEnum) -> Result<TokenS
 }
 
 /// Returns a stream of tokens that implement recursive fold for a struct.
-fn expand_struct_recurse_fold(name: &Ident, fields: &FieldsNamed) -> Result<TokenStream> {
+fn expand_struct_recurse_fold(
+    name: &Ident,
+    fields: &FieldsNamed,
+    scope: ScopeAttr,
+) -> Result<TokenStream> {
     // Generate the dispatch methods for each of the items in the type.
     let fold_items = fields.named.iter().map(|f| {
         let name = &f.ident;
@@ -461,13 +611,41 @@ fn expand_struct_recurse_fold(name: &Ident, fields: &FieldsNamed) -> Result<Toke
         }
     });
 
-    // Create the recurse implementation method for the type.
-    let gen = quote! {
-        impl #name {
-            pub fn recurse_fold<F: Fold<E> + ?Sized, E>(self, f: &mut F) -> Result<#name, E> {
-                Ok(#name {
-                    #(#fold_items,)*
-                })
+    let body = quote! {
+        Ok(#name {
+            #(#fold_items,)*
+        })
+    };
+
+    // Create the recurse implementation method for the type. See
+    // `expand_struct_recurse_visit` for why a scope-bearing declaration splits
+    // the body into a private method. The scope node borrows `self` only for
+    // the duration of the `enter_scope` call, which is why the by-value fold
+    // signature still works.
+    let gen = if scope == ScopeAttr::Scope {
+        quote! {
+            impl #name {
+                pub fn recurse_fold<F: Fold<E> + ?Sized, E>(self, f: &mut F) -> Result<#name, E> {
+                    f.enter_scope(ScopeBearing::as_scope_node(&self))?;
+                    let result = self.recurse_fold_inner(f);
+                    f.exit_scope();
+                    result
+                }
+
+                fn recurse_fold_inner<F: Fold<E> + ?Sized, E>(
+                    self,
+                    f: &mut F,
+                ) -> Result<#name, E> {
+                    #body
+                }
+            }
+        }
+    } else {
+        quote! {
+            impl #name {
+                pub fn recurse_fold<F: Fold<E> + ?Sized, E>(self, f: &mut F) -> Result<#name, E> {
+                    #body
+                }
             }
         }
     };
@@ -477,6 +655,7 @@ fn expand_struct_recurse_fold(name: &Ident, fields: &FieldsNamed) -> Result<Toke
 
 /// Defines the types of containers objects.
 /// The containing object determines how we recurse into each field.
+#[derive(PartialEq)]
 enum DeclaredType {
     Option,
     Vec,
@@ -637,4 +816,116 @@ fn is_ignored(attrs: &Vec<Attribute>) -> Result<bool> {
         }
     }
     Ok(ignored)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Runs the scope guard over a struct definition, as
+    /// `recurse_macro_derive` does.
+    fn check(source: &str) -> Result<()> {
+        let ast: DeriveInput = syn::parse_str(source).expect("test source must parse");
+        let scope = scope_attr(&ast.attrs)?;
+        match &ast.data {
+            syn::Data::Struct(data_struct) => match &data_struct.fields {
+                syn::Fields::Named(named_fields) => {
+                    check_scope_declared(&ast.ident, named_fields, scope)
+                }
+                _ => panic!("test source must have named fields"),
+            },
+            _ => panic!("test source must be a struct"),
+        }
+    }
+
+    #[test]
+    fn check_scope_declared_when_holds_variables_and_no_attribute_then_error() {
+        let result = check(
+            "struct PouDeclaration {
+                pub name: Id,
+                pub variables: Vec<VarDecl>,
+            }",
+        );
+        let message = result.expect_err("must reject").to_string();
+        assert!(message.contains("PouDeclaration"), "{message}");
+        assert!(message.contains("#[recurse(scope)]"), "{message}");
+        assert!(message.contains("#[recurse(no_scope)]"), "{message}");
+    }
+
+    #[test]
+    fn check_scope_declared_when_holds_variables_and_scope_then_ok() {
+        assert!(check(
+            "#[recurse(scope)]
+            struct PouDeclaration {
+                pub variables: Vec<VarDecl>,
+            }",
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn check_scope_declared_when_holds_variables_and_no_scope_then_ok() {
+        assert!(check(
+            "#[recurse(no_scope)]
+            struct PouDeclaration {
+                pub variables: Vec<VarDecl>,
+            }",
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn check_scope_declared_when_holds_no_variables_then_ok() {
+        assert!(check(
+            "struct NotAPou {
+                pub name: Id,
+                pub body: Vec<StmtKind>,
+            }",
+        )
+        .is_ok());
+    }
+
+    /// The guard is deliberately syntactic: it asks about
+    /// `variables: Vec<VarDecl>` and nothing else, so a declaration
+    /// holding some other kind of variable is not swept in.
+    #[test]
+    fn check_scope_declared_when_variables_are_not_var_decls_then_ok() {
+        assert!(check(
+            "struct NotAPou {
+                pub variables: Vec<TypeName>,
+            }",
+        )
+        .is_ok());
+    }
+
+    /// A single `VarDecl` rather than a collection of them is a field of
+    /// a declaration, not the declaration's variable block.
+    #[test]
+    fn check_scope_declared_when_variables_field_is_not_a_vec_then_ok() {
+        assert!(check(
+            "struct NotAPou {
+                pub variables: VarDecl,
+            }",
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn scope_attr_when_unrecognized_value_then_error() {
+        let ast: DeriveInput = syn::parse_str(
+            "#[recurse(nonsense)]
+            struct Thing {
+                pub name: Id,
+            }",
+        )
+        .expect("test source must parse");
+        assert!(scope_attr(&ast.attrs).is_err());
+    }
+
+    #[test]
+    fn scope_attr_when_no_attribute_then_absent() {
+        let ast: DeriveInput =
+            syn::parse_str("struct Thing { pub name: Id }").expect("test source must parse");
+        assert!(scope_attr(&ast.attrs).expect("must parse") == ScopeAttr::Absent);
+    }
 }

--- a/compiler/dsl_macro_derive/tests/fail/scope_attribute_required.rs
+++ b/compiler/dsl_macro_derive/tests/fail/scope_attribute_required.rs
@@ -1,0 +1,16 @@
+//! A declaration that owns variables must say whether it scopes them.
+//!
+//! This proves the guard is wired into the derive itself, which the unit
+//! tests over `check_scope_declared` cannot: they would still pass if the
+//! call from `recurse_macro_derive` were removed.
+
+use dsl_macro_derive::Recurse;
+
+struct VarDecl;
+
+#[derive(Recurse)]
+struct PouDeclaration {
+    pub variables: Vec<VarDecl>,
+}
+
+fn main() {}

--- a/compiler/dsl_macro_derive/tests/fail/scope_attribute_required.stderr
+++ b/compiler/dsl_macro_derive/tests/fail/scope_attribute_required.stderr
@@ -1,0 +1,5 @@
+error: `PouDeclaration` declares `variables: Vec<VarDecl>`, so it must say whether it opens a lexical scope: add `#[recurse(scope)]` to bracket its contents with `enter_scope`/`exit_scope`, or `#[recurse(no_scope)]` to state that its variables are visible to the enclosing scope
+  --> tests/fail/scope_attribute_required.rs:13:9
+   |
+13 |     pub variables: Vec<VarDecl>,
+   |         ^^^^^^^^^

--- a/compiler/dsl_macro_derive/tests/main.rs
+++ b/compiler/dsl_macro_derive/tests/main.rs
@@ -1,5 +1,5 @@
 #[test]
 fn tests() {
-    trybuild::TestCases::new();
-    //t.pass("tests/struct-buildins.rs")
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/fail/*.rs");
 }

--- a/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
+++ b/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
@@ -2,11 +2,12 @@
 
 Fixes [#1439](https://github.com/ironplc/ironplc/issues/1439).
 
-Delivered as eight slices, one pull request each. Every slice builds,
-passes `cd compiler && just`, and is independently releasable — no slice
-leaves the compiler in a state where `check` and `compile` disagree.
-Slices 1-6 close #1439; slices 7-8 are the symbol-environment half and
-can be deferred without reopening it.
+Delivered as four pull requests. Each builds, passes
+`cd compiler && just`, and is independently releasable — none leaves the
+compiler in a state where `check` and `compile` disagree. PR 1 is a
+prefactor with no behaviour change; PR 2 closes #1439; PR 3 fixes the
+type-checking half; PR 4 is the symbol-environment half and can be
+deferred without reopening the issue.
 
 ## Problem
 
@@ -204,104 +205,99 @@ stamping pass), so nothing here forecloses it.
 
 ### Behaviour change
 
-Source that compiles today starts erroring: the sibling-method leak
-(slice 4), the method-local constant leak (slice 5), and type errors
-inside method bodies that were previously invisible (slice 6). That is
+Source that compiles today starts erroring: the sibling-method leak and
+the method-local constant leak (PR 2), and type errors inside method
+bodies that were previously invisible (PR 3). That is
 the point of the change. No `.st` corpus file uses `METHOD`, and the
 existing METHOD tests are parser- and plc2plc-level, so the blast radius
 is small.
 
-## Slices
+## Pull requests
 
-| # | Slice | Crates | Behaviour |
+Four pull requests. The first is a prefactor that promises nothing
+changed; the second makes the change the prefactor made easy.
+
+| # | Pull request | Crates | Behaviour |
 |---|---|---|---|
-| 1 | Scope hooks in the traversal | `dsl`, `dsl_macro_derive` | none |
-| 2 | Derive guard for scope-bearing structs | `dsl_macro_derive` | none |
-| 3 | Codegen isolates method variables and binds the result name | `codegen` | fixes a latent miscompile |
-| 4 | `rule_use_declared_symbolic_var` on the hooks | `analyzer`, docs | **closes #1439** |
-| 5 | `xform_fold_initializer_expressions` on the hooks | `analyzer` | method-local constants stop leaking |
-| 6 | `xform_resolve_expr_types` on `ScopedTable` | `analyzer` | method bodies get type-checked |
-| 7 | `ScopePath` data model | `analyzer` | none |
-| 8 | `EnvironmentResolver` pushes method scopes | `analyzer`, `mcp` | method symbols scoped for LSP/MCP |
-
-**Why 3 precedes 4.** `ctx.var_index` (`compile.rs:1230`) reports
-`Problem::VariableUndefined` for a name it cannot resolve. If slice 4
-landed first, there would be a release where `check` accepts
-`GetSpeed := speed` and `compile` rejects it with the same P4007 the
-analyzer just stopped reporting. Binding the name in codegen first
-removes that window.
-
-Slices 5 and 6 are independent of each other and of 4; they may land in
-any order after 1. Slices 7-8 depend only on 1.
+| 1 | Prefactor: existing scopes move onto the traversal hooks | `dsl`, `dsl_macro_derive`, `analyzer` | **none** |
+| 2 | `METHOD` is a scope | `dsl`, `analyzer`, `codegen`, docs | **closes #1439** |
+| 3 | `xform_resolve_expr_types` on `ScopedTable` | `analyzer` | method bodies get type-checked |
+| 4 | Scope paths in `SymbolEnvironment` | `analyzer`, `mcp` | method symbols scoped for LSP/MCP |
 
 ---
 
-### Slice 1 — Scope hooks in the traversal
+### PR 1 — Prefactor: existing scopes move onto the traversal hooks
 
-*No behaviour change. Nothing implements the hooks yet.*
+*No behaviour change. No new tests. The existing suite is the proof.*
 
-- `compiler/dsl/src/scope.rs` (new) — `ScopeNode`, the `ScopeBearing`
-  trait, and the four impls. `MethodDeclaration::as_scope_node` documents
-  the `return_type.is_some()` rule, though each consuming pass makes the
-  decision.
-- `compiler/dsl/src/visitor.rs`, `compiler/dsl/src/fold.rs` — add
-  `enter_scope`/`exit_scope` with no-op defaults to both traits.
-- `compiler/dsl_macro_derive/src/lib.rs` — parse `scope` in the `recurse`
-  attribute. In `expand_struct_recurse_visit` and
+`ScopeNode` ships with **three** variants — `Function`, `FunctionBlock`,
+`Program` — and `MethodDeclaration` is deliberately not a scope yet. That
+is what keeps this pull request honest, and it sets up the next one: PR 2
+adds the fourth variant, and every exhaustive match fails to compile
+until it is handled. The enforcement mechanism gets exercised on its
+first real use rather than sitting untested until the next contributor
+needs it.
+
+- `compiler/dsl/src/scope.rs` (new) — `ScopeNode` (three variants), the
+  `ScopeBearing` trait, three impls.
+- `compiler/dsl/src/visitor.rs`, `compiler/dsl/src/fold.rs` —
+  `enter_scope`/`exit_scope` with no-op defaults on both traits.
+- `compiler/dsl_macro_derive/src/lib.rs` — parse `scope` and `no_scope`
+  in the `recurse` attribute; in `expand_struct_recurse_visit` and
   `expand_struct_recurse_fold`, move the existing body into a private
-  `*_inner` and emit the enter/exit wrapper when `scope` is set.
-- `compiler/dsl/src/common.rs` — `#[recurse(scope)]` on the four POU
-  structs.
+  `*_inner` and emit the enter/exit wrapper when `scope` is set. Add the
+  `variables: Vec<VarDecl>` guard described above.
+- `compiler/dsl/src/common.rs` — `#[recurse(scope)]` on
+  `FunctionDeclaration`, `FunctionBlockDeclaration` and
+  `ProgramDeclaration`; `#[recurse(no_scope)]` on `MethodDeclaration`,
+  with a comment citing #1439. The guard forces the annotation, so the
+  marker records today's (incorrect) behaviour explicitly rather than
+  leaving it implied by an omission — and PR 2's diff becomes one word
+  plus one match arm.
+- `compiler/analyzer/src/rule_use_declared_symbolic_var.rs` — three
+  `visit_*_declaration` overrides become one `enter_scope`/`exit_scope`
+  pair. A pure move: the same names are seeded into the same table at the
+  same points.
+- `compiler/analyzer/src/xform_fold_initializer_expressions.rs` — the
+  three enter/exit pairs at `:292`, `:303`, `:314` become the trait pair.
+  Also a pure move.
 
-Tests, in `dsl` beside the existing `Descender` visitor
-(`visitor.rs:456`): a recording visitor and a recording folder that
-capture enter/exit events and assert (a) the order and nesting for a
-function block containing two methods, (b) that depth returns to zero,
-and (c) that an error raised inside a body still fires `exit_scope`.
-These also keep the new code covered — no other slice exercises it.
+The only new test is the compile-fail case for the derive guard, which is
+the guarantee itself and cannot be deferred without weakening it. The
+generated wrapper needs no synthetic test: both migrated passes run under
+the existing suite, which is the point of migrating them in the same pull
+request.
 
-### Slice 2 — Derive guard for scope-bearing structs
+`xform_resolve_expr_types` is *not* migrated here — see PR 3.
 
-*No behaviour change.*
+### PR 2 — `METHOD` is a scope
 
-- `compiler/dsl_macro_derive/src/lib.rs` — a struct with a
-  `variables: Vec<VarDecl>` field must carry `#[recurse(scope)]` or
-  `#[recurse(no_scope)]`; otherwise emit a `syn::Error` naming the struct
-  and both spellings.
-- Compile-fail test (`trybuild` or equivalent) proving the rejection and
-  the message. **This test is the by-design guarantee** — without it the
-  guard can be silently weakened later.
+*Closes #1439 defects 1, 2 and 5.*
 
-### Slice 3 — Codegen isolates method variables and binds the result name
-
-*Fixes problem 4. No source-visible change yet.*
-
+- `compiler/dsl/src/scope.rs` — add `ScopeNode::Method` and the
+  `ScopeBearing` impl. Both migrated passes now fail to compile until
+  their match handles it, which is the mechanism doing its job.
+- `compiler/dsl/src/common.rs` — `no_scope` becomes `scope` on
+  `MethodDeclaration`.
+- `rule_use_declared_symbolic_var` — the `Method` arm seeds the method
+  name **only when `return_type` is `Some`**. Fixes defects 1 and 2.
+- `xform_fold_initializer_expressions` — the `Method` arm enters a scope
+  and seeds nothing. Fixes defect 5.
 - `compiler/codegen/src/compile_method.rs` — save and restore
   `ctx.variables` and `ctx.var_types` around each method, as
-  `compile_user_function` does at `compile_fn.rs:78`/`:467`; and insert
+  `compile_user_function` does at `compile_fn.rs:78`/`:467`; insert
   `return_id → return_var_index` before `emit_function_local_prologue`,
-  mirroring `compile_fn.rs:258`.
-
-Codegen keeps its own map — it binds names to `VarIndex` slots, not to
-declarations — so it shares the discipline, not the table.
-
-Test: two methods on one function block each declaring a local of the
-same name compile to *distinct* slots. That source is legal both before
-and after slice 4, so the test survives the analyzer change; a test built
-on the leak itself would not.
-
-### Slice 4 — `rule_use_declared_symbolic_var` on the hooks
-
-*Closes #1439 defects 1 and 2.*
-
-- `compiler/analyzer/src/rule_use_declared_symbolic_var.rs` — replace the
-  three `visit_*_declaration` overrides with one `enter_scope` matching
-  `ScopeNode` exhaustively (function block also seeds `inherited_fields`;
-  method seeds its name only when `return_type` is `Some`) and one
-  `exit_scope` calling `self.table.exit()`.
+  mirroring `compile_fn.rs:258`. Fixes defect 4, and must land no later
+  than this pull request: `ctx.var_index` (`compile.rs:1230`) reports
+  `Problem::VariableUndefined`, so an analyzer that accepts
+  `GetSpeed := speed` while codegen cannot resolve the name would ship a
+  release where `check` passes and `compile` fails with the same P4007
+  the analyzer just stopped reporting. It is ~40 lines and independently
+  justifiable as a latent-bug fix, so it can be split off to land first
+  if this pull request feels large.
 - `compiler/analyzer/src/scoped_table.rs` — debug assertion that the
   stack is back to depth 1 when a walk ends, so a leaked scope fails the
-  existing suite rather than surfacing later as a mis-resolution.
+  suite rather than surfacing later as a mis-resolution.
 - `docs/reference/language/object-orientation/method.rst:104-115` — the
   limitation currently covers both halves in one sentence. Narrow it: a
   method body assigns its own name to set the result value; `x :=
@@ -309,7 +305,7 @@ on the leak itself would not.
   `--allow-fb-inheritance` note at `:33-34` points at the same anchor and
   needs the same narrowing.
 
-Tests in the rule's own module:
+Tests in `rule_use_declared_symbolic_var`:
 
 - `apply_when_method_assigns_own_name_then_ok`
 - `apply_when_method_without_return_type_assigns_own_name_then_error`
@@ -317,6 +313,16 @@ Tests in the rule's own module:
 - `apply_when_method_references_function_block_field_then_ok`
 - `apply_when_method_references_inherited_field_then_ok`
 - `apply_when_two_methods_declare_same_local_name_then_ok`
+
+In `xform_fold_initializer_expressions`:
+`apply_when_method_local_constant_not_visible_in_sibling_method_then_error`,
+the sibling of the existing
+`apply_when_fb_local_constant_not_visible_in_other_fb_then_error`.
+
+In codegen: two methods on one function block each declaring a local of
+the same name compile to *distinct* slots. That source is legal both
+before and after this change, so the test does not depend on the leak it
+is proving absent.
 
 Plus, per the syntax-support guide, a `plc2plc` round-trip in
 `compiler/plc2plc/src/tests/methods.rs` and an execution test in
@@ -326,75 +332,70 @@ computes its result via `MethodName := …`. The execution test exercises
 blocked on #1421, so the value is observed through a field the method
 writes rather than through `v := m.GetSpeed()`.
 
-### Slice 5 — `xform_fold_initializer_expressions` on the hooks
+### PR 3 — `xform_resolve_expr_types` on `ScopedTable`
 
-*Fixes problem 5.*
+*Fixes defect 3.*
 
-- Replace the three enter/exit pairs at `:292`, `:303`, `:314` with the
-  trait pair.
-- Test:
-  `apply_when_method_local_constant_not_visible_in_sibling_method_then_error`,
-  the sibling of the existing
-  `apply_when_fb_local_constant_not_visible_in_other_fb_then_error`.
+Held out of PR 1 because it is not a call-site move. `ExprTypeResolver`
+keeps flat `var_types` / `array_element_types` maps that it `clear()`s at
+each POU boundary (`:526`, `:543`, `:555`); clearing at a method boundary
+would wipe the enclosing function block's fields, so the maps themselves
+have to become scoped. More importantly, this is the one pass where a
+mistake is silent — an unresolved name does not error, it skips the type
+check, which is exactly how defect 3 stayed hidden — so "existing tests
+pass" is a weaker promise here than elsewhere and deserves its own
+review.
 
-### Slice 6 — `xform_resolve_expr_types` on `ScopedTable`
+One deliberate behaviour delta: every POU fold inserts locals and then
+calls `seed_implicit_globals()` (`:513-514`), so a global currently
+overwrites a same-named local; under a scope stack the local shadows the
+global, which is correct. It is close to unreachable today — top-level
+`VAR_GLOBAL` never reaches `global_var_types` (verified: `y := i` with a
+`BOOL` global and an `INT` local exits 0), leaving only the two
+`__SYSTEM_UP_*` names — but it is a real change and is the reason this
+pull request cannot claim behaviour neutrality.
 
-*Fixes problem 3. The largest analyzer change.*
-
-`ExprTypeResolver` keeps flat `var_types` / `array_element_types` maps
-that it `clear()`s at each POU boundary (`:526`, `:543`, `:555`).
-Clearing at a method boundary would wipe the enclosing function block's
-fields, so the existing idiom cannot be extended to methods — the maps
-have to become scoped.
-
-Order within the slice, so review can follow it:
+Order within the pull request, so review can follow it:
 
 1. Convert both maps to `ScopedTable`, keeping function, function block
    and program behaviour identical. Move globals into the base frame in
    `fold_library`, which lets `seed_implicit_globals` and its per-POU
    re-seeding go away. Existing tests must pass unchanged.
 2. The `ScopeNode::Method` arm then falls out of the machinery, which is
-   what fixes problem 3.
+   what fixes defect 3.
 3. Seed the method's own name at its resolved return type, mirroring the
-   function case at `:520-525`, so the assignment slice 4 made legal is
-   also type-checked.
+   function case at `:520-525`, so the assignment PR 2 made legal is also
+   type-checked.
 
 Tests:
 
 - `apply_when_method_local_assigned_wrong_type_then_error` — the P4035
-  that problem 3 currently swallows
+  that defect 3 currently swallows
 - `apply_when_method_local_shadows_field_then_uses_local_type`
 - `apply_when_method_assigns_own_name_then_result_type_resolved`
 - `apply_when_method_assigns_own_name_wrong_type_then_error`
 
-### Slice 7 — `ScopePath` data model
+### PR 4 — Scope paths in `SymbolEnvironment`
 
-*No behaviour change: every path is still depth 1 until slice 8.*
+*Method symbols become correctly scoped for LSP and MCP consumers.*
 
 - `compiler/analyzer/src/symbol_environment.rs` — `ScopePath`, the new
   `ScopeKind`, `parent()`, and the chain-walking `find`. Delete
   `resolution_cache` (constructed and cleared, never read) and
   `find_in_scope_hierarchy` (`#[allow(dead_code)]`, subsumed by the new
   `find`).
-- Four production call sites construct `ScopeKind::Named` and each names
-  a POU scope at depth 1, so each becomes a one-segment path:
-  `extractors.rs:220` and `:238`,
-  `mcp/src/tools/project_io.rs:100`, `mcp/src/runner.rs:74`. Six further
-  sites are in tests.
-- Test: `find` reaches an outer scope through two levels of nesting, and
-  an inner declaration shadows an outer one of the same name.
-
-### Slice 8 — `EnvironmentResolver` pushes method scopes
-
-*Method symbols become correctly scoped for LSP and MCP consumers.*
-
 - `compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs`
   — `scope: Option<Id>` becomes a `Vec<Id>` stack driven by
   `enter_scope`/`exit_scope`; `current_scope()` reads it.
-- Tests: a method parameter resolves at `⟨FB, Method⟩` and not at
-  `⟨FB⟩`; two methods with the same local name keep distinct entries; a
-  function block field is still found from inside a method by the parent
-  walk.
+- Four production call sites construct `ScopeKind::Named` and each names
+  a POU scope at depth 1, so each becomes a one-segment path:
+  `extractors.rs:220` and `:238`, `mcp/src/tools/project_io.rs:100`,
+  `mcp/src/runner.rs:74`. Six further sites are in tests.
+- Tests: `find` reaches an outer scope through two levels of nesting; an
+  inner declaration shadows an outer one of the same name; a method
+  parameter resolves at `⟨FB, Method⟩` and not at `⟨FB⟩`; two methods
+  with the same local name keep distinct entries; a function block field
+  is still found from inside a method by the parent walk.
 - Check whether `specs/design/expression-type-resolution.md` needs a
   requirement for method-scoped resolution.
 
@@ -407,7 +408,7 @@ Tests:
   Both must land before `METHOD … : T` is usable end to end.
 - **`CONFIGURATION` and `RESOURCE` scopes.** Both implement
   `HasVariables` (`configuration.rs:41`, `:77`) over differently named
-  fields, so neither is caught by the slice 2 guard. Under IEC 61131-3
+  fields, so neither is caught by the PR 1 guard. Under IEC 61131-3
   §2.7.1 a resource's `VAR_GLOBAL` is visible to the programs on it, so
   they are arguably scopes; `EnvironmentResolver` does not handle them
   today either, and nothing in #1439 depends on it. Recorded here so the
@@ -421,16 +422,13 @@ them fire correctly.
 ## Tasks
 
 - [ ] Commit this plan
-- [ ] Slice 1 — scope hooks in the traversal (`dsl`, `dsl_macro_derive`)
-- [ ] Slice 2 — derive guard + compile-fail test
-- [ ] Slice 3 — codegen method variable isolation and result-name binding
-- [ ] Slice 4 — `rule_use_declared_symbolic_var`, balance assertion, docs, round-trip and execution tests
-- [ ] Slice 5 — `xform_fold_initializer_expressions`
-- [ ] Slice 6 — `xform_resolve_expr_types` on `ScopedTable`
-- [ ] Confirm every reproduction in *Problem* now behaves correctly
-- [ ] Slice 7 — `ScopePath` data model
-- [ ] Slice 8 — `EnvironmentResolver` method scopes
+- [ ] PR 1 — prefactor: hooks, derive guard, migrate the two pure-move passes
+- [ ] PR 2 — `METHOD` is a scope: dsl, analyzer, codegen, docs, tests
+- [ ] Confirm reproductions 1, 2, 4 and 5 in *Problem* now behave correctly
+- [ ] PR 3 — `xform_resolve_expr_types` on `ScopedTable`
+- [ ] Confirm reproduction 3 in *Problem* now behaves correctly
+- [ ] PR 4 — scope paths in `SymbolEnvironment`
 
 ## Verification
 
-`cd compiler && just` on every slice.
+`cd compiler && just` on every pull request.

--- a/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
+++ b/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
@@ -2,6 +2,12 @@
 
 Fixes [#1439](https://github.com/ironplc/ironplc/issues/1439).
 
+Delivered as eight slices, one pull request each. Every slice builds,
+passes `cd compiler && just`, and is independently releasable — no slice
+leaves the compiler in a state where `check` and `compile` disagree.
+Slices 1-6 close #1439; slices 7-8 are the symbol-environment half and
+can be deferred without reopening it.
+
 ## Problem
 
 Five passes each maintain their own idea of what is in scope, and none of
@@ -58,11 +64,7 @@ make the omission impossible instead.
 
 ## Design
 
-Two independent mechanisms. Phase 1 moves scope entry into the traversal
-machinery and closes #1439. Phase 2 gives `SymbolEnvironment` a real
-nesting model. Phase 2 can be deferred without reopening the bug.
-
-### Phase 1: the traversal opens scopes, not the passes
+### The traversal opens scopes, not the passes
 
 Today each pass overrides `visit_function_declaration`,
 `visit_program_declaration` and `visit_function_block_declaration` and
@@ -117,7 +119,7 @@ its own table during the call. `exit_scope` takes no argument and returns
 no `Result`: it runs on the error path, and a pass that needs to know
 what it is closing already has its own stack.
 
-### Phase 1: `ScopeNode` is an exhaustive enum
+### `ScopeNode` is an exhaustive enum
 
 ```rust
 pub enum ScopeNode<'a> {
@@ -139,10 +141,10 @@ unconditionally, and a method seeds its name **only when `return_type` is
 The corresponding `ScopeBearing` trait (`fn as_scope_node(&self) ->
 ScopeNode<'_>`) is the content half — four hand-written impls. It is
 deduplication, not enforcement; the enforcement is the enum's
-exhaustiveness and the derive below. Writing `#[recurse(scope)]` without
-the impl does not compile.
+exhaustiveness and the derive guard below. Writing `#[recurse(scope)]`
+without the impl does not compile.
 
-### Phase 1: closing the "forgot the attribute" hole
+### Closing the "forgot the attribute" hole
 
 Exactly four AST structs have a `variables: Vec<VarDecl>` field —
 `FunctionDeclaration` (`common.rs:2734`), `FunctionBlockDeclaration`
@@ -160,7 +162,7 @@ could close on their own, and it is worth the twenty lines in the macro.
 implement `HasVariables` under different field names, so the guard does
 not reach them — see *Out of scope*.
 
-### Phase 2: scope paths in `SymbolEnvironment`
+### Scope paths in `SymbolEnvironment`
 
 `ScopeKind` is `Global | Named(Id)` — one level, no nesting — and its
 builder tracks `scope: Option<Id>`
@@ -200,93 +202,114 @@ at `core.rs:158` already establishes how to keep an identity field out of
 AST equality, and `xform_assign_file_id` establishes the post-parse
 stamping pass), so nothing here forecloses it.
 
-While in the file, delete `resolution_cache` (constructed and cleared,
-never read) and `find_in_scope_hierarchy` (`#[allow(dead_code)]`, and
-subsumed by the new `find`).
-
 ### Behaviour change
 
-Source that compiles today starts erroring: the sibling-method leak, and
-type errors inside method bodies that were previously invisible. That is
+Source that compiles today starts erroring: the sibling-method leak
+(slice 4), the method-local constant leak (slice 5), and type errors
+inside method bodies that were previously invisible (slice 6). That is
 the point of the change. No `.st` corpus file uses `METHOD`, and the
 existing METHOD tests are parser- and plc2plc-level, so the blast radius
 is small.
 
-## Implementation
+## Slices
 
-### Phase 1
+| # | Slice | Crates | Behaviour |
+|---|---|---|---|
+| 1 | Scope hooks in the traversal | `dsl`, `dsl_macro_derive` | none |
+| 2 | Derive guard for scope-bearing structs | `dsl_macro_derive` | none |
+| 3 | Codegen isolates method variables and binds the result name | `codegen` | fixes a latent miscompile |
+| 4 | `rule_use_declared_symbolic_var` on the hooks | `analyzer`, docs | **closes #1439** |
+| 5 | `xform_fold_initializer_expressions` on the hooks | `analyzer` | method-local constants stop leaking |
+| 6 | `xform_resolve_expr_types` on `ScopedTable` | `analyzer` | method bodies get type-checked |
+| 7 | `ScopePath` data model | `analyzer` | none |
+| 8 | `EnvironmentResolver` pushes method scopes | `analyzer`, `mcp` | method symbols scoped for LSP/MCP |
 
-**`compiler/dsl/src/scope.rs`** (new) — `ScopeNode`, the `ScopeBearing`
-trait, and the four impls. `MethodDeclaration::as_scope_node` is where
-the `return_type.is_some()` rule is documented, though the decision is
-made by each consuming pass.
+**Why 3 precedes 4.** `ctx.var_index` (`compile.rs:1230`) reports
+`Problem::VariableUndefined` for a name it cannot resolve. If slice 4
+landed first, there would be a release where `check` accepts
+`GetSpeed := speed` and `compile` rejects it with the same P4007 the
+analyzer just stopped reporting. Binding the name in codegen first
+removes that window.
 
-**`compiler/dsl/src/visitor.rs`, `compiler/dsl/src/fold.rs`** — add
-`enter_scope`/`exit_scope` with no-op defaults to both traits.
+Slices 5 and 6 are independent of each other and of 4; they may land in
+any order after 1. Slices 7-8 depend only on 1.
 
-**`compiler/dsl_macro_derive/src/lib.rs`** — parse `scope` and `no_scope`
-in the `recurse` attribute. In `expand_struct_recurse_visit` and
-`expand_struct_recurse_fold`, move the existing body into a private
-`*_inner` and emit the enter/exit wrapper when `scope` is set. Add the
-`variables: Vec<VarDecl>` guard, with a `syn::Error` naming the struct
-and both attribute spellings.
+---
 
-**`compiler/dsl/src/common.rs`** — `#[recurse(scope)]` on the four POU
-structs.
+### Slice 1 — Scope hooks in the traversal
 
-**`compiler/analyzer/src/rule_use_declared_symbolic_var.rs`** — replace
-the three `visit_*_declaration` overrides with one `enter_scope` that
-matches `ScopeNode` exhaustively (function block also seeds
-`inherited_fields`; method seeds its name only when `return_type` is
-`Some`) and one `exit_scope` calling `self.table.exit()`. Closes #1439
-defects 1 and 2.
+*No behaviour change. Nothing implements the hooks yet.*
 
-**`compiler/analyzer/src/xform_fold_initializer_expressions.rs`** —
-replace the three enter/exit pairs at `:292`, `:303`, `:314` with the
-trait pair. Closes problem 5.
+- `compiler/dsl/src/scope.rs` (new) — `ScopeNode`, the `ScopeBearing`
+  trait, and the four impls. `MethodDeclaration::as_scope_node` documents
+  the `return_type.is_some()` rule, though each consuming pass makes the
+  decision.
+- `compiler/dsl/src/visitor.rs`, `compiler/dsl/src/fold.rs` — add
+  `enter_scope`/`exit_scope` with no-op defaults to both traits.
+- `compiler/dsl_macro_derive/src/lib.rs` — parse `scope` in the `recurse`
+  attribute. In `expand_struct_recurse_visit` and
+  `expand_struct_recurse_fold`, move the existing body into a private
+  `*_inner` and emit the enter/exit wrapper when `scope` is set.
+- `compiler/dsl/src/common.rs` — `#[recurse(scope)]` on the four POU
+  structs.
 
-**`compiler/analyzer/src/xform_resolve_expr_types.rs`** — the substantive
-one. `ExprTypeResolver` keeps flat `var_types` / `array_element_types`
-maps that it `clear()`s at each POU boundary (`:526`, `:543`, `:555`);
-clearing at a method boundary would wipe the enclosing function block's
-fields, so the existing idiom cannot be extended to methods. Convert both
-maps to `ScopedTable`. `enter_scope` pushes a frame and inserts the
-declaration's variables plus, for `Function` and for `Method` with a
-return type, the declaration's own name at its resolved return type
-(`:520-525` is the existing function case). `exit_scope` pops. Globals
-move into the base frame in `fold_library`, which lets
-`seed_implicit_globals` and its per-POU re-seeding go away entirely.
-Closes problem 3, and gives the newly legal `GetSpeed := speed` a type.
+Tests, in `dsl` beside the existing `Descender` visitor
+(`visitor.rs:456`): a recording visitor and a recording folder that
+capture enter/exit events and assert (a) the order and nesting for a
+function block containing two methods, (b) that depth returns to zero,
+and (c) that an error raised inside a body still fires `exit_scope`.
+These also keep the new code covered — no other slice exercises it.
 
-**`compiler/codegen/src/compile_method.rs`** — save and restore
-`ctx.variables` and `ctx.var_types` around each method, as
-`compile_user_function` does at `compile_fn.rs:78`/`:467`; and insert
-`return_id → return_var_index` before `emit_function_local_prologue`,
-mirroring `compile_fn.rs:258`, so the assignment the analyzer now accepts
-actually compiles. Closes problem 4. Codegen keeps its own map — it binds
-names to `VarIndex` slots, not to declarations — so it shares the
-discipline, not the table.
+### Slice 2 — Derive guard for scope-bearing structs
 
-### Phase 2
+*No behaviour change.*
 
-**`compiler/analyzer/src/symbol_environment.rs`** — `ScopePath`, the new
-`ScopeKind`, `parent()`, the chain-walking `find`; delete
-`resolution_cache` and `find_in_scope_hierarchy`.
+- `compiler/dsl_macro_derive/src/lib.rs` — a struct with a
+  `variables: Vec<VarDecl>` field must carry `#[recurse(scope)]` or
+  `#[recurse(no_scope)]`; otherwise emit a `syn::Error` naming the struct
+  and both spellings.
+- Compile-fail test (`trybuild` or equivalent) proving the rejection and
+  the message. **This test is the by-design guarantee** — without it the
+  guard can be silently weakened later.
 
-**`compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs`**
-— `scope: Option<Id>` becomes a `Vec<Id>` stack driven by
-`enter_scope`/`exit_scope`; `current_scope()` reads it. Method parameters
-and locals then land in `⟨FB, Method⟩` rather than in the function
-block's scope.
+### Slice 3 — Codegen isolates method variables and binds the result name
 
-**Callers** — four production sites construct `ScopeKind::Named`:
-`extractors.rs:220` and `:238`, `mcp/src/tools/project_io.rs:100`,
-`mcp/src/runner.rs:74`. Each names a POU scope at depth 1 and becomes a
-one-segment path. Six more sites are in tests.
+*Fixes problem 4. No source-visible change yet.*
 
-## Tests
+- `compiler/codegen/src/compile_method.rs` — save and restore
+  `ctx.variables` and `ctx.var_types` around each method, as
+  `compile_user_function` does at `compile_fn.rs:78`/`:467`; and insert
+  `return_id → return_var_index` before `emit_function_local_prologue`,
+  mirroring `compile_fn.rs:258`.
 
-Phase 1, `compiler/analyzer/src/rule_use_declared_symbolic_var.rs`:
+Codegen keeps its own map — it binds names to `VarIndex` slots, not to
+declarations — so it shares the discipline, not the table.
+
+Test: two methods on one function block each declaring a local of the
+same name compile to *distinct* slots. That source is legal both before
+and after slice 4, so the test survives the analyzer change; a test built
+on the leak itself would not.
+
+### Slice 4 — `rule_use_declared_symbolic_var` on the hooks
+
+*Closes #1439 defects 1 and 2.*
+
+- `compiler/analyzer/src/rule_use_declared_symbolic_var.rs` — replace the
+  three `visit_*_declaration` overrides with one `enter_scope` matching
+  `ScopeNode` exhaustively (function block also seeds `inherited_fields`;
+  method seeds its name only when `return_type` is `Some`) and one
+  `exit_scope` calling `self.table.exit()`.
+- `compiler/analyzer/src/scoped_table.rs` — debug assertion that the
+  stack is back to depth 1 when a walk ends, so a leaked scope fails the
+  existing suite rather than surfacing later as a mis-resolution.
+- `docs/reference/language/object-orientation/method.rst:104-115` — the
+  limitation currently covers both halves in one sentence. Narrow it: a
+  method body assigns its own name to set the result value; `x :=
+  instance.Method()` is still a syntax error pending #1421. The
+  `--allow-fb-inheritance` note at `:33-34` points at the same anchor and
+  needs the same narrowing.
+
+Tests in the rule's own module:
 
 - `apply_when_method_assigns_own_name_then_ok`
 - `apply_when_method_without_return_type_assigns_own_name_then_error`
@@ -295,57 +318,87 @@ Phase 1, `compiler/analyzer/src/rule_use_declared_symbolic_var.rs`:
 - `apply_when_method_references_inherited_field_then_ok`
 - `apply_when_two_methods_declare_same_local_name_then_ok`
 
-`compiler/analyzer/src/xform_resolve_expr_types.rs`:
+Plus, per the syntax-support guide, a `plc2plc` round-trip in
+`compiler/plc2plc/src/tests/methods.rs` and an execution test in
+`compiler/codegen/tests/it/end_to_end_methods.rs` for a method that
+computes its result via `MethodName := …`. The execution test exercises
+*production* only: consuming a method result in an expression stays
+blocked on #1421, so the value is observed through a field the method
+writes rather than through `v := m.GetSpeed()`.
+
+### Slice 5 — `xform_fold_initializer_expressions` on the hooks
+
+*Fixes problem 5.*
+
+- Replace the three enter/exit pairs at `:292`, `:303`, `:314` with the
+  trait pair.
+- Test:
+  `apply_when_method_local_constant_not_visible_in_sibling_method_then_error`,
+  the sibling of the existing
+  `apply_when_fb_local_constant_not_visible_in_other_fb_then_error`.
+
+### Slice 6 — `xform_resolve_expr_types` on `ScopedTable`
+
+*Fixes problem 3. The largest analyzer change.*
+
+`ExprTypeResolver` keeps flat `var_types` / `array_element_types` maps
+that it `clear()`s at each POU boundary (`:526`, `:543`, `:555`).
+Clearing at a method boundary would wipe the enclosing function block's
+fields, so the existing idiom cannot be extended to methods — the maps
+have to become scoped.
+
+Order within the slice, so review can follow it:
+
+1. Convert both maps to `ScopedTable`, keeping function, function block
+   and program behaviour identical. Move globals into the base frame in
+   `fold_library`, which lets `seed_implicit_globals` and its per-POU
+   re-seeding go away. Existing tests must pass unchanged.
+2. The `ScopeNode::Method` arm then falls out of the machinery, which is
+   what fixes problem 3.
+3. Seed the method's own name at its resolved return type, mirroring the
+   function case at `:520-525`, so the assignment slice 4 made legal is
+   also type-checked.
+
+Tests:
 
 - `apply_when_method_local_assigned_wrong_type_then_error` — the P4035
   that problem 3 currently swallows
 - `apply_when_method_local_shadows_field_then_uses_local_type`
 - `apply_when_method_assigns_own_name_then_result_type_resolved`
+- `apply_when_method_assigns_own_name_wrong_type_then_error`
 
-`compiler/analyzer/src/xform_fold_initializer_expressions.rs`:
+### Slice 7 — `ScopePath` data model
 
-- `apply_when_method_local_constant_not_visible_in_sibling_method_then_error`
-  — the sibling of the existing
-  `apply_when_fb_local_constant_not_visible_in_other_fb_then_error`
+*No behaviour change: every path is still depth 1 until slice 8.*
 
-`compiler/dsl_macro_derive` — a `trybuild` (or equivalent compile-fail)
-case proving a struct with `variables: Vec<VarDecl>` and no scope
-attribute fails to compile, and that the message names both spellings.
-This test *is* the by-design guarantee; without it the guard can be
-silently weakened later.
+- `compiler/analyzer/src/symbol_environment.rs` — `ScopePath`, the new
+  `ScopeKind`, `parent()`, and the chain-walking `find`. Delete
+  `resolution_cache` (constructed and cleared, never read) and
+  `find_in_scope_hierarchy` (`#[allow(dead_code)]`, subsumed by the new
+  `find`).
+- Four production call sites construct `ScopeKind::Named` and each names
+  a POU scope at depth 1, so each becomes a one-segment path:
+  `extractors.rs:220` and `:238`,
+  `mcp/src/tools/project_io.rs:100`, `mcp/src/runner.rs:74`. Six further
+  sites are in tests.
+- Test: `find` reaches an outer scope through two levels of nesting, and
+  an inner declaration shadows an outer one of the same name.
 
-Scope-balance assertion — `ScopedTable` gains a debug assertion that the
-stack is back to depth 1 when a walk ends, so a leaked scope fails the
-existing suite rather than surfacing as a mis-resolution.
+### Slice 8 — `EnvironmentResolver` pushes method scopes
 
-`compiler/plc2plc/src/tests/methods.rs` — round-trip a method that
-assigns its own name, per the syntax-support guide.
+*Method symbols become correctly scoped for LSP and MCP consumers.*
 
-`compiler/codegen/tests/it/end_to_end_methods.rs` — compile and run a
-function block whose method computes and returns a value via
-`MethodName := …`, called from a program, asserting the variable value.
-Note this exercises *production* only: consuming a method result in an
-expression stays blocked on #1421, so the call site is a statement and
-the value is observed through a `VAR_OUTPUT`-style field or a second
-method that stores it.
+- `compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs`
+  — `scope: Option<Id>` becomes a `Vec<Id>` stack driven by
+  `enter_scope`/`exit_scope`; `current_scope()` reads it.
+- Tests: a method parameter resolves at `⟨FB, Method⟩` and not at
+  `⟨FB⟩`; two methods with the same local name keep distinct entries; a
+  function block field is still found from inside a method by the parent
+  walk.
+- Check whether `specs/design/expression-type-resolution.md` needs a
+  requirement for method-scoped resolution.
 
-Phase 2 — `xform_resolve_symbol_and_function_environment.rs`: a method
-parameter resolves at `⟨FB, Method⟩` and not at `⟨FB⟩`; two methods with
-the same local name keep distinct entries; a function block field is
-still found from inside a method by the parent walk.
-
-## Documentation
-
-`docs/reference/language/object-orientation/method.rst:104-115` states
-the current limitation as a single sentence covering both halves. After
-Phase 1 only the consumption half remains: rewrite it to say that a
-method body assigns its own name to set the result value, and that
-`x := instance.Method()` is still a syntax error pending #1421. The
-`--allow-fb-inheritance` note at `:33-34` points at the same anchor and
-needs the same narrowing.
-
-No new problem codes. P4007 and P4035 already exist; this change makes
-them fire correctly.
+---
 
 ## Out of scope
 
@@ -354,44 +407,30 @@ them fire correctly.
   Both must land before `METHOD … : T` is usable end to end.
 - **`CONFIGURATION` and `RESOURCE` scopes.** Both implement
   `HasVariables` (`configuration.rs:41`, `:77`) over differently named
-  fields, so neither is caught by the derive guard. Under IEC 61131-3
+  fields, so neither is caught by the slice 2 guard. Under IEC 61131-3
   §2.7.1 a resource's `VAR_GLOBAL` is visible to the programs on it, so
   they are arguably scopes; `EnvironmentResolver` does not handle them
   today either, and nothing in #1439 depends on it. Recorded here so the
   omission is deliberate rather than rediscovered.
-- **Node ids and a resolution map.** See the Phase 2 rationale.
+- **Node ids and a resolution map.** See the scope-path rationale.
 - **`ScopeId` interning.** Only if profiling asks for it.
+
+No new problem codes. P4007 and P4035 already exist; this change makes
+them fire correctly.
 
 ## Tasks
 
-Phase 1 — closes #1439:
-
 - [ ] Commit this plan
-- [ ] `dsl/src/scope.rs`: `ScopeNode`, `ScopeBearing`, four impls
-- [ ] `dsl/src/visitor.rs` + `fold.rs`: `enter_scope`/`exit_scope` defaults
-- [ ] `dsl_macro_derive`: `scope`/`no_scope` attributes, `*_inner` split, enter/exit wrapper
-- [ ] `dsl_macro_derive`: `variables: Vec<VarDecl>` compile-fail guard + its test
-- [ ] `dsl/src/common.rs`: `#[recurse(scope)]` on the four POU structs
-- [ ] `rule_use_declared_symbolic_var`: three overrides → one enter/exit pair
-- [ ] `xform_fold_initializer_expressions`: three enter/exit pairs → trait pair
-- [ ] `xform_resolve_expr_types`: maps → `ScopedTable`, drop `seed_implicit_globals`
-- [ ] `compile_method.rs`: save/restore `ctx.variables`+`ctx.var_types`, bind `return_id`
-- [ ] `ScopedTable`: debug assertion for balanced depth at end of walk
-- [ ] Analyzer, plc2plc round-trip, and codegen end-to-end tests
-- [ ] `method.rst`: narrow the limitation to the consumption half
-- [ ] Confirm the reproductions from *Problem* now behave correctly
-- [ ] `cd compiler && just`
-
-Phase 2 — scope paths (separate PR):
-
-- [ ] `symbol_environment.rs`: `ScopePath`, `ScopeKind::parent`, chain-walking `find`
-- [ ] `symbol_environment.rs`: delete `resolution_cache`, `find_in_scope_hierarchy`
-- [ ] `EnvironmentResolver`: `Option<Id>` → stack, driven by enter/exit
-- [ ] Update the four production `ScopeKind::Named` call sites and the tests
-- [ ] Check whether `specs/design/expression-type-resolution.md` needs a
-      requirement for method-scoped resolution
-- [ ] `cd compiler && just`
+- [ ] Slice 1 — scope hooks in the traversal (`dsl`, `dsl_macro_derive`)
+- [ ] Slice 2 — derive guard + compile-fail test
+- [ ] Slice 3 — codegen method variable isolation and result-name binding
+- [ ] Slice 4 — `rule_use_declared_symbolic_var`, balance assertion, docs, round-trip and execution tests
+- [ ] Slice 5 — `xform_fold_initializer_expressions`
+- [ ] Slice 6 — `xform_resolve_expr_types` on `ScopedTable`
+- [ ] Confirm every reproduction in *Problem* now behaves correctly
+- [ ] Slice 7 — `ScopePath` data model
+- [ ] Slice 8 — `EnvironmentResolver` method scopes
 
 ## Verification
 
-`cd compiler && just`
+`cd compiler && just` on every slice.

--- a/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
+++ b/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
@@ -1,0 +1,397 @@
+# Plan: Traversal-driven scopes and scope paths
+
+Fixes [#1439](https://github.com/ironplc/ironplc/issues/1439).
+
+## Problem
+
+Five passes each maintain their own idea of what is in scope, and none of
+them knows that a `METHOD` opens one. `MethodDeclaration` falls through to
+the `dispatch!` default in `compiler/dsl/src/visitor.rs:275`, which
+recurses without entering a scope.
+
+Verified against `634c868` with
+`ironplcc check --dialect iec61131-3-ed3`:
+
+1. **A method cannot produce its return value.** `GetSpeed := speed;`
+   inside `METHOD GetSpeed : REAL` reports P4007. The identical shape in a
+   `FUNCTION` body is accepted. (#1439 defect 1)
+
+2. **Method locals leak into sibling methods.** A second method
+   referencing the first method's `VAR_INPUT` parameter is accepted.
+   Every method's declarations land in the function block's scope.
+   (#1439 defect 2)
+
+3. **Method bodies are not type-checked at all.** With
+   `b : BOOL; i : INT`, the assignment `b := i` inside a method exits 0;
+   the same two lines in the function block body report P4035.
+   `ExprTypeResolver` never inserts a method's variables, so every
+   method-local reference resolves to `None` and the type rules skip
+   silently. Not in the issue.
+
+4. **Codegen leaks the same way, and miscompiles rather than
+   diagnosing.** `compile_user_method`
+   (`compiler/codegen/src/compile_method.rs:111`, `:128`) inserts each
+   method's parameters and locals into `ctx.variables` with no
+   save/restore — `compile_user_function` does exactly that at
+   `compile_fn.rs:78` and `:467`. Method B still sees method A's names
+   bound to A's `VarIndex`, which may sit outside B's frame bounds
+   window. Reachable today precisely because defect 2 lets it past the
+   analyzer. Not in the issue.
+
+5. **A method-local `VAR CONSTANT` leaks into sibling methods.**
+   `xform_fold_initializer_expressions` enters a scope for function
+   (`:292`), program (`:303`) and function block (`:314`), and not for a
+   method. Not in the issue.
+
+One correction to the issue's "Downstream" note: codegen no longer has to
+learn the method return slot. `compile_method.rs:138-197` already
+allocates it, sets `current_function_return`, and loads it before `RET`
+(landed in a860646). The only missing piece is binding the *name* to that
+slot — one line, mirroring `compile_fn.rs:258`.
+
+Nothing here was implemented incorrectly. `dispatch!(MethodDeclaration)`
+was added, the ~37 passes that do not care about scope kept working
+correctly, and the five that do kept compiling while silently doing the
+wrong thing. **The defect is omission at a call site.** Fixing five call
+sites leaves the sixth to be discovered the same way, so the fix has to
+make the omission impossible instead.
+
+## Design
+
+Two independent mechanisms. Phase 1 moves scope entry into the traversal
+machinery and closes #1439. Phase 2 gives `SymbolEnvironment` a real
+nesting model. Phase 2 can be deferred without reopening the bug.
+
+### Phase 1: the traversal opens scopes, not the passes
+
+Today each pass overrides `visit_function_declaration`,
+`visit_program_declaration` and `visit_function_block_declaration` and
+does its own `enter()`/`exit()`. That is opt-in: a pass that does not
+override a node kind is silently unscoped for it, which is exactly the
+failure that produced this bug. Invert it. `Visitor` and `Fold` each gain
+
+```rust
+fn enter_scope(&mut self, node: ScopeNode<'_>) -> Result<(), E> { Ok(()) }
+fn exit_scope(&mut self) {}
+```
+
+and the `Recurse` derive, for a struct carrying `#[recurse(scope)]`,
+wraps the generated recursion:
+
+```rust
+pub fn recurse_visit<V: Visitor<E> + ?Sized, E>(&self, v: &mut V) -> Result<V::Value, E> {
+    v.enter_scope(self.as_scope_node())?;
+    let result = self.recurse_visit_inner(v);
+    v.exit_scope();
+    result
+}
+```
+
+`recurse_fold` gets the same shape. `as_scope_node()` borrows `self`
+before the fold consumes it, and the borrow ends when `enter_scope`
+returns, so the by-value fold signature still works.
+
+Three properties follow:
+
+- A pass implements one enter/exit pair instead of one override per node
+  kind. `rule_use_declared_symbolic_var`'s three near-identical overrides
+  become a single pair.
+- Annotating a new scope-bearing node scopes it in *every* pass at once.
+- Enter and exit are generated as a matched pair around the recursion,
+  including the `?` paths, so no pass can leak a scope on an error
+  return. `rule_use_declared_symbolic_var` is correct today only because
+  someone remembered to bind `let ret = …;` rather than writing `?`
+  before `exit()`.
+
+The ~37 passes that do not care about scope take the no-op defaults and
+are untouched.
+
+**Invariant to document:** enter/exit fire if and only if the traversal
+recurses. A pass that overrides `visit_method_declaration` and returns
+without calling `recurse_visit` opens no scope, which is the correct
+behaviour — it visited nothing.
+
+**Constraint on the signature:** `enter_scope` receives a borrow it may
+not retain. A pass copies what it needs (the name, the declarations) into
+its own table during the call. `exit_scope` takes no argument and returns
+no `Result`: it runs on the error path, and a pass that needs to know
+what it is closing already has its own stack.
+
+### Phase 1: `ScopeNode` is an exhaustive enum
+
+```rust
+pub enum ScopeNode<'a> {
+    Function(&'a FunctionDeclaration),
+    FunctionBlock(&'a FunctionBlockDeclaration),
+    Program(&'a ProgramDeclaration),
+    Method(&'a MethodDeclaration),
+}
+```
+
+Passes match on it without a wildcard arm, so adding a variant is a build
+error in every pass that discriminates by kind. That matters because the
+kinds genuinely differ: a function block seeds its own name plus its
+`EXTENDS`-inherited fields, a function and a program seed their own name
+unconditionally, and a method seeds its name **only when `return_type` is
+`Some`** — a method with no return type has no result to assign, so
+`MethodName := …` in that body must keep reporting P4007.
+
+The corresponding `ScopeBearing` trait (`fn as_scope_node(&self) ->
+ScopeNode<'_>`) is the content half — four hand-written impls. It is
+deduplication, not enforcement; the enforcement is the enum's
+exhaustiveness and the derive below. Writing `#[recurse(scope)]` without
+the impl does not compile.
+
+### Phase 1: closing the "forgot the attribute" hole
+
+Exactly four AST structs have a `variables: Vec<VarDecl>` field —
+`FunctionDeclaration` (`common.rs:2734`), `FunctionBlockDeclaration`
+(`:2755`), `MethodDeclaration` (`:2792`), `ProgramDeclaration` (`:2915`).
+The `Recurse` derive already inspects every field, so it can refuse to
+compile a struct that has that field and carries neither
+`#[recurse(scope)]` nor an explicit `#[recurse(no_scope)]`. Adding the
+next POU-like construct without deciding which it is then becomes a build
+error at the declaration, three lines above the struct it governs.
+
+This is the one hole that neither the enum nor the derive-generated calls
+could close on their own, and it is worth the twenty lines in the macro.
+
+`ResourceDeclaration.global_vars` and `ConfigurationDeclaration.global_var`
+implement `HasVariables` under different field names, so the guard does
+not reach them — see *Out of scope*.
+
+### Phase 2: scope paths in `SymbolEnvironment`
+
+`ScopeKind` is `Global | Named(Id)` — one level, no nesting — and its
+builder tracks `scope: Option<Id>`
+(`xform_resolve_symbol_and_function_environment.rs:63`), so it cannot
+represent a method scope at all. Replace the single `Id` with the chain
+of declaration names from the library root:
+
+```rust
+pub struct ScopePath(Vec<Id>);        // ⟨FB_Motor, GetSpeed⟩
+
+pub enum ScopeKind {
+    Global,
+    Named(ScopePath),                 // never empty
+}
+
+impl ScopeKind {
+    /// The enclosing scope: pops the last segment, `Global` at depth 1.
+    pub fn parent(&self) -> Option<ScopeKind>;
+}
+```
+
+`find` walks the chain — method, then function block, then global —
+instead of today's scope-then-global hop. `Id` already implements `Hash`
+and `Eq` (case-insensitively, on `lower_case`), so `ScopePath` derives
+both and remains usable as a `HashMap` key.
+
+No interning. The parent walk allocates, but symbol lookup is not hot on
+PLC-sized inputs, and a `ScopeId` interner is a mechanical follow-up if
+profiling ever disagrees.
+
+**Why a path and not a `NodeId`.** Scopes are nameable, so a path *is*
+stable identity and costs no AST change. Node ids would be needed for a
+`reference → declaration` resolution map — go-to-definition,
+find-references, rename — which is a real feature and not this bug. The
+groundwork is cheap when we want it (`SourceSpan`'s trivial `PartialEq`
+at `core.rs:158` already establishes how to keep an identity field out of
+AST equality, and `xform_assign_file_id` establishes the post-parse
+stamping pass), so nothing here forecloses it.
+
+While in the file, delete `resolution_cache` (constructed and cleared,
+never read) and `find_in_scope_hierarchy` (`#[allow(dead_code)]`, and
+subsumed by the new `find`).
+
+### Behaviour change
+
+Source that compiles today starts erroring: the sibling-method leak, and
+type errors inside method bodies that were previously invisible. That is
+the point of the change. No `.st` corpus file uses `METHOD`, and the
+existing METHOD tests are parser- and plc2plc-level, so the blast radius
+is small.
+
+## Implementation
+
+### Phase 1
+
+**`compiler/dsl/src/scope.rs`** (new) — `ScopeNode`, the `ScopeBearing`
+trait, and the four impls. `MethodDeclaration::as_scope_node` is where
+the `return_type.is_some()` rule is documented, though the decision is
+made by each consuming pass.
+
+**`compiler/dsl/src/visitor.rs`, `compiler/dsl/src/fold.rs`** — add
+`enter_scope`/`exit_scope` with no-op defaults to both traits.
+
+**`compiler/dsl_macro_derive/src/lib.rs`** — parse `scope` and `no_scope`
+in the `recurse` attribute. In `expand_struct_recurse_visit` and
+`expand_struct_recurse_fold`, move the existing body into a private
+`*_inner` and emit the enter/exit wrapper when `scope` is set. Add the
+`variables: Vec<VarDecl>` guard, with a `syn::Error` naming the struct
+and both attribute spellings.
+
+**`compiler/dsl/src/common.rs`** — `#[recurse(scope)]` on the four POU
+structs.
+
+**`compiler/analyzer/src/rule_use_declared_symbolic_var.rs`** — replace
+the three `visit_*_declaration` overrides with one `enter_scope` that
+matches `ScopeNode` exhaustively (function block also seeds
+`inherited_fields`; method seeds its name only when `return_type` is
+`Some`) and one `exit_scope` calling `self.table.exit()`. Closes #1439
+defects 1 and 2.
+
+**`compiler/analyzer/src/xform_fold_initializer_expressions.rs`** —
+replace the three enter/exit pairs at `:292`, `:303`, `:314` with the
+trait pair. Closes problem 5.
+
+**`compiler/analyzer/src/xform_resolve_expr_types.rs`** — the substantive
+one. `ExprTypeResolver` keeps flat `var_types` / `array_element_types`
+maps that it `clear()`s at each POU boundary (`:526`, `:543`, `:555`);
+clearing at a method boundary would wipe the enclosing function block's
+fields, so the existing idiom cannot be extended to methods. Convert both
+maps to `ScopedTable`. `enter_scope` pushes a frame and inserts the
+declaration's variables plus, for `Function` and for `Method` with a
+return type, the declaration's own name at its resolved return type
+(`:520-525` is the existing function case). `exit_scope` pops. Globals
+move into the base frame in `fold_library`, which lets
+`seed_implicit_globals` and its per-POU re-seeding go away entirely.
+Closes problem 3, and gives the newly legal `GetSpeed := speed` a type.
+
+**`compiler/codegen/src/compile_method.rs`** — save and restore
+`ctx.variables` and `ctx.var_types` around each method, as
+`compile_user_function` does at `compile_fn.rs:78`/`:467`; and insert
+`return_id → return_var_index` before `emit_function_local_prologue`,
+mirroring `compile_fn.rs:258`, so the assignment the analyzer now accepts
+actually compiles. Closes problem 4. Codegen keeps its own map — it binds
+names to `VarIndex` slots, not to declarations — so it shares the
+discipline, not the table.
+
+### Phase 2
+
+**`compiler/analyzer/src/symbol_environment.rs`** — `ScopePath`, the new
+`ScopeKind`, `parent()`, the chain-walking `find`; delete
+`resolution_cache` and `find_in_scope_hierarchy`.
+
+**`compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs`**
+— `scope: Option<Id>` becomes a `Vec<Id>` stack driven by
+`enter_scope`/`exit_scope`; `current_scope()` reads it. Method parameters
+and locals then land in `⟨FB, Method⟩` rather than in the function
+block's scope.
+
+**Callers** — four production sites construct `ScopeKind::Named`:
+`extractors.rs:220` and `:238`, `mcp/src/tools/project_io.rs:100`,
+`mcp/src/runner.rs:74`. Each names a POU scope at depth 1 and becomes a
+one-segment path. Six more sites are in tests.
+
+## Tests
+
+Phase 1, `compiler/analyzer/src/rule_use_declared_symbolic_var.rs`:
+
+- `apply_when_method_assigns_own_name_then_ok`
+- `apply_when_method_without_return_type_assigns_own_name_then_error`
+- `apply_when_method_references_sibling_method_local_then_error`
+- `apply_when_method_references_function_block_field_then_ok`
+- `apply_when_method_references_inherited_field_then_ok`
+- `apply_when_two_methods_declare_same_local_name_then_ok`
+
+`compiler/analyzer/src/xform_resolve_expr_types.rs`:
+
+- `apply_when_method_local_assigned_wrong_type_then_error` — the P4035
+  that problem 3 currently swallows
+- `apply_when_method_local_shadows_field_then_uses_local_type`
+- `apply_when_method_assigns_own_name_then_result_type_resolved`
+
+`compiler/analyzer/src/xform_fold_initializer_expressions.rs`:
+
+- `apply_when_method_local_constant_not_visible_in_sibling_method_then_error`
+  — the sibling of the existing
+  `apply_when_fb_local_constant_not_visible_in_other_fb_then_error`
+
+`compiler/dsl_macro_derive` — a `trybuild` (or equivalent compile-fail)
+case proving a struct with `variables: Vec<VarDecl>` and no scope
+attribute fails to compile, and that the message names both spellings.
+This test *is* the by-design guarantee; without it the guard can be
+silently weakened later.
+
+Scope-balance assertion — `ScopedTable` gains a debug assertion that the
+stack is back to depth 1 when a walk ends, so a leaked scope fails the
+existing suite rather than surfacing as a mis-resolution.
+
+`compiler/plc2plc/src/tests/methods.rs` — round-trip a method that
+assigns its own name, per the syntax-support guide.
+
+`compiler/codegen/tests/it/end_to_end_methods.rs` — compile and run a
+function block whose method computes and returns a value via
+`MethodName := …`, called from a program, asserting the variable value.
+Note this exercises *production* only: consuming a method result in an
+expression stays blocked on #1421, so the call site is a statement and
+the value is observed through a `VAR_OUTPUT`-style field or a second
+method that stores it.
+
+Phase 2 — `xform_resolve_symbol_and_function_environment.rs`: a method
+parameter resolves at `⟨FB, Method⟩` and not at `⟨FB⟩`; two methods with
+the same local name keep distinct entries; a function block field is
+still found from inside a method by the parent walk.
+
+## Documentation
+
+`docs/reference/language/object-orientation/method.rst:104-115` states
+the current limitation as a single sentence covering both halves. After
+Phase 1 only the consumption half remains: rewrite it to say that a
+method body assigns its own name to set the result value, and that
+`x := instance.Method()` is still a syntax error pending #1421. The
+`--allow-fb-inheritance` note at `:33-34` points at the same anchor and
+needs the same narrowing.
+
+No new problem codes. P4007 and P4035 already exist; this change makes
+them fire correctly.
+
+## Out of scope
+
+- **#1421, the consumption half.** A method call is reachable only from
+  statement position, so `v := m.GetSpeed()` remains a syntax error.
+  Both must land before `METHOD … : T` is usable end to end.
+- **`CONFIGURATION` and `RESOURCE` scopes.** Both implement
+  `HasVariables` (`configuration.rs:41`, `:77`) over differently named
+  fields, so neither is caught by the derive guard. Under IEC 61131-3
+  §2.7.1 a resource's `VAR_GLOBAL` is visible to the programs on it, so
+  they are arguably scopes; `EnvironmentResolver` does not handle them
+  today either, and nothing in #1439 depends on it. Recorded here so the
+  omission is deliberate rather than rediscovered.
+- **Node ids and a resolution map.** See the Phase 2 rationale.
+- **`ScopeId` interning.** Only if profiling asks for it.
+
+## Tasks
+
+Phase 1 — closes #1439:
+
+- [ ] Commit this plan
+- [ ] `dsl/src/scope.rs`: `ScopeNode`, `ScopeBearing`, four impls
+- [ ] `dsl/src/visitor.rs` + `fold.rs`: `enter_scope`/`exit_scope` defaults
+- [ ] `dsl_macro_derive`: `scope`/`no_scope` attributes, `*_inner` split, enter/exit wrapper
+- [ ] `dsl_macro_derive`: `variables: Vec<VarDecl>` compile-fail guard + its test
+- [ ] `dsl/src/common.rs`: `#[recurse(scope)]` on the four POU structs
+- [ ] `rule_use_declared_symbolic_var`: three overrides → one enter/exit pair
+- [ ] `xform_fold_initializer_expressions`: three enter/exit pairs → trait pair
+- [ ] `xform_resolve_expr_types`: maps → `ScopedTable`, drop `seed_implicit_globals`
+- [ ] `compile_method.rs`: save/restore `ctx.variables`+`ctx.var_types`, bind `return_id`
+- [ ] `ScopedTable`: debug assertion for balanced depth at end of walk
+- [ ] Analyzer, plc2plc round-trip, and codegen end-to-end tests
+- [ ] `method.rst`: narrow the limitation to the consumption half
+- [ ] Confirm the reproductions from *Problem* now behave correctly
+- [ ] `cd compiler && just`
+
+Phase 2 — scope paths (separate PR):
+
+- [ ] `symbol_environment.rs`: `ScopePath`, `ScopeKind::parent`, chain-walking `find`
+- [ ] `symbol_environment.rs`: delete `resolution_cache`, `find_in_scope_hierarchy`
+- [ ] `EnvironmentResolver`: `Option<Id>` → stack, driven by enter/exit
+- [ ] Update the four production `ScopeKind::Named` call sites and the tests
+- [ ] Check whether `specs/design/expression-type-resolution.md` needs a
+      requirement for method-scoped resolution
+- [ ] `cd compiler && just`
+
+## Verification
+
+`cd compiler && just`


### PR DESCRIPTION
Plans the fix for #1439: a METHOD opens no scope, so a method body
cannot assign its own name to set the return value, and method locals
leak into sibling methods.

The plan records three further defects of the same omission found while
investigating: method bodies are not type-checked at all, codegen leaks
one method's variable bindings into the next, and method-local constants
leak into sibling methods.

Phase 1 moves scope entry into the Recurse-derived traversal so passes
implement one enter/exit pair instead of one override per node kind, and
adds a derive-level guard that makes a new scope-bearing POU a build
error until it declares whether it is a scope. Phase 2 replaces
SymbolEnvironment's flat Global | Named(Id) with a scope path.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DdDr6NVSimqUjzZupHf3jE