### PR TITLE
Document TwinCAT discovery as it is: a manifest chain, not a search

### DIFF
--- a/docs/how-to-guides/twincat/check-twincat-projects.rst
+++ b/docs/how-to-guides/twincat/check-twincat-projects.rst
@@ -11,19 +11,27 @@ for correctness — without changing the project.
 Check a Solution from the Command Line
 -------------------------------------------
 
-Point IronPLC at your solution directory and select the ``twincat``
-dialect:
+Point IronPLC at the directory that holds your :file:`.sln` file — or at
+the :file:`.sln` itself — and select the ``twincat`` dialect:
 
 .. code-block:: shell
 
    ironplcc check --dialect twincat path/to/my-solution
+   ironplcc check --dialect twincat path/to/my-solution/MySolution.sln
 
-IronPLC walks the solution layout the same way TwinCAT XAE does: past the
-:file:`.sln` and :file:`.tsproj` files, into each :file:`.plcproj` PLC
-project, which it reads to discover the :file:`.TcPOU`, :file:`.TcGVL`,
+IronPLC follows the solution layout the same way TwinCAT XAE does. It
+reads the :file:`.sln` to find the :file:`.tsproj` files, each
+:file:`.tsproj` to find the :file:`.plcproj` PLC projects, and each
+:file:`.plcproj` to find the :file:`.TcPOU`, :file:`.TcGVL`,
 :file:`.TcDUT`, and :file:`.TcIO` files to analyze. A solution that
 contains more than one PLC project is checked as a whole, so code in one
 project can use types and functions declared in another.
+
+Name the directory that holds the :file:`.sln`, not a directory above it.
+IronPLC does not search subdirectories for a project file. A directory
+that holds no :file:`.sln` or :file:`.plcproj` is checked as a folder of
+loose files instead, which ignores what the project files say — see
+:doc:`/reference/compiler/source-formats/twincat` for the full rules.
 
 On success, the command produces no output. If there are problems, IronPLC
 prints diagnostics with the file name, line number, and a description of

--- a/docs/how-to-guides/twincat/run-twincat-projects.rst
+++ b/docs/how-to-guides/twincat/run-twincat-projects.rst
@@ -14,15 +14,16 @@ Compile the Solution
 -------------------------------------------
 
 Compile your solution into a bytecode container: point
-:program:`ironplcc` at the solution directory and select the ``twincat``
-dialect:
+:program:`ironplcc` at the directory that holds your :file:`.sln` file and
+select the ``twincat`` dialect:
 
 .. code-block:: shell
 
    ironplcc compile --dialect twincat path/to/my-solution --output main.iplc
 
-IronPLC discovers the sources through the :file:`.plcproj` project files,
-activates any referenced Beckhoff libraries (see
+IronPLC reads the :file:`.sln`, follows it through the :file:`.tsproj`
+files to each :file:`.plcproj` project, and takes the sources from there.
+It activates any referenced Beckhoff libraries (see
 :doc:`use-beckhoff-libraries`), and on success creates :file:`main.iplc` —
 the compiled bytecode that the IronPLC virtual machine executes.
 
@@ -54,7 +55,8 @@ Run in a CI/CD Pipeline
 -------------------------------------------
 
 Both tools return a non-zero exit code on failure, so the same commands
-work as a pipeline gate:
+work as a pipeline gate. Run them from the directory that holds your
+:file:`.sln` file:
 
 .. code-block:: shell
 

--- a/docs/how-to-guides/twincat/use-beckhoff-libraries.rst
+++ b/docs/how-to-guides/twincat/use-beckhoff-libraries.rst
@@ -72,26 +72,30 @@ Use Your Own Libraries
 -------------------------------------------
 
 If you factor shared code into your own PLC library project, keep the
-library's *source* project inside the solution (or workspace) you give
-IronPLC. IronPLC merges every :file:`.plcproj` it discovers into one
+library's *source* project inside the solution you give IronPLC, and make
+sure the solution lists it. IronPLC finds the PLC projects by reading the
+:file:`.sln` and :file:`.tsproj` files, not by searching the directory
+tree. It merges every :file:`.plcproj` the solution names into one
 compilation unit, so your application resolves the library's functions,
 function blocks, and types directly from their source:
 
 .. code-block:: text
 
    MySolution/
-   ├── MySolution.sln
-   ├── App/
-   │   ├── App.plcproj
-   │   └── POUs/MAIN.TcPOU          (calls F_Scale)
-   └── MyLib/
-       ├── MyLib.plcproj
-       └── POUs/F_Scale.TcPOU
+   ├── MySolution.sln                (names MySolution/MySolution.tsproj)
+   └── MySolution/
+       ├── MySolution.tsproj         (names App.plcproj, MyLib.plcproj)
+       ├── App/
+       │   ├── App.plcproj
+       │   └── POUs/MAIN.TcPOU       (calls F_Scale)
+       └── MyLib/
+           ├── MyLib.plcproj
+           └── POUs/F_Scale.TcPOU
 
 IronPLC does not read precompiled or managed library files
 (:file:`.library` / :file:`.compiled-library`), so a library that exists
 only in TwinCAT's library repository is not visible to IronPLC — the
-library's source must be present in the directory you check.
+library's source must be part of the solution you check.
 
 -------------------------------------------
 About the Compatibility Libraries

--- a/docs/reference/compiler/source-formats/twincat.rst
+++ b/docs/reference/compiler/source-formats/twincat.rst
@@ -34,31 +34,79 @@ Supported Elements
 Project Discovery
 -----------------
 
-When you point IronPLC at a directory, the compiler searches it
-recursively for :file:`.plcproj` files — the marker of a TwinCAT 3 PLC
-project. This means you can point IronPLC at any level of the Visual
-Studio solution layout that TwinCAT XAE creates:
+Point IronPLC at a TwinCAT project manifest — a :file:`.sln` or a
+:file:`.plcproj` — or at the directory that holds exactly one manifest:
+
+.. code-block:: shell
+
+   ironplcc check --dialect twincat MySolution/MySolution.sln
+   ironplcc check --dialect twincat MySolution
+
+IronPLC reads the directory you name and nothing below it. It does not
+search the tree for :file:`.plcproj` files. Instead it follows the chain
+of references that TwinCAT XAE follows: a :file:`.sln` names its
+:file:`.tsproj` files, each :file:`.tsproj` names its :file:`.plcproj`
+files, and each :file:`.plcproj` names the source files to analyze (its
+``<Compile>`` items).
 
 .. code-block:: text
 
    MySolution/
-   ├── MySolution.sln
+   ├── MySolution.sln              (names MySolution/MySolution.tsproj)
    └── MySolution/
-       ├── MySolution.tsproj
+       ├── MySolution.tsproj       (names PlcProject/PlcProject.plcproj)
        └── PlcProject/
-           ├── PlcProject.plcproj
+           ├── PlcProject.plcproj  (names POUs/MAIN.TcPOU, POUs/F_Helper.TcPOU)
            └── POUs/
                ├── MAIN.TcPOU
                └── F_Helper.TcPOU
 
-The :file:`.sln` and :file:`.tsproj` files are not themselves parsed;
-discovery walks past them to each :file:`.plcproj`, which it reads to
-determine the source files to analyze (the ``<Compile>`` items).
+For this layout, name :file:`MySolution/` or
+:file:`MySolution/MySolution.sln` to check the whole solution, or
+:file:`PlcProject/` or :file:`PlcProject/PlcProject.plcproj` to check that
+one PLC project.
 
-When discovery finds more than one :file:`.plcproj`, all discovered
-projects are merged into a single compilation unit, so code in one
-project can use declarations from another. A project entry that cannot
-be resolved does not abort discovery of the remaining sources.
+Every file in the chain is parsed, so every file in the chain must be
+correct. A manifest that cannot be read, that is not well-formed, or that
+names a file that does not exist reports
+:doc:`P6012 </reference/compiler/problems/P6012>`. IronPLC reports the
+broken manifest rather than looking for the sources another way: the
+manifest is the record of which files belong to the project.
+
+A :file:`.tsproj` is part of the chain but is not an entry point. Name the
+:file:`.sln` above it or a :file:`.plcproj` below it.
+
+Solutions with Several PLC Projects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the chain names more than one :file:`.plcproj` — an application
+project plus the library projects it uses — IronPLC merges them into a
+single compilation unit, so code in one project can use declarations from
+another. A ``<Compile>`` entry naming a file that does not exist is
+reported as a problem, and IronPLC still analyzes the entries that do
+resolve.
+
+Directories That Name No Project
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A directory holding *no* manifest — the solution's parent directory, or a
+folder of loose TwinCAT files — is not a TwinCAT project. Neither is a
+directory holding *more than one* manifest, because it names no single
+project. In both cases IronPLC enumerates every supported file in the
+directory and its subdirectories and analyzes them together.
+
+That fallback differs from opening the project in two ways that matter:
+
+- IronPLC does not read the ``<Compile>`` items, so it analyzes every
+  supported file it finds — including files the project does not list,
+  such as a POU excluded from the project or one left behind by a rename.
+- IronPLC does not read the :file:`.plcproj` library references, so the
+  referenced Beckhoff libraries are not activated. Use the ``--library``
+  option to activate them explicitly (see
+  :doc:`/how-to-guides/twincat/use-beckhoff-libraries`).
+
+To analyze the project as TwinCAT defines it, name the manifest, or the
+directory that holds it, rather than a directory further up the tree.
 
 ------------------
 Library References


### PR DESCRIPTION
The TwinCAT source-format page said discovery searches a directory
recursively for .plcproj files and walks "past" the .sln and .tsproj
without parsing them. The compiler does the opposite: it reads the
directory it is given and nothing below it, and follows the
.sln -> .tsproj -> .plcproj chain by reference, parsing every manifest
on the way. A broken .sln therefore reports P6012 rather than being
stepped over, and a directory holding two manifests names no project at
all.

Rewrite the Project Discovery section from the behaviour the discovery
tests pin down: what to point IronPLC at, that the chain is parsed and
must resolve, that several .plcproj files named by one chain merge into
a single compilation unit, and what the fallback for a directory naming
no project does differently (it ignores <Compile> items and library
references). That last distinction is what the old "point at any level"
advice hid.

Correct the same claims in the how-to guides: "past the .sln and
.tsproj" in the check guide, "every .plcproj it discovers" plus a
solution tree with no .tsproj in the Beckhoff libraries guide, and the
discovery sentence in the run guide.

Fixes #1569