### PR TITLE
Remove outdated known limitations from P9999 documentation

### DIFF
--- a/compiler/mcp/src/tools/explain_diagnostic.rs
+++ b/compiler/mcp/src/tools/explain_diagnostic.rs
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn build_response_when_code_has_no_fix_section_then_none() {
-        // P9999 has "Known Limitations" but no "To fix this error" paragraph.
+        // P9999 has a "Reporting the program" section but no "To fix this error" paragraph.
         let resp = build_response("P9999");
         assert!(resp.ok);
         assert!(resp.found);

--- a/docs/reference/compiler/problems/P9999.rst
+++ b/docs/reference/compiler/problems/P9999.rst
@@ -17,10 +17,6 @@ requires adding support for the elements to the IronPLC compiler.
 Reporting the program
 ---------------------
 
-The set of unsupported elements changes with every release, so this page does
-not list them. If your program is valid IEC 61131-3 and produces this error,
-report it — that is how the gap gets closed.
-
 We can only add support for an unsupported capability once we can see the
 program that needs it. Sending us the program gives the best results, so please
 do — there are two ways, and no GitHub account is required:

--- a/docs/reference/compiler/problems/P9999.rst
+++ b/docs/reference/compiler/problems/P9999.rst
@@ -17,6 +17,10 @@ requires adding support for the elements to the IronPLC compiler.
 Reporting the program
 ---------------------
 
+The set of unsupported elements changes with every release, so this page does
+not list them. If your program is valid IEC 61131-3 and produces this error,
+report it — that is how the gap gets closed.
+
 We can only add support for an unsupported capability once we can see the
 program that needs it. Sending us the program gives the best results, so please
 do — there are two ways, and no GitHub account is required:
@@ -32,21 +36,6 @@ do — there are two ways, and no GitHub account is required:
    Whichever route you choose, the program you submit is shared with the
    IronPLC team and **may become public** — for example in a GitHub issue.
    Do not submit anything confidential.
-
-Known Limitations
------------------
-
-The following features are not yet supported in code generation and will
-produce this error:
-
-* ``ARRAY`` element access
-* ``STRUCT`` member access
-* ``FUNCTION_BLOCK`` with SFC bodies
-* ``STRING`` pass-by-reference (``VAR_IN_OUT``)
-* Direct variables (hardware-mapped I/O such as ``%IX0.0``)
-* Enumerated values in expressions and ``CASE`` selectors
-* :doc:`Object-oriented programming </reference/language/object-orientation/index>`
-  constructs (``EXTENDS``, ``IMPLEMENTS``, ``ABSTRACT``, ``INTERFACE``)
 
 .. _IronPLC Playground: https://playground.ironplc.com/
 .. _GitHub issue: https://github.com/ironplc/ironplc/issues/new?template=todo_report.md


### PR DESCRIPTION
## Summary
Updates the P9999 error documentation to remove the static "Known Limitations" section that listed unsupported features. This section became outdated as features were added over time, creating maintenance burden and potential confusion for users.

## Changes
- **docs/reference/compiler/problems/P9999.rst**: 
  - Added clarification that the set of unsupported elements changes with each release, so a static list is not maintained
  - Removed the "Known Limitations" section that listed specific unsupported features (ARRAY access, STRUCT member access, FUNCTION_BLOCK with SFC bodies, STRING pass-by-reference, direct variables, enumerated values, and OOP constructs)
  - Encourages users to report valid IEC 61131-3 programs that produce this error as the mechanism for closing gaps

- **compiler/mcp/src/tools/explain_diagnostic.rs**:
  - Updated test comment to reflect the new documentation structure (references "Reporting the program" section instead of "Known Limitations")

## Rationale
The static list of known limitations required ongoing maintenance and could become stale. By removing it and emphasizing that users should report unsupported valid programs, the documentation becomes more maintainable and reinforces the project's approach to feature prioritization based on real-world usage.

https://claude.ai/code/session_015UQXVnBxiydX7Jr6H1wjFJ