### PR TITLE
Extend shipped-binaries guard to verify payloads

### DIFF
--- a/compiler/homebrew/Formula/ironplc.rb
+++ b/compiler/homebrew/Formula/ironplc.rb
@@ -33,7 +33,8 @@ class Ironplc < Formula
       # compatibility libraries from <exedir>/resources/libs at runtime, and
       # current_exe() resolves the bin symlink back to libexec -- so the
       # libraries must sit beside the real binaries here, not in bin.
-      libexec.install "ironplcc", "ironplcvm", "ironplcmcp", "ironplcvmd", "resources"
+      # The SBOM sits beside the binaries it describes.
+      libexec.install "ironplcc", "ironplcvm", "ironplcmcp", "ironplcvmd", "resources", "bom.cdx.json"
       bin.install_symlink libexec/"ironplcc"
       bin.install_symlink libexec/"ironplcvm"
       bin.install_symlink libexec/"ironplcmcp"

--- a/compiler/install.sh
+++ b/compiler/install.sh
@@ -346,6 +346,13 @@ install_binaries() {
         warn "archive does not include compatibility libraries (released before they existed); skipping"
     fi
 
+    # The SBOM ships beside the binaries it describes.
+    if [ -f "${_tmp}/bom.cdx.json" ]; then
+        mv -f "${_tmp}/bom.cdx.json" "${INSTALL_DIR}/bin/bom.cdx.json"
+    else
+        warn "archive does not include an SBOM (released before it existed); skipping"
+    fi
+
     # macOS may set com.apple.quarantine on extracted binaries. Best-effort removal.
     if [ "$PLATFORM_OS" = "macos" ] && have xattr; then
         xattr -dr com.apple.quarantine "${INSTALL_DIR}/bin" 2>/dev/null || true

--- a/justfile
+++ b/justfile
@@ -307,6 +307,10 @@ _install-script-smoke-verify:
     echo "warning: compatibility libraries not installed (release predates library shipping); skipping PI check" >&2
   fi
 
+  # The SBOM ships beside the binaries. Every release install.sh can install
+  # carries it, so a missing file here means the installer regressed.
+  test -f "$BIN/bom.cdx.json"
+
   # install.sh installs every binary or fails, so each one below is checked
   # unconditionally: a missing server here means the installer regressed.
 


### PR DESCRIPTION
Extends the `shipped_binaries_guard` test to verify that non-binary payloads (SBOM and compatibility libraries) are consistently packaged and installed across all distribution channels.

## Summary

The guard previously verified only that every built binary was shipped by every installer. This change extends it to also verify payloads — files packaged alongside binaries but not executables themselves — are consistently handled across all five distribution paths (Unix archives, Windows installer, Homebrew, and curl install script).

## Key Changes

- **New `payloads` list in justfile**: Defines the non-binary files (`bom.cdx.json` and `resources`) that ship with every release
- **Extended guard test**: Splits into two tests:
  - `every_built_binary_is_shipped_by_every_installer` — existing binary verification
  - `every_archive_payload_is_installed_by_every_installer` — new payload verification
- **Archive integrity check**: New test `unix_archives_contain_exactly_the_packaging_lists` verifies tar recipes archive only the two packaging lists, preventing silent inclusion of untracked files
- **Updated all installers** to explicitly handle payloads:
  - `install.sh`: Added `PAYLOADS` list and verification logic
  - `setup.nsi`: Payload path components checked alongside binaries
  - Homebrew formula: Updated `libexec.install` to include `bom.cdx.json`
  - justfile: Updated tar recipes to use `{{payloads}}` variable
- **Parser functions**: Added `just_payloads()`, `install_sh_payloads()`, `tar_archive_members()`, `nsis_file_path_components()`, and helper `require()` function
- **Refactored Homebrew check**: Renamed `formula_installed_binaries()` to `formula_installed()` to reflect that it now handles both binaries and payloads
- **Installer struct**: Introduced `Installers` struct to read all manifests once per test run

## Implementation Details

The guard now enforces that:
1. Every payload in the justfile's `payloads` list is named by `install.sh`'s `PAYLOADS` list
2. Every payload is installed by the Windows installer (via `setup.nsi` `File` directives)
3. Every payload is installed by Homebrew (via `libexec.install`)
4. Tar recipes archive exactly `{{binaries}}` and `{{payloads}}` — no extra files can slip in undetected

The `require()` helper function checks that expected items are present without reporting extras, used for installers that legitimately name more than the packaging lists (e.g., NSIS `File` paths include directory components).

https://claude.ai/code/session_0159xygYagFiVTFLgt888fF1