### PR TITLE
Split steering standards by component and scope context loading

### DIFF
--- a/.kiro/steering/compatibility-library-authoring.md
+++ b/.kiro/steering/compatibility-library-authoring.md
@@ -1,3 +1,8 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "compiler/sources/resources/compat-libraries/**"
+---
+
 # Compatibility Library Authoring Policy
 
 See [specs/steering/compatibility-library-authoring.md](../../specs/steering/compatibility-library-authoring.md) for the full policy.

--- a/.kiro/steering/compiler-architecture.md
+++ b/.kiro/steering/compiler-architecture.md
@@ -1,3 +1,8 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "compiler/**"
+---
+
 # Compiler Architecture
 
 See [specs/steering/compiler-architecture.md](../../specs/steering/compiler-architecture.md) for the full compiler architecture guidance.

--- a/.kiro/steering/compiler-standards.md
+++ b/.kiro/steering/compiler-standards.md
@@ -1,0 +1,10 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "compiler/**"
+---
+
+# Compiler Standards
+
+See [specs/steering/compiler-standards.md](../../specs/steering/compiler-standards.md) for the full compiler coding standards.
+
+This file covers Rust coding standards for the `compiler/` workspace: module structure, testing, error handling, performance, and Rust-specific rules (`unsafe`, clippy).

--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -2,4 +2,4 @@
 
 See [specs/steering/development-standards.md](../../specs/steering/development-standards.md) for the full development standards.
 
-This file defines core project conventions, prefactoring expectations, testing patterns, error handling, and documentation standards for the IronPLC project.
+This file defines cross-component process and conventions that apply to all work: the specs directory structure, planning, prefactoring, and duplication rules. Component-specific standards live in compiler-standards, doc-standards, and extension-standards.

--- a/.kiro/steering/doc-standards.md
+++ b/.kiro/steering/doc-standards.md
@@ -1,0 +1,10 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "docs/**"
+---
+
+# Documentation Standards
+
+See [specs/steering/doc-standards.md](../../specs/steering/doc-standards.md) for the full documentation website standards.
+
+This file covers the documentation quadrants framework, writing style, RST annotation conventions, playground directives, and problem/format documentation for the `docs/` Sphinx website.

--- a/.kiro/steering/extension-standards.md
+++ b/.kiro/steering/extension-standards.md
@@ -1,0 +1,10 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "integrations/vscode/**"
+---
+
+# VS Code Extension Standards
+
+See [specs/steering/extension-standards.md](../../specs/steering/extension-standards.md) for the full extension coding standards.
+
+This file covers TypeScript coding standards for the VS Code extension: README synchronization, and pointers to the extension testing gates and `E####` error codes.

--- a/.kiro/steering/steering-file-guidelines.md
+++ b/.kiro/steering/steering-file-guidelines.md
@@ -1,3 +1,8 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "specs/steering/**,.kiro/steering/**"
+---
+
 # Steering File Guidelines
 
 See [specs/steering/steering-file-guidelines.md](../../specs/steering/steering-file-guidelines.md) for the complete guide on creating and maintaining steering files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,11 @@ This file provides entry points for Claude Code when working on the IronPLC proj
 Before making changes, read the relevant steering files in `specs/steering/`:
 
 - **[Glossary](specs/steering/glossary.md)** - Authoritative definitions of core vocabulary (dialect, vendor, extension, edition); resolve terminology questions here before coining a new term
-- **[Development Standards](specs/steering/development-standards.md)** - Core project conventions, prefactoring, testing patterns, error handling, and documentation standards
-- **[Compiler Architecture](specs/steering/compiler-architecture.md)** - Patterns for implementing language features, module organization, and semantic analysis
+- **[Development Standards](specs/steering/development-standards.md)** - Cross-component process and conventions that apply to all work: specs directory structure, planning, prefactoring, and duplication rules
+- **[Compiler Standards](specs/steering/compiler-standards.md)** - Rust coding standards: module structure, testing, error handling, performance, `unsafe`/clippy rules (especially relevant for `compiler/**` files)
+- **[Documentation Standards](specs/steering/doc-standards.md)** - Documentation website standards: quadrants, writing style, RST roles, playground directives (especially relevant for `docs/**` files)
+- **[Extension Standards](specs/steering/extension-standards.md)** - VS Code extension coding standards: README sync, testing gates, `E####` error codes (especially relevant for `integrations/vscode/**` files)
+- **[Compiler Architecture](specs/steering/compiler-architecture.md)** - Patterns for implementing language features, module organization, and semantic analysis (especially relevant for `compiler/**` files)
 - **[IEC 61131-3 Compliance](specs/steering/iec-61131-3-compliance.md)** - Standards compliance and validation rules (especially relevant for `**/analyzer/**` files)
 - **[PLCopen XML Module](specs/steering/plcopen-xml-module.md)** - Architecture and patterns for the PLCopen XML parsing module (especially relevant for `compiler/sources/src/xml/` files)
 - **[Syntax Support Guide](specs/steering/syntax-support-guide.md)** - Checklist and patterns for adding new syntax support, including `--allow-x` flags, plc2plc round-trip tests, and end-to-end execution tests (especially relevant for `**/parser/**`, `**/codegen/**`, `**/plc2plc/**` files)

--- a/specs/steering/compiler-standards.md
+++ b/specs/steering/compiler-standards.md
@@ -1,0 +1,134 @@
+# Compiler Standards
+
+This steering file defines the coding standards and conventions for the IronPLC
+compiler — the Rust workspace under `compiler/`. It covers module organization,
+testing, error handling, performance, and Rust-specific rules.
+
+> **Note**: This file covers *how to write compiler code*. For the compiler's
+> structure and pipeline, see [compiler-architecture.md](compiler-architecture.md).
+> For problem-code mechanics, see
+> [problem-code-management.md](problem-code-management.md). For adding syntax, see
+> [syntax-support-guide.md](syntax-support-guide.md). For build/test commands and
+> the pre-PR CI gate, see [common-tasks.md](common-tasks.md).
+
+## Applies To
+
+This guidance is relevant when working with Rust code in `compiler/**` (all
+crates). Cross-component process rules — planning, prefactoring, the specs
+directory, the git workflow — live in
+[development-standards.md](development-standards.md).
+
+## Code Organization
+
+### Module Structure
+- Follow the existing pattern of organizing related functionality in subdirectories (e.g., `analyzer/src/intermediates/`)
+- Use descriptive module names that reflect their purpose in the compilation pipeline
+- Keep modules focused on a single responsibility
+- **Maximum 1000 lines per module.** Split a module that grows past the limit
+  into smaller, focused modules (see
+  [compiler-architecture.md](compiler-architecture.md#size-constraints))
+
+## Testing Standards
+
+### Test Naming
+**Always use BDD-style test names** following the pattern:
+```rust
+#[test]
+fn function_name_when_condition_then_expected_result() {
+    // Test implementation
+}
+```
+
+Examples:
+- `validate_subrange_bounds_with_various_types_then_validates_correctly`
+- `try_from_with_invalid_range_then_p0004_error`
+
+### Test Implementation Rules
+- **No branching logic** in tests (no `if`, `match`, loops)
+- **No global state dependencies** - each test must be self-contained
+- **Terminate on failure** - use `assert!`, `assert_eq!`, etc. rather than continuing
+- **One assertion per logical concept** - but multiple assertions for the same concept are fine
+- **No panic! in tests** - Use `assert!` macros instead of `panic!()` for test failures
+  - ❌ Bad: `match result { Ok(x) => assert_eq!(x, 5), _ => panic!("Expected Ok") }`
+  - ✅ Good: `assert!(result.is_ok()); assert_eq!(result.unwrap(), 5);`
+  - ✅ Better: `assert!(matches!(result, Ok(5)))`
+
+### Test Organization
+- Group related tests in the same module
+- Use descriptive test function names that explain the scenario and expected outcome
+- Include both positive and negative test cases
+- Test edge cases and boundary conditions
+
+For where each kind of test lives (VM, codegen, plc2plc, parser) and which leg
+asserts what, see [compiler-architecture.md](compiler-architecture.md#testing-architecture)
+and [syntax-support-guide.md](syntax-support-guide.md).
+
+## Error Handling
+
+Every user-facing error message **must** have a unique `P####` problem code. The
+full lifecycle — choosing a code, the CSV registry, the documentation template,
+and the diagnostic-construction patterns — lives in
+[problem-code-management.md](problem-code-management.md). Do not restate that
+material here.
+
+When writing compiler code:
+- Prefer `Result<T, Diagnostic>` for fallible operations; propagate with `?`
+- Collect multiple diagnostics rather than failing on the first, where practical
+- Provide clear, actionable error messages: include what was expected vs. found
+- Use `Diagnostic::problem()` with an appropriate `Label::span()` for source location
+- Match IEC 61131-3 terminology in messages
+
+## Code Documentation
+- **Best effort** documentation for now, but focus on public APIs
+- Use Rust doc comments (`///`) for public functions and types
+- Include examples in documentation when helpful
+- Document complex algorithms or IEC 61131-3 specific behavior
+- A comment carrying a decision states what was chosen and why, not only what
+  the code does — the next reader's question is whether they may change it
+- Nothing checks that a comment is still true. A comment asserting behaviour is
+  as capable of going stale as a design document, and is read more often; when
+  you change behaviour, re-read the comments around it
+
+## Performance Considerations
+
+### Memory Usage
+- Design for embedded/PLC contexts where memory may be constrained
+- Use appropriate data structures for the compilation pipeline
+- Consider memory layout for type representations (see `ByteSized` enum)
+
+### Compilation Speed
+- Optimize for reasonable compilation times
+- Use efficient algorithms for type checking and semantic analysis
+- Profile performance-critical paths when needed
+
+## Code Quality
+
+### Rust Best Practices
+- Do not suppress clippy warnings with `#[allow(...)]` — fix the underlying code instead. The only acceptable exception is `#[allow(dead_code)]` or `#[allow(unused_*)]` for in-progress code that is not yet wired up; remove these suppressions once the code is complete
+- Prefer `Result<T, E>` for error handling over panics
+- Use appropriate visibility modifiers (`pub`, `pub(crate)`, etc.)
+- Follow Rust naming conventions and idioms
+
+### Safety
+- Leverage Rust's safety guarantees
+- **`unsafe` code is rejected at compile time.** The workspace sets `unsafe_code = "deny"` in `[workspace.lints.rust]` (root `compiler/Cargo.toml`), and every member crate inherits it via `[lints] workspace = true`. Any `unsafe` block, function, trait, or impl in IronPLC code fails the build
+- **Do not bypass the check with `#[allow(unsafe_code)]`.** The standards already forbid `#[allow(...)]` suppressions (see [Rust Best Practices](#rust-best-practices)); `unsafe_code` is no exception. `deny` (rather than `forbid`) is the chosen level only so that proc-macros which wrap unsafe internally — e.g. `ctor::ctor`, whose expansion includes `#[allow(unsafe_code)]` — keep working. If a feature appears to require `unsafe`, raise it for discussion
+- Use strong typing to prevent logic errors (e.g., `TypeName` vs `String`)
+
+### Dependencies
+- Keep dependencies minimal and well-justified
+- Use workspace dependencies for consistency
+- Regular dependency updates via `just update`
+
+## Cross-Platform Support
+- Support Windows, macOS, and Linux
+- Use platform-specific just recipes when needed (`_command-{{os_family()}}`)
+- Test in Dev Container environment when possible
+
+## IEC 61131-3 Compliance
+
+The compiler follows a **permissive parsing, configurable validation** approach.
+The compliance philosophy, type-system expectations, and validation rules live in
+[iec-61131-3-compliance.md](iec-61131-3-compliance.md) (especially relevant for
+`**/analyzer/**`). Reference the relevant IEC 61131-3 standard sections in error
+messages when applicable.

--- a/specs/steering/compiler-standards.md
+++ b/specs/steering/compiler-standards.md
@@ -55,6 +55,9 @@ Examples:
 
 ### Test Organization
 - Group related tests in the same module
+- Use `rstest` to group related tests and eliminate boilerplate — parameterize
+  cases with `#[case(...)]` and share setup with fixtures instead of copying a
+  test body per input
 - Use descriptive test function names that explain the scenario and expected outcome
 - Include both positive and negative test cases
 - Test edge cases and boundary conditions
@@ -65,9 +68,10 @@ and [syntax-support-guide.md](syntax-support-guide.md).
 
 ## Error Handling
 
-Every user-facing error message **must** have a unique `P####` problem code. The
-full lifecycle — choosing a code, the CSV registry, the documentation template,
-and the diagnostic-construction patterns — lives in
+Every user-facing error message **must** have a unique problem code: `P####`
+for the compiler and `V####` for the runtime. The full lifecycle — choosing a
+code, the CSV registry, the documentation template, and the
+diagnostic-construction patterns — lives in
 [problem-code-management.md](problem-code-management.md). Do not restate that
 material here.
 
@@ -76,6 +80,10 @@ When writing compiler code:
 - Collect multiple diagnostics rather than failing on the first, where practical
 - Provide clear, actionable error messages: include what was expected vs. found
 - Use `Diagnostic::problem()` with an appropriate `Label::span()` for source location
+- Use the `internal_error` and `not_supported` helpers for the special cases they
+  name — a compiler invariant that was violated (a bug) and a construct that is
+  valid IEC 61131-3 but not yet implemented — rather than inventing a new
+  problem code for either
 - Match IEC 61131-3 terminology in messages
 
 ## Code Documentation
@@ -105,7 +113,9 @@ When writing compiler code:
 
 ### Rust Best Practices
 - Do not suppress clippy warnings with `#[allow(...)]` — fix the underlying code instead. The only acceptable exception is `#[allow(dead_code)]` or `#[allow(unused_*)]` for in-progress code that is not yet wired up; remove these suppressions once the code is complete
-- Prefer `Result<T, E>` for error handling over panics
+- Never use `panic!`, `unwrap`, `expect`, `todo!`, `unreachable!`, or similar
+  panicking constructs. Return `Result<T, E>` and propagate; for a violated
+  compiler invariant use `Diagnostic::internal_error()` instead of panicking
 - Use appropriate visibility modifiers (`pub`, `pub(crate)`, etc.)
 - Follow Rust naming conventions and idioms
 
@@ -113,7 +123,11 @@ When writing compiler code:
 - Leverage Rust's safety guarantees
 - **`unsafe` code is rejected at compile time.** The workspace sets `unsafe_code = "deny"` in `[workspace.lints.rust]` (root `compiler/Cargo.toml`), and every member crate inherits it via `[lints] workspace = true`. Any `unsafe` block, function, trait, or impl in IronPLC code fails the build
 - **Do not bypass the check with `#[allow(unsafe_code)]`.** The standards already forbid `#[allow(...)]` suppressions (see [Rust Best Practices](#rust-best-practices)); `unsafe_code` is no exception. `deny` (rather than `forbid`) is the chosen level only so that proc-macros which wrap unsafe internally — e.g. `ctor::ctor`, whose expansion includes `#[allow(unsafe_code)]` — keep working. If a feature appears to require `unsafe`, raise it for discussion
-- Use strong typing to prevent logic errors (e.g., `TypeName` vs `String`)
+- Use strong typing to prevent logic errors: wrap primitives in newtypes so the
+  compiler rejects mixing them up. Prefer a domain type over a bare `String`
+  (e.g., `TypeName` vs `String`) or a bare integer — wrap a `u16` element count
+  as `struct ElementCount(u16)` and a `u16` address as `struct Address(u16)` so
+  one cannot be passed where the other is expected
 
 ### Dependencies
 - Keep dependencies minimal and well-justified

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -15,6 +15,16 @@ IronPLC consists of four primary components:
 
 **Critical**: The build will fail if the compiler, VS Code extension, and documentation website get out of sync. Always ensure version numbers, problem codes, and language features are synchronized across those three components.
 
+## Component-Specific Standards
+
+This file holds the cross-component process and conventions that apply to *all*
+work. Standards specific to one component live in their own steering files, which
+load only when you touch that component's files:
+
+- **[compiler-standards.md](compiler-standards.md)** — Rust coding standards for `compiler/**` (module structure, testing, error handling, performance, `unsafe`)
+- **[doc-standards.md](doc-standards.md)** — documentation website standards for `docs/**` (quadrants, writing style, RST roles)
+- **[extension-standards.md](extension-standards.md)** — VS Code extension standards for `integrations/vscode/**`
+
 ## Specs Directory Structure
 
 The `specs/` directory contains internal technical documentation organized into four folders:
@@ -25,7 +35,7 @@ Trade-off analyses that capture **why** a particular approach was chosen over al
 
 ### `specs/design/` — Design Documents
 
-Specifications that describe **what** to build: architecture, formats, interfaces, algorithms, data structures, and component interactions. A design document answers "what does this system look like?" without prescribing the step-by-step work to get there. Cross-reference the implementation plan if one exists.
+Specifications that describe **what** to build: architecture, formats, interfaces, algorithms, data structures, and component interactions. A design document answers "what does this system look like?" without prescribing the step-by-step work to get there.
 
 ### `specs/plans/` — Implementation Plans
 
@@ -60,8 +70,6 @@ moves.
 
 Reserve `specs/` for what a code comment cannot hold: a decision that constrains
 a subsystem, spans crates, or picks between alternatives someone will re-litigate.
-
-When a document contains both design and plan content, split it into two files. The design file goes in `specs/design/` and the plan file goes in `specs/plans/`. The reference is one-way: the plan cites the design it implements, and the design never cites the plan — the design outlives the plan.
 
 **Important**: Plan and design documents must **never** be placed in `docs/`. The `docs/` directory is exclusively for the public Sphinx documentation website. All internal technical documents (plans, designs, ADRs, steering files) belong in `specs/`.
 
@@ -99,25 +107,40 @@ The completeness half is weaker than it reads. A requirement counts as tested wh
 
 See [Spec Conformance Testing](../design/spec-conformance-testing.md) for the full enforcement mechanism, and [ADR-0043](../adrs/0043-spec-conformance-tests-over-a-workflow-framework.md) for why this mechanism rather than a spec-driven-development framework.
 
-### Planning Requirement
+## AI Development Process
 
-All non-trivial features and changes **must** begin with an implementation plan. The plan is a branch-local artifact: it is reviewed as a file diff, then deleted before merge.
+A person is accountable for all changes. We use a custom process for all non-trivial features and changes to ensure human review.
 
-1. Write the plan to `specs/plans/YYYY-MM-DD-short-description.md` and commit it as the **first commit on the branch** — before any implementation code. This is what makes it reviewable as a file diff.
-2. Implement, following the plan.
-3. Any decision worth keeping lands as an ADR or a `specs/design/` update **in the same pull request**.
-4. **Anything the plan describes that the pull request does not deliver becomes a tracked issue** before the plan file is removed. A code comment saying "follow-up slice" is not tracking — the plan is about to be deleted, so an untracked deferral disappears with it.
-5. `git rm` the plan file before merge.
+### Required Steps
 
-**Work that spans more than one pull request must have an issue.** The issue is the durable record across the series: it holds the slice breakdown, stays open until every slice has landed, and is where a slice's undelivered work goes. Each pull request commits only its own slice's plan, and each plan references the issue.
+**Planning**
 
-A single self-contained pull request does not need an issue. The plan is reviewed, the work lands, and the plan goes — nothing is left to track.
+1. AI researches the code base and desired changes
+2. AI creates a **plan branch**, writes the plan to `specs/plans/YYYY-MM-DD-short-description.md`, and creates a PR for the plan.
+3. A person reviews and provides feedback on the plan until the plan is approved. This PR is never merged.
+
+**Preparation**
+4. AI creates one or more **prefactor branches**, implements any pre-factoring, and creates PRs for prefactors.
+5. A person reviews, provides feedback and merges the prefactor PRs.
+
+**Core Change**
+6. If the change requires one or more **core change PRs**, then AI creates a GitHub issue detailing the planned work. The issue is the durable record so that we complete all work in the plan.
+7. AI creates one or more **core change branches**, implements the changes, and creates PRs for the changes.
+8. A person reviews, provides feedback and merges the core change PRs.
+
+**Cleanup**
+9. AI discards the plan branch.
+10. If there was an associated GitHub issue, then AI closes the GitHub issue.
+
+AI can help write code but all  **must** use the following process so that someone can review.
+
+### Planning Document
 
 A plan document should include:
 
 - **Goal** — a concise statement of what the change accomplishes
 - **Architecture** — brief summary of the technical approach
-- **Prefactoring** — the simplification to make *before* adding the new
+- **Prefactoring** — the simplifications to make *before* adding the new
   behaviour, or an explicit statement that none is needed and why (see
   [Prefactoring](#prefactoring))
 - **Design doc reference** — link to `specs/design/` doc if one exists
@@ -126,33 +149,17 @@ A plan document should include:
 
 Name plan files with a date prefix: `YYYY-MM-DD-short-description.md` (e.g., `2026-04-01-planning-requirement.md`).
 
-**When a plan may be skipped:** Changes that are clearly mechanical and self-contained — typo fixes, formatting, dependency bumps, single-line bug fixes, or documentation-only edits — do not require a plan.
-
-## Prefactoring
+### Prefactoring
 
 **Prefactoring** is refactoring done *before* new behaviour is added: reshape the
 existing code so the new behaviour drops in, then add it. It is the opposite
 order from the more familiar "make it work, then clean it up" — and it is the
 order this project uses.
 
-Every change **must** start by looking for a prefactoring opportunity. Without
-that step, each change is bolted onto whatever shape the code already has —
-another `if`, another flag, another near-copy of an existing function. The cost
-compounds twice: the code gets harder to read, and every new branch multiplies
-the paths that tests have to cover, so the suite grows faster than the feature
-set.
+Every change **must** start by looking for related prefactoring opportunities t
+prevent complexity creep and avoid the need for premature abstractions.
 
-### Requirement
-
-- For any change that needs a plan, the plan **must** contain a **Prefactoring**
-  section naming the simplification the change will make first — or stating
-  explicitly that none is needed and why.
-- The prefactoring lands in its own commit (or commits) **before** the commits
-  that add the new behaviour.
-- Mechanical changes that skip the plan (see
-  [Planning Requirement](#planning-requirement)) also skip this.
-
-### Signals that a change needs prefactoring
+#### Signals that a change needs prefactoring
 
 Look for these while reading the code you are about to modify. Any one of them
 means stop and reshape first:
@@ -160,30 +167,24 @@ means stop and reshape first:
 - The new behaviour needs a new `match` arm or `if` in **more than one place** —
   the distinction wants to be a type or a data table, not repeated branching
 - You would copy an existing function and change a few lines of it
-- You would add a boolean parameter (or a second one) to select behaviour inside
-  a function
 - The new tests would duplicate an existing test's setup wholesale, or you would
   need a combinatorial matrix of tests to cover how the new flag interacts with
   the existing ones
-- The module would cross the [1000-line limit](#module-structure) once the change
+- The module would cross the 1000-line limit (see
+  [compiler-standards.md](compiler-standards.md#code-organization)) once the change
   lands
-- The code has to know *where in the pipeline it is* to decide what to do
-- The change is easy to describe in a sentence but hard to place in the code —
-  usually a sign the responsibility it belongs to does not exist yet
+- A similar bug could occur rather than being prevented at compile time
 
-### How to prefactor
+#### How to prefactor
 
 1. **Change the shape, not the behaviour.** The existing tests must pass
    unchanged. If they have to be edited to accept the prefactoring — beyond
    mechanical renames — the commit is not behaviour-preserving; split it.
 2. **Commit the prefactoring separately.** A reviewer can then read a diff that
-   provably changes nothing, followed by a small diff that adds the feature.
+   provably changes nothing, followed by a smaller diff that adds the feature.
    Either can be reverted alone.
-3. **Add the new behaviour.** If the feature diff is still branchy and large,
-   the prefactoring picked the wrong shape — go back to step 1 rather than
-   pushing through.
 
-### When *not* to prefactor
+#### When *not* to prefactor
 
 Prefactoring is a tool for reducing the cost of the change in hand, not a
 licence to rewrite:
@@ -202,14 +203,9 @@ licence to rewrite:
 A well-prefactored change shows up as a *smaller* feature diff and *fewer* new
 tests than the same feature added on top of the old shape — because there are
 fewer distinct paths to cover, not because anything went untested. The coverage
-gate (see [Just Commands](#just-commands)) still applies unchanged.
+gate (see [common-tasks.md](common-tasks.md#coverage-requirements)) still applies unchanged.
 
 ## Code Organization
-
-### Module Structure
-- Follow the existing pattern of organizing related functionality in subdirectories (e.g., `analyzer/src/intermediates/`)
-- Use descriptive module names that reflect their purpose in the compilation pipeline
-- Keep modules focused on a single responsibility
 
 ### Avoid Duplication
 
@@ -247,65 +243,6 @@ Duplication that is acceptable, and should be left alone:
 [docs/CONTRIBUTING.md](../../docs/CONTRIBUTING.md) for what the check can and
 cannot currently see.
 
-### Naming Conventions
-- Use `snake_case` for functions, variables, and module names
-- Use `PascalCase` for types, structs, and enums
-- Use `SCREAMING_SNAKE_CASE` for constants
-- Problem codes follow the pattern `P####` (e.g., P2016)
-- Problem enum variants use descriptive names (e.g., `SubrangeOutOfBounds`)
-
-## Testing Standards
-
-### Test Naming
-**Always use BDD-style test names** following the pattern:
-```rust
-#[test]
-fn function_name_when_condition_then_expected_result() {
-    // Test implementation
-}
-```
-
-Examples:
-- `validate_subrange_bounds_with_various_types_then_validates_correctly`
-- `try_from_with_invalid_range_then_p0004_error`
-
-### Test Implementation Rules
-- **No branching logic** in tests (no `if`, `match`, loops)
-- **No global state dependencies** - each test must be self-contained
-- **Terminate on failure** - use `assert!`, `assert_eq!`, etc. rather than continuing
-- **One assertion per logical concept** - but multiple assertions for the same concept are fine
-- **No panic! in tests** - Use `assert!` macros instead of `panic!()` for test failures
-  - ❌ Bad: `match result { Ok(x) => assert_eq!(x, 5), _ => panic!("Expected Ok") }`
-  - ✅ Good: `assert!(result.is_ok()); assert_eq!(result.unwrap(), 5);`
-  - ✅ Better: `assert!(matches!(result, Ok(5)))`
-
-### Test Organization
-- Group related tests in the same module
-- Use descriptive test function names that explain the scenario and expected outcome
-- Include both positive and negative test cases
-- Test edge cases and boundary conditions
-
-## Error Handling
-
-### Problem Codes
-Error handling is **critical** for developer experience. Follow these rules:
-
-1. **Unique codes**: Each problem gets its own unique P#### code - never reuse codes
-2. **Descriptive names**: Problem enum variants should clearly describe the issue
-3. **Shared definitions**: Problem codes are defined in `compiler/problems/resources/problem-codes.csv`
-4. **Documentation required**: Every problem code MUST have documentation in `docs/reference/compiler/problems/P####.rst`
-
-### Problem Code Format
-```csv
-Code,Name,Message
-P2016,SubrangeOutOfBounds,Subrange is outside base type bounds
-```
-
-### Error Messages
-- Provide clear, actionable error messages
-- Include context about what was expected vs. what was found
-- Use `Diagnostic::problem()` with appropriate `Label::span()` for source location
-
 ## Steering Files for AI Assistants
 
 IronPLC uses **steering files** to guide AI assistants in working with the codebase. These files follow a specific two-file pattern:
@@ -325,270 +262,29 @@ When creating or updating steering files:
 
 For complete guidance on steering files, see [steering-file-guidelines.md](./steering-file-guidelines.md).
 
-## Documentation Standards
-
-### Documentation Quadrants Framework
-All IronPLC documentation follows the **Documentation Quadrants** approach, organizing content into four distinct types:
-
-#### 1. Tutorials (Learning-Oriented)
-- **Purpose**: Guide newcomers through their first successful experience
-- **Audience**: People studying and learning
-- **Content**: Step-by-step lessons that work reliably
-- **Examples**: "Getting Started with IronPLC", "Your First PLC Program"
-- **Location**: `docs/quickstart/`
-
-#### 2. How-To Guides (Problem-Oriented)
-- **Purpose**: Show how to solve specific real-world problems
-- **Audience**: Practitioners at work who need to accomplish something
-- **Content**: Series of steps focused on achieving a goal
-- **Examples**: "How to Debug Compilation Errors", "How to Add a New Data Type"
-- **Location**: `docs/how-to-guides/`
-
-#### 3. Technical Reference (Information-Oriented)
-- **Purpose**: Describe the machinery and how to operate it
-- **Audience**: Practitioners at work who need accurate information
-- **Content**: Structured descriptions of APIs, commands, and features
-- **Examples**: "Compiler CLI Reference", "Problem Code Reference", "Language Grammar"
-- **Location**: `docs/reference/`
-
-#### 4. Explanation (Understanding-Oriented)
-- **Purpose**: Clarify and illuminate topics for deeper understanding
-- **Audience**: People studying who want to understand concepts
-- **Content**: Discussions of design decisions, alternatives, and context
-- **Examples**: "IEC 61131-3 Compliance Strategy", "Compiler Architecture Overview"
-- **Location**: `docs/explanation/`
-
-### Documentation Relationships
-- **Tutorials + How-To Guides**: Both describe practical steps
-- **How-To Guides + Reference**: Both serve practitioners at work
-- **Reference + Explanation**: Both provide theoretical knowledge
-- **Tutorials + Explanation**: Both support learning and study
-
-### Writing Style
-
-All documentation follows these writing style principles to keep content clear, direct, and easy to scan.
-
-#### Voice and Tense
-
-- **Use active voice.** Name the actor (the compiler, the runtime, IEC 61131-3, the user) as the subject of the sentence.
-  - ✅ "Edition 3 introduced the following features"
-  - ❌ "The following features were introduced in Edition 3"
-  - ✅ "IronPLC supports the following platforms"
-  - ❌ "IronPLC is supported on the following platforms"
-- **Use present tense.** Describe what the software *does*, not what it *will do* or *did*.
-  - ✅ "The compiler reports an error when..."
-  - ❌ "The compiler will report an error when..."
-- **Passive voice is acceptable** in two cases:
-  1. The actor is genuinely unknown or irrelevant (e.g., "the file may be corrupted").
-  2. Active voice would blame the user for an error (e.g., "This error occurs when a comment is not properly closed" is better than "You forgot to close the comment").
-
-#### Person and Mood
-
-- **Use second person ("you")** in tutorials and how-to guides.
-- **Use imperative mood** for instructions: "Run the command", not "You should run the command" or "The command can be run".
-- **Avoid third-person references to the reader**: "the user", "the developer", "one".
-
-#### Sentence Structure
-
-- **Lead with the action or result**, not the context. Put the most important information first.
-  - ✅ "Set the ``--std`` flag to enable Edition 3 features."
-  - ❌ "In order to enable Edition 3 features, you need to set the ``--std`` flag."
-- **Keep sentences short.** Prefer one idea per sentence. If a sentence has more than one comma-separated clause, consider splitting it.
-- **Avoid nominalizations.** Use verbs instead of noun forms of verbs.
-  - ✅ "The compiler validates the program"
-  - ❌ "The compiler performs validation of the program"
-
-### RST Annotation Conventions
-
-All Sphinx documentation must use the correct RST roles for consistent rendering. **Never use plain text or double backticks for elements that have a dedicated role.**
-
-| Element | Role | Example |
-|---------|------|---------|
-| Menu paths | `:menuselection:` | `:menuselection:\`File --> New File...\`` |
-| UI elements (buttons, panels) | `:guilabel:` | `:guilabel:\`Install\`` |
-| Keyboard shortcuts | `:kbd:` | `:kbd:\`Ctrl+Shift+P\`` |
-| File names and extensions | `:file:` | `:file:\`main.st\``, `:file:\`.st\`` |
-| Commands and executables | `:program:` | `:program:\`ironplcc --version\`` |
-| Code keywords | `:code:` | `:code:\`PROGRAM\`` |
-| User-typed text | `:samp:` | `:samp:\`IronPLC\`` |
-| Cross-document links | `:doc:` | `:doc:\`/reference/compiler/problems/index\`` |
-
-**Menu paths** use ` --> ` as separator: `:menuselection:\`File --> Preferences --> Settings\``
-
-**Platform-specific keyboard shortcuts** use separate `:kbd:` roles: `:kbd:\`Ctrl+Shift+X\`` for Windows/Linux, `:kbd:\`⌘+Shift+X\`` for macOS.
-
-### Interactive Examples in Documentation
-
-Documentation pages that include IEC 61131-3 code examples **should** use interactive playground directives instead of static `.. code-block::` when the example is a valid, compilable program or snippet. This lets readers edit and run the code directly in the browser.
-
-Two Sphinx directives are available (defined in `docs/extensions/ironplc_playground.py`):
-
-| Directive | Use when |
-|-----------|----------|
-| `.. playground::` | The example is a complete program (includes `PROGRAM`/`END_PROGRAM`) |
-| `.. playground-with-program::` | The example is a code snippet that should be auto-wrapped in a `PROGRAM` scaffold |
-
-**`playground-with-program` options:**
-- `:vars:` — semicolon-separated variable declarations (e.g., `:vars: result : DINT; value : REAL;`)
-- `:height:` — custom iframe height (auto-calculated by default)
-
-**Example** (from a standard library function page):
-```rst
-.. playground-with-program::
-   :vars: result : DINT;
-
-   result := ABS(-42);    (* result = 42 *)
-```
-
-**When NOT to use playground directives:**
-- Problem code documentation (`docs/reference/compiler/problems/`) — these show invalid code that would fail compilation
-- Partial syntax fragments that are not runnable
-
-**Source of truth for the playground:**
-- Frontend: `playground/` (HTML/JS/CSS single-page app)
-- WASM compiler crate: `compiler/playground/` (Rust compiled to WebAssembly via wasm-pack)
-- Sphinx extension: `docs/extensions/ironplc_playground.py` (directive implementation)
-- Build system: `playground/justfile`
-
-### Documentation Content Guidelines
-
-- **Describe features as they are, not as future plans.** The website documents current capabilities. Do not include forward-looking statements like "this page will be updated when..." or "future versions will support...". If a feature is not yet supported, say so plainly (e.g., "Not yet supported") without speculating about when it will be added.
-- **Do not document architecture or internals** in user-facing reference docs. Architecture belongs in `docs/explanation/` if anywhere.
-- **Do not explain standard VS Code concepts** (e.g., workspace vs. user settings). Assume the reader knows VS Code.
-- **Use platform tabs** (via `sphinx_inline_tabs`) for platform-specific instructions.
-
-### Edition-Gated Features
-
-Some IEC 61131-3 features require the user to enable a specific edition of the standard. When documenting an edition-gated feature:
-
-1. **Use the reusable include** — add `.. include:: ../../../includes/requires-edition3.rst` near the top of the page (after the description, before the detail table). Do not write a custom note.
-2. **Link to the edition support matrix** — in the feature's detail table, use `:doc:\`Edition 3 </reference/language/edition-support>\`` in the Support row instead of hardcoding the flag name.
-3. **Update the matrix** — add the feature to `docs/reference/language/edition-support.rst`.
-
-The centralized explanation page at `docs/explanation/enabling-dialects-and-features.rst` covers how to enable editions in both the CLI and VS Code. Individual feature pages link there rather than duplicating instructions.
-
-### Problem Documentation Format
-Each problem code must have a corresponding `.rst` file in `docs/reference/compiler/problems/` with:
-
-```rst
-=====
-P####
-=====
-
-.. problem-summary:: P####
-
-[Clear description of when this error occurs]
-
-Example
--------
-
-The following code will generate error P####:
-
-.. code-block::
-
-   [Example that triggers the error]
-
-[Explanation of why this is an error]
-
-To fix this error, [solution]:
-
-.. code-block::
-
-   [Corrected example]
-```
-
-### Supported File Format Synchronization
-File extensions and format details are listed in **two** canonical locations. All other docs cross-reference these rather than repeating extension lists. When adding or modifying a supported source file format, update:
-
-1. **Compiler source** - `compiler/sources/src/file_type.rs` (the source of truth for detection)
-2. **VS Code extension** - `integrations/vscode/package.json` (language contributions) and `integrations/vscode/src/extension.ts` (document selector)
-3. **Source format reference page** - the format-specific page in `docs/reference/compiler/source-formats/` (e.g., `twincat.rst`)
-4. **Editor overview** - `docs/reference/editor/overview.rst` (Supported Languages section)
-
-### README Synchronization
-The project has multiple README files that must stay synchronized:
-
-- **Root `README.md`**: Main project overview, mission, progress, and capabilities
-- **`integrations/vscode/README.md`**: VS Code Extension specific documentation for the Marketplace
-
-**When updating the main README:**
-1. Review if the extension README needs corresponding updates
-2. The extension README should reflect the same capabilities/limitations
-3. Keep the "warning" banner (`⚠`) consistent between both files
-4. Ensure feature lists match (e.g., syntax highlighting, analysis capabilities)
-
-**When updating the extension README:**
-1. Keep it focused on VS Code-specific usage and features
-2. Include extension settings, commands, and configuration
-3. Reference the main documentation website for detailed information
-
-### Code Documentation
-- **Best effort** documentation for now, but focus on public APIs
-- Use Rust doc comments (`///`) for public functions and types
-- Include examples in documentation when helpful
-- Document complex algorithms or IEC 61131-3 specific behavior
-- A comment carrying a decision states what was chosen and why, not only what
-  the code does — the next reader's question is whether they may change it
-- Nothing checks that a comment is still true. A comment asserting behaviour is
-  as capable of going stale as a design document, and is read more often; when
-  you change behaviour, re-read the comments around it
-
-### Example Synchronization
-**Important**: Examples in documentation should also exist as tests in the Rust compiler to ensure documentation accuracy. Follow the existing naming conventions for test examples.
-
-## IEC 61131-3 Compliance
-
-### Compliance Levels
-The compiler supports various levels of IEC 61131-3 compliance:
-
-- **Parse everything**: The compiler should be able to parse any 61131-3 code
-- **Compatibility flags**: Users pass flags/options to enable/disable specific syntax validation
-- **Graceful degradation**: Invalid syntax should be parsed but flagged with appropriate problem codes
-
-### Implementation Approach
-- Design for flexibility in compliance checking
-- Use feature flags or configuration options for different compliance levels
-- Ensure error messages reference the relevant IEC 61131-3 standard sections when applicable
-
 ## Build System Integration
 
-### Just Commands
-Use `just` for all build tasks. Key commands:
-- `just` - Run full CI pipeline for the current component
-- `just compile` - Build the component
-- `just test` - Run tests
-- `just lint` - Run linting (clippy + fmt for Rust)
-- `just devenv-smoke` - Quick environment check
+IronPLC uses `just` as its command runner. The full command reference — per
+component, coverage, packaging, and troubleshooting — lives in
+[common-tasks.md](common-tasks.md). Do not restate it here.
 
-For complete setup and development workflow instructions, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+### Git Workflow and Pre-PR Quality Gate
 
-### CRITICAL: Git Workflow and Pre-PR Quality Gate
-
-**NEVER commit or push directly to `main`.** Always create a feature branch and open a pull request. This ensures CI validates all changes before they reach main.
-
-**Before creating any pull request, you MUST run and pass the full CI pipeline:**
+**NEVER commit or push directly to `main`.** Create a feature branch and open a
+pull request so CI validates every change before it reaches `main`. Before
+creating any PR, run and pass the full pipeline:
 
 ```bash
 cd compiler && just
 ```
 
-This runs compile, test, coverage, and lint. The **lint step includes clippy**, which catches common Rust issues. PRs that fail clippy will be rejected by CI.
-
-**Do not:**
-- Push directly to `main` — always use a feature branch and PR
-- Skip running `just` before creating a PR
-- Suppress clippy warnings with `#[allow(...)]` — fix the underlying issue instead. The only acceptable exception is `#[allow(dead_code)]` or `#[allow(unused_*)]` for in-progress code that is not yet wired up
-- Create a PR if any check fails
-
-See [common-tasks.md](./common-tasks.md) for detailed pre-PR requirements and troubleshooting.
+See [common-tasks.md](common-tasks.md#critical-pre-pr-requirements) for what this
+runs and how to fix failures. The clippy-suppression rule lives in
+[compiler-standards.md](compiler-standards.md#code-quality).
 
 ### Version Management
-**Version numbers are generated and incremented automatically** - no manual version management is required:
-
-- **Automated versioning**: The build system handles version increments automatically
-- **No manual updates**: Do not manually edit version numbers in `Cargo.toml` or other files
-- **Synchronization**: The build system ensures version numbers stay synchronized across all components
-- **Release process**: Version bumps happen as part of the automated release workflow
+**Version numbers are generated and incremented automatically** — never edit them
+manually (see [common-tasks.md](common-tasks.md#version-management)).
 
 ### Synchronization Checks
 The build system enforces synchronization between components:
@@ -597,37 +293,6 @@ The build system enforces synchronization between components:
 - Examples in docs must have corresponding tests
 
 ### Cross-Platform Support
-- Support Windows, macOS, and Linux
-- Use platform-specific just recipes when needed (`_command-{{os_family()}}`)
-- Test in Dev Container environment when possible
-
-## Performance Considerations
-
-### Memory Usage
-- Design for embedded/PLC contexts where memory may be constrained
-- Use appropriate data structures for the compilation pipeline
-- Consider memory layout for type representations (see `ByteSized` enum)
-
-### Compilation Speed
-- Optimize for reasonable compilation times
-- Use efficient algorithms for type checking and semantic analysis
-- Profile performance-critical paths when needed
-
-## Code Quality
-
-### Rust Best Practices
-- Do not suppress clippy warnings with `#[allow(...)]` — fix the underlying code instead. The only acceptable exception is `#[allow(dead_code)]` or `#[allow(unused_*)]` for in-progress code that is not yet wired up; remove these suppressions once the code is complete
-- Prefer `Result<T, E>` for error handling over panics
-- Use appropriate visibility modifiers (`pub`, `pub(crate)`, etc.)
-- Follow Rust naming conventions and idioms
-
-### Safety
-- Leverage Rust's safety guarantees
-- **`unsafe` code is rejected at compile time.** The workspace sets `unsafe_code = "deny"` in `[workspace.lints.rust]` (root `compiler/Cargo.toml`), and every member crate inherits it via `[lints] workspace = true`. Any `unsafe` block, function, trait, or impl in IronPLC code fails the build
-- **Do not bypass the check with `#[allow(unsafe_code)]`.** The standards already forbid `#[allow(...)]` suppressions (see [Code Quality](#code-quality)); `unsafe_code` is no exception. `deny` (rather than `forbid`) is the chosen level only so that proc-macros which wrap unsafe internally — e.g. `ctor::ctor`, whose expansion includes `#[allow(unsafe_code)]` — keep working. If a feature appears to require `unsafe`, raise it for discussion
-- Use strong typing to prevent logic errors (e.g., `TypeName` vs `String`)
-
-### Dependencies
-- Keep dependencies minimal and well-justified
-- Use workspace dependencies for consistency
-- Regular dependency updates via `just update`
+The compiler, extension, and playground all target Windows, macOS, and Linux.
+Component-specific cross-platform guidance (e.g. the compiler's `just` recipes)
+lives in the relevant [component standards file](#component-specific-standards).

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -119,7 +119,7 @@ A person is accountable for all changes. We use a custom process for all non-tri
 2. AI creates a **plan branch**, writes the plan to `specs/plans/YYYY-MM-DD-short-description.md`, and creates a PR for the plan.
 3. A person reviews and provides feedback on the plan until the plan is approved. This PR is never merged.
 
-**Preparation**
+**Prefactoring**
 4. AI creates one or more **prefactor branches**, implements any pre-factoring, and creates PRs for prefactors.
 5. A person reviews, provides feedback and merges the prefactor PRs.
 

--- a/specs/steering/doc-standards.md
+++ b/specs/steering/doc-standards.md
@@ -1,0 +1,160 @@
+## Documentation Standards
+
+### Documentation Quadrants Framework
+All IronPLC documentation follows the **Documentation Quadrants** approach, organizing content into four distinct types:
+
+#### 1. Tutorials (Learning-Oriented)
+- **Purpose**: Guide newcomers through their first successful experience
+- **Audience**: People studying and learning
+- **Content**: Step-by-step lessons that work reliably
+- **Examples**: "Getting Started with IronPLC", "Your First PLC Program"
+- **Location**: `docs/quickstart/`
+
+#### 2. How-To Guides (Problem-Oriented)
+- **Purpose**: Show how to solve specific real-world problems
+- **Audience**: Practitioners at work who need to accomplish something
+- **Content**: Series of steps focused on achieving a goal
+- **Examples**: "How to Debug Compilation Errors", "How to Add a New Data Type"
+- **Location**: `docs/how-to-guides/`
+
+#### 3. Technical Reference (Information-Oriented)
+- **Purpose**: Describe the machinery and how to operate it
+- **Audience**: Practitioners at work who need accurate information
+- **Content**: Structured descriptions of APIs, commands, and features
+- **Examples**: "Compiler CLI Reference", "Problem Code Reference", "Language Grammar"
+- **Location**: `docs/reference/`
+
+#### 4. Explanation (Understanding-Oriented)
+- **Purpose**: Clarify and illuminate topics for deeper understanding
+- **Audience**: People studying who want to understand concepts
+- **Content**: Discussions of design decisions, alternatives, and context
+- **Examples**: "IEC 61131-3 Compliance Strategy", "Compiler Architecture Overview"
+- **Location**: `docs/explanation/`
+
+### Documentation Relationships
+- **Tutorials + How-To Guides**: Both describe practical steps
+- **How-To Guides + Reference**: Both serve practitioners at work
+- **Reference + Explanation**: Both provide theoretical knowledge
+- **Tutorials + Explanation**: Both support learning and study
+
+### Writing Style
+
+All documentation follows these writing style principles to keep content clear, direct, and easy to scan.
+
+#### Voice and Tense
+
+- **Use active voice.** Name the actor (the compiler, the runtime, IEC 61131-3, the user) as the subject of the sentence.
+  - ✅ "Edition 3 introduced the following features"
+  - ❌ "The following features were introduced in Edition 3"
+  - ✅ "IronPLC supports the following platforms"
+  - ❌ "IronPLC is supported on the following platforms"
+- **Use present tense.** Describe what the software *does*, not what it *will do* or *did*.
+  - ✅ "The compiler reports an error when..."
+  - ❌ "The compiler will report an error when..."
+- **Passive voice is acceptable** in two cases:
+  1. The actor is genuinely unknown or irrelevant (e.g., "the file may be corrupted").
+  2. Active voice would blame the user for an error (e.g., "This error occurs when a comment is not properly closed" is better than "You forgot to close the comment").
+
+#### Person and Mood
+
+- **Use second person ("you")** in tutorials and how-to guides.
+- **Use imperative mood** for instructions: "Run the command", not "You should run the command" or "The command can be run".
+- **Avoid third-person references to the reader**: "the user", "the developer", "one".
+
+#### Sentence Structure
+
+- **Lead with the action or result**, not the context. Put the most important information first.
+  - ✅ "Set the ``--std`` flag to enable Edition 3 features."
+  - ❌ "In order to enable Edition 3 features, you need to set the ``--std`` flag."
+- **Keep sentences short.** Prefer one idea per sentence. If a sentence has more than one comma-separated clause, consider splitting it.
+- **Avoid nominalizations.** Use verbs instead of noun forms of verbs.
+  - ✅ "The compiler validates the program"
+  - ❌ "The compiler performs validation of the program"
+
+### RST Annotation Conventions
+
+All Sphinx documentation must use the correct RST roles for consistent rendering. **Never use plain text or double backticks for elements that have a dedicated role.**
+
+| Element | Role | Example |
+|---------|------|---------|
+| Menu paths | `:menuselection:` | `:menuselection:\`File --> New File...\`` |
+| UI elements (buttons, panels) | `:guilabel:` | `:guilabel:\`Install\`` |
+| Keyboard shortcuts | `:kbd:` | `:kbd:\`Ctrl+Shift+P\`` |
+| File names and extensions | `:file:` | `:file:\`main.st\``, `:file:\`.st\`` |
+| Commands and executables | `:program:` | `:program:\`ironplcc --version\`` |
+| Code keywords | `:code:` | `:code:\`PROGRAM\`` |
+| User-typed text | `:samp:` | `:samp:\`IronPLC\`` |
+| Cross-document links | `:doc:` | `:doc:\`/reference/compiler/problems/index\`` |
+
+**Menu paths** use ` --> ` as separator: `:menuselection:\`File --> Preferences --> Settings\``
+
+**Platform-specific keyboard shortcuts** use separate `:kbd:` roles: `:kbd:\`Ctrl+Shift+X\`` for Windows/Linux, `:kbd:\`⌘+Shift+X\`` for macOS.
+
+### Interactive Examples in Documentation
+
+Documentation pages that include IEC 61131-3 code examples **should** use interactive playground directives instead of static `.. code-block::` when the example is a valid, compilable program or snippet. This lets readers edit and run the code directly in the browser.
+
+Two Sphinx directives are available (defined in `docs/extensions/ironplc_playground.py`):
+
+| Directive | Use when |
+|-----------|----------|
+| `.. playground::` | The example is a complete program (includes `PROGRAM`/`END_PROGRAM`) |
+| `.. playground-with-program::` | The example is a code snippet that should be auto-wrapped in a `PROGRAM` scaffold |
+
+**`playground-with-program` options:**
+- `:vars:` — semicolon-separated variable declarations (e.g., `:vars: result : DINT; value : REAL;`)
+- `:height:` — custom iframe height (auto-calculated by default)
+
+**Example** (from a standard library function page):
+```rst
+.. playground-with-program::
+   :vars: result : DINT;
+
+   result := ABS(-42);    (* result = 42 *)
+```
+
+**When NOT to use playground directives:**
+- Problem code documentation (`docs/reference/compiler/problems/`) — these show invalid code that would fail compilation
+- Partial syntax fragments that are not runnable
+
+**Source of truth for the playground:**
+- Frontend: `playground/` (HTML/JS/CSS single-page app)
+- WASM compiler crate: `compiler/playground/` (Rust compiled to WebAssembly via wasm-pack)
+- Sphinx extension: `docs/extensions/ironplc_playground.py` (directive implementation)
+- Build system: `playground/justfile`
+
+### Documentation Content Guidelines
+
+- **Describe features as they are, not as future plans.** The website documents current capabilities. Do not include forward-looking statements like "this page will be updated when..." or "future versions will support...". If a feature is not yet supported, say so plainly (e.g., "Not yet supported") without speculating about when it will be added.
+- **Do not document architecture or internals** in user-facing reference docs. Architecture belongs in `docs/explanation/` if anywhere.
+- **Do not explain standard VS Code concepts** (e.g., workspace vs. user settings). Assume the reader knows VS Code.
+- **Use platform tabs** (via `sphinx_inline_tabs`) for platform-specific instructions.
+
+### Edition-Gated Features
+
+Some IEC 61131-3 features require the user to enable a specific edition of the standard. When documenting an edition-gated feature:
+
+1. **Use the reusable include** — add `.. include:: ../../../includes/requires-edition3.rst` near the top of the page (after the description, before the detail table). Do not write a custom note.
+2. **Link to the edition support matrix** — in the feature's detail table, use `:doc:\`Edition 3 </reference/language/edition-support>\`` in the Support row instead of hardcoding the flag name.
+3. **Update the matrix** — add the feature to `docs/reference/language/edition-support.rst`.
+
+The centralized explanation page at `docs/explanation/enabling-dialects-and-features.rst` covers how to enable editions in both the CLI and VS Code. Individual feature pages link there rather than duplicating instructions.
+
+### Problem Documentation Format
+Each problem code has a corresponding `.rst` file under
+`docs/reference/compiler/problems/` (P-codes),
+`docs/vscode/problems/` (E-codes), or `docs/reference/runtime/problems/`
+(V-codes). The `.rst` templates and the full add-a-code lifecycle live in
+[problem-code-management.md](problem-code-management.md) — follow the template
+there rather than an inline copy.
+
+### Supported File Format Synchronization
+File extensions and format details are listed in **two** canonical locations. All other docs cross-reference these rather than repeating extension lists. When adding or modifying a supported source file format, update:
+
+1. **Compiler source** - `compiler/sources/src/file_type.rs` (the source of truth for detection)
+2. **VS Code extension** - `integrations/vscode/package.json` (language contributions) and `integrations/vscode/src/extension.ts` (document selector)
+3. **Source format reference page** - the format-specific page in `docs/reference/compiler/source-formats/` (e.g., `twincat.rst`)
+4. **Editor overview** - `docs/reference/editor/overview.rst` (Supported Languages section)
+
+### Example Synchronization
+**Important**: Examples in documentation should also exist as tests in the Rust compiler to ensure documentation accuracy. Follow the existing naming conventions for test examples.

--- a/specs/steering/extension-standards.md
+++ b/specs/steering/extension-standards.md
@@ -1,0 +1,53 @@
+# VS Code Extension Standards
+
+This steering file defines the coding standards and conventions for the IronPLC
+VS Code extension under `integrations/vscode/` (TypeScript). It covers README
+synchronization and points to the extension-specific testing and error-code
+rules.
+
+> **Note**: This file covers *how to write extension code*. For the extension's
+> CI test gates and structural invariants, see
+> [extension-testing-requirements.md](extension-testing-requirements.md). For the
+> `E####` extension error codes, see
+> [problem-code-management.md](problem-code-management.md). For build/test
+> commands, see [common-tasks.md](common-tasks.md).
+
+## Applies To
+
+This guidance is relevant when working with `integrations/vscode/**`.
+Cross-component process rules — planning, prefactoring, the git workflow — live
+in [development-standards.md](development-standards.md).
+
+## Testing and Coverage
+
+The extension enforces its own coverage threshold (80% on unit-testable modules)
+and a set of structural invariants that fail the build when a declared
+capability (language, command, custom editor) ships without a test. These gates
+and the rules for adding new capabilities are defined in
+[extension-testing-requirements.md](extension-testing-requirements.md). Do not
+restate them here.
+
+## Error Codes
+
+Extension errors use the `E####` prefix and are generated from
+`integrations/vscode/resources/problem-codes.csv`. Never hardcode error strings;
+use the generated `formatProblem(ProblemCode.Name, context)` helper. The full
+lifecycle is in [problem-code-management.md](problem-code-management.md).
+
+## README Synchronization
+
+The project has multiple README files that must stay synchronized:
+
+- **Root `README.md`**: Main project overview, mission, progress, and capabilities
+- **`integrations/vscode/README.md`**: VS Code Extension specific documentation for the Marketplace
+
+**When updating the main README:**
+1. Review if the extension README needs corresponding updates
+2. The extension README should reflect the same capabilities/limitations
+3. Keep the "warning" banner (`⚠`) consistent between both files
+4. Ensure feature lists match (e.g., syntax highlighting, analysis capabilities)
+
+**When updating the extension README:**
+1. Keep it focused on VS Code-specific usage and features
+2. Include extension settings, commands, and configuration
+3. Reference the main documentation website for detailed information

--- a/specs/steering/steering-file-guidelines.md
+++ b/specs/steering/steering-file-guidelines.md
@@ -19,6 +19,24 @@ All detailed steering documentation lives in **`specs/steering/`**. Different AI
 - **Cursor**: Uses `CURSOR.md` at the repository root (full entry point, same content pattern as `CLAUDE.md`) plus `.cursor/rules/ironplc-steering.mdc` with `alwaysApply: true` so the agent always sees a short pointer to `specs/steering/`
 - **Other AI tools**: Can reference `specs/steering/` files directly or through custom entry points
 
+### Core Principle: Scope to the Narrowest Path
+
+Every steering file declares the **narrowest** `fileMatch` that fits its
+subject, so it loads only when work actually touches that area. Reserve
+`inclusion: always` for genuinely cross-cutting process that applies to *all*
+work (the specs directory, planning, prefactoring, the glossary). A file about
+one component (`compiler/`, `docs/`, `integrations/vscode/`) or one subsystem
+(`**/analyzer/**`, `compiler/problems/*`) is `fileMatch`-scoped to that path.
+
+Keeping the always-loaded set small is a feature, not an accident: context that
+is loaded but irrelevant costs tokens and dilutes attention. A file that
+restates a rule another file owns forces that rule into every context the copy
+appears in — prefer a cross-reference so the rule travels only with its owner.
+
+For Claude, the equivalent of `fileMatch` is the "especially relevant for
+`<path>`" hint on the file's bullet in `CLAUDE.md`. Add one whenever a steering
+file is component- or subsystem-specific.
+
 ### 1. Detailed Documentation (in `specs/steering/`)
 
 **Purpose**: Complete guidance that works standalone for any AI system
@@ -28,11 +46,10 @@ All detailed steering documentation lives in **`specs/steering/`**. Different AI
 **Format**: Full markdown documentation with all details
 
 **Key characteristics**:
-- Self-contained (doesn't rely on any specific AI tool's features)
+- Self-contained *on its own topic* — tool-agnostic prose that works when copied into any AI chat. This means not relying on a specific AI tool's features; it does **not** mean restating rules another file owns. Cross-reference those instead (see [Scope to the Narrowest Path](#core-principle-scope-to-the-narrowest-path))
 - Can be referenced by any AI system through their pointer mechanism
-- Works when copied/pasted into any AI chat
-- Contains all the actual guidance content
-- Single source of truth for all AI tools
+- Contains all the guidance for its own subject, and links out for the rest
+- Single source of truth for its topic across all AI tools
 
 ### 2. AI Tool-Specific Pointers
 
@@ -410,7 +427,7 @@ For AI-assisted development patterns, see `specs/steering/`.
 
 ### Good: development-standards.md
 
-- **Detailed**: `specs/steering/development-standards.md` (400+ lines)
+- **Detailed**: `specs/steering/development-standards.md` (cross-cutting process; component specifics split into `compiler-standards.md`, `doc-standards.md`, `extension-standards.md`)
 - **Kiro pointer**: `.kiro/steering/development-standards.md` (3 lines)
 - **Claude reference**: Listed in `CLAUDE.md`
 - **Why it works**: Single source of truth, multiple access methods
@@ -424,37 +441,35 @@ For AI-assisted development patterns, see `specs/steering/`.
 
 ### Pattern to Follow
 
+The `.kiro/steering/` pointer's frontmatter is the authoritative inclusion
+setting; the scopes below are a snapshot for orientation.
+
 ```
-specs/steering/                          # Single source of truth
-├── development-standards.md             # Steering doc (context)
-├── compiler-architecture.md             # Steering doc (context)
-├── iec-61131-3-compliance.md           # Steering doc (context)
-├── plcopen-xml-module.md               # Steering doc (context)
-├── common-tasks.md                      # Skill source (actionable)
-├── problem-code-management.md          # Skill source (actionable)
-├── extension-testing-requirements.md   # Skill source (actionable)
-└── steering-file-guidelines.md         # Skill source (actionable)
+specs/steering/                        # Single source of truth (full docs)
+  # always — cross-cutting process / vocabulary:
+  development-standards.md             # always
+  common-tasks.md                      # always
+  glossary.md                          # always
+  # fileMatch — load only for the relevant path:
+  compiler-standards.md                # compiler/**
+  compiler-architecture.md             # compiler/**
+  syntax-support-guide.md              # **/parser|analyzer|codegen|plc2plc**
+  iec-61131-3-compliance.md            # **/analyzer/**
+  problem-code-management.md           # compiler/problems/*
+  plcopen-xml-module.md                # compiler/sources/src/xml/**
+  compatibility-library-authoring.md   # compiler/sources/resources/compat-libraries/**
+  doc-standards.md                     # docs/**
+  coming-from-guide-authoring.md       # docs/how-to-guides/**
+  extension-standards.md               # integrations/vscode/**
+  extension-testing-requirements.md    # integrations/vscode/**
+  steering-file-guidelines.md          # specs/steering/**, .kiro/steering/**
 
-.kiro/steering/                          # Kiro-specific pointers
-├── common-tasks.md                      # Pointer (always)
-├── compiler-architecture.md             # Pointer (always)
-├── development-standards.md             # Pointer (always)
-├── iec-61131-3-compliance.md           # Pointer (fileMatch)
-├── problem-code-management.md          # Pointer (fileMatch)
-├── extension-testing-requirements.md   # Pointer (fileMatch)
-├── plcopen-xml-module.md               # Pointer (fileMatch)
-└── steering-file-guidelines.md         # Pointer (always)
-
-.claude/                                 # Claude Code configuration
-├── settings.json                        # SessionStart hook (installs just)
-└── commands/                            # Slash commands (skill pointers)
-    ├── build.md                         # /project:build
-    ├── test.md                          # /project:test
-    ├── ci.md                            # /project:ci
-    └── format.md                        # /project:format
-
-CLAUDE.md                                # Claude entry point
-                                         # Steering docs + skills list
+.kiro/steering/<name>.md               # One pointer per file above; the
+                                       # pointer's frontmatter sets inclusion.
+.claude/commands/*.md                  # Slash commands (skill pointers)
+CLAUDE.md / CURSOR.md                  # Entry points: steering links (with
+                                       # "especially relevant for <path>"
+                                       # hints) + skills list.
 ```
 
 ## AI Assistant Instructions

--- a/specs/steering/steering-file-guidelines.md
+++ b/specs/steering/steering-file-guidelines.md
@@ -441,36 +441,23 @@ For AI-assisted development patterns, see `specs/steering/`.
 
 ### Pattern to Follow
 
-The `.kiro/steering/` pointer's frontmatter is the authoritative inclusion
-setting; the scopes below are a snapshot for orientation.
+Each topic lives once and is reached from every tool. Rather than enumerate the
+current files and their scopes here — a list that would drift out of date — the
+pattern is:
 
 ```
-specs/steering/                        # Single source of truth (full docs)
-  # always — cross-cutting process / vocabulary:
-  development-standards.md             # always
-  common-tasks.md                      # always
-  glossary.md                          # always
-  # fileMatch — load only for the relevant path:
-  compiler-standards.md                # compiler/**
-  compiler-architecture.md             # compiler/**
-  syntax-support-guide.md              # **/parser|analyzer|codegen|plc2plc**
-  iec-61131-3-compliance.md            # **/analyzer/**
-  problem-code-management.md           # compiler/problems/*
-  plcopen-xml-module.md                # compiler/sources/src/xml/**
-  compatibility-library-authoring.md   # compiler/sources/resources/compat-libraries/**
-  doc-standards.md                     # docs/**
-  coming-from-guide-authoring.md       # docs/how-to-guides/**
-  extension-standards.md               # integrations/vscode/**
-  extension-testing-requirements.md    # integrations/vscode/**
-  steering-file-guidelines.md          # specs/steering/**, .kiro/steering/**
-
-.kiro/steering/<name>.md               # One pointer per file above; the
-                                       # pointer's frontmatter sets inclusion.
-.claude/commands/*.md                  # Slash commands (skill pointers)
-CLAUDE.md / CURSOR.md                  # Entry points: steering links (with
-                                       # "especially relevant for <path>"
-                                       # hints) + skills list.
+specs/steering/<name>.md    # Single source of truth (full, tool-agnostic doc)
+.kiro/steering/<name>.md    # One pointer per doc; its frontmatter is the
+                            #   authoritative inclusion setting (always /
+                            #   fileMatch <path> / manual)
+.claude/commands/*.md       # Slash commands (skill pointers)
+CLAUDE.md / CURSOR.md       # Entry points: steering links (with "especially
+                            #   relevant for <path>" hints) + skills list
 ```
+
+For the current set of docs and the paths each is scoped to, read the
+`.kiro/steering/` pointers' frontmatter — that is where scope is defined and
+kept current.
 
 ## AI Assistant Instructions
 


### PR DESCRIPTION
## Problem

The `specs/steering/` files had grown into overlapping grab-bags. `development-standards.md` was always loaded into AI context, yet roughly half of it was Rust/compiler-specific — so working on the VS Code extension or the docs website pulled in irrelevant guidance. Cross-cutting rules (git gate, problem-code templates, test naming) were also duplicated across three or more files, and three Kiro pointers were silently always-loaded because they were missing `fileMatch` frontmatter.

## Changes

**Component extraction (scope by path)**
- New `compiler-standards.md` (`compiler/**`) — module structure, testing, error handling, performance, Rust/`unsafe`/clippy rules.
- New `doc-standards.md` (`docs/**`) — renamed from the in-progress `documentation-standards.md`; content preserved.
- New `extension-standards.md` (`integrations/vscode/**`) — README sync + pointers to the extension testing gates and `E####` codes.
- Each gets a `fileMatch` Kiro pointer and a `CLAUDE.md` entry with an "especially relevant for `<path>`" hint (Claude's `fileMatch` equivalent).

**Slim the always-on core**
- `development-standards.md`: 447 → 298 lines, now cross-cutting process only (specs structure, planning, prefactoring, duplication principle, git workflow), plus a Component-Specific Standards index.

**Dedup**
- Full CI-pipeline explanation → single owner `common-tasks.md`.
- Problem-code CSV + `.rst` templates → single owner `problem-code-management.md`.

**Fix silently-always-loaded pointers**
- Added `fileMatch` frontmatter to `compiler-architecture.md`, `compatibility-library-authoring.md`, and `steering-file-guidelines.md`.

**Fix the root cause**
- Added a "Scope to the Narrowest Path" principle to `steering-file-guidelines.md`, clarified that "self-contained" means tool-agnostic (not restating other files' rules), and refreshed the stale file-tree example.

## Effect

The always-loaded Kiro set drops from 6 files to 3 (`development-standards`, `common-tasks`, `glossary`). Extension and docs sessions no longer load the compiler/Rust standards.

Documentation-only change (markdown steering files); no compiler CI gate applies. Cross-reference anchors were verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)