### PR TITLE
Fix unbalanced scope stack in the aggregate assignment rule (main is red)

### DIFF
--- a/compiler/analyzer/src/rule_assignment_aggregate_type_compat.rs
+++ b/compiler/analyzer/src/rule_assignment_aggregate_type_compat.rs
@@ -67,16 +67,19 @@ pub fn apply(
     context: &SemanticContext,
     _options: &CompilerOptions,
 ) -> SemanticResult {
-    let mut rule = RuleAggregateAssignment {
-        type_environment: context.types(),
-        declarations: scoped_table::ScopedTable::new(),
-        diagnostics: Vec::new(),
-    };
-    // The outermost scope holds declarations made outside any POU --
-    // a CONFIGURATION's VAR_GLOBAL block, most importantly -- so a POU
-    // scope's lookups fall through to them.
-    rule.declarations.enter();
-    run_rule(rule, lib)
+    run_rule(
+        RuleAggregateAssignment {
+            type_environment: context.types(),
+            // `ScopedTable::new` opens the base scope. That is where
+            // declarations made outside any POU land -- a CONFIGURATION's
+            // VAR_GLOBAL block, most importantly -- so a POU scope's lookups
+            // fall through to them. Opening another here would leave the
+            // stack unbalanced when the table drops.
+            declarations: scoped_table::ScopedTable::new(),
+            diagnostics: Vec::new(),
+        },
+        lib,
+    )
 }
 
 /// A variable's declared type, as spelled at its declaration site.


### PR DESCRIPTION
**`main` is currently red.** Every analyzer test panics:

```
scope stack unbalanced: ended at depth 2, expected 1
  at analyzer/src/scoped_table.rs:199
```

One-line fix.

## Cause

`rule_assignment_aggregate_type_compat::apply` (added in #1443) called `ScopedTable::enter()` to open a scope for declarations made outside any POU, with no matching `exit()`.

`ScopedTable::new()` already opens that base scope, so the call was redundant from the start. It became fatal when `ScopedTable` gained a `Drop` assertion that the stack unwinds to depth 1. Because this rule runs on every program, the panic takes down far more tests than its own — `extractors`, `rule_bit_access_range` and others all fail with it.

The fix is to drop the `enter()` rather than add an `exit()`: the base scope from `new()` is exactly the outside-any-POU scope that was wanted, so the behaviour it was reaching for is unchanged. The comment now says so, to stop it being re-added.

## Why CI did not catch it

The two changes landed through separate pull requests that were each green on their own:

- #1443 added the rule with the unbalanced `enter()`, before the `Drop` assertion existed.
- The `ScopedTable` `Drop` assertion came in on a different branch, before this rule existed.

Neither run exercised the combination, and the merge of the two was clean — no conflict, because the two edits are in different files. The first build of the merged result was the one that failed.

## Verification

`cd compiler && just` passes: compile, coverage (≥85%), clippy, fmt, duplication.

Confirmed the failure reproduces on `main` at e879a64 before the change and is gone after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdURgoQ8MJtYKuhVAQ6UjD)_