### PR TITLE
Point VS Code users at the Marketplace VSIX

### DIFF
--- a/docs/how-to-guides/troubleshoot-editor.rst
+++ b/docs/how-to-guides/troubleshoot-editor.rst
@@ -151,8 +151,10 @@ If all else fails, try a clean reset:
 4. Reinstall the extension from the Extensions view: search for ``ironplc``,
    then select :guilabel:`IronPLC IDE` in Visual Studio Code or
    :guilabel:`IronPLC` in editors that install from Open VSX (Cursor, Kiro,
-   Devin, VSCodium). If neither registry is reachable, download the latest
-   ``ironplc-vscode-extension.vsix`` from the
-   `IronPLC GitHub releases <https://github.com/ironplc/ironplc/releases/>`_
+   Devin, VSCodium). If neither registry is reachable, download the VSIX that
+   matches your development environment from the
+   `IronPLC GitHub releases <https://github.com/ironplc/ironplc/releases/>`_ —
+   ``ironplc-vscode-extension-marketplace.vsix`` for Visual Studio Code,
+   ``ironplc-vscode-extension.vsix`` for editors that install from Open VSX —
    and use :menuselection:`... (View and More Actions) --> Install from VSIX...`
    in the Extensions view

--- a/docs/how-to-guides/update.rst
+++ b/docs/how-to-guides/update.rst
@@ -29,9 +29,7 @@ Follow the steps below to update IronPLC.
 
    .. rubric:: Update IronPLC Extension
 
-   #. Download the latest IronPLC extension
-      :download_artifact:`ironplc-vscode-extension.vsix` from
-      `IronPLC GitHub releases`_.
+   .. include:: /includes/download-extension-vsix.rst
 
    Run your development environment, then:
 
@@ -39,7 +37,7 @@ Follow the steps below to update IronPLC.
       :guilabel:`Activity Bar` on the side of the window or using the
       View: Extensions command (:kbd:`Ctrl+Shift+X`).
    #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
-   #. In the :guilabel:`Install from VISX` dialog, select the VISX file you downloaded earlier.
+   #. In the :guilabel:`Install from VSIX` dialog, select the VSIX file you downloaded earlier.
 
 
 .. tab:: macOS
@@ -62,9 +60,7 @@ Follow the steps below to update IronPLC.
 
    .. rubric:: Update IronPLC Extension
 
-   #. Download the latest IronPLC extension
-      :download_artifact:`ironplc-vscode-extension.vsix` from
-      `IronPLC GitHub releases`_.
+   .. include:: /includes/download-extension-vsix.rst
 
    Run your development environment, then:
 
@@ -72,7 +68,7 @@ Follow the steps below to update IronPLC.
       :guilabel:`Activity Bar` on the side of the window or using the
       View: Extensions command (:kbd:`⌘+Shift+X`).
    #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
-   #. In the dialog, select the VISX file you downloaded earlier.
+   #. In the dialog, select the VSIX file you downloaded earlier.
 
 
 .. tab:: Linux
@@ -88,9 +84,7 @@ Follow the steps below to update IronPLC.
 
    .. rubric:: Update IronPLC Extension
 
-   #. Download the latest IronPLC extension
-      :download_artifact:`ironplc-vscode-extension.vsix` from
-      `IronPLC GitHub releases`_.
+   .. include:: /includes/download-extension-vsix.rst
 
    Run your development environment, then:
 
@@ -98,7 +92,7 @@ Follow the steps below to update IronPLC.
       :guilabel:`Activity Bar` on the side of the window or using the
       View: Extensions command (:kbd:`Ctrl+Shift+X`).
    #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
-   #. In the dialog, select the VISX file you downloaded earlier.
+   #. In the dialog, select the VSIX file you downloaded earlier.
 
 
 .. _IronPLC GitHub releases: https://github.com/ironplc/ironplc/releases/

--- a/docs/includes/download-extension-vsix.rst
+++ b/docs/includes/download-extension-vsix.rst
@@ -1,0 +1,12 @@
+#. Download the VSIX that matches your development environment from
+   `IronPLC GitHub releases`_:
+
+   * Visual Studio Code —
+     :download_artifact:`ironplc-vscode-extension-marketplace.vsix`
+   * Cursor, Kiro, Devin, VSCodium, and other environments that install from
+     Open VSX — :download_artifact:`ironplc-vscode-extension.vsix`
+
+   Each registry uses a different extension ID, so the two VSIX files are not
+   interchangeable. Visual Studio Code updates an extension from the
+   Marketplace listing that matches its ID, so a VS Code installation of the
+   Open VSX VSIX never receives updates.

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -19,8 +19,8 @@ Installation
    Both listings are the same extension; only the name differs, because the
    two registries are separate namespaces. Visual Studio Code installs from
    the Marketplace, and editors such as Cursor, Kiro, Devin, and VSCodium
-   install from Open VSX. A VSIX for manual installation is attached to every
-   `IronPLC GitHub releases`_.
+   install from Open VSX. Each release on `IronPLC GitHub releases`_ attaches
+   one VSIX per registry for manual installation.
 
 IronPLC supports the following platforms:
 
@@ -84,12 +84,13 @@ Follow the steps below to install IronPLC.
    .. rubric:: Install IronPLC Extension from a VSIX
 
    If your development environment cannot reach either registry, install the
-   extension manually:
+   extension manually.
 
-   #. Download the latest IronPLC extension
-      :download_artifact:`ironplc-vscode-extension.vsix` from
-      `IronPLC GitHub releases`_.
-   #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
+   .. include:: /includes/download-extension-vsix.rst
+
+   Then, in the Extensions view:
+
+   #. Select the :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
    #. In the :guilabel:`Install from VSIX` dialog, select the VSIX file you downloaded earlier.
 
 .. tab:: macOS
@@ -133,12 +134,13 @@ Follow the steps below to install IronPLC.
    .. rubric:: Install IronPLC Extension from a VSIX
 
    If your development environment cannot reach either registry, install the
-   extension manually:
+   extension manually.
 
-   #. Download the latest IronPLC extension
-      :download_artifact:`ironplc-vscode-extension.vsix` from
-      `IronPLC GitHub releases`_.
-   #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
+   .. include:: /includes/download-extension-vsix.rst
+
+   Then, in the Extensions view:
+
+   #. Select the :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
    #. In the :guilabel:`Install from VSIX` dialog, select the VSIX file you downloaded earlier.
 
 .. tab:: Linux
@@ -177,12 +179,13 @@ Follow the steps below to install IronPLC.
    .. rubric:: Install IronPLC Extension from a VSIX
 
    If your development environment cannot reach either registry, install the
-   extension manually:
+   extension manually.
 
-   #. Download the latest IronPLC extension
-      :download_artifact:`ironplc-vscode-extension.vsix` from
-      `IronPLC GitHub releases`_.
-   #. In the Extensions view, select :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
+   .. include:: /includes/download-extension-vsix.rst
+
+   Then, in the Extensions view:
+
+   #. Select the :menuselection:`... (View and More Actions) --> Install from VSIX...` button.
    #. In the :guilabel:`Install from VSIX` dialog, select the VSIX file you downloaded earlier.
 
 --------------------------------------


### PR DESCRIPTION
Every release attaches two VSIX files: ironplc-vscode-extension.vsix
(Open VSX, extension ID ironplc.ironplc) and
ironplc-vscode-extension-marketplace.vsix (Marketplace, extension ID
ironplc.ironplc-vscode). The docs named only the Open VSX file, so a VS
Code user following the sideload fallback installed an extension whose
ID has no Marketplace listing and therefore never updates.

Name both files and say which one to download for which environment.
The six numbered download steps in installation.rst and update.rst now
share docs/includes/download-extension-vsix.rst; troubleshoot-editor.rst
names both files inline because its instruction is prose.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J5rh1j3xoFhdo3ezQoCBiE