### PR TITLE
Remove unused SymbolEnvironment API

### DIFF
--- a/compiler/analyzer/src/extractors.rs
+++ b/compiler/analyzer/src/extractors.rs
@@ -217,7 +217,7 @@ impl SemanticContext {
             .get_programs()
             .into_iter()
             .map(|(name, info)| {
-                let scope = ScopeKind::Named(name.clone());
+                let scope = ScopeKind::Named(name.clone().into());
                 let variables = self.symbols().variables_in_scope(&scope);
                 ProgramSymbol {
                     name,
@@ -235,7 +235,7 @@ impl SemanticContext {
             .get_function_blocks()
             .into_iter()
             .map(|(name, info)| {
-                let scope = ScopeKind::Named(name.clone());
+                let scope = ScopeKind::Named(name.clone().into());
                 let variables = self.symbols().variables_in_scope(&scope);
                 FunctionBlockSymbol {
                     name,

--- a/compiler/analyzer/src/semantic_context.rs
+++ b/compiler/analyzer/src/semantic_context.rs
@@ -252,9 +252,8 @@ mod tests {
         // Just verify the mutable reference works
         let _ = types.iter().count();
 
-        let symbols = ctx.symbols_mut();
         // Verify mutable access to symbols works
-        let _ = symbols.total_symbols();
+        let _ = ctx.symbols_mut();
     }
 
     #[test]

--- a/compiler/analyzer/src/symbol_environment.rs
+++ b/compiler/analyzer/src/symbol_environment.rs
@@ -84,20 +84,8 @@ impl SymbolInfo {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn with_data_type(mut self, data_type: String) -> Self {
-        self.data_type = Some(data_type);
-        self
-    }
-
     pub fn with_external(mut self, is_external: bool) -> Self {
         self.is_external = is_external;
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn with_visibility_scope(mut self, visibility_scope: ScopeKind) -> Self {
-        self.visibility_scope = visibility_scope;
         self
     }
 
@@ -130,8 +118,6 @@ pub struct SymbolEnvironment {
     global_symbols: HashMap<Id, SymbolInfo>,
     /// Scoped symbols (variables within functions, function blocks, etc.)
     scoped_symbols: HashMap<ScopeKind, HashMap<Id, SymbolInfo>>,
-    /// Symbol resolution cache for performance
-    resolution_cache: HashMap<(Id, ScopeKind), Option<&'static SymbolInfo>>,
 }
 
 impl SymbolEnvironment {
@@ -139,7 +125,6 @@ impl SymbolEnvironment {
         Self {
             global_symbols: HashMap::new(),
             scoped_symbols: HashMap::new(),
-            resolution_cache: HashMap::new(),
         }
     }
 
@@ -336,161 +321,10 @@ impl SymbolEnvironment {
         self.global_symbols.get(name)
     }
 
-    /// Find a symbol in the current scope, searching outward through parent scopes
-    #[allow(dead_code)]
-    pub fn find_in_scope_hierarchy(
-        &self,
-        name: &Id,
-        current_scope: &ScopeKind,
-    ) -> Option<&SymbolInfo> {
-        // Start with current scope
-        if let Some(symbol) = self.find(name, current_scope) {
-            return Some(symbol);
-        }
-
-        // If current scope is named, also check global scope
-        if let ScopeKind::Named(_) = current_scope {
-            return self.global_symbols.get(name);
-        }
-
-        None
-    }
-
-    /// Get all symbols in a specific scope
-    #[allow(dead_code)]
-    pub fn get_scope_symbols(&self, scope: &ScopeKind) -> Option<&HashMap<Id, SymbolInfo>> {
-        match scope {
-            ScopeKind::Global => Some(&self.global_symbols),
-            ScopeKind::Named(_) => self.scoped_symbols.get(scope),
-        }
-    }
-
-    /// Check if a symbol exists in the given scope
-    #[allow(dead_code)]
-    pub fn contains(&self, name: &Id, scope: &ScopeKind) -> bool {
-        self.find(name, scope).is_some()
-    }
-
     /// Get a symbol by name and scope (alias for find)
     #[allow(dead_code)]
     pub fn get(&self, name: &Id, scope: &ScopeKind) -> Option<&SymbolInfo> {
         self.find(name, scope)
-    }
-
-    /// Get all global symbols
-    #[allow(dead_code)]
-    pub fn get_global_symbols(&self) -> &HashMap<Id, SymbolInfo> {
-        &self.global_symbols
-    }
-
-    /// Get all scoped symbols
-    #[allow(dead_code)]
-    pub fn get_scoped_symbols(&self) -> &HashMap<ScopeKind, HashMap<Id, SymbolInfo>> {
-        &self.scoped_symbols
-    }
-
-    /// Clear the resolution cache (useful after modifications)
-    #[allow(dead_code)]
-    pub fn clear_cache(&mut self) {
-        self.resolution_cache.clear();
-    }
-
-    /// Get the total number of symbols in the environment
-    #[allow(dead_code)]
-    pub fn total_symbols(&self) -> usize {
-        let global_count = self.global_symbols.len();
-        let scoped_count: usize = self.scoped_symbols.values().map(|scope| scope.len()).sum();
-        global_count + scoped_count
-    }
-
-    /// Generate a comprehensive summary of the symbol table
-    #[allow(dead_code)]
-    pub fn generate_summary(&self) -> String {
-        let mut summary = String::new();
-
-        // Global symbols summary
-        summary.push_str(&format!(
-            "📚 Global Symbols ({}):\n",
-            self.global_symbols.len()
-        ));
-        for (name, symbol) in &self.global_symbols {
-            summary.push_str(&format!(
-                "  • {}: {:?} at {:?}\n",
-                name.original(),
-                symbol.kind,
-                symbol.span
-            ));
-        }
-
-        // Scoped symbols summary
-        summary.push_str(&format!(
-            "\n🔧 Scoped Symbols ({} scopes):\n",
-            self.scoped_symbols.len()
-        ));
-        for (scope, symbols) in &self.scoped_symbols {
-            let scope_name = match scope {
-                ScopeKind::Global => "Global".to_string(),
-                ScopeKind::Named(id) => format!("Named({})", id.original()),
-            };
-            summary.push_str(&format!(
-                "  📍 {} ({} symbols):\n",
-                scope_name,
-                symbols.len()
-            ));
-            for (name, symbol) in symbols {
-                summary.push_str(&format!(
-                    "    • {}: {:?} at {:?}\n",
-                    name.original(),
-                    symbol.kind,
-                    symbol.span
-                ));
-            }
-        }
-
-        // Statistics
-        let total_symbols = self.total_symbols();
-        let global_count = self.global_symbols.len();
-        let scoped_count: usize = self.scoped_symbols.values().map(|scope| scope.len()).sum();
-
-        summary.push_str("\n📊 Summary Statistics:\n");
-        summary.push_str(&format!("  • Total symbols: {total_symbols}\n"));
-        summary.push_str(&format!("  • Global symbols: {global_count}\n"));
-        summary.push_str(&format!("  • Scoped symbols: {scoped_count}\n"));
-        summary.push_str(&format!(
-            "  • Number of scopes: {}\n",
-            self.scoped_symbols.len()
-        ));
-
-        summary
-    }
-
-    /// Get detailed information about a specific symbol
-    #[allow(dead_code)]
-    pub fn get_symbol_details(&self, name: &Id, scope: &ScopeKind) -> Option<String> {
-        if let Some(symbol) = self.find(name, scope) {
-            let scope_name = match &symbol.scope {
-                ScopeKind::Global => "Global".to_string(),
-                ScopeKind::Named(id) => format!("Named({})", id.original()),
-            };
-
-            let visibility_name = match &symbol.visibility_scope {
-                ScopeKind::Global => "Global".to_string(),
-                ScopeKind::Named(id) => format!("Named({})", id.original()),
-            };
-
-            Some(format!(
-                "Symbol: {}\n  Kind: {:?}\n  Scope: {}\n  Visibility: {}\n  External: {}\n  Data Type: {:?}\n  Location: {:?}",
-                name.original(),
-                symbol.kind,
-                scope_name,
-                visibility_name,
-                symbol.is_external,
-                symbol.data_type,
-                symbol.span
-            ))
-        } else {
-            None
-        }
     }
 
     /// Returns all program declarations from the global scope.
@@ -527,26 +361,6 @@ impl SymbolEnvironment {
                 )
             })
             .collect()
-    }
-
-    /// Get all symbols that are accessible from a given scope
-    #[allow(dead_code)]
-    pub fn get_accessible_symbols(&self, scope: &ScopeKind) -> Vec<(&Id, &SymbolInfo)> {
-        let mut accessible = Vec::new();
-
-        // Add global symbols (always accessible)
-        for (name, symbol) in &self.global_symbols {
-            accessible.push((name, symbol));
-        }
-
-        // Add symbols from the current scope
-        if let Some(scope_symbols) = self.scoped_symbols.get(scope) {
-            for (name, symbol) in scope_symbols {
-                accessible.push((name, symbol));
-            }
-        }
-
-        accessible
     }
 
     /// Iterate over every symbol in the environment: the global symbols
@@ -634,7 +448,7 @@ mod tests {
         assert_eq!(symbol3.kind, SymbolKind::Variable);
 
         // Test scope hierarchy (local scope should find global symbols)
-        let symbol1_in_scope = env.find_in_scope_hierarchy(&id1, &scope).unwrap();
+        let symbol1_in_scope = env.find(&id1, &scope).unwrap();
         assert_eq!(symbol1_in_scope.kind, SymbolKind::Variable);
     }
 
@@ -669,92 +483,11 @@ mod tests {
         assert!(env.find(&local_id, &ScopeKind::Global).is_none());
 
         // Verify global symbols are visible from local scope
-        assert!(env
-            .find_in_scope_hierarchy(&global_id, &function_scope)
-            .is_some());
+        assert!(env.find(&global_id, &function_scope).is_some());
     }
 
     #[test]
-    fn symbol_info_builder_methods_when_using_builder_pattern_then_creates_correct_symbol_info() {
-        let span = ironplc_dsl::core::SourceSpan::default();
-        let mut symbol_info = SymbolInfo::new(SymbolKind::Variable, ScopeKind::Global, span);
-
-        // Test with_data_type
-        symbol_info = symbol_info.with_data_type("INT".to_string());
-        assert_eq!(symbol_info.data_type, Some("INT".to_string()));
-
-        // Test with_external
-        symbol_info = symbol_info.with_external(true);
-        assert!(symbol_info.is_external);
-
-        // Test with_visibility_scope
-        let named_scope = ScopeKind::Named(Id::from("FUNCTION"));
-        symbol_info = symbol_info.with_visibility_scope(named_scope.clone());
-        assert_eq!(symbol_info.visibility_scope, named_scope);
-    }
-
-    #[test]
-    fn total_symbols_count_when_counting_symbols_then_returns_correct_total() {
-        let mut env = SymbolEnvironment::new();
-
-        // Initially empty
-        assert_eq!(env.total_symbols(), 0);
-
-        // Add global symbols
-        let id1 = Id::from("GLOBAL1");
-        let id2 = Id::from("GLOBAL2");
-        env.insert(&id1, SymbolKind::Variable, &ScopeKind::Global)
-            .unwrap();
-        env.insert(&id2, SymbolKind::Program, &ScopeKind::Global)
-            .unwrap();
-        assert_eq!(env.total_symbols(), 2);
-
-        // Add scoped symbols
-        let scope = ScopeKind::Named(Id::from("FUNCTION"));
-        let id3 = Id::from("LOCAL1");
-        let id4 = Id::from("LOCAL2");
-        env.insert(&id3, SymbolKind::Variable, &scope).unwrap();
-        env.insert(&id4, SymbolKind::Parameter, &scope).unwrap();
-        assert_eq!(env.total_symbols(), 4);
-    }
-
-    #[test]
-    fn get_scope_symbols_when_getting_symbols_from_scope_then_returns_correct_symbols() {
-        let mut env = SymbolEnvironment::new();
-
-        // Test global scope
-        let global_symbols = env.get_scope_symbols(&ScopeKind::Global).unwrap();
-        assert_eq!(global_symbols.len(), 0); // Initially empty
-
-        // Add global symbols
-        let id1 = Id::from("GLOBAL1");
-        let id2 = Id::from("GLOBAL2");
-        env.insert(&id1, SymbolKind::Variable, &ScopeKind::Global)
-            .unwrap();
-        env.insert(&id2, SymbolKind::Program, &ScopeKind::Global)
-            .unwrap();
-
-        let global_symbols = env.get_scope_symbols(&ScopeKind::Global).unwrap();
-        assert_eq!(global_symbols.len(), 2);
-        assert!(global_symbols.contains_key(&id1));
-        assert!(global_symbols.contains_key(&id2));
-
-        // Test named scope
-        let scope = ScopeKind::Named(Id::from("FUNCTION"));
-        let named_symbols = env.get_scope_symbols(&scope);
-        assert!(named_symbols.is_none()); // Scope doesn't exist yet
-
-        // Add symbols to named scope
-        let id3 = Id::from("LOCAL1");
-        env.insert(&id3, SymbolKind::Variable, &scope).unwrap();
-
-        let named_symbols = env.get_scope_symbols(&scope).unwrap();
-        assert_eq!(named_symbols.len(), 1);
-        assert!(named_symbols.contains_key(&id3));
-    }
-
-    #[test]
-    fn contains_and_get_methods_when_checking_symbol_existence_then_returns_correct_results() {
+    fn get_when_checking_symbol_existence_then_returns_correct_results() {
         let mut env = SymbolEnvironment::new();
 
         let id1 = Id::from("GLOBAL_VAR");
@@ -763,12 +496,6 @@ mod tests {
         // Insert global symbol
         env.insert(&id1, SymbolKind::Variable, &ScopeKind::Global)
             .unwrap();
-
-        // Test contains method
-        assert!(env.contains(&id1, &ScopeKind::Global));
-        // Global symbols are accessible from any scope, so this should be true
-        assert!(env.contains(&id1, &ScopeKind::Named(Id::from("FUNCTION"))));
-        assert!(!env.contains(&id2, &ScopeKind::Global));
 
         // Test get method (alias for find)
         let symbol1 = env.get(&id1, &ScopeKind::Global).unwrap();
@@ -779,190 +506,15 @@ mod tests {
     }
 
     #[test]
-    fn get_global_and_scoped_symbols_when_getting_all_symbols_then_returns_correct_symbols() {
-        let mut env = SymbolEnvironment::new();
-
-        // Initially empty
-        let global_symbols = env.get_global_symbols();
-        assert_eq!(global_symbols.len(), 0);
-
-        let scoped_symbols = env.get_scoped_symbols();
-        assert_eq!(scoped_symbols.len(), 0);
-
-        // Add global symbols
-        let id1 = Id::from("GLOBAL1");
-        let id2 = Id::from("GLOBAL2");
-        env.insert(&id1, SymbolKind::Variable, &ScopeKind::Global)
-            .unwrap();
-        env.insert(&id2, SymbolKind::Program, &ScopeKind::Global)
-            .unwrap();
-
-        let global_symbols = env.get_global_symbols();
-        assert_eq!(global_symbols.len(), 2);
-        assert!(global_symbols.contains_key(&id1));
-        assert!(global_symbols.contains_key(&id2));
-
-        // Add scoped symbols
-        let scope1 = ScopeKind::Named(Id::from("FUNCTION1"));
-        let scope2 = ScopeKind::Named(Id::from("FUNCTION2"));
-
-        let id3 = Id::from("LOCAL1");
-        let id4 = Id::from("LOCAL2");
-        env.insert(&id3, SymbolKind::Variable, &scope1).unwrap();
-        env.insert(&id4, SymbolKind::Parameter, &scope2).unwrap();
-
-        let scoped_symbols = env.get_scoped_symbols();
-        assert_eq!(scoped_symbols.len(), 2);
-        assert!(scoped_symbols.contains_key(&scope1));
-        assert!(scoped_symbols.contains_key(&scope2));
-
-        let scope1_symbols = &scoped_symbols[&scope1];
-        assert_eq!(scope1_symbols.len(), 1);
-        assert!(scope1_symbols.contains_key(&id3));
-
-        let scope2_symbols = &scoped_symbols[&scope2];
-        assert_eq!(scope2_symbols.len(), 1);
-        assert!(scope2_symbols.contains_key(&id4));
-    }
-
-    #[test]
-    fn clear_cache_when_clearing_cache_then_symbols_are_removed() {
-        let mut env = SymbolEnvironment::new();
-
-        // clear_cache should not panic even when empty
-        env.clear_cache();
-
-        // Add some symbols and clear cache again
-        let id = Id::from("TEST_VAR");
-        env.insert(&id, SymbolKind::Variable, &ScopeKind::Global)
-            .unwrap();
-        env.clear_cache();
-
-        // Symbols should still be accessible after clearing cache
-        assert!(env.contains(&id, &ScopeKind::Global));
-    }
-
-    #[test]
     fn default_implementation_when_creating_default_then_creates_empty_environment() {
         let env = SymbolEnvironment::default();
 
         // Default should create an empty environment
-        assert_eq!(env.total_symbols(), 0);
-        assert_eq!(env.get_global_symbols().len(), 0);
-        assert_eq!(env.get_scoped_symbols().len(), 0);
+        assert_eq!(env.all_symbols().count(), 0);
 
         // Should be equivalent to new()
         let env2 = SymbolEnvironment::new();
-        assert_eq!(env.total_symbols(), env2.total_symbols());
-    }
-
-    #[test]
-    fn get_accessible_symbols_when_getting_accessible_symbols_then_returns_correct_symbols() {
-        let mut env = SymbolEnvironment::new();
-
-        // Add global symbols
-        let global_id1 = Id::from("GLOBAL1");
-        let global_id2 = Id::from("GLOBAL2");
-        env.insert(&global_id1, SymbolKind::Variable, &ScopeKind::Global)
-            .unwrap();
-        env.insert(&global_id2, SymbolKind::Program, &ScopeKind::Global)
-            .unwrap();
-
-        // Add scoped symbols
-        let scope = ScopeKind::Named(Id::from("FUNCTION"));
-        let local_id1 = Id::from("LOCAL1");
-        let local_id2 = Id::from("LOCAL2");
-        env.insert(&local_id1, SymbolKind::Variable, &scope)
-            .unwrap();
-        env.insert(&local_id2, SymbolKind::Parameter, &scope)
-            .unwrap();
-
-        // Test accessible symbols from global scope
-        let global_accessible = env.get_accessible_symbols(&ScopeKind::Global);
-        assert_eq!(global_accessible.len(), 2); // Only global symbols
-        assert!(global_accessible.iter().any(|(id, _)| **id == global_id1));
-        assert!(global_accessible.iter().any(|(id, _)| **id == global_id2));
-
-        // Test accessible symbols from named scope
-        let scope_accessible = env.get_accessible_symbols(&scope);
-        assert_eq!(scope_accessible.len(), 4); // Global + local symbols
-        assert!(scope_accessible.iter().any(|(id, _)| **id == global_id1));
-        assert!(scope_accessible.iter().any(|(id, _)| **id == global_id2));
-        assert!(scope_accessible.iter().any(|(id, _)| **id == local_id1));
-        assert!(scope_accessible.iter().any(|(id, _)| **id == local_id2));
-    }
-
-    #[test]
-    fn generate_summary_when_generating_summary_then_returns_correct_summary() {
-        let mut env = SymbolEnvironment::new();
-
-        // Test empty summary
-        let empty_summary = env.generate_summary();
-        assert!(empty_summary.contains("Global Symbols (0)"));
-        assert!(empty_summary.contains("Scoped Symbols (0 scopes)"));
-        assert!(empty_summary.contains("Total symbols: 0"));
-
-        // Add some symbols and test populated summary
-        let global_id = Id::from("GLOBAL_VAR");
-        let function_id = Id::from("TEST_FUNCTION");
-        let local_id = Id::from("LOCAL_VAR");
-
-        env.insert(&global_id, SymbolKind::Variable, &ScopeKind::Global)
-            .unwrap();
-        env.insert(&function_id, SymbolKind::Program, &ScopeKind::Global)
-            .unwrap();
-
-        let scope = ScopeKind::Named(function_id.clone());
-        env.insert(&local_id, SymbolKind::Parameter, &scope)
-            .unwrap();
-
-        let summary = env.generate_summary();
-        assert!(summary.contains("Global Symbols (2)"));
-        assert!(summary.contains("Scoped Symbols (1 scopes)"));
-        assert!(summary.contains("Total symbols: 3"));
-        assert!(summary.contains("GLOBAL_VAR"));
-        assert!(summary.contains("TEST_FUNCTION"));
-        assert!(summary.contains("LOCAL_VAR"));
-        assert!(summary.contains("Named(TEST_FUNCTION)"));
-    }
-
-    #[test]
-    fn get_symbol_details_when_getting_symbol_details_then_returns_correct_details() {
-        let mut env = SymbolEnvironment::new();
-
-        // Test getting details for non-existent symbol
-        let non_existent_id = Id::from("NON_EXISTENT");
-        let details = env.get_symbol_details(&non_existent_id, &ScopeKind::Global);
-        assert!(details.is_none());
-
-        // Test getting details for existing global symbol
-        let global_id = Id::from("GLOBAL_VAR");
-        env.insert(&global_id, SymbolKind::Variable, &ScopeKind::Global)
-            .unwrap();
-
-        let details = env
-            .get_symbol_details(&global_id, &ScopeKind::Global)
-            .unwrap();
-        assert!(details.contains("Symbol: GLOBAL_VAR"));
-        assert!(details.contains("Kind: Variable"));
-        assert!(details.contains("Scope: Global"));
-        assert!(details.contains("Visibility: Global"));
-        assert!(details.contains("External: false"));
-        assert!(details.contains("Data Type: None"));
-
-        // Test getting details for scoped symbol
-        let function_id = Id::from("TEST_FUNCTION");
-        let scope = ScopeKind::Named(function_id.clone());
-        let local_id = Id::from("LOCAL_PARAM");
-
-        env.insert(&local_id, SymbolKind::Parameter, &scope)
-            .unwrap();
-
-        let details = env.get_symbol_details(&local_id, &scope).unwrap();
-        assert!(details.contains("Symbol: LOCAL_PARAM"));
-        assert!(details.contains("Kind: Parameter"));
-        assert!(details.contains("Scope: Named(TEST_FUNCTION)"));
-        assert!(details.contains("Visibility: Named(TEST_FUNCTION)"));
+        assert_eq!(env.all_symbols().count(), env2.all_symbols().count());
     }
 
     #[test]
@@ -1028,16 +580,8 @@ mod tests {
 
         // Test scope hierarchy with non-existent scope
         let non_existent_scope = ScopeKind::Named(Id::from("NON_EXISTENT"));
-        let found = env.find_in_scope_hierarchy(&global_id, &non_existent_scope);
+        let found = env.find(&global_id, &non_existent_scope);
         assert!(found.is_some()); // Should find in global scope
-
-        // Test empty scopes
-        let empty_scope = ScopeKind::Named(Id::from("EMPTY_FUNCTION"));
-        let scope_symbols = env.get_scope_symbols(&empty_scope);
-        assert!(scope_symbols.is_none());
-
-        let accessible = env.get_accessible_symbols(&empty_scope);
-        assert_eq!(accessible.len(), 2); // Both global symbols (DUPLICATE_VAR and GLOBAL_ONLY)
     }
 
     #[test]

--- a/compiler/analyzer/src/symbol_environment.rs
+++ b/compiler/analyzer/src/symbol_environment.rs
@@ -3,13 +3,47 @@ use ironplc_dsl::core::{Id, Located};
 use ironplc_dsl::diagnostic::Diagnostic;
 use std::collections::HashMap;
 
+/// A scope's position in the nesting tree: the chain of declaration
+/// names from the library root.
+///
+/// A function block is `⟨FB_Motor⟩`; a method declared on it is
+/// `⟨FB_Motor, GetSpeed⟩`. Scopes are nameable, which is why this is a
+/// path of names rather than an id assigned to an AST node -- see
+/// `specs/plans/2026-08-28-method-scoping-and-scope-paths.md`.
+///
+/// Never empty: an empty path would be the global scope, which
+/// [`ScopeKind::Global`] already represents.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ScopePath(Vec<Id>);
+
+impl ScopePath {
+    pub fn new(segments: Vec<Id>) -> Self {
+        debug_assert!(
+            !segments.is_empty(),
+            "a scope path is never empty; the empty scope is ScopeKind::Global"
+        );
+        Self(segments)
+    }
+
+    pub fn segments(&self) -> &[Id] {
+        &self.0
+    }
+}
+
+impl From<Id> for ScopePath {
+    /// A scope directly inside the library, such as a function block.
+    fn from(name: Id) -> Self {
+        Self::new(vec![name])
+    }
+}
+
 /// Represents the kind of scope a symbol belongs to
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ScopeKind {
     /// Global scope (library level)
     Global,
-    /// Named scope (function, function block, program, etc.)
-    Named(Id),
+    /// Named scope (function, function block, program, method, etc.)
+    Named(ScopePath),
 }
 
 /// Represents the kind of symbol
@@ -146,11 +180,8 @@ impl SymbolEnvironment {
                 }
                 self.global_symbols.insert(name.clone(), symbol_info);
             }
-            ScopeKind::Named(scope_name) => {
-                let scope_symbols = self
-                    .scoped_symbols
-                    .entry(ScopeKind::Named(scope_name.clone()))
-                    .or_default();
+            ScopeKind::Named(_) => {
+                let scope_symbols = self.scoped_symbols.entry(scope.clone()).or_default();
 
                 // Check for duplicate symbols in the same scope
                 if let Some(_existing) = scope_symbols.get(name) {
@@ -187,11 +218,8 @@ impl SymbolEnvironment {
             ScopeKind::Global => {
                 self.global_symbols.insert(name.clone(), symbol_info);
             }
-            ScopeKind::Named(scope_name) => {
-                let scope_symbols = self
-                    .scoped_symbols
-                    .entry(ScopeKind::Named(scope_name.clone()))
-                    .or_default();
+            ScopeKind::Named(_) => {
+                let scope_symbols = self.scoped_symbols.entry(scope.clone()).or_default();
                 scope_symbols.insert(name.clone(), symbol_info);
             }
         }
@@ -213,11 +241,8 @@ impl SymbolEnvironment {
             ScopeKind::Global => {
                 self.global_symbols.insert(name.clone(), symbol_info);
             }
-            ScopeKind::Named(scope_name) => {
-                let scope_symbols = self
-                    .scoped_symbols
-                    .entry(ScopeKind::Named(scope_name.clone()))
-                    .or_default();
+            ScopeKind::Named(_) => {
+                let scope_symbols = self.scoped_symbols.entry(scope.clone()).or_default();
 
                 scope_symbols.insert(name.clone(), symbol_info);
             }
@@ -240,11 +265,8 @@ impl SymbolEnvironment {
             ScopeKind::Global => {
                 self.global_symbols.insert(name.clone(), symbol_info);
             }
-            ScopeKind::Named(scope_name) => {
-                let scope_symbols = self
-                    .scoped_symbols
-                    .entry(ScopeKind::Named(scope_name.clone()))
-                    .or_default();
+            ScopeKind::Named(_) => {
+                let scope_symbols = self.scoped_symbols.entry(scope.clone()).or_default();
 
                 scope_symbols.insert(name.clone(), symbol_info);
             }
@@ -308,12 +330,23 @@ impl SymbolEnvironment {
         Ok(())
     }
 
-    /// Find a symbol in the given scope, with fallback to global scope
+    /// Finds a symbol visible from the given scope.
+    ///
+    /// Walks outward through the enclosing scopes and then the global
+    /// scope, so a method body sees its function block's fields and an
+    /// inner declaration shadows an outer one of the same name.
     pub fn find(&self, name: &Id, scope: &ScopeKind) -> Option<&SymbolInfo> {
-        // First try to find in the specified scope
-        if let Some(scope_symbols) = self.scoped_symbols.get(scope) {
-            if let Some(symbol) = scope_symbols.get(name) {
-                return Some(symbol);
+        if let ScopeKind::Named(path) = scope {
+            let segments = path.segments();
+            for depth in (1..=segments.len()).rev() {
+                let enclosing = ScopeKind::Named(ScopePath::new(segments[..depth].to_vec()));
+                if let Some(symbol) = self
+                    .scoped_symbols
+                    .get(&enclosing)
+                    .and_then(|symbols| symbols.get(name))
+                {
+                    return Some(symbol);
+                }
             }
         }
 
@@ -439,7 +472,7 @@ mod tests {
         assert_eq!(symbol2.kind, SymbolKind::Program);
 
         // Test scoped symbols
-        let scope = ScopeKind::Named(Id::from("FUNCTION_BLOCK"));
+        let scope = ScopeKind::Named(Id::from("FUNCTION_BLOCK").into());
         let id3 = Id::from("LOCAL_VAR");
 
         env.insert(&id3, SymbolKind::Variable, &scope).unwrap();
@@ -470,7 +503,7 @@ mod tests {
             .unwrap();
 
         // Insert local symbol in function scope
-        let function_scope = ScopeKind::Named(function_id.clone());
+        let function_scope = ScopeKind::Named(function_id.clone().into());
         env.insert(&local_id, SymbolKind::Variable, &function_scope)
             .unwrap();
 
@@ -546,8 +579,8 @@ mod tests {
 
         // Test Named scope
         let function_id = Id::from("TEST_FUNCTION");
-        let named_scope = ScopeKind::Named(function_id.clone());
-        assert_eq!(named_scope, ScopeKind::Named(function_id));
+        let named_scope = ScopeKind::Named(function_id.clone().into());
+        assert_eq!(named_scope, ScopeKind::Named(function_id.into()));
 
         // Test scope comparison
         assert_ne!(global_scope, named_scope);
@@ -573,13 +606,13 @@ mod tests {
         env.insert(&global_id, SymbolKind::Variable, &ScopeKind::Global)
             .unwrap();
 
-        let wrong_scope = ScopeKind::Named(Id::from("WRONG_FUNCTION"));
+        let wrong_scope = ScopeKind::Named(Id::from("WRONG_FUNCTION").into());
         let found = env.find(&global_id, &wrong_scope);
         // Global symbols are accessible from any scope, so this should find the symbol
         assert!(found.is_some());
 
         // Test scope hierarchy with non-existent scope
-        let non_existent_scope = ScopeKind::Named(Id::from("NON_EXISTENT"));
+        let non_existent_scope = ScopeKind::Named(Id::from("NON_EXISTENT").into());
         let found = env.find(&global_id, &non_existent_scope);
         assert!(found.is_some()); // Should find in global scope
     }
@@ -595,7 +628,7 @@ mod tests {
         env.insert_enumeration_value(&Id::from("RED"), &enum_type, &ScopeKind::Global)
             .unwrap();
         // Scoped enumeration value of the requested type.
-        let scope = ScopeKind::Named(Id::from("FB"));
+        let scope = ScopeKind::Named(Id::from("FB").into());
         env.insert_enumeration_value(&Id::from("GREEN"), &enum_type, &scope)
             .unwrap();
         // Enumeration value of a different type (should be excluded).
@@ -631,7 +664,7 @@ mod tests {
         env.insert_structure_field(&Id::from("X"), &struct_type, &ScopeKind::Global)
             .unwrap();
         // Scoped structure field of the requested type.
-        let scope = ScopeKind::Named(Id::from("FB"));
+        let scope = ScopeKind::Named(Id::from("FB").into());
         env.insert_structure_field(&Id::from("Y"), &struct_type, &scope)
             .unwrap();
         // Structure field of a different type (should be excluded).
@@ -660,7 +693,7 @@ mod tests {
     #[test]
     fn symbol_info_span_and_scope_when_creating_symbol_info_then_has_correct_span_and_scope() {
         let span = ironplc_dsl::core::SourceSpan::default();
-        let scope = ScopeKind::Named(Id::from("TEST_FUNCTION"));
+        let scope = ScopeKind::Named(Id::from("TEST_FUNCTION").into());
 
         let symbol_info = SymbolInfo::new(SymbolKind::Variable, scope.clone(), span);
 
@@ -670,5 +703,64 @@ mod tests {
         assert_eq!(symbol_info.span, ironplc_dsl::core::SourceSpan::default());
         assert!(!symbol_info.is_external);
         assert!(symbol_info.data_type.is_none());
+    }
+
+    /// A scope path nests, so a symbol declared in an enclosing scope is
+    /// visible from an inner one -- how a method body sees the fields of
+    /// the function block it is declared on.
+    #[test]
+    fn find_when_symbol_is_in_enclosing_scope_then_found_from_inner_scope() {
+        let mut env = SymbolEnvironment::new();
+
+        let outer = ScopeKind::Named(Id::from("FB_Motor").into());
+        let inner = ScopeKind::Named(ScopePath::new(vec![
+            Id::from("FB_Motor"),
+            Id::from("GetSpeed"),
+        ]));
+
+        let field = Id::from("speed");
+        env.insert(&field, SymbolKind::Variable, &outer).unwrap();
+
+        assert!(
+            env.find(&field, &inner).is_some(),
+            "an enclosing scope's symbol should be visible from the inner scope"
+        );
+    }
+
+    /// The innermost declaration of a name wins, so a method local
+    /// shadows a function block field of the same name.
+    #[test]
+    fn find_when_inner_scope_redeclares_name_then_inner_symbol_shadows_outer() {
+        let mut env = SymbolEnvironment::new();
+
+        let outer = ScopeKind::Named(Id::from("FB_Motor").into());
+        let inner = ScopeKind::Named(ScopePath::new(vec![
+            Id::from("FB_Motor"),
+            Id::from("GetSpeed"),
+        ]));
+
+        let name = Id::from("v");
+        env.insert(&name, SymbolKind::Variable, &outer).unwrap();
+        env.insert(&name, SymbolKind::Parameter, &inner).unwrap();
+
+        assert_eq!(env.find(&name, &inner).unwrap().kind, SymbolKind::Parameter);
+        assert_eq!(env.find(&name, &outer).unwrap().kind, SymbolKind::Variable);
+    }
+
+    /// A name declared only in an inner scope does not leak outward.
+    #[test]
+    fn find_when_symbol_is_in_inner_scope_then_not_found_from_enclosing_scope() {
+        let mut env = SymbolEnvironment::new();
+
+        let outer = ScopeKind::Named(Id::from("FB_Motor").into());
+        let inner = ScopeKind::Named(ScopePath::new(vec![
+            Id::from("FB_Motor"),
+            Id::from("GetSpeed"),
+        ]));
+
+        let local = Id::from("q");
+        env.insert(&local, SymbolKind::Variable, &inner).unwrap();
+
+        assert!(env.find(&local, &outer).is_none());
     }
 }

--- a/compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs
+++ b/compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs
@@ -15,6 +15,7 @@ use ironplc_dsl::{
     },
     core::{Id, Located},
     diagnostic::Diagnostic,
+    scope::ScopeNode,
     visitor::Visitor,
 };
 use log::debug;
@@ -23,7 +24,7 @@ use crate::{
     function_environment::{FunctionEnvironment, FunctionSignature},
     intermediate_type::IntermediateFunctionParameter,
     result::SemanticResult,
-    symbol_environment::{ScopeKind, SymbolEnvironment, SymbolKind},
+    symbol_environment::{ScopeKind, ScopePath, SymbolEnvironment, SymbolKind},
 };
 
 pub fn apply(
@@ -44,7 +45,7 @@ pub fn apply_impl(
     let mut resolver = EnvironmentResolver {
         symbol_env,
         function_env,
-        scope: None,
+        scope: Vec::new(),
     };
     let result = resolver.walk(lib).map_err(|e| vec![e]);
 
@@ -59,20 +60,41 @@ pub fn apply_impl(
 struct EnvironmentResolver<'a> {
     symbol_env: &'a mut SymbolEnvironment,
     function_env: &'a mut FunctionEnvironment,
-    scope: Option<Id>,
+    /// The chain of declarations the traversal is currently inside,
+    /// outermost first. A stack rather than a single name because
+    /// declarations nest: a method is inside its function block.
+    scope: Vec<Id>,
 }
 
 impl<'a> EnvironmentResolver<'a> {
     fn current_scope(&self) -> ScopeKind {
-        match &self.scope {
-            Some(name) => ScopeKind::Named(name.clone().into()),
-            None => ScopeKind::Global,
+        if self.scope.is_empty() {
+            ScopeKind::Global
+        } else {
+            ScopeKind::Named(ScopePath::new(self.scope.clone()))
         }
     }
 }
 
 impl<'a> Visitor<Diagnostic> for EnvironmentResolver<'a> {
     type Value = ();
+
+    /// Pushes the declaration the traversal is entering onto the scope
+    /// stack, so the variables it declares are recorded against its own
+    /// path rather than the enclosing declaration's.
+    fn enter_scope(&mut self, node: ScopeNode<'_>) -> Result<(), Diagnostic> {
+        self.scope.push(match node {
+            ScopeNode::Function(node) => node.name.clone(),
+            ScopeNode::FunctionBlock(node) => node.name.name.clone(),
+            ScopeNode::Program(node) => node.name.clone(),
+            ScopeNode::Method(node) => node.name.clone(),
+        });
+        Ok(())
+    }
+
+    fn exit_scope(&mut self) {
+        self.scope.pop();
+    }
 
     // TODO fn visit_program_access_decl
 
@@ -129,8 +151,6 @@ impl<'a> Visitor<Diagnostic> for EnvironmentResolver<'a> {
         &mut self,
         node: &ironplc_dsl::common::FunctionDeclaration,
     ) -> Result<Self::Value, Diagnostic> {
-        self.scope = Some(node.name.clone());
-
         // Build function signature for function environment
         // (Functions are tracked in FunctionEnvironment, not SymbolEnvironment)
         // Collect parameters (INPUT, OUTPUT, INOUT variables)
@@ -191,39 +211,28 @@ impl<'a> Visitor<Diagnostic> for EnvironmentResolver<'a> {
             FunctionSignature::new(node.name.clone(), return_type, parameters, node.name.span());
         self.function_env.insert(signature)?;
 
-        let result = node.recurse_visit(self);
-        self.scope = None;
-
-        result
+        node.recurse_visit(self)
     }
 
     fn visit_function_block_declaration(
         &mut self,
         node: &ironplc_dsl::common::FunctionBlockDeclaration,
     ) -> Result<Self::Value, Diagnostic> {
-        self.scope = Some(node.name.name.clone());
         self.symbol_env.insert(
             &node.name.name,
             SymbolKind::FunctionBlock,
             &ScopeKind::Global,
         )?;
-        let result = node.recurse_visit(self);
-        self.scope = None;
-
-        result
+        node.recurse_visit(self)
     }
 
     fn visit_program_declaration(
         &mut self,
         node: &ironplc_dsl::common::ProgramDeclaration,
     ) -> Result<Self::Value, Diagnostic> {
-        self.scope = Some(node.name.clone());
         self.symbol_env
             .insert(&node.name, SymbolKind::Program, &ScopeKind::Global)?;
-        let result = node.recurse_visit(self);
-        self.scope = None;
-
-        result
+        node.recurse_visit(self)
     }
 
     fn visit_data_type_declaration_kind(
@@ -352,8 +361,8 @@ mod test {
 
     use crate::{
         function_environment::FunctionEnvironment,
-        symbol_environment::{ScopeKind, SymbolEnvironment, SymbolKind},
-        test_helpers::parse_and_resolve_types,
+        symbol_environment::{ScopeKind, ScopePath, SymbolEnvironment, SymbolKind},
+        test_helpers::{parse_and_resolve_types, parse_and_resolve_types_with_options},
         xform_resolve_symbol_and_function_environment::apply_impl,
     };
 
@@ -530,5 +539,126 @@ END_FUNCTION";
         // Check output parameters
         assert!(func_sig.parameters[1].is_output);
         assert!(func_sig.parameters[2].is_output);
+    }
+
+    // ---------------------------------------------------------------------
+    // METHOD scoping.
+    // See specs/plans/2026-08-28-method-scoping-and-scope-paths.md and
+    // https://github.com/ironplc/ironplc/issues/1439.
+    // ---------------------------------------------------------------------
+
+    fn resolve_with_methods(program: &str) -> (SymbolEnvironment, FunctionEnvironment) {
+        let options = ironplc_parser::options::CompilerOptions {
+            allow_fb_inheritance: true,
+            ..ironplc_parser::options::CompilerOptions::default()
+        };
+        let (library, _context) = parse_and_resolve_types_with_options(program, &options);
+        let mut symbol_env = SymbolEnvironment::new();
+        let mut function_env = FunctionEnvironment::new();
+        apply_impl(&library, &mut symbol_env, &mut function_env).unwrap();
+        (symbol_env, function_env)
+    }
+
+    fn method_scope(function_block: &str, method: &str) -> ScopeKind {
+        ScopeKind::Named(ScopePath::new(vec![
+            Id::from(function_block),
+            Id::from(method),
+        ]))
+    }
+
+    /// A method's parameters belong to the method. They used to be
+    /// recorded against the enclosing function block, which is what made
+    /// them visible to its siblings.
+    #[test]
+    fn apply_when_method_has_parameter_then_recorded_in_method_scope() {
+        let (symbol_env, _) = resolve_with_methods(
+            "
+FUNCTION_BLOCK FB_Motor
+VAR
+    speed : INT;
+END_VAR
+METHOD SetSpeed
+VAR_INPUT
+    newSpeed : INT;
+END_VAR
+    speed := newSpeed;
+END_METHOD
+END_FUNCTION_BLOCK",
+        );
+
+        let param = Id::from("newSpeed");
+        let fb_scope = ScopeKind::Named(Id::from("FB_Motor").into());
+
+        assert!(
+            symbol_env
+                .get_variables_in_scope(&method_scope("FB_Motor", "SetSpeed"))
+                .iter()
+                .any(|(name, _)| *name == &param),
+            "the parameter belongs to the method's own scope"
+        );
+        assert!(
+            !symbol_env
+                .get_variables_in_scope(&fb_scope)
+                .iter()
+                .any(|(name, _)| *name == &param),
+            "and not to the function block's"
+        );
+    }
+
+    /// Sibling methods are sibling scopes, so the same name in each is
+    /// two distinct symbols rather than one overwriting the other.
+    #[test]
+    fn apply_when_two_methods_declare_same_name_then_each_scope_has_its_own() {
+        let (symbol_env, _) = resolve_with_methods(
+            "
+FUNCTION_BLOCK FB_Motor
+METHOD a
+VAR
+    q : INT;
+END_VAR
+    q := 1;
+END_METHOD
+METHOD b
+VAR
+    q : INT;
+END_VAR
+    q := 2;
+END_METHOD
+END_FUNCTION_BLOCK",
+        );
+
+        for method in ["a", "b"] {
+            assert!(
+                symbol_env
+                    .get_variables_in_scope(&method_scope("FB_Motor", method))
+                    .iter()
+                    .any(|(name, _)| *name == &Id::from("q")),
+                "method {method} should have its own q"
+            );
+        }
+    }
+
+    /// The method scope nests inside the function block's, so a lookup
+    /// from inside a method still reaches the instance's fields.
+    #[test]
+    fn apply_when_looking_up_field_from_method_scope_then_found() {
+        let (symbol_env, _) = resolve_with_methods(
+            "
+FUNCTION_BLOCK FB_Motor
+VAR
+    speed : INT;
+END_VAR
+METHOD SetSpeed
+VAR_INPUT
+    newSpeed : INT;
+END_VAR
+    speed := newSpeed;
+END_METHOD
+END_FUNCTION_BLOCK",
+        );
+
+        assert!(symbol_env
+            .find(&Id::from("speed"), &method_scope("FB_Motor", "SetSpeed"))
+            .is_some());
     }
 }

--- a/compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs
+++ b/compiler/analyzer/src/xform_resolve_symbol_and_function_environment.rs
@@ -65,7 +65,7 @@ struct EnvironmentResolver<'a> {
 impl<'a> EnvironmentResolver<'a> {
     fn current_scope(&self) -> ScopeKind {
         match &self.scope {
-            Some(name) => ScopeKind::Named(name.clone()),
+            Some(name) => ScopeKind::Named(name.clone().into()),
             None => ScopeKind::Global,
         }
     }
@@ -377,7 +377,10 @@ END_FUNCTION_BLOCK";
 
         assert!(result.is_ok());
         let attributes = symbol_env
-            .get(&Id::from("LEVEL"), &ScopeKind::Named(Id::from("LOGGER")))
+            .get(
+                &Id::from("LEVEL"),
+                &ScopeKind::Named(Id::from("LOGGER").into()),
+            )
             .unwrap();
         assert_eq!(attributes.kind, SymbolKind::Parameter);
 
@@ -412,24 +415,36 @@ END_FUNCTION_BLOCK";
 
         // Check that input parameters are captured
         let reset_symbol = symbol_env
-            .get(&Id::from("Reset"), &ScopeKind::Named(Id::from("Counter")))
+            .get(
+                &Id::from("Reset"),
+                &ScopeKind::Named(Id::from("Counter").into()),
+            )
             .unwrap();
         assert_eq!(reset_symbol.kind, SymbolKind::Parameter);
 
         let count_symbol = symbol_env
-            .get(&Id::from("Count"), &ScopeKind::Named(Id::from("Counter")))
+            .get(
+                &Id::from("Count"),
+                &ScopeKind::Named(Id::from("Counter").into()),
+            )
             .unwrap();
         assert_eq!(count_symbol.kind, SymbolKind::Parameter);
 
         // Check that output parameters are captured
         let out_symbol = symbol_env
-            .get(&Id::from("OUT"), &ScopeKind::Named(Id::from("Counter")))
+            .get(
+                &Id::from("OUT"),
+                &ScopeKind::Named(Id::from("Counter").into()),
+            )
             .unwrap();
         assert_eq!(out_symbol.kind, SymbolKind::OutputParameter);
 
         // Check that local variables are captured
         let cnt_symbol = symbol_env
-            .get(&Id::from("Cnt"), &ScopeKind::Named(Id::from("Counter")))
+            .get(
+                &Id::from("Cnt"),
+                &ScopeKind::Named(Id::from("Counter").into()),
+            )
             .unwrap();
         assert_eq!(cnt_symbol.kind, SymbolKind::Variable);
 

--- a/compiler/mcp/src/runner.rs
+++ b/compiler/mcp/src/runner.rs
@@ -71,7 +71,7 @@ pub fn build_symbol_map(context: &SemanticContext, container: &Container) -> Var
     // Program-scoped variables: qualify as `<program>.<var>`.
     for (program_name, _) in context.symbols().get_programs() {
         let program = program_name.original().to_string();
-        let scope = ScopeKind::Named((*program_name).clone());
+        let scope = ScopeKind::Named((*program_name).clone().into());
         for (var_name, info) in context.symbols().get_variables_in_scope(&scope) {
             let bare = var_name.original().as_str();
             let Some(entries) = bare_index.get(bare) else {

--- a/compiler/mcp/src/tools/project_io.rs
+++ b/compiler/mcp/src/tools/project_io.rs
@@ -97,7 +97,7 @@ fn collect_io(context: &SemanticContext) -> (Vec<IoEntry>, Vec<IoEntry>) {
 
     // Programs: name variables as `<program>.<variable>`.
     for (program_name, _) in context.symbols().get_programs() {
-        let scope = ScopeKind::Named(program_name.clone());
+        let scope = ScopeKind::Named(program_name.clone().into());
         for (var_name, info) in context.symbols().get_variables_in_scope(&scope) {
             let qualified = format!("{}.{}", program_name, var_name);
             classify(&qualified, info, true, false, &mut inputs, &mut outputs);

--- a/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
+++ b/specs/plans/2026-08-28-method-scoping-and-scope-paths.md
@@ -90,8 +90,16 @@ to that borrow, and `find` took `&mut self` although it bottoms out in
 `HashMap::get`. Without that one-word change the conversion would have had
 to widen unrelated signatures to `&mut`.
 
-PR 4's prefactoring is giving `ScopeKind` a path before anything pushes a
-nested scope onto it.
+PR 4 carries two prefactoring commits before its behaviour change.
+First, removing the unused `SymbolEnvironment` API — thirteen items
+reachable only from that module's own tests, seven of them typed in terms
+of `ScopeKind`, so the path change has seven fewer signatures to carry.
+Second, giving `ScopeKind` a path while every scope is still one segment
+deep, so `find` resolves exactly what it did before.
+
+No `ScopeKind::parent()`, which earlier drafts of this plan named: `find`
+walks the path by slicing it and nothing else needs one, so building it
+would be the speculative generality the standard warns against.
 
 ## Design
 
@@ -483,7 +491,7 @@ them fire correctly.
 - [x] Confirm reproductions 1, 2, 4 and 5 in *Problem* now behave correctly
 - [x] PR 3 — `xform_resolve_expr_types` on `ScopedTable`
 - [x] Confirm reproduction 3 in *Problem* now behaves correctly
-- [ ] PR 4 — scope paths in `SymbolEnvironment`
+- [x] PR 4 — scope paths in `SymbolEnvironment`
 
 ## Verification
 


### PR DESCRIPTION
No behaviour change. Every one of these was reachable only from
symbol_environment.rs's own tests: SymbolInfo::with_data_type and
with_visibility_scope; SymbolEnvironment::find_in_scope_hierarchy,
get_scope_symbols, contains, get_global_symbols, get_scoped_symbols,
clear_cache, total_symbols, generate_summary, get_symbol_details and
get_accessible_symbols; and the resolution_cache field, which was
constructed and cleared but never read.

This is the prefactor's prefactor. Seven of the removed items are typed
in terms of ScopeKind, so giving ScopeKind a scope path -- the next
commit -- has seven fewer signatures to carry along.

SymbolEnvironment::get stays: unlike its siblings it has real callers, in
xform_resolve_symbol_and_function_environment's tests.

Tests that merely touched a removed method keep their live assertions:
the two find_in_scope_hierarchy calls asserted that a global resolves
from a named scope, which find already does, so they now call find; the
contains half of contains_and_get goes and the get half stays; and the
Default test asserts emptiness through all_symbols. Only the eight tests
whose entire subject was removed are gone with it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DdDr6NVSimqUjzZupHf3jE