### PR TITLE
Balance the aggregate-assignment rule's scope stack

### DIFF
--- a/compiler/analyzer/src/rule_assignment_aggregate_type_compat.rs
+++ b/compiler/analyzer/src/rule_assignment_aggregate_type_compat.rs
@@ -72,10 +72,10 @@ pub fn apply(
         declarations: scoped_table::ScopedTable::new(),
         diagnostics: Vec::new(),
     };
-    // The outermost scope holds declarations made outside any POU --
-    // a CONFIGURATION's VAR_GLOBAL block, most importantly -- so a POU
-    // scope's lookups fall through to them.
-    rule.declarations.enter();
+    // The table's base scope holds declarations made outside any POU -- a
+    // CONFIGURATION's VAR_GLOBAL block, most importantly -- so a POU scope's
+    // lookups fall through to them. `new` opens it; entering another here
+    // would leave a scope that nothing exits.
     run_rule(rule, lib)
 }
 


### PR DESCRIPTION
## What

`main` is red: 110 analyzer tests panic in `ScopedTable`'s `Drop` with

```
scope stack unbalanced: ended at depth 2, expected 1
```

`RuleAggregateAssignment::apply` (from #1443) enters a scope that nothing ever
exits:

```rust
rule.declarations.enter();
run_rule(rule, lib)
```

`ScopedTable::new` already pushes the base scope that the comment above that
line describes, so the extra `enter` leaves the table one level deep when it
drops. The `debug_assert` added with the table caught it — working exactly as
its doc comment says it should, in every test that runs a semantic pass.

Deleting the `enter` is the whole fix. Declarations made outside any POU now
live in the base scope, which is where the comment says they belong. Lookups
are unaffected: `find` walks the whole stack either way, and the only change
is that the stack is one shallower throughout.

## Verification

- `cargo test -p ironplc-analyzer`: **795 passed, 0 failed** (110 were failing
  before).
- `cd compiler && just` passes in full: compile, coverage, clippy, rustfmt,
  duplication gate.
- The rule's own coverage of this behaviour passes unchanged —
  `apply_when_global_array_type_matches_then_accepted` and
  `apply_when_pou_ends_then_its_declarations_leave_scope` are exactly the
  cases the scope depth affects.

Found while merging `main` into #1481, whose CI this is currently failing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcAd4pVBghkuACdMryhivR)_