### PR TITLE
Collect positional arguments once in compile_call

### DIFF
--- a/compiler/codegen/src/compile_call.rs
+++ b/compiler/codegen/src/compile_call.rs
@@ -257,14 +257,7 @@ fn compile_user_function_call(
     func: &Function,
     func_info: &UserFunctionInfo,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     // Compile each argument with the corresponding parameter's OpType.
     // STRING parameters are copied into the function's data region before CALL;
@@ -360,14 +353,7 @@ fn compile_generic_builtin(
 
     let expected_args = opcode::builtin::arg_count(func_id) as usize;
 
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != expected_args {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -401,21 +387,9 @@ fn compile_two_arg_operator(
     op_type: OpType,
     emit_fn: impl FnOnce(&mut Emitter, OpType),
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
-
-    if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(func.name.span()));
-    }
-
-    compile_expr(emitter, ctx, args[0], op_type)?;
-    compile_expr(emitter, ctx, args[1], op_type)?;
+    let (in1, in2) = extract_two_positional_args(func)?;
+    compile_expr(emitter, ctx, in1, op_type)?;
+    compile_expr(emitter, ctx, in2, op_type)?;
     emit_fn(emitter, op_type);
     Ok(())
 }
@@ -444,14 +418,7 @@ fn compile_operator_form(
             })
         }
         FormOf::Not => {
-            let args: Vec<&Expr> = func
-                .param_assignment
-                .iter()
-                .filter_map(|p| match p {
-                    ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-                    _ => None,
-                })
-                .collect();
+            let args = collect_positional_args(func);
             let [term] = args.as_slice() else {
                 return Err(Diagnostic::todo_with_span(func.name.span()));
             };
@@ -463,20 +430,10 @@ fn compile_operator_form(
 
 /// Extracts two positional input arguments from a function call.
 fn extract_two_positional_args(func: &Function) -> Result<(&Expr, &Expr), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
-
-    if args.len() != 2 {
-        return Err(Diagnostic::todo_with_span(func.name.span()));
+    match collect_positional_args(func).as_slice() {
+        [in1, in2] => Ok((in1, in2)),
+        _ => Err(Diagnostic::todo_with_span(func.name.span())),
     }
-
-    Ok((args[0], args[1]))
 }
 
 /// Compiles ADD_DT_TIME, SUB_DT_TIME, and CONCAT_DATE_TOD.
@@ -530,14 +487,7 @@ fn compile_dt_to_date(
     ctx: &mut CompileContext,
     func: &Function,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -567,14 +517,7 @@ fn compile_dt_to_tod(
     ctx: &mut CompileContext,
     func: &Function,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -677,14 +620,7 @@ fn compile_move(
     func: &Function,
     op_type: OpType,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -707,14 +643,7 @@ fn compile_trunc(
     func: &Function,
     target_op_type: OpType,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -759,14 +688,7 @@ fn compile_sizeof(
     ctx: &mut CompileContext,
     func: &Function,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -813,14 +735,7 @@ fn compile_bcd_to_int(
     func: &Function,
     _target_op_type: OpType,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -851,14 +766,7 @@ fn compile_int_to_bcd(
     func: &Function,
     target_op_type: OpType,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -899,14 +807,7 @@ fn compile_mux(
     func: &Function,
     op_type: OpType,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     // Must have at least 3 args (K + 2 IN values)
     if args.len() < 3 {
@@ -965,14 +866,7 @@ pub(crate) fn compile_type_conversion(
 ) -> Result<(), Diagnostic> {
     let source_op_type: OpType = (source.op_width, source.signedness);
 
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 1 {
         return Err(Diagnostic::todo_with_span(func.name.span()));
@@ -1072,14 +966,7 @@ fn compile_shift_rotate(
     op_type: OpType,
     name: &str,
 ) -> Result<(), Diagnostic> {
-    let args: Vec<&Expr> = func
-        .param_assignment
-        .iter()
-        .filter_map(|p| match p {
-            ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-            _ => None,
-        })
-        .collect();
+    let args = collect_positional_args(func);
 
     if args.len() != 2 {
         return Err(Diagnostic::todo_with_span(func.name.span()));


### PR DESCRIPTION
## Summary

Prefactor for [#1618](https://github.com/ironplc/ironplc/issues/1618) (extensible `ADD`, `MUL`, `AND`, `OR`, `XOR`). Behaviour-preserving; no test changes.

Fifteen call compilers in `compiler/codegen/src/compile_call.rs` each repeated the `filter_map` over `param_assignment` that `collect_positional_args` already provides. They all use it now, and the two-argument helpers (`compile_two_arg_operator`, `extract_two_positional_args`) share one slice match instead of two copies of the length check.

Net effect: the function forms of operators have one argument list to work on, which is where the left fold for the n-input calls will go.

- 1 file changed, 19 insertions, 132 deletions

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets` on the analyzer and codegen crates: clean
- `cargo test -p ironplc-analyzer -p ironplc-codegen`: same pass counts as `main`
- The full `cd compiler && just` pipeline passed on the stacked feature branch that includes this commit

Related prefactors, independent of this one: [operator-form arity column](https://github.com/ironplc/ironplc/tree/claude/prefactor-operator-form-arity) and [optional extensible bound](https://github.com/ironplc/ironplc/tree/claude/prefactor-extensible-optional-bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoJdckSvqETagZM2iiJZfk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoJdckSvqETagZM2iiJZfk)_