### PR TITLE
Add prefactoring requirement to development standards

### DIFF
--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -2,4 +2,4 @@
 
 See [specs/steering/development-standards.md](../../specs/steering/development-standards.md) for the full development standards.
 
-This file defines core project conventions, testing patterns, error handling, and documentation standards for the IronPLC project.
+This file defines core project conventions, prefactoring expectations, testing patterns, error handling, and documentation standards for the IronPLC project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides entry points for Claude Code when working on the IronPLC proj
 Before making changes, read the relevant steering files in `specs/steering/`:
 
 - **[Glossary](specs/steering/glossary.md)** - Authoritative definitions of core vocabulary (dialect, vendor, extension, edition); resolve terminology questions here before coining a new term
-- **[Development Standards](specs/steering/development-standards.md)** - Core project conventions, testing patterns, error handling, and documentation standards
+- **[Development Standards](specs/steering/development-standards.md)** - Core project conventions, prefactoring, testing patterns, error handling, and documentation standards
 - **[Compiler Architecture](specs/steering/compiler-architecture.md)** - Patterns for implementing language features, module organization, and semantic analysis
 - **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules (especially relevant for `**/analyzer/**` files)
 - **[PLCopen XML Module](specs/steering/plcopen-xml-module.md)** - Architecture and patterns for the PLCopen XML parsing module (especially relevant for `compiler/sources/src/xml/` files)
@@ -35,9 +35,10 @@ For full details, see [specs/steering/common-tasks.md](specs/steering/common-tas
 
 1. Create a feature branch from `main`
 2. **Write an implementation plan** in `specs/plans/` and commit it to the branch (see [Development Standards — Planning Requirement](specs/steering/development-standards.md#planning-requirement))
-3. Implement the changes following the plan
-4. Run the full CI pipeline: `cd compiler && just`
-5. Push the feature branch and create a PR via `gh pr create`
+3. **Prefactor first** — simplify the existing code so the change drops in, in its own commit, before adding new behaviour (see [Development Standards — Prefactoring](specs/steering/development-standards.md#prefactoring))
+4. Implement the changes following the plan
+5. Run the full CI pipeline: `cd compiler && just`
+6. Push the feature branch and create a PR via `gh pr create`
 
 > **Skip the plan** for mechanical changes: typo fixes, formatting, dependency bumps, single-line bug fixes, or documentation-only edits.
 
@@ -82,9 +83,10 @@ See [specs/steering/common-tasks.md](specs/steering/common-tasks.md) for complet
 ### Critical Rules
 1. **NEVER push directly to `main`** - Always use a feature branch and pull request
 2. **Plan first** - Non-trivial changes must start with a plan in `specs/plans/` committed before implementation code
-3. **Run `cd compiler && just` before creating any PR** - This runs clippy, tests, and all checks
-4. **BDD-style test names**: `function_when_condition_then_result`
-5. **Module size limit**: Max 1000 lines per module
-6. **No duplicated content** - Including in documentation; share via `docs/includes/` and `.. include::` ([Avoid Duplication](specs/steering/development-standards.md#avoid-duplication))
-7. **Problem codes**: Must be documented in `docs/compiler/problems/P####.rst`
-8. **Version numbers**: Automatically managed - do not edit manually
+3. **Prefactor before adding** - Every change looks for a simplification to make first; the plan says what it is, or why none is needed
+4. **Run `cd compiler && just` before creating any PR** - This runs clippy, tests, and all checks
+5. **BDD-style test names**: `function_when_condition_then_result`
+6. **Module size limit**: Max 1000 lines per module
+7. **No duplicated content** - Including in documentation; share via `docs/includes/` and `.. include::` ([Avoid Duplication](specs/steering/development-standards.md#avoid-duplication))
+8. **Problem codes**: Must be documented in `docs/compiler/problems/P####.rst`
+9. **Version numbers**: Automatically managed - do not edit manually

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -86,6 +86,9 @@ A plan document should include:
 
 - **Goal** — a concise statement of what the change accomplishes
 - **Architecture** — brief summary of the technical approach
+- **Prefactoring** — the simplification to make *before* adding the new
+  behaviour, or an explicit statement that none is needed and why (see
+  [Prefactoring](#prefactoring))
 - **Design doc reference** — link to `specs/design/` doc if one exists
 - **File map** — which files will be created or modified
 - **Tasks** — ordered steps with checkboxes (`- [ ]`) for tracking progress
@@ -93,6 +96,82 @@ A plan document should include:
 Name plan files with a date prefix: `YYYY-MM-DD-short-description.md` (e.g., `2026-04-01-planning-requirement.md`).
 
 **When a plan may be skipped:** Changes that are clearly mechanical and self-contained — typo fixes, formatting, dependency bumps, single-line bug fixes, or documentation-only edits — do not require a plan.
+
+## Prefactoring
+
+**Prefactoring** is refactoring done *before* new behaviour is added: reshape the
+existing code so the new behaviour drops in, then add it. It is the opposite
+order from the more familiar "make it work, then clean it up" — and it is the
+order this project uses.
+
+Every change **must** start by looking for a prefactoring opportunity. Without
+that step, each change is bolted onto whatever shape the code already has —
+another `if`, another flag, another near-copy of an existing function. The cost
+compounds twice: the code gets harder to read, and every new branch multiplies
+the paths that tests have to cover, so the suite grows faster than the feature
+set.
+
+### Requirement
+
+- For any change that needs a plan, the plan **must** contain a **Prefactoring**
+  section naming the simplification the change will make first — or stating
+  explicitly that none is needed and why.
+- The prefactoring lands in its own commit (or commits) **before** the commits
+  that add the new behaviour.
+- Mechanical changes that skip the plan (see
+  [Planning Requirement](#planning-requirement)) also skip this.
+
+### Signals that a change needs prefactoring
+
+Look for these while reading the code you are about to modify. Any one of them
+means stop and reshape first:
+
+- The new behaviour needs a new `match` arm or `if` in **more than one place** —
+  the distinction wants to be a type or a data table, not repeated branching
+- You would copy an existing function and change a few lines of it
+- You would add a boolean parameter (or a second one) to select behaviour inside
+  a function
+- The new tests would duplicate an existing test's setup wholesale, or you would
+  need a combinatorial matrix of tests to cover how the new flag interacts with
+  the existing ones
+- The module would cross the [1000-line limit](#module-structure) once the change
+  lands
+- The code has to know *where in the pipeline it is* to decide what to do
+- The change is easy to describe in a sentence but hard to place in the code —
+  usually a sign the responsibility it belongs to does not exist yet
+
+### How to prefactor
+
+1. **Change the shape, not the behaviour.** The existing tests must pass
+   unchanged. If they have to be edited to accept the prefactoring — beyond
+   mechanical renames — the commit is not behaviour-preserving; split it.
+2. **Commit the prefactoring separately.** A reviewer can then read a diff that
+   provably changes nothing, followed by a small diff that adds the feature.
+   Either can be reverted alone.
+3. **Add the new behaviour.** If the feature diff is still branchy and large,
+   the prefactoring picked the wrong shape — go back to step 1 rather than
+   pushing through.
+
+### When *not* to prefactor
+
+Prefactoring is a tool for reducing the cost of the change in hand, not a
+licence to rewrite:
+
+- **No speculative generality.** Do not build an abstraction for a case nobody
+  has asked for. Extract a shared shape when the second or third caller arrives,
+  not the first.
+- **No unbounded rewrites.** If the reshaping is far larger than the feature,
+  write it up as its own plan and change, and land the feature the simple way
+  in the meantime — with a note saying so.
+- **Not for one-line fixes.** Typos, dependency bumps, and single-line bug fixes
+  stay single-line.
+
+### What good looks like
+
+A well-prefactored change shows up as a *smaller* feature diff and *fewer* new
+tests than the same feature added on top of the old shape — because there are
+fewer distinct paths to cover, not because anything went untested. The coverage
+gate (see [Just Commands](#just-commands)) still applies unchanged.
 
 ## Code Organization
 


### PR DESCRIPTION
Changes were being layered onto whatever shape the code already had —
another branch, another flag, another near-copy — which compounds both
code complexity and the number of tests needed to cover the added paths.

Add a Prefactoring section to the development standards: what it is, the
requirement that every planned change names its prefactoring (or says
why none is needed), signals that a change needs it, how to sequence the
commits, and when not to prefactor. Add a Prefactoring section to the
required plan contents, and surface the rule in the CLAUDE.md workflow
and critical rules.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BfKEBRVjg6jcPYXmRDX3D1