### PR TITLE
Prefactor: declare the function form of an operator once, for the analyzer and codegen

### DIFF
--- a/compiler/analyzer/src/intermediates/mod.rs
+++ b/compiler/analyzer/src/intermediates/mod.rs
@@ -1,6 +1,7 @@
 pub mod array;
 pub mod enumeration;
 pub mod inherited_fields;
+pub mod operator_function_form;
 pub mod stdlib_function;
 pub mod stdlib_function_block;
 pub mod string;

--- a/compiler/analyzer/src/intermediates/operator_function_form.rs
+++ b/compiler/analyzer/src/intermediates/operator_function_form.rs
@@ -1,0 +1,272 @@
+//! The function forms of operators: `ADD(a, b)` for `a + b`, `GT(a, b)` for
+//! `a > b`, `AND(a, b)` for `a AND b`, `NOT(a)` for `NOT a`, and so on.
+//!
+//! IEC 61131-3 defines these as standard functions (Sections 2.5.1.5.1 to
+//! 2.5.1.5.3), so they are registered in the function environment like any
+//! other standard function. What sets them apart is that each one *is* an
+//! operator: it accepts what the operator accepts and compiles to what the
+//! operator compiles to. [`OPERATOR_FUNCTION_FORMS`] states each of them
+//! once, as a row, and both the analyzer (through [`signatures`]) and
+//! codegen (through [`operator_function_form`]) read the row.
+
+use ironplc_dsl::common::TypeName;
+use ironplc_dsl::textual::{CompareOp, Operator};
+
+use super::stdlib_function::input_param;
+use crate::function_environment::FunctionSignature;
+
+/// The operator a standard function is the function form of.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FormOf {
+    /// A binary arithmetic operator: `+`, `-`, `*`, `/`, `MOD`.
+    Arithmetic(Operator),
+    /// A binary comparison, logical or bitwise operator: `>`, `=`, `AND`, ...
+    Compare(CompareOp),
+    /// The unary `NOT` operator.
+    Not,
+}
+
+/// How the result type of a function form follows from its operands.
+#[derive(Debug, Clone, PartialEq)]
+enum FormResult {
+    /// The result has the operand type (`ADD`, `AND`).
+    Operand,
+    /// The result is `BOOL` whatever the operand type (`GT`, `EQ`).
+    Bool,
+}
+
+/// One function form of an operator: the row that both the analyzer's
+/// signature and codegen's dispatch are derived from.
+///
+/// The row states the operand category once. The parameter list and the
+/// return type are derived from it by [`OperatorFunctionForm::signature`],
+/// so the return type of a function form cannot disagree with its operands.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorFunctionForm {
+    /// The function name as written in source; lookup is case-insensitive.
+    pub name: &'static str,
+    /// The operator this function is a form of.
+    pub operator: FormOf,
+    /// The type category of every operand.
+    operands: &'static str,
+    /// How the result type follows from the operands.
+    result: FormResult,
+}
+
+/// Builds one row of [`OPERATOR_FUNCTION_FORMS`].
+const fn form(
+    name: &'static str,
+    operator: FormOf,
+    operands: &'static str,
+    result: FormResult,
+) -> OperatorFunctionForm {
+    OperatorFunctionForm {
+        name,
+        operator,
+        operands,
+        result,
+    }
+}
+
+/// The function form of every operator that has one.
+///
+/// A row is the single definition of that function: the analyzer registers
+/// the signature [`OperatorFunctionForm::signature`] derives from it, and
+/// codegen compiles a call to it as the operator in its `operator` column.
+/// The `operands` column is the one fact the row states by hand, so a
+/// change to what an operator accepts is a change to that cell.
+const OPERATOR_FUNCTION_FORMS: &[OperatorFunctionForm] = &[
+    // Arithmetic (IEC 61131-3 Section 2.5.1.5.2): the result has the operand type.
+    form(
+        "ADD",
+        FormOf::Arithmetic(Operator::Add),
+        "ANY_NUM",
+        FormResult::Operand,
+    ),
+    form(
+        "SUB",
+        FormOf::Arithmetic(Operator::Sub),
+        "ANY_NUM",
+        FormResult::Operand,
+    ),
+    form(
+        "MUL",
+        FormOf::Arithmetic(Operator::Mul),
+        "ANY_NUM",
+        FormResult::Operand,
+    ),
+    form(
+        "DIV",
+        FormOf::Arithmetic(Operator::Div),
+        "ANY_NUM",
+        FormResult::Operand,
+    ),
+    form(
+        "MOD",
+        FormOf::Arithmetic(Operator::Mod),
+        "ANY_NUM",
+        FormResult::Operand,
+    ),
+    // Comparison (IEC 61131-3 Section 2.5.1.5.3, Table 33): defined for
+    // ANY_ELEMENTARY, which includes ANY_NUM, ANY_BIT and the string and
+    // time types; the result is BOOL.
+    form(
+        "GT",
+        FormOf::Compare(CompareOp::Gt),
+        "ANY_ELEMENTARY",
+        FormResult::Bool,
+    ),
+    form(
+        "GE",
+        FormOf::Compare(CompareOp::GtEq),
+        "ANY_ELEMENTARY",
+        FormResult::Bool,
+    ),
+    form(
+        "EQ",
+        FormOf::Compare(CompareOp::Eq),
+        "ANY_ELEMENTARY",
+        FormResult::Bool,
+    ),
+    form(
+        "LE",
+        FormOf::Compare(CompareOp::LtEq),
+        "ANY_ELEMENTARY",
+        FormResult::Bool,
+    ),
+    form(
+        "LT",
+        FormOf::Compare(CompareOp::Lt),
+        "ANY_ELEMENTARY",
+        FormResult::Bool,
+    ),
+    form(
+        "NE",
+        FormOf::Compare(CompareOp::Ne),
+        "ANY_ELEMENTARY",
+        FormResult::Bool,
+    ),
+    // Boolean (IEC 61131-3 Section 2.5.1.5.1): the result has the operand type.
+    form(
+        "AND",
+        FormOf::Compare(CompareOp::And),
+        "BOOL",
+        FormResult::Operand,
+    ),
+    form(
+        "OR",
+        FormOf::Compare(CompareOp::Or),
+        "BOOL",
+        FormResult::Operand,
+    ),
+    form(
+        "XOR",
+        FormOf::Compare(CompareOp::Xor),
+        "BOOL",
+        FormResult::Operand,
+    ),
+    form("NOT", FormOf::Not, "BOOL", FormResult::Operand),
+];
+
+impl OperatorFunctionForm {
+    /// Derives the function's signature from the row.
+    ///
+    /// A unary form takes `IN`; a binary form takes `IN1` and `IN2`. Every
+    /// parameter has the row's operand category, and so does the return type
+    /// unless the row says the result is `BOOL`.
+    pub(crate) fn signature(&self) -> FunctionSignature {
+        let operand = |name: &str| input_param(name, self.operands);
+        let parameters = match self.operator {
+            FormOf::Not => vec![operand("IN")],
+            FormOf::Arithmetic(_) | FormOf::Compare(_) => vec![operand("IN1"), operand("IN2")],
+        };
+        let return_type = match self.result {
+            FormResult::Operand => TypeName::from(self.operands),
+            FormResult::Bool => TypeName::from("BOOL"),
+        };
+        FunctionSignature::stdlib(self.name, return_type, parameters)
+    }
+}
+
+/// Returns the row for the function form named `name`, or `None` when `name`
+/// is not the function form of an operator.
+///
+/// Function names are case-insensitive, and so is this lookup.
+pub fn operator_function_form(name: &str) -> Option<&'static OperatorFunctionForm> {
+    OPERATOR_FUNCTION_FORMS
+        .iter()
+        .find(|form| form.name.eq_ignore_ascii_case(name))
+}
+
+/// Returns the signatures of the function forms of operators, in table order.
+pub(super) fn signatures() -> Vec<FunctionSignature> {
+    OPERATOR_FUNCTION_FORMS
+        .iter()
+        .map(OperatorFunctionForm::signature)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironplc_dsl::core::Id;
+    use rstest::rstest;
+
+    /// Every row of the operator-form table, pinned. A change to what an
+    /// operator accepts shows up as a change to the row's cell and to its
+    /// case here, and nowhere else.
+    #[rstest]
+    #[case::add("ADD", &["IN1", "IN2"], "ANY_NUM", "ANY_NUM")]
+    #[case::sub("SUB", &["IN1", "IN2"], "ANY_NUM", "ANY_NUM")]
+    #[case::mul("MUL", &["IN1", "IN2"], "ANY_NUM", "ANY_NUM")]
+    #[case::div("DIV", &["IN1", "IN2"], "ANY_NUM", "ANY_NUM")]
+    #[case::modulo("MOD", &["IN1", "IN2"], "ANY_NUM", "ANY_NUM")]
+    #[case::gt("GT", &["IN1", "IN2"], "ANY_ELEMENTARY", "BOOL")]
+    #[case::ge("GE", &["IN1", "IN2"], "ANY_ELEMENTARY", "BOOL")]
+    #[case::eq("EQ", &["IN1", "IN2"], "ANY_ELEMENTARY", "BOOL")]
+    #[case::le("LE", &["IN1", "IN2"], "ANY_ELEMENTARY", "BOOL")]
+    #[case::lt("LT", &["IN1", "IN2"], "ANY_ELEMENTARY", "BOOL")]
+    #[case::ne("NE", &["IN1", "IN2"], "ANY_ELEMENTARY", "BOOL")]
+    #[case::and("AND", &["IN1", "IN2"], "BOOL", "BOOL")]
+    #[case::or("OR", &["IN1", "IN2"], "BOOL", "BOOL")]
+    #[case::xor("XOR", &["IN1", "IN2"], "BOOL", "BOOL")]
+    #[case::not("NOT", &["IN"], "BOOL", "BOOL")]
+    fn operator_function_form_when_row_then_signature_is_derived_from_it(
+        #[case] name: &str,
+        #[case] param_names: &[&str],
+        #[case] operands: &str,
+        #[case] return_type: &str,
+    ) {
+        let signature = operator_function_form(name).unwrap().signature();
+        assert_eq!(signature.name, Id::from(name));
+        assert_eq!(
+            signature.return_type.unwrap().to_type_name(),
+            TypeName::from(return_type)
+        );
+        let params: Vec<(Id, TypeName)> = signature
+            .parameters
+            .iter()
+            .map(|p| (p.name.clone(), p.param_type.clone()))
+            .collect();
+        let expected: Vec<(Id, TypeName)> = param_names
+            .iter()
+            .map(|n| (Id::from(n), TypeName::from(operands)))
+            .collect();
+        assert_eq!(params, expected);
+        assert!(signature.parameters.iter().all(|p| p.is_input));
+    }
+
+    #[test]
+    fn operator_function_form_when_lower_case_then_found() {
+        let form = operator_function_form("and").unwrap();
+        assert_eq!(form.name, "AND");
+        assert_eq!(form.operator, FormOf::Compare(CompareOp::And));
+    }
+
+    #[test]
+    fn operator_function_form_when_not_a_form_of_an_operator_then_none() {
+        assert!(operator_function_form("ABS").is_none());
+        assert!(operator_function_form("SHL").is_none());
+        assert!(operator_function_form("MOVE").is_none());
+    }
+}

--- a/compiler/analyzer/src/intermediates/stdlib_function.rs
+++ b/compiler/analyzer/src/intermediates/stdlib_function.rs
@@ -13,9 +13,10 @@ use ironplc_dsl::core::Id;
 
 use crate::function_environment::FunctionSignature;
 use crate::intermediate_type::IntermediateFunctionParameter;
+use crate::intermediates::operator_function_form;
 
 /// Helper to create an input parameter.
-fn input_param(name: &str, param_type_name: &str) -> IntermediateFunctionParameter {
+pub(super) fn input_param(name: &str, param_type_name: &str) -> IntermediateFunctionParameter {
     IntermediateFunctionParameter {
         name: Id::from(name),
         param_type: TypeName::from(param_type_name),
@@ -489,144 +490,6 @@ fn get_numeric_functions() -> Vec<FunctionSignature> {
 }
 
 // =============================================================================
-// Arithmetic Function Definitions (IEC 61131-3 Section 2.5.1.5.2)
-// =============================================================================
-
-/// Returns standard arithmetic function definitions.
-///
-/// These are the functional equivalents of the arithmetic operators:
-/// ADD (+), SUB (-), MUL (*), DIV (/), MOD (MOD).
-/// Each takes two inputs and returns a result of the same type.
-fn get_arithmetic_functions() -> Vec<FunctionSignature> {
-    vec![
-        FunctionSignature::stdlib(
-            "ADD",
-            TypeName::from("ANY_NUM"),
-            vec![input_param("IN1", "ANY_NUM"), input_param("IN2", "ANY_NUM")],
-        ),
-        FunctionSignature::stdlib(
-            "SUB",
-            TypeName::from("ANY_NUM"),
-            vec![input_param("IN1", "ANY_NUM"), input_param("IN2", "ANY_NUM")],
-        ),
-        FunctionSignature::stdlib(
-            "MUL",
-            TypeName::from("ANY_NUM"),
-            vec![input_param("IN1", "ANY_NUM"), input_param("IN2", "ANY_NUM")],
-        ),
-        FunctionSignature::stdlib(
-            "DIV",
-            TypeName::from("ANY_NUM"),
-            vec![input_param("IN1", "ANY_NUM"), input_param("IN2", "ANY_NUM")],
-        ),
-        FunctionSignature::stdlib(
-            "MOD",
-            TypeName::from("ANY_NUM"),
-            vec![input_param("IN1", "ANY_NUM"), input_param("IN2", "ANY_NUM")],
-        ),
-    ]
-}
-
-// =============================================================================
-// Comparison Function Definitions (IEC 61131-3 Section 2.5.1.5.3)
-// =============================================================================
-
-/// Returns standard comparison function definitions.
-///
-/// These are the functional equivalents of the comparison operators:
-/// GT (>), GE (>=), EQ (=), LE (<=), LT (<), NE (<>).
-/// Each takes two inputs and returns BOOL.
-///
-/// IEC 61131-3 Table 33 defines these for ANY_ELEMENTARY, which includes
-/// numeric types (ANY_NUM), bit-string types (ANY_BIT), and others.
-fn get_comparison_functions() -> Vec<FunctionSignature> {
-    vec![
-        FunctionSignature::stdlib(
-            "GT",
-            TypeName::from("BOOL"),
-            vec![
-                input_param("IN1", "ANY_ELEMENTARY"),
-                input_param("IN2", "ANY_ELEMENTARY"),
-            ],
-        ),
-        FunctionSignature::stdlib(
-            "GE",
-            TypeName::from("BOOL"),
-            vec![
-                input_param("IN1", "ANY_ELEMENTARY"),
-                input_param("IN2", "ANY_ELEMENTARY"),
-            ],
-        ),
-        FunctionSignature::stdlib(
-            "EQ",
-            TypeName::from("BOOL"),
-            vec![
-                input_param("IN1", "ANY_ELEMENTARY"),
-                input_param("IN2", "ANY_ELEMENTARY"),
-            ],
-        ),
-        FunctionSignature::stdlib(
-            "LE",
-            TypeName::from("BOOL"),
-            vec![
-                input_param("IN1", "ANY_ELEMENTARY"),
-                input_param("IN2", "ANY_ELEMENTARY"),
-            ],
-        ),
-        FunctionSignature::stdlib(
-            "LT",
-            TypeName::from("BOOL"),
-            vec![
-                input_param("IN1", "ANY_ELEMENTARY"),
-                input_param("IN2", "ANY_ELEMENTARY"),
-            ],
-        ),
-        FunctionSignature::stdlib(
-            "NE",
-            TypeName::from("BOOL"),
-            vec![
-                input_param("IN1", "ANY_ELEMENTARY"),
-                input_param("IN2", "ANY_ELEMENTARY"),
-            ],
-        ),
-    ]
-}
-
-// =============================================================================
-// Boolean Function Definitions (IEC 61131-3 Section 2.5.1.5.1)
-// =============================================================================
-
-/// Returns standard boolean function definitions.
-///
-/// These are the functional equivalents of the boolean operators:
-/// AND, OR, XOR (two inputs), NOT (one input).
-/// All take BOOL inputs and return BOOL.
-fn get_boolean_functions() -> Vec<FunctionSignature> {
-    vec![
-        FunctionSignature::stdlib(
-            "AND",
-            TypeName::from("BOOL"),
-            vec![input_param("IN1", "BOOL"), input_param("IN2", "BOOL")],
-        ),
-        FunctionSignature::stdlib(
-            "OR",
-            TypeName::from("BOOL"),
-            vec![input_param("IN1", "BOOL"), input_param("IN2", "BOOL")],
-        ),
-        FunctionSignature::stdlib(
-            "XOR",
-            TypeName::from("BOOL"),
-            vec![input_param("IN1", "BOOL"), input_param("IN2", "BOOL")],
-        ),
-        FunctionSignature::stdlib(
-            "NOT",
-            TypeName::from("BOOL"),
-            vec![input_param("IN", "BOOL")],
-        ),
-    ]
-}
-
-// =============================================================================
 // Selection Function Definitions (IEC 61131-3 Section 2.5.1.5.4)
 // =============================================================================
 
@@ -994,14 +857,8 @@ pub fn get_all_stdlib_functions() -> Vec<FunctionSignature> {
     // Numeric functions
     functions.extend(get_numeric_functions());
 
-    // Arithmetic functions (functional forms of +, -, *, /, MOD)
-    functions.extend(get_arithmetic_functions());
-
-    // Comparison functions (functional forms of >, >=, =, <=, <, <>)
-    functions.extend(get_comparison_functions());
-
-    // Boolean functions (functional forms of AND, OR, XOR, NOT)
-    functions.extend(get_boolean_functions());
+    // Function forms of operators (+, -, *, /, MOD, comparisons, AND, OR, XOR, NOT)
+    functions.extend(operator_function_form::signatures());
 
     // Truncation function
     functions.extend(get_trunc_function());
@@ -1544,5 +1401,16 @@ mod tests {
         let functions = get_all_stdlib_functions();
         assert!(functions.iter().any(|f| f.name.original() == "__TRUNC"));
         assert!(functions.iter().any(|f| f.name.original() == "__MOD"));
+    }
+
+    #[test]
+    fn get_all_stdlib_functions_when_called_then_registers_every_operator_form() {
+        let names: Vec<Id> = get_all_stdlib_functions()
+            .into_iter()
+            .map(|f| f.name)
+            .collect();
+        for name in ["ADD", "GT", "AND", "NOT"] {
+            assert!(names.contains(&Id::from(name)), "{name} missing");
+        }
     }
 }

--- a/compiler/analyzer/src/lib.rs
+++ b/compiler/analyzer/src/lib.rs
@@ -93,6 +93,9 @@ pub use function_environment::{
 };
 pub use intermediate_type::IntermediateType;
 pub use intermediates::enumeration::resolve_ordinal_values;
+pub use intermediates::operator_function_form::{
+    operator_function_form, FormOf, OperatorFunctionForm,
+};
 pub use semantic_context::{SemanticContext, SemanticContextBuilder};
 pub use type_attributes::TypeAttributes;
 pub use type_category::TypeCategory;

--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use ironplc_analyzer::{operator_function_form, FormOf};
 use ironplc_container::opcode;
 use ironplc_dsl::core::{Id, Located};
 use ironplc_dsl::diagnostic::Diagnostic;
@@ -17,9 +18,8 @@ use super::compile::{
     CompileContext, OpType, OpWidth, Signedness, UserFunctionInfo, VarTypeInfo, DEFAULT_OP_TYPE,
 };
 use super::compile_expr::{
-    compile_expr, emit_add, emit_and, emit_div, emit_eq, emit_ge, emit_gt, emit_le, emit_lt,
-    emit_mod, emit_mul, emit_ne, emit_or, emit_sub, emit_truncation, emit_xor, op_type,
-    op_type_from_expr, storage_bits,
+    compile_expr, emit_add, emit_arithmetic_op, emit_compare_op, emit_div, emit_mod, emit_mul,
+    emit_not, emit_sub, emit_truncation, op_type, op_type_from_expr, storage_bits,
 };
 use super::compile_string::{
     compile_concat, compile_delete, compile_find, compile_insert, compile_left, compile_len,
@@ -173,29 +173,16 @@ pub(crate) fn compile_function_call(
     op_type: OpType,
 ) -> Result<(), Diagnostic> {
     let name = func.name.lower_case();
+    // A function form of an operator (ADD, GT, AND, NOT, ...) compiles as
+    // the operator it is a form of; the analyzer's table says which.
+    if let Some(form) = operator_function_form(name.as_str()) {
+        return compile_operator_form(emitter, ctx, func, op_type, &form.operator);
+    }
     match name.as_str() {
         "shl" | "shr" | "rol" | "ror" => {
             compile_shift_rotate(emitter, ctx, func, op_type, name.as_str())
         }
         "mux" => compile_mux(emitter, ctx, func, op_type),
-        // Arithmetic function forms (equivalent to +, -, *, /, MOD operators)
-        "add" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_add),
-        "sub" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_sub),
-        "mul" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_mul),
-        "div" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_div),
-        "mod" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_mod),
-        // Comparison function forms (equivalent to >, >=, =, <=, <, <> operators)
-        "gt" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_gt),
-        "ge" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_ge),
-        "eq" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_eq),
-        "le" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_le),
-        "lt" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_lt),
-        "ne" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_ne),
-        // Boolean function forms (equivalent to AND, OR, XOR, NOT operators)
-        "and" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_and),
-        "or" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_or),
-        "xor" => compile_two_arg_operator(emitter, ctx, func, op_type, emit_xor),
-        "not" => compile_not_function(emitter, ctx, func, op_type),
         // Assignment function (equivalent to := operator)
         "move" => compile_move(emitter, ctx, func, op_type),
         // Truncation function
@@ -412,7 +399,7 @@ fn compile_two_arg_operator(
     ctx: &mut CompileContext,
     func: &Function,
     op_type: OpType,
-    emit_fn: fn(&mut Emitter, OpType),
+    emit_fn: impl FnOnce(&mut Emitter, OpType),
 ) -> Result<(), Diagnostic> {
     let args: Vec<&Expr> = func
         .param_assignment
@@ -431,6 +418,47 @@ fn compile_two_arg_operator(
     compile_expr(emitter, ctx, args[1], op_type)?;
     emit_fn(emitter, op_type);
     Ok(())
+}
+
+/// Compiles the function form of an operator as the operator itself.
+///
+/// The arguments compile at the enclosing expression's operation type, as
+/// every function argument does, and the opcode comes from the emitter the
+/// operator expression uses, so `AND(a, b)` and `a AND b` cannot diverge.
+fn compile_operator_form(
+    emitter: &mut Emitter,
+    ctx: &mut CompileContext,
+    func: &Function,
+    op_type: OpType,
+    operator: &FormOf,
+) -> Result<(), Diagnostic> {
+    match operator {
+        FormOf::Arithmetic(op) => {
+            compile_two_arg_operator(emitter, ctx, func, op_type, |emitter, op_type| {
+                emit_arithmetic_op(emitter, op, op_type)
+            })
+        }
+        FormOf::Compare(op) => {
+            compile_two_arg_operator(emitter, ctx, func, op_type, |emitter, op_type| {
+                emit_compare_op(emitter, op, op_type)
+            })
+        }
+        FormOf::Not => {
+            let args: Vec<&Expr> = func
+                .param_assignment
+                .iter()
+                .filter_map(|p| match p {
+                    ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
+                    _ => None,
+                })
+                .collect();
+            let [term] = args.as_slice() else {
+                return Err(Diagnostic::todo_with_span(func.name.span()));
+            };
+            compile_expr(emitter, ctx, term, op_type)?;
+            emit_not(emitter, op_type, term)
+        }
+    }
 }
 
 /// Extracts two positional input arguments from a function call.
@@ -636,33 +664,6 @@ fn compile_mul_div_time(
         }
     }
 
-    Ok(())
-}
-
-/// Compiles the NOT function form.
-///
-/// NOT(IN) is equivalent to the NOT operator. Takes a single BOOL argument.
-fn compile_not_function(
-    emitter: &mut Emitter,
-    ctx: &mut CompileContext,
-    func: &Function,
-    op_type: OpType,
-) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
-
-    if args.len() != 1 {
-        return Err(Diagnostic::todo_with_span(func.name.span()));
-    }
-
-    compile_expr(emitter, ctx, args[0], op_type)?;
-    emitter.emit_bool_not();
     Ok(())
 }
 

--- a/compiler/codegen/src/compile_expr.rs
+++ b/compiler/codegen/src/compile_expr.rs
@@ -146,14 +146,7 @@ pub(crate) fn compile_expr(
         ExprKind::BinaryOp(binary) => {
             compile_expr(emitter, ctx, &binary.left, op_type)?;
             compile_expr(emitter, ctx, &binary.right, op_type)?;
-            match binary.op {
-                Operator::Add => emit_add(emitter, op_type),
-                Operator::Sub => emit_sub(emitter, op_type),
-                Operator::Mul => emit_mul(emitter, op_type),
-                Operator::Div => emit_div(emitter, op_type),
-                Operator::Mod => emit_mod(emitter, op_type),
-                Operator::Pow => emit_pow(emitter, op_type),
-            }
+            emit_arithmetic_op(emitter, &binary.op, op_type);
             Ok(())
         }
         ExprKind::UnaryOp(unary) => match unary.op {
@@ -164,19 +157,7 @@ pub(crate) fn compile_expr(
             }
             UnaryOp::Not => {
                 compile_expr(emitter, ctx, &unary.term, op_type)?;
-                match op_type {
-                    (OpWidth::W32, Signedness::Unsigned) => {
-                        emitter.emit_bit_not_32();
-                        match storage_bits(&unary.term)? {
-                            8 => emitter.emit_trunc_u8(),
-                            16 => emitter.emit_trunc_u16(),
-                            _ => {}
-                        }
-                    }
-                    (OpWidth::W64, Signedness::Unsigned) => emitter.emit_bit_not_64(),
-                    _ => emitter.emit_bool_not(),
-                }
-                Ok(())
+                emit_not(emitter, op_type, &unary.term)
             }
         },
         ExprKind::LateBound(late_bound) => {
@@ -255,22 +236,7 @@ fn compile_compare(
         .unwrap_or(op_type);
     compile_expr(emitter, ctx, &compare.left, operand_op_type)?;
     compile_expr(emitter, ctx, &compare.right, operand_op_type)?;
-    match compare.op {
-        CompareOp::Eq => emit_eq(emitter, operand_op_type),
-        CompareOp::Ne => emit_ne(emitter, operand_op_type),
-        CompareOp::Lt => emit_lt(emitter, operand_op_type),
-        CompareOp::Gt => emit_gt(emitter, operand_op_type),
-        CompareOp::LtEq => emit_le(emitter, operand_op_type),
-        CompareOp::GtEq => emit_ge(emitter, operand_op_type),
-        CompareOp::And => emit_and(emitter, operand_op_type),
-        CompareOp::Or => emit_or(emitter, operand_op_type),
-        CompareOp::Xor => emit_xor(emitter, operand_op_type),
-        // Only reached for non-BOOL operands, where there is no boolean to
-        // short-circuit on and the operator degenerates to its eager
-        // counterpart. See `ShortCircuitOp::for_expr`.
-        CompareOp::AndThen => emit_and(emitter, operand_op_type),
-        CompareOp::OrElse => emit_or(emitter, operand_op_type),
-    }
+    emit_compare_op(emitter, &compare.op, operand_op_type);
     Ok(())
 }
 
@@ -1888,6 +1854,74 @@ emit_signed_op!(ge);
 emit_logical_op!(and);
 emit_logical_op!(or);
 emit_logical_op!(xor);
+
+/// Emits the opcode of a binary arithmetic operator for operands of `op_type`.
+///
+/// The operator expression and the function form of the operator (`ADD`,
+/// `SUB`, ...) both come through here, so the two spellings cannot emit
+/// differently.
+pub(crate) fn emit_arithmetic_op(emitter: &mut Emitter, op: &Operator, op_type: OpType) {
+    match op {
+        Operator::Add => emit_add(emitter, op_type),
+        Operator::Sub => emit_sub(emitter, op_type),
+        Operator::Mul => emit_mul(emitter, op_type),
+        Operator::Div => emit_div(emitter, op_type),
+        Operator::Mod => emit_mod(emitter, op_type),
+        Operator::Pow => emit_pow(emitter, op_type),
+    }
+}
+
+/// Emits the opcode of a comparison, logical or bitwise operator for
+/// operands of `op_type`.
+///
+/// The operator expression and the function form of the operator (`GT`,
+/// `AND`, ...) both come through here, so the two spellings cannot emit
+/// differently.
+pub(crate) fn emit_compare_op(emitter: &mut Emitter, op: &CompareOp, op_type: OpType) {
+    match op {
+        CompareOp::Eq => emit_eq(emitter, op_type),
+        CompareOp::Ne => emit_ne(emitter, op_type),
+        CompareOp::Lt => emit_lt(emitter, op_type),
+        CompareOp::Gt => emit_gt(emitter, op_type),
+        CompareOp::LtEq => emit_le(emitter, op_type),
+        CompareOp::GtEq => emit_ge(emitter, op_type),
+        CompareOp::And => emit_and(emitter, op_type),
+        CompareOp::Or => emit_or(emitter, op_type),
+        CompareOp::Xor => emit_xor(emitter, op_type),
+        // Only reached for non-BOOL operands, where there is no boolean to
+        // short-circuit on and the operator degenerates to its eager
+        // counterpart. See `ShortCircuitOp::for_expr`.
+        CompareOp::AndThen => emit_and(emitter, op_type),
+        CompareOp::OrElse => emit_or(emitter, op_type),
+    }
+}
+
+/// Emits the complement of the value of `term`, already on the stack.
+///
+/// The unsigned operation types are the bit strings, so they take the
+/// bitwise complement, truncated back to `term`'s storage width where the
+/// 32-bit complement would widen a BYTE or WORD. Every other type takes the
+/// boolean complement. The `NOT` operator and the `NOT` function form both
+/// come through here, so the two spellings cannot emit differently.
+pub(crate) fn emit_not(
+    emitter: &mut Emitter,
+    op_type: OpType,
+    term: &Expr,
+) -> Result<(), Diagnostic> {
+    match op_type {
+        (OpWidth::W32, Signedness::Unsigned) => {
+            emitter.emit_bit_not_32();
+            match storage_bits(term)? {
+                8 => emitter.emit_trunc_u8(),
+                16 => emitter.emit_trunc_u16(),
+                _ => {}
+            }
+        }
+        (OpWidth::W64, Signedness::Unsigned) => emitter.emit_bit_not_64(),
+        _ => emitter.emit_bool_not(),
+    }
+    Ok(())
+}
 
 // Hand-written one-offs that do not fit the generated shapes above:
 


### PR DESCRIPTION
Prefactor for #1567 (`AND(w1, w2)` on `WORD` rejected with P4026 while `w1 AND w2` checks clean). No behaviour change; the existing suites pass untouched. The fix follows in a stacked PR on `claude/bit-arguments-rejection-bx7olg`, whose first commit is the plan.

## Why a prefactor

The fix is four tokens (`BOOL` → `ANY_BIT`), but the shape around them is what let the defect in and would let the next one in the same way:

- Three hand-written copies said what the function form of an operator is: the parser's keyword list, the analyzer's fifteen expanded signatures (each family's category stated in a comment and restated twelve times as strings), and codegen's sixteen name→emitter arms. Nothing tied them together.
- The return type was typed separately from the operands, although the expression type resolver infers a generic return from the parameter that declares the same type, so the two must agree and nothing made them.
- The `NOT` function form had its own codegen that always emitted `BOOL_NOT`, while the `NOT` operator picks the bitwise complement for bit strings. `NOT(IN := w)` reaches the function path (positional `NOT(x)` parses as the operator), so widening the analyzer alone would have turned a false positive into a miscompile. That is the first prefactoring signal in the development standards: the change needs a new arm in more than one place.

## What changes

**Analyzer** (`intermediates/operator_function_form.rs`, new): each function form is one table row — name, the DSL operator it is a form of, operand category, and whether the result is the operand type or `BOOL`. The signature is derived from the row, so a family's category is one cell and its return type cannot disagree with its operands. `operator_function_form(name)` is exported for codegen. A table-driven test pins every row's current signature, so the fix's diff will show exactly the cells it changes. `stdlib_function.rs` shrinks by ~130 lines.

**Codegen** (`compile_call.rs`, `compile_expr.rs`): a call asks the analyzer's table which operator it is a form of and emits through the same dispatch as the operator expression — `emit_arithmetic_op` and `emit_compare_op` extracted from `compile_expr`, and a shared `emit_not`. The sixteen name arms and the `BOOL`-only `compile_not_function` go away. `BOOL` compiles as `W32`/`Signed`, so `emit_not` reaches the same `BOOL_NOT` for today's programs; function forms keep compiling their operands at the enclosing operation type, as before.

## Verification

`cd compiler && just` passes (compile, coverage, lint, dupes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GErPKvxsfPnYcBkz4cHq3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01GErPKvxsfPnYcBkz4cHq3v)_