### PR TITLE
Stop the FMI design doc citing specs/plans/

### DIFF
--- a/specs/design/fmi-co-simulation-support.md
+++ b/specs/design/fmi-co-simulation-support.md
@@ -6,7 +6,7 @@
 review feedback. Points that are now settled are recorded under
 [Decisions](#decisions-settled-in-review); the genuinely unresolved items are in
 [Open Questions](#open-questions). The design will be finalized from the
-remaining answers before an implementation plan is written under `specs/plans/`.
+remaining answers before an implementation plan is written.
 
 ## Overview
 
@@ -545,8 +545,8 @@ cross-platform is [Q6](#open-questions)).
 
 ## Implementation Phases
 
-Each phase is independently testable. Detailed plans follow in `specs/plans/`
-once the open questions are resolved.
+Each phase is independently testable. Detailed plans follow once the open
+questions are resolved.
 
 1. **Typed variable access.** Widen `VmRunning` setters (today `write_variable`
    only accepts `i32`, `compiler/vm/src/vm.rs:603`) to mirror the read side —


### PR DESCRIPTION
`cd specs && just` fails on `main` (`d1e4bbf`), so the **Check Specs** job is red on every open PR, not just the one that surfaced it:

```
$ cd specs && just
ADR numbers: all unique. Check passed.
error: specs/plans/ is cited outside specs/plans/ itself.
specs/design/fmi-co-simulation-support.md:9
specs/design/fmi-co-simulation-support.md:548
error: recipe `plan-citations` failed with exit code 1
```

The design document landed in #1258 (`93bfa89`) and names `specs/plans/` twice. The check rejects that from a design document deliberately — its own comment says so:

> The process documents below describe the rule, so they are allowed to name the directory. Everything else — code, tests, workflows, this justfile, **design documents**, ADRs — is not.

## Fix

Both references only say *where* a future plan will live, which neither sentence needs:

- "…before an implementation plan is written ~~under `specs/plans/`~~."
- "Detailed plans follow ~~in `specs/plans/`~~ once the open questions are resolved."

Dropping the path leaves both sentences saying exactly what they said.

I did not touch the check. Its rule is deliberate and a design document is squarely on the side of it that may not name the directory — loosening it to allow bare directory mentions would be a policy change, and this doc doesn't need one.

`cd specs && just` and `cd compiler && just` both pass on the branch.

## Note

This unblocks #1644, whose Check Specs failure was this, inherited through the PR's merge with `main`. #1641 and #1642 are affected the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm6N9yZCc1CGAPN5Ekqsag

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pm6N9yZCc1CGAPN5Ekqsag)_