### PR TITLE
Highlight AND_THEN and OR_ELSE as logical operators

### DIFF
--- a/integrations/vscode/syntaxes/61131-3-st.tmLanguage.json
+++ b/integrations/vscode/syntaxes/61131-3-st.tmLanguage.json
@@ -209,7 +209,7 @@
         },
         {
           "name": "keyword.operator.logical.st",
-          "match": "(?i)\\b(?:OR|XOR|AND|NOT)\\b|&"
+          "match": "(?i)\\b(?:AND_THEN|OR_ELSE|OR|XOR|AND|NOT)\\b|&"
         },
         {
           "name": "keyword.operator.arithmetic.st",

--- a/integrations/vscode/tests/grammar/snap/structured-text.st
+++ b/integrations/vscode/tests/grammar/snap/structured-text.st
@@ -61,6 +61,8 @@ END_VAR
     (* Operators *)
     myBool := (input1 = input2) OR (input1 <> 0);
     myBool := myBool AND NOT FALSE;
+    myBool := (input1 <> 0) AND_THEN (input2 = 0);
+    myBool := (input1 = 0) OR_ELSE (input2 <> 0);
     myBool := input1 < input2;
     myBool := input1 >= input2;
 

--- a/integrations/vscode/tests/grammar/snap/structured-text.st.snap
+++ b/integrations/vscode/tests/grammar/snap/structured-text.st.snap
@@ -423,6 +423,54 @@
 #                            ^ source.61131-3-st
 #                             ^^^^^ source.61131-3-st constant.language.boolean.st
 #                                  ^ source.61131-3-st punctuation.separator.st
+>    myBool := (input1 <> 0) AND_THEN (input2 = 0);
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^^ source.61131-3-st keyword.operator.assignment.st
+#             ^ source.61131-3-st
+#              ^ source.61131-3-st punctuation.section.parens.st
+#               ^^^^^^ source.61131-3-st variable.other.st
+#                     ^ source.61131-3-st
+#                      ^^ source.61131-3-st keyword.operator.comparison.st
+#                        ^ source.61131-3-st
+#                         ^ source.61131-3-st constant.numeric.decimal.st
+#                          ^ source.61131-3-st punctuation.section.parens.st
+#                           ^ source.61131-3-st
+#                            ^^^^^^^^ source.61131-3-st keyword.operator.logical.st
+#                                    ^ source.61131-3-st
+#                                     ^ source.61131-3-st punctuation.section.parens.st
+#                                      ^^^^^^ source.61131-3-st variable.other.st
+#                                            ^ source.61131-3-st
+#                                             ^ source.61131-3-st keyword.operator.comparison.st
+#                                              ^ source.61131-3-st
+#                                               ^ source.61131-3-st constant.numeric.decimal.st
+#                                                ^ source.61131-3-st punctuation.section.parens.st
+#                                                 ^ source.61131-3-st punctuation.separator.st
+>    myBool := (input1 = 0) OR_ELSE (input2 <> 0);
+#^^^^ source.61131-3-st
+#    ^^^^^^ source.61131-3-st variable.other.st
+#          ^ source.61131-3-st
+#           ^^ source.61131-3-st keyword.operator.assignment.st
+#             ^ source.61131-3-st
+#              ^ source.61131-3-st punctuation.section.parens.st
+#               ^^^^^^ source.61131-3-st variable.other.st
+#                     ^ source.61131-3-st
+#                      ^ source.61131-3-st keyword.operator.comparison.st
+#                       ^ source.61131-3-st
+#                        ^ source.61131-3-st constant.numeric.decimal.st
+#                         ^ source.61131-3-st punctuation.section.parens.st
+#                          ^ source.61131-3-st
+#                           ^^^^^^^ source.61131-3-st keyword.operator.logical.st
+#                                  ^ source.61131-3-st
+#                                   ^ source.61131-3-st punctuation.section.parens.st
+#                                    ^^^^^^ source.61131-3-st variable.other.st
+#                                          ^ source.61131-3-st
+#                                           ^^ source.61131-3-st keyword.operator.comparison.st
+#                                             ^ source.61131-3-st
+#                                              ^ source.61131-3-st constant.numeric.decimal.st
+#                                               ^ source.61131-3-st punctuation.section.parens.st
+#                                                ^ source.61131-3-st punctuation.separator.st
 >    myBool := input1 < input2;
 #^^^^ source.61131-3-st
 #    ^^^^^^ source.61131-3-st variable.other.st


### PR DESCRIPTION
Follow-up to #1534, which gave the short-circuit operators codegen. They compile, but the editor still colours them as variables.

## The gap

`61131-3-st.tmLanguage.json` matched `OR|XOR|AND|NOT`, so `AND_THEN` and `OR_ELSE` fell through to the identifier rule. Adding them to the fixture *before* changing the grammar shows it concretely:

```
>    myBool := (input1 <> 0) AND_THEN (input2 = 0);
#                            ^^^^^^^^ source.61131-3-st variable.other.st
```

after:

```
>    myBool := (input1 <> 0) AND_THEN (input2 = 0);
#                            ^^^^^^^^ source.61131-3-st keyword.operator.logical.st
```

Worth noting the two were never *nearly* matched: `_` is a word character, so `\bAND\b` cannot match inside `AND_THEN`. There was no partial highlighting to fix, just no rule.

`AND_THEN` has been unhighlighted since it was first parsed; `OR_ELSE` inherited the same gap in #1534.

## The change

One alternation, listed longest-first so the intent is legible to the next reader even though `\b` makes the order immaterial here:

```diff
-"match": "(?i)\\b(?:OR|XOR|AND|NOT)\\b|&"
+"match": "(?i)\\b(?:AND_THEN|OR_ELSE|OR|XOR|AND|NOT)\\b|&"
```

Plus two lines of fixture coverage in `structured-text.st` and the regenerated snapshot. `plcopen-xml.tmLanguage.json` does not carry its own copy of this pattern, so there is one place to change.

**The snapshot diff is +50/−0.** That is the evidence that no existing token's scope moved — `AND`, `OR`, `XOR` and `NOT` highlight exactly as before.

## Verification

`just compile`, `check-invariants`, `lint` (including `validate-grammars`), `test-grammar` and `test-unit` all pass.

`just test` (the functional suite) could **not** be run here: it downloads VS Code from `update.code.visualstudio.com`, which this sandbox's proxy refuses with a 403. It fails at "Resolving version…", before the extension is loaded, so the failure is environmental rather than anything to do with this change — but it does mean the functional suite is unverified on my side and wants CI to confirm.

## Note on process

No plan document for this one: it is a single-line grammar change with test coverage, which the standards' mechanical-change exemption covers. Say the word if you would rather have one.

---
_Generated by [Claude Code](https://claude.ai/code/session_017pV9wT7cLsCo2DxMWF3G8N)_