### PR TITLE
Widen plan-citations to catch relative markdown links

### DIFF
--- a/compiler/codegen/src/spec_conformance_adr.rs
+++ b/compiler/codegen/src/spec_conformance_adr.rs
@@ -20,8 +20,9 @@ use ironplc_vm::test_support::load_and_start;
 use ironplc_vm::VmBuffers;
 use spec_test_macro::spec_test;
 
-/// The plan's Goal example: a function-block instance binding a pointer to
-/// one of its own members and reading it back through `^`. The member value
+/// The Goal example from `specs/design/adr-and-pointer-to.md`: a function-block
+/// instance binding a pointer to one of its own members and reading it back
+/// through `^`. The member value
 /// is assigned in the body rather than by a `:= 5` member initializer:
 /// declared initial values are not yet applied to user FB instance fields (a
 /// pre-existing gap unrelated to `ADR`).

--- a/compiler/codegen/tests/it/end_to_end_adr.rs
+++ b/compiler/codegen/tests/it/end_to_end_adr.rs
@@ -24,8 +24,9 @@ fn adr_options() -> CompilerOptions {
     }
 }
 
-/// The plan's Goal example: an FB instance binding a pointer to one of its
-/// own members and reading it back through `^`. The member value is assigned
+/// The Goal example from `specs/design/adr-and-pointer-to.md`: an FB instance
+/// binding a pointer to one of its own members and reading it back through
+/// `^`. The member value is assigned
 /// in the body because declared initial values are not yet applied to user
 /// FB instance fields (a pre-existing gap unrelated to `ADR`).
 ///

--- a/compiler/justfile
+++ b/compiler/justfile
@@ -58,11 +58,19 @@ plan-citations:
   # Matches both the repo-relative form (specs/plans/...) and relative links
   # such as ../plans/foo.md or ../../plans/foo.md, which markdown cross-links
   # inside specs/ use and which a literal "specs/plans" search misses entirely.
+  common_excludes=(':!specs/plans'
+    ':!CLAUDE.md' ':!CURSOR.md' ':!CONTRIBUTING.md'
+    ':!.cursor' ':!specs/steering'
+    ':!compiler/justfile')
   hits=$(git grep -nE "specs/plans|\.\./plans/|\.\./\.\./plans/" -- . \
-    ':!specs/plans' \
-    ':!CLAUDE.md' ':!CURSOR.md' ':!CONTRIBUTING.md' \
-    ':!.cursor' ':!specs/steering' \
-    ':!compiler/justfile' || true)
+    "${common_excludes[@]}" || true)
+  # A citation need not carry a path: "see the plan's X section" dangles just
+  # as badly once the plan is gone, and the reader cannot even tell which file
+  # was meant. Prose form is checked outside markdown only -- a design document
+  # saying "the plan" is referring to itself.
+  prose=$(git grep -nE "[Tt]he plan'?s?\b" -- . \
+    "${common_excludes[@]}" ':!*.md' || true)
+  hits=$(printf '%s\n%s' "$hits" "$prose" | grep -v '^$' || true)
   if [ -n "$hits" ]; then
     echo "error: specs/plans/ is cited outside specs/plans/ itself." >&2
     echo "A plan is deleted before its PR merges and is not a stable reference" >&2

--- a/compiler/justfile
+++ b/compiler/justfile
@@ -55,7 +55,10 @@ plan-citations:
   #!/usr/bin/env bash
   set -euo pipefail
   cd {{justfile_directory()}}/..
-  hits=$(git grep -n "specs/plans" -- . \
+  # Matches both the repo-relative form (specs/plans/...) and relative links
+  # such as ../plans/foo.md or ../../plans/foo.md, which markdown cross-links
+  # inside specs/ use and which a literal "specs/plans" search misses entirely.
+  hits=$(git grep -nE "specs/plans|\.\./plans/|\.\./\.\./plans/" -- . \
     ':!specs/plans' \
     ':!CLAUDE.md' ':!CURSOR.md' ':!CONTRIBUTING.md' \
     ':!.cursor' ':!specs/steering' \

--- a/compiler/parser/src/tests/this_super.rs
+++ b/compiler/parser/src/tests/this_super.rs
@@ -151,8 +151,8 @@ fn parse_when_instance_method_call_then_instance_receiver() {
 }
 
 /// Whitespace between the keyword and its caret is accepted: nothing in
-/// the grammar joins them into a single token. See the plan's
-/// "whitespace question" section.
+/// the grammar joins them into a single token. See `tests/whitespace.rs`
+/// for the general free-format invariance tables.
 #[rstest]
 #[case::no_space("    THIS^.count := 1;")]
 #[case::space("    THIS ^.count := 1;")]

--- a/compiler/parser/src/tests/whitespace.rs
+++ b/compiler/parser/src/tests/whitespace.rs
@@ -284,6 +284,10 @@ fn parse_when_gap_filled_then_same_ast(
 /// apply and a gap must stay a parse error. Issue #1437 lists them explicitly
 /// as adjacencies a whitespace fix must *not* widen; a row that starts passing
 /// is the signal that one did.
+///
+/// `REF=` is deliberately not a row here. It is a single token, so #1437 could
+/// not have widened it, and `tests/reference_to.rs` already owns that
+/// assertion -- a row here would only duplicate it.
 #[rstest]
 #[case::typed_integer("v := INT·#·16;", in_program, CompilerOptions::default)]
 #[case::typed_real("v := REAL·#·1.5;", in_program, CompilerOptions::default)]

--- a/compiler/sources/src/parsers/xml_parser.rs
+++ b/compiler/sources/src/parsers/xml_parser.rs
@@ -25,7 +25,7 @@ use crate::xml::{position::parse_plcopen_xml, transform::transform_project};
 /// Returns a `Diagnostic` if:
 /// - The XML is malformed (P0006)
 /// - The XML doesn't conform to PLCopen schema (P0007)
-/// - An unsupported body language is used (P9999 - not yet implemented)
+/// - An unsupported body language is used (P9003)
 pub fn parse(
     content: &str,
     file_id: &FileId,

--- a/compiler/vm-cli/src/dap/launch.rs
+++ b/compiler/vm-cli/src/dap/launch.rs
@@ -104,8 +104,8 @@ pub fn load_container(path: &Path) -> Result<Container, LaunchError> {
 
 /// Checks the two v1 launch preconditions against a loaded container.
 ///
-/// Debug info is checked first (per the plan), then the single-instance limit,
-/// so a container that is both missing debug info and multi-instance reports
+/// Debug info is checked first, then the single-instance limit, so a
+/// container that is both missing debug info and multi-instance reports
 /// [`LaunchError::NoDebugInfo`].
 pub fn check_preconditions(container: &Container) -> Result<(), LaunchError> {
     if container.debug_section.is_none() {

--- a/compiler/vm-cli/src/dap/types.rs
+++ b/compiler/vm-cli/src/dap/types.rs
@@ -11,12 +11,9 @@
 //! effectively unmaintained, and used by nothing mainstream; the established
 //! Rust DAP implementations (Helix, Lapce, probe-rs) all define their own
 //! types. Our v1 surface is a handful of small `serde` structs — trivial to own
-//! and not worth an alpha dependency on the public build. See the plan's
-//! "DAP types: hand-rolled" section for the full rationale.
+//! and not worth an alpha dependency on the public build.
 //!
-//! The types are consumed by the request-dispatch loop that lands in a later
-//! commit (Phase 4.4); for this commit they are exercised only by the wire
-//! round-trip unit tests below.
+//! The types are consumed by the request-dispatch loop in [`super::server`].
 #![allow(dead_code)]
 
 use ironplc_container::{SourceColumn, SourceLine};

--- a/specs/adrs/0010-no-std-vm-for-embedded-targets.md
+++ b/specs/adrs/0010-no-std-vm-for-embedded-targets.md
@@ -27,7 +27,7 @@ Today, both the `ironplc-vm` and `ironplc-container` crates depend on `std`. Sho
 
 Chosen option: "`no_std` without `alloc` (fully static)", because it maximizes the range of deployable targets (including AVR with 8 KB SRAM) and aligns with the PLC philosophy of deterministic, bounded resource usage. The implementation uses **two separate crates** instead of feature flags: `ironplc-vm` is unconditionally `#![no_std]` (the execution engine), and a new `ironplc-vm-cli` crate provides the desktop CLI binary with full `std`. Feature flags are confined to the `ironplc-container` crate, which uses `#[cfg(feature = "std")]` to gate its I/O serialization and builder modules.
 
-See [no_std VM Design](../design/no-std-vm.md) for the design and [Implementation Plan: no_std VM](../plans/no-std-vm-impl.md) for the phased implementation.
+See [no_std VM Design](../design/no-std-vm.md) for the design.
 
 ### Consequences
 

--- a/specs/adrs/0042-library-functions-over-compiler-intrinsics.md
+++ b/specs/adrs/0042-library-functions-over-compiler-intrinsics.md
@@ -217,9 +217,8 @@ is small and falls into four categories. Anything outside them is expressible
 Borderline case worth recording: numeric-to-string *formatting* with runtime
 precision (`LREAL_TO_FMTSTR`) is expressible in principle (integer math plus
 the string stdlib) but numerically-faithful float formatting is subtle enough
-that neither medium is chosen yet — the plan lands it declare-only, and the
-follow-up decides ST versus a formatting builtin on fidelity grounds, not
-convenience.
+that neither medium is chosen yet — it lands declare-only, and the follow-up
+decides ST versus a formatting builtin on fidelity grounds, not convenience.
 
 ### Related decisions
 

--- a/specs/design/61131-task-support.md
+++ b/specs/design/61131-task-support.md
@@ -655,10 +655,6 @@ The diagnostic interface should be extended to expose per-task information:
 | Program instances | instance_id, task_id, entry_function_id | On request |
 | Ready queue | Currently ready tasks and their order | On request |
 
-## Implementation Plan
-
-See [Implementation Plan: IEC 61131-3 Task Support](../plans/61131-task-support-impl.md) for the phased implementation roadmap.
-
 ## Open Questions (Resolved)
 
 These questions were identified during design and resolved through comparative research across CODESYS, TwinCAT 3, Siemens S7, B&R Automation Runtime, and OpenPLC.

--- a/specs/design/adr-and-pointer-to.md
+++ b/specs/design/adr-and-pointer-to.md
@@ -22,8 +22,7 @@ It is the follow-on work deferred by
 [reference-to-twincat.md](reference-to-twincat.md) and supersedes the
 "out of scope" pointer notes there and the parse-only sketch in
 [beckhoff-twincat-dialect.md](beckhoff-twincat-dialect.md) §2.1
-(`TypeSpec::PointerTo`). The implementation plan is
-[2026-08-11-adr-operator-and-pointer-to.md](../plans/2026-08-11-adr-operator-and-pointer-to.md).
+(`TypeSpec::PointerTo`).
 
 References: [Beckhoff ADR](https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529015179.html),
 [Beckhoff POINTER](https://infosys.beckhoff.com/content/1033/tc3_plc_intro/2529453451.html),

--- a/specs/design/adr-and-pointer-to.md
+++ b/specs/design/adr-and-pointer-to.md
@@ -59,7 +59,7 @@ variable's table index stored as a `u64` (`ExprKind::Ref` pushes the
 
 ## Delivery
 
-The feature is delivered in phases, mirroring the plan:
+The feature is delivered in phases:
 
 - **Phase 1 — `POINTER TO` declarations (this document's requirements
   `0xx`–`3xx` and `6xx`).** The `allow_pointer_to` flag, the `POINTER`

--- a/specs/design/compatibility-libraries.md
+++ b/specs/design/compatibility-libraries.md
@@ -18,11 +18,9 @@ by the same machinery user source does.
 > **Requirement markers.** This document carries `REQ-CL-*` requirement markers
 > (area `CL` = compatibility libraries) for each testable claim, per the
 > [design requirement](../steering/development-standards.md). They become
-> build-enforced only once a crate's `build.rs` lists this doc; the
-> [implementation plan](../plans/2026-08-04-compatibility-libraries.md) wires
-> each owning crate and adds the matching `#[spec_test]` conformance tests
-> (using `#[ignore]` for claims not yet implemented). Until then the markers are
-> inert.
+> build-enforced: the owning crates — `sources`, `analyzer`, `plc2plc` and
+> `playground` — list this document in their `build.rs` and carry the matching
+> `#[spec_test]` conformance tests.
 
 ## The Portability Promise
 
@@ -451,10 +449,9 @@ No open questions remain for the first increment.
 ## Implementation
 
 The on-disk package format and installation/discovery are specified separately in
-[Compatibility Library Format](compatibility-library-format.md) (`REQ-LF-*`). The
-[implementation plan](../plans/2026-08-04-compatibility-libraries.md) delivers
-`.plcproj` library-list reading and the `Tc2_System` library (defining `PI`) in its
-early phases and wires each `REQ-CL-*` / `REQ-LF-*` marker to a `#[spec_test]`.
+[Compatibility Library Format](compatibility-library-format.md) (`REQ-LF-*`).
+`.plcproj` library-list reading and the bundled libraries have shipped, and each
+`REQ-CL-*` / `REQ-LF-*` marker is wired to a `#[spec_test]` in its owning crate.
 
 ## Appendix: `.plcproj` library-reference shapes
 

--- a/specs/design/complete-numeric-stdlib.md
+++ b/specs/design/complete-numeric-stdlib.md
@@ -26,7 +26,10 @@ These types route through existing I32 signed handlers and produce correct resul
 | LIMIT    | SINT, INT, USINT, UINT          |
 
 USINT (0-255) and UINT (0-65535) are correct with signed comparison because
-their values always fall in i32's positive range.
+their values always fall in i32's positive range. UDINT and ULINT do not:
+a UDINT at or above 2^31 reinterprets as a negative i32, so a signed `MIN`
+returns the larger value. That is what the U32 and U64 variants below exist
+to prevent.
 
 ## New Opcodes Needed
 
@@ -34,7 +37,7 @@ their values always fall in i32's positive range.
 
 | Opcode     | Function | Behavior |
 |------------|----------|----------|
-| EXPT_I64   | EXPT     | a.wrapping_pow(b as u64), trap on b < 0 |
+| EXPT_I64   | EXPT     | a.wrapping_pow(b as u32), trap on b < 0 |
 | ABS_I64    | ABS      | a.wrapping_abs() |
 | MIN_I64    | MIN      | a.min(b) signed |
 | MAX_I64    | MAX      | a.max(b) signed |
@@ -56,9 +59,8 @@ their values always fall in i32's positive range.
 | MIN_U64    | MIN      | (a as u64).min(b as u64) |
 | MAX_U64    | MAX      | (a as u64).max(b as u64) |
 | LIMIT_U64  | LIMIT    | (in_val as u64).clamp(mn as u64, mx as u64) |
-| SEL_U64    | SEL      | if g==0 { in0 } else { in1 } |
 
-Total: 16 new opcodes.
+Total: 12 new opcodes.
 
 Note: SEL does not need U32 because SEL_I32 works correctly for UDINT (no
 comparison, just selection). SEL does need a U64/I64 variant because ULINT/LINT
@@ -71,7 +73,11 @@ not defined for unsigned types in the standard).
 ## Changes Per Layer
 
 ### container/src/opcode.rs
-- Add 16 new `pub const` entries in the `builtin` module (0x0360-0x036F)
+- Add 12 new `pub const` entries in the `builtin` module (0x0360-0x036B).
+  `0x036C` onward is already allocated to the math builtins (`LN_F32`
+  through the trigonometric functions) -- see
+  [bytecode-instruction-set.md](bytecode-instruction-set.md). func_ids are
+  wire format, so a collision here is permanent.
 - Extend `arg_count()` match arms
 
 ### codegen/src/compile.rs
@@ -81,7 +87,7 @@ not defined for unsigned types in the standard).
 - Add routing for W64+Unsigned → U64 variants
 
 ### vm/src/builtin.rs
-- Add 16 new match arms in `dispatch()`
+- Add 12 new match arms in `dispatch()`
 - I64 handlers use `as_i64()`/`from_i64()`
 - U32 handlers cast via `as_i32() as u32` then back
 - U64 handlers cast via `as_i64() as u64` then back

--- a/specs/design/debugger-support.md
+++ b/specs/design/debugger-support.md
@@ -1390,7 +1390,7 @@ This supersedes the original decision to feature-gate DAP behind `--features dap
 | `vm-cli` | `Cargo.toml` | Second `[[bin]]` target, `ironplcvmd`, built unconditionally |
 | `vm-cli` | new `dap_main.rs` | Entry point for `ironplcvmd`; speaks DAP on stdin/stdout and takes no arguments (the program under debug arrives in the `launch` request). `main.rs`/`ironplcvm` is untouched. |
 | `vm-cli` | new `dap/framing.rs` | Content-Length framing reader/writer |
-| `vm-cli` | new `dap/types.rs` | DAP protocol types (Request, Response, Event, Capabilities). Prefer the `dap-types` crate if it's a fit; otherwise hand-rolled with `serde`. |
+| `vm-cli` | new `dap/types.rs` | DAP protocol types (Request, Response, Event, Capabilities). Hand-rolled with `serde`: the `dap` crate is alpha and effectively unmaintained, and the established Rust DAP implementations (Helix, Lapce, probe-rs) all define their own types. |
 | `vm-cli` | new `dap/server.rs` | **Single-threaded** event loop: alternate between draining queued DAP requests at natural stop points and running the VM under `run_round_debug` (see §Single-threaded DAP loop). No I/O thread, no `Send`/`Sync`, no `Arc`, no `AtomicBool`. |
 | `vm-cli` | new `dap/state.rs` | `Phase` mirror plus per-state legality checks (returns `requestNotApplicable` for illegal requests, including `pause` and `setVariable` which are unsupported in v1) |
 | `vm-cli` | new `dap/launch.rs` | `launch` precondition: reject containers with multiple program instances (`MultiInstanceUnsupported`); reject containers without a debug section (`NoDebugInfo`) — see §Launch errors. |

--- a/specs/design/extension-error-code-consolidation.md
+++ b/specs/design/extension-error-code-consolidation.md
@@ -139,7 +139,3 @@ VS Code and the message shown in docs come from the same CSV row.
 2. **Generated file in git**: Gitignored, generated on build. This mirrors the
    compiler's approach where `problems.rs` is generated into `OUT_DIR` and not
    committed.
-
-## Implementation Plan
-
-See [Implementation Plan: Extension Error Code Consolidation](../plans/extension-error-code-consolidation-impl.md) for the detailed implementation steps.

--- a/specs/design/extension-testing-implementation.md
+++ b/specs/design/extension-testing-implementation.md
@@ -203,7 +203,3 @@ export const CLIENT_STATE_RUNNING = 2;
 | `src/test/functional/suite/extension.test.ts` | Add TwinCAT language detection tests |
 | `package.json` | Add `test:unit` script; add `c8` devDependency |
 | `justfile` | Add `check-invariants`, `test-unit` targets; update `ci` target |
-
-## Implementation Plan
-
-See [Implementation Plan: Extension Testing](../plans/extension-testing-impl.md) for the phased implementation steps.

--- a/specs/design/iplc-file-viewer.md
+++ b/specs/design/iplc-file-viewer.md
@@ -215,7 +215,3 @@ This viewer is the foundation for a source-level debugger. Future work:
   bytecode on the right, with linked highlighting.
 - **Step debugging:** Integrate with VS Code's Debug Adapter Protocol to
   highlight the current instruction during execution.
-
-## Implementation Plan
-
-See [Implementation Plan: IPLC File Viewer](../plans/iplc-file-viewer-impl.md) for the file changes and testing plan.

--- a/specs/design/library-interfaces/tc2-math.md
+++ b/specs/design/library-interfaces/tc2-math.md
@@ -45,9 +45,9 @@ function is a fully-defined ST body.
 All four signatures are **`LREAL`-only**, matching Beckhoff (whose
 `Tc2_Math` signatures are not generic). A call with `REAL` arguments is
 not this library's concern: TwinCAT accepts it by implicitly widening the
-argument REAL→LREAL at the call site, which is separately planned work
-([2026-07-27-twincat-real-to-lreal-widening.md](../../plans/2026-07-27-twincat-real-to-lreal-widening.md))
-and serves every LREAL-taking function uniformly.
+argument REAL→LREAL at the call site — implicit widening is handled separately
+(see [ADR-0031](../../adrs/0031-expanded-implicit-type-widening.md)) and serves
+every LREAL-taking function uniformly.
 
 Formal parameter names are normalized to IronPLC's stdlib `IN`/`IN1`/`IN2`
 convention, consistent with how IronPLC records every other function

--- a/specs/design/no-std-vm.md
+++ b/specs/design/no-std-vm.md
@@ -163,7 +163,3 @@ Note: `ironplc-vm` needs no `--no-default-features` flag because it has no featu
 1. **Caller-provided slices** — the VM accepts `&mut [Slot]` slices rather than const generics. The container header determines sizes at runtime, so const generics would add type noise without real safety benefit. Slices keep VM types simple (`VmRunning<'a>` — one lifetime) and let each caller choose its allocation strategy.
 
 2. **Feature flags confined to the container crate** — the container crate uses `#[cfg(feature = "std")]` to gate its I/O and builder modules. The shared types (`FileHeader`, opcodes, `ContainerError`) make a crate split awkward, and the `#[cfg]` usage is minimal and contained. The VM crate and CLI crate have zero conditional compilation.
-
-## Implementation Plan
-
-See [Implementation Plan: no_std VM](../plans/no-std-vm-impl.md) for the phased implementation.

--- a/specs/design/type-conversion-stdlib.md
+++ b/specs/design/type-conversion-stdlib.md
@@ -15,7 +15,11 @@ Implement all 90 numeric type conversion functions defined in IEC 61131-3 Sectio
 | Real → Int | 16 | REAL_TO_INT, LREAL_TO_UDINT |
 | Real → Real | 2 | REAL_TO_LREAL, LREAL_TO_REAL |
 
-**Out of scope**: Boolean conversions (not in analyzer), string conversions (no string runtime).
+**Out of scope when this document was written**: Boolean conversions (not in
+analyzer) and string conversions (no string runtime). Both have since landed;
+the opcodes are assigned in
+[bytecode-instruction-set.md](bytecode-instruction-set.md)
+(`CONV_I32_TO_BOOL` onward, and the `*_TO_STR` family).
 
 ## Architecture
 

--- a/specs/design/vm-testing.md
+++ b/specs/design/vm-testing.md
@@ -64,7 +64,7 @@ Total: **15 codegen tests**.
 
 The current tests cover the "happy path" steel-thread scenario well but have significant gaps:
 
-**Instruction-level coverage**: Only `LOAD_CONST_I32`, `LOAD_VAR_I32`, `STORE_VAR_I32`, `ADD_I32`, and `RET_VOID` are tested (the only 5 opcodes that exist). As the instruction set grows per the [bytecode instruction set plan](../plans/bytecode-instruction-set.md), each new opcode needs systematic testing.
+**Instruction-level coverage**: Only `LOAD_CONST_I32`, `LOAD_VAR_I32`, `STORE_VAR_I32`, `ADD_I32`, and `RET_VOID` are tested (the only 5 opcodes that exist). As the instruction set grows per the [bytecode instruction set](bytecode-instruction-set.md), each new opcode needs systematic testing.
 
 **Error path coverage**: The `execute()` function has 5 `Trap` variants that can fire during execution, but only `InvalidInstruction` is tested through the VM. `StackOverflow`, `StackUnderflow`, `InvalidConstantIndex`, and `InvalidVariableIndex` are tested at the component level (stack, variable table) but not through the full `execute()` path.
 

--- a/specs/steering/compatibility-library-authoring.md
+++ b/specs/steering/compatibility-library-authoring.md
@@ -105,7 +105,8 @@ Never feed to an AI tool, paste, or transliterate:
 
 ## Enforcement: automated vs. review
 
-- **Automated (a conformance test — see the implementation plan).** Every
+- **Automated (a conformance test — `sources_spec_req_cl_007_*` in
+  `compiler/sources/src/spec_conformance.rs`).** Every
   manifest is well-formed and records a non-empty `references` list. The test
   verifies the record *exists and is well-formed* — it makes no legal judgment.
 - **Review-only (cannot be tested).** That the declared provenance is *true* —

--- a/specs/steering/plcopen-xml-module.md
+++ b/specs/steering/plcopen-xml-module.md
@@ -18,6 +18,11 @@ transform.rs (Schema Structs → DSL Library)
 ironplc_dsl::Library (shared AST)
 ```
 
+XML and ST sources lower to the same `ironplc_dsl::Library`, so a project may
+mix both formats and references resolve across them: an XML POU can call an ST
+POU and an ST POU can use a type declared in XML. Everything downstream of the
+transform is format-blind.
+
 ## Module Structure
 
 ### `schema.rs`
@@ -56,7 +61,11 @@ Key patterns:
 Transforms schema structs into IronPLC DSL:
 
 ```rust
-pub fn transform_project(project: &Project, file_id: &FileId) -> Result<Library, Diagnostic>
+pub fn transform_project(
+    project: &Project,
+    file_id: &FileId,
+    compiler_options: &CompilerOptions,
+) -> Result<Library, Diagnostic>
 ```
 
 Key patterns:
@@ -163,10 +172,16 @@ fn parse_st_body(
     file_id: &FileId,
     line_offset: usize,   // XML line where ST starts
     col_offset: usize,    // XML column where ST starts
+    compiler_options: &CompilerOptions,
 ) -> Result<Vec<StmtKind>, Diagnostic>
 ```
 
 The offsets ensure error positions in ST code point to correct XML file locations.
+
+The `<ST>` element holds its text either inside an `<xhtml>` child or directly.
+Look for the child first and fall back to the direct text. Pass the text on
+raw: the ST parser owns leading whitespace, so this module must not trim it or
+the offsets stop lining up.
 
 ## Testing Patterns
 

--- a/specs/steering/syntax-support-guide.md
+++ b/specs/steering/syntax-support-guide.md
@@ -17,6 +17,7 @@ When adding new syntax, ensure every applicable item is complete:
 - [ ] **plc2plc renderer**: Update `plc2plc/src/renderer.rs` to render the new syntax
 - [ ] **plc2plc round-trip test**: Parse → render → **re-parse** (in a focused file under `plc2plc/src/tests/` — see [Test File Organization](#test-file-organization-avoid-merge-conflicts) and [plc2plc round-trip tests](#plc2plc-round-trip-tests-always-re-parse))
 - [ ] **End-to-end execution test**: Parse → compile → run → verify variable values
+- [ ] **Whitespace invariance**: Every `_` a new grammar rule introduces earns a row in `parser/src/tests/whitespace.rs`, so a rule that later loses its `_` fails there (see [Which leg asserts what](#which-leg-asserts-what-avoid-duplicate-tests))
 - [ ] **Non-standard gating**: If not standard IEC 61131-3, gate behind `--allow-x` flag
 - [ ] **LSP integration**: If a new `--allow-x` flag, add to LSP `extract_compiler_options`
 - [ ] **Documentation**: If a new `--allow-x` flag, update `docs/explanation/enabling-dialects-and-features.rst`, `docs/reference/compiler/ironplcc.rst`, and the flag table in this file
@@ -100,6 +101,7 @@ adds no signal — it is subsumed. Keep the legs distinct:
 | **codegen `compile_*`** | The emitted instruction sequence / container structure | Run results |
 | **codegen `end_to_end_*`** | Run results — the nominal behavior matrix reachable from ST | — |
 | **VM** (`vm/tests/it/`) | Traps, overflow/wrap edges, and states codegen cannot emit | A nominal case its codegen twin already runs |
+| **Whitespace** (`parser/src/tests/whitespace.rs`) | That the gaps the grammar permits stay permitted, and that adjacencies inside one lexical unit stay rejected | A row duplicating a rejection another file already owns — `REF=` belongs to `parser/src/tests/reference_to.rs` |
 
 Parser tests asserting only `is_ok()` are still right when there is **no**
 round-trip counterpart — a dialect-flag rejection, a pragma, or a corpus file


### PR DESCRIPTION
The check greps for the literal string "specs/plans", which misses the
relative form that markdown cross-links inside specs/ actually use --
../plans/foo.md and ../../plans/foo.md. Eleven such links exist across one ADR
and eight design documents, and the check reported a clean tree.

This is the same blind spot twice: the Phase 1 audit that cleared 92 citations
used the same literal string, so it never saw these, and the Phase 2 check
inherited the flaw. The audit's "zero citations remain" conclusion was wrong.

One of the eleven is already dangling: specs/design/vm-testing.md links to
../plans/bytecode-instruction-set.md, which does not exist.

The links themselves are fixed separately -- two of them describe work as
pending that has since shipped, so the prose needs rewriting rather than
delinking.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016RWos6WEczkF7kDTLgLSRY