### PR TITLE
Share callee resolution between the call rules

### DIFF
--- a/compiler/analyzer/src/call_assignment_check.rs
+++ b/compiler/analyzer/src/call_assignment_check.rs
@@ -8,6 +8,11 @@
 //! context key used in the resulting `Diagnostic` (a function block calls
 //! itself "invocation"; a method calls itself "method"). Shared here so the
 //! two rules can't drift out of sync on the actual validation logic.
+//!
+//! The binding of each argument to the parameter it names or occupies,
+//! [`bind_inputs`], is the part of that validation any other analysis of a
+//! call needs too, so it is a function of its own that the check builds on.
+//! Finding the callee in the first place is `callee_resolution`'s job.
 
 use ironplc_dsl::{
     common::{HasVariables, VarDecl, VariableType},
@@ -55,6 +60,34 @@ fn find_input_type<'a>(owner: &'a dyn HasVariables, name: &'a Id) -> Option<&'a 
 /// through the input `:=` syntax so not included for this rule.
 fn find_output_type<'a>(owner: &'a dyn HasVariables, name: &'a Id) -> Option<&'a VarDecl> {
     find(owner, name, &[VariableType::Output])
+}
+
+/// Pairs every input argument of a call with the declared parameter it
+/// binds to: a named input (`x := e`) by name against `VAR_INPUT` and
+/// `VAR_IN_OUT`, a positional input by its position among the `VAR_INPUT`
+/// declarations alone, in declaration order. The parameter is `None` when
+/// the callee declares nothing for the argument -- an unknown name, or more
+/// positional arguments than inputs -- which [`check_assignments`] reports.
+///
+/// Output assignments (`=>`) are not inputs and are not returned.
+pub(crate) fn bind_inputs<'a>(
+    owner: &'a dyn HasVariables,
+    params: &'a [ParamAssignmentKind],
+) -> Vec<(&'a ParamAssignmentKind, Option<&'a VarDecl>)> {
+    let mut positional = owner
+        .variables()
+        .iter()
+        .filter(|item| item.var_type == VariableType::Input);
+    params
+        .iter()
+        .filter_map(|param| match param {
+            ParamAssignmentKind::NamedInput(named) => {
+                Some((param, find_input_type(owner, &named.name)))
+            }
+            ParamAssignmentKind::PositionalInput(_) => Some((param, positional.next())),
+            ParamAssignmentKind::Output(_) => None,
+        })
+        .collect()
 }
 
 /// Labels used to build the diagnostics `check_assignments` returns, so
@@ -125,8 +158,8 @@ pub(crate) fn check_assignments(
     // permitted so we use the assignments as the set to iterate
     if !formal.is_empty() {
         // TODO check the types.
-        for name in &formal {
-            if find_input_type(owner, &name.name).is_none() {
+        for (param, declared) in bind_inputs(owner, params) {
+            if let (ParamAssignmentKind::NamedInput(name), None) = (param, declared) {
                 diagnostics.push(
                     Diagnostic::problem(
                         Problem::FunctionInvocationMissingInput,
@@ -174,4 +207,116 @@ pub(crate) fn check_assignments(
     }
 
     diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::parse_and_resolve_types;
+    use ironplc_dsl::common::{
+        FunctionBlockBodyKind, FunctionBlockDeclaration, Library, LibraryElementKind,
+    };
+    use ironplc_dsl::textual::{ExprKind, FbCall, StmtKind};
+
+    /// A function block with one input, one in-out and one output, and a
+    /// program that calls it with `params`.
+    fn parse_call(params: &str) -> Library {
+        let program = format!(
+            "
+FUNCTION_BLOCK FB_Bump
+VAR_INPUT
+    step : INT;
+END_VAR
+VAR_IN_OUT
+    total : INT;
+END_VAR
+VAR_OUTPUT
+    done : BOOL;
+END_VAR
+END_FUNCTION_BLOCK
+PROGRAM main
+VAR
+    inst : FB_Bump;
+    a : INT;
+    b : INT;
+    q : BOOL;
+END_VAR
+    inst({params});
+END_PROGRAM"
+        );
+        parse_and_resolve_types(&program)
+    }
+
+    /// The function block and the one call the program makes to it.
+    fn fb_and_call(lib: &Library) -> (&FunctionBlockDeclaration, &FbCall) {
+        let fb = lib
+            .elements
+            .iter()
+            .find_map(|element| match element {
+                LibraryElementKind::FunctionBlockDeclaration(fb) => Some(fb),
+                _ => None,
+            })
+            .unwrap();
+        let call = lib
+            .elements
+            .iter()
+            .find_map(|element| match element {
+                LibraryElementKind::ProgramDeclaration(program) => match &program.body {
+                    FunctionBlockBodyKind::Statements(statements) => {
+                        statements.body.iter().find_map(|stmt| match stmt {
+                            StmtKind::FbCall(call) => Some(call),
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .unwrap();
+        (fb, call)
+    }
+
+    /// The names of the parameters each input argument binds to, in argument
+    /// order, with `-` for an unbound argument.
+    fn bound_names(lib: &Library) -> Vec<String> {
+        let (fb, call) = fb_and_call(lib);
+        bind_inputs(fb, &call.params)
+            .iter()
+            .map(|(_, declared)| match declared {
+                Some(decl) => decl.identifier.to_string(),
+                None => "-".to_owned(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn bind_inputs_when_named_then_binds_input_and_in_out_by_name() {
+        let lib = parse_call("total := b, step := a, done => q");
+        assert_eq!(vec!["total", "step"], bound_names(&lib));
+    }
+
+    #[test]
+    fn bind_inputs_when_named_unknown_then_unbound() {
+        let lib = parse_call("nope := a");
+        assert_eq!(vec!["-"], bound_names(&lib));
+    }
+
+    #[test]
+    fn bind_inputs_when_positional_then_binds_inputs_in_order_and_extra_is_unbound() {
+        let lib = parse_call("a, b");
+        assert_eq!(vec!["step", "-"], bound_names(&lib));
+    }
+
+    #[test]
+    fn bind_inputs_when_argument_bound_then_pairs_it_with_its_expression() {
+        let lib = parse_call("step := a");
+        let (fb, call) = fb_and_call(&lib);
+        let bound = bind_inputs(fb, &call.params);
+        assert_eq!(1, bound.len());
+        assert!(matches!(
+            bound[0],
+            (ParamAssignmentKind::NamedInput(named), Some(_))
+                if matches!(named.expr.kind, ExprKind::Variable(_))
+        ));
+    }
 }

--- a/compiler/analyzer/src/callee_resolution.rs
+++ b/compiler/analyzer/src/callee_resolution.rs
@@ -1,0 +1,248 @@
+//! Shared resolution of an invocation's callee.
+//!
+//! A function-block invocation (`inst(...)`) and a method call
+//! (`inst.M(...)`) start the same way: find the declared type of the instance
+//! variable, find that function block's declaration, and for a method walk
+//! up the `EXTENDS` chain to the block that declares it. Any later analysis
+//! that needs to know which declared parameter a call argument binds to --
+//! a type check, a write analysis -- needs the same lookups. The rules used
+//! to keep private copies of them; this module is the one copy, so they
+//! cannot drift.
+//!
+//! Argument-to-parameter binding for a resolved callee lives beside the
+//! parameter-assignment checks in `call_assignment_check`.
+
+use std::collections::{HashMap, HashSet};
+
+use ironplc_dsl::common::{
+    FunctionBlockDeclaration, InitialValueAssignmentKind, Library, LibraryElementKind,
+    MethodDeclaration, TypeName, VarDecl,
+};
+use ironplc_dsl::core::Id;
+
+/// The function blocks a library declares, by name.
+pub(crate) struct FunctionBlocks<'a> {
+    by_name: HashMap<TypeName, &'a FunctionBlockDeclaration>,
+}
+
+impl<'a> FunctionBlocks<'a> {
+    pub(crate) fn from_library(lib: &'a Library) -> Self {
+        let by_name = lib
+            .elements
+            .iter()
+            .filter_map(|element| match element {
+                LibraryElementKind::FunctionBlockDeclaration(fb) => Some((fb.name.clone(), fb)),
+                _ => None,
+            })
+            .collect();
+        FunctionBlocks { by_name }
+    }
+
+    /// The declaration of the function block named `name`, if the library
+    /// declares one. Standard-library function blocks are not declared in
+    /// the library and so are never found here.
+    pub(crate) fn get(&self, name: &TypeName) -> Option<&'a FunctionBlockDeclaration> {
+        self.by_name.get(name).copied()
+    }
+
+    pub(crate) fn contains(&self, name: &TypeName) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    /// Resolves `method_name` against `fb_name`'s own methods, then its
+    /// `EXTENDS` base, then that base's base, and so on (ADR-0041 Phase 1
+    /// static dispatch). Returns the function block that actually declares
+    /// the method (which may be a base, not `fb_name` itself) together
+    /// with the method declaration.
+    pub(crate) fn resolve_method(
+        &self,
+        fb_name: &TypeName,
+        method_name: &Id,
+    ) -> Option<(&'a FunctionBlockDeclaration, &'a MethodDeclaration)> {
+        let mut current = self.get(fb_name);
+        let mut visited: HashSet<TypeName> = HashSet::new();
+
+        while let Some(fb) = current {
+            // Guards against an EXTENDS cycle causing an infinite loop.
+            // Cycles are also independently invalid (and expected to be
+            // rejected elsewhere); this is just a safety net.
+            if !visited.insert(fb.name.clone()) {
+                return None;
+            }
+
+            if let Some(method) = fb.methods.iter().find(|m| &m.name == method_name) {
+                return Some((fb, method));
+            }
+
+            current = fb
+                .oop
+                .as_ref()
+                .and_then(|oop| oop.base.as_ref())
+                .and_then(|base| self.get(base));
+        }
+
+        None
+    }
+}
+
+/// The function-block instances declared in the program organization unit
+/// being walked, by variable name.
+///
+/// Instances are declared per unit, so a walk records each declaration as
+/// it meets it and calls [`InstanceTypes::clear`] when it leaves the unit,
+/// exactly as the rules that own a walk have always done.
+#[derive(Default)]
+pub(crate) struct InstanceTypes {
+    var_to_fb: HashMap<Id, TypeName>,
+}
+
+impl InstanceTypes {
+    /// Records `decl` when it declares a function-block instance; any other
+    /// declaration is ignored.
+    pub(crate) fn declare(&mut self, decl: &VarDecl) {
+        if let InitialValueAssignmentKind::FunctionBlock(init) = &decl.initializer {
+            if let Some(name) = decl.identifier.symbolic_id() {
+                self.var_to_fb.insert(name.clone(), init.type_name.clone());
+            }
+        }
+    }
+
+    /// The declared function-block type of the variable `instance`.
+    pub(crate) fn type_of(&self, instance: &Id) -> Option<&TypeName> {
+        self.var_to_fb.get(instance)
+    }
+
+    /// Forgets every instance, on leaving the unit that declared them.
+    pub(crate) fn clear(&mut self) {
+        self.var_to_fb.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::parse_and_resolve_types_with_options;
+    use ironplc_dsl::common::ProgramDeclaration;
+    use ironplc_dsl::core::FileId;
+    use ironplc_parser::{options::CompilerOptions, parse_program};
+
+    fn oop_options() -> CompilerOptions {
+        CompilerOptions {
+            allow_fb_inheritance: true,
+            ..CompilerOptions::default()
+        }
+    }
+
+    /// Parses only: these lookups read declarations as the parser leaves
+    /// them, so no type resolution is needed.
+    fn parse(program: &str) -> Library {
+        parse_program(program, &FileId::default(), &oop_options()).unwrap()
+    }
+
+    const HIERARCHY: &str = "
+FUNCTION_BLOCK FB_Base
+METHOD Start
+    ;
+END_METHOD
+END_FUNCTION_BLOCK
+FUNCTION_BLOCK FB_Derived EXTENDS FB_Base
+METHOD Stop
+    ;
+END_METHOD
+END_FUNCTION_BLOCK";
+
+    #[test]
+    fn from_library_when_function_blocks_declared_then_finds_each_by_name() {
+        let lib = parse(HIERARCHY);
+        let fbs = FunctionBlocks::from_library(&lib);
+        assert!(fbs.contains(&TypeName::from("FB_Base")));
+        assert!(fbs.get(&TypeName::from("FB_Derived")).is_some());
+        assert!(fbs.get(&TypeName::from("FB_Missing")).is_none());
+    }
+
+    #[test]
+    fn resolve_method_when_declared_on_own_block_then_returns_own_block() {
+        let lib = parse(HIERARCHY);
+        let fbs = FunctionBlocks::from_library(&lib);
+        let (owner, method) = fbs
+            .resolve_method(&TypeName::from("FB_Derived"), &Id::from("Stop"))
+            .unwrap();
+        assert_eq!(TypeName::from("FB_Derived"), owner.name);
+        assert_eq!(Id::from("Stop"), method.name);
+    }
+
+    #[test]
+    fn resolve_method_when_declared_on_base_then_returns_base_block() {
+        let lib = parse(HIERARCHY);
+        let fbs = FunctionBlocks::from_library(&lib);
+        let (owner, method) = fbs
+            .resolve_method(&TypeName::from("FB_Derived"), &Id::from("Start"))
+            .unwrap();
+        assert_eq!(TypeName::from("FB_Base"), owner.name);
+        assert_eq!(Id::from("Start"), method.name);
+    }
+
+    #[test]
+    fn resolve_method_when_not_declared_anywhere_then_none() {
+        let lib = parse(HIERARCHY);
+        let fbs = FunctionBlocks::from_library(&lib);
+        assert!(fbs
+            .resolve_method(&TypeName::from("FB_Derived"), &Id::from("Reset"))
+            .is_none());
+    }
+
+    #[test]
+    fn resolve_method_when_extends_cycle_then_none() {
+        let lib = parse(
+            "
+FUNCTION_BLOCK FB_A EXTENDS FB_B
+END_FUNCTION_BLOCK
+FUNCTION_BLOCK FB_B EXTENDS FB_A
+END_FUNCTION_BLOCK",
+        );
+        let fbs = FunctionBlocks::from_library(&lib);
+        assert!(fbs
+            .resolve_method(&TypeName::from("FB_A"), &Id::from("Reset"))
+            .is_none());
+    }
+
+    fn program(lib: &Library) -> &ProgramDeclaration {
+        lib.elements
+            .iter()
+            .find_map(|element| match element {
+                LibraryElementKind::ProgramDeclaration(program) => Some(program),
+                _ => None,
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn instance_types_when_instance_declared_then_type_of_finds_it() {
+        // An instance declaration is late-bound until type resolution, so
+        // the declarations must be resolved before they can be recorded.
+        let (lib, _) = parse_and_resolve_types_with_options(
+            "
+FUNCTION_BLOCK FB_Base
+END_FUNCTION_BLOCK
+PROGRAM main
+VAR
+    inst : FB_Base;
+    count : INT;
+END_VAR
+END_PROGRAM",
+            &oop_options(),
+        );
+        let mut instances = InstanceTypes::default();
+        for decl in &program(&lib).variables {
+            instances.declare(decl);
+        }
+        assert_eq!(
+            Some(&TypeName::from("FB_Base")),
+            instances.type_of(&Id::from("inst"))
+        );
+        assert_eq!(None, instances.type_of(&Id::from("count")));
+
+        instances.clear();
+        assert_eq!(None, instances.type_of(&Id::from("inst")));
+    }
+}

--- a/compiler/analyzer/src/function_environment.rs
+++ b/compiler/analyzer/src/function_environment.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use ironplc_dsl::common::{FunctionReturnType, TypeName};
 use ironplc_dsl::core::{Id, SourceSpan};
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
+use ironplc_dsl::textual::{Expr, ParamAssignmentKind};
 use ironplc_problems::Problem;
 
 use crate::intermediate_type::IntermediateFunctionParameter;
@@ -107,6 +108,25 @@ impl FunctionSignature {
     /// Returns the number of input parameters.
     pub fn input_parameter_count(&self) -> usize {
         self.parameters.iter().filter(|p| p.is_input).count()
+    }
+
+    /// Pairs each positional input argument of a call with the parameter it
+    /// binds to, in argument order, continuing past the declared parameters
+    /// for an extensible function (see [`Self::input_parameters`]).
+    ///
+    /// Only positional inputs bind: by the time a call is checked,
+    /// `xform_named_to_positional_args` has rewritten its named inputs, and
+    /// an output assignment binds no input. Arguments beyond the parameter
+    /// list are dropped; the arity check reports them.
+    pub fn bind_inputs<'a>(
+        &'a self,
+        params: &'a [ParamAssignmentKind],
+    ) -> impl Iterator<Item = (IntermediateFunctionParameter, &'a Expr)> + 'a {
+        let positional = params.iter().filter_map(|param| match param {
+            ParamAssignmentKind::PositionalInput(input) => Some(&input.expr),
+            ParamAssignmentKind::NamedInput(_) | ParamAssignmentKind::Output(_) => None,
+        });
+        self.input_parameters().zip(positional)
     }
 
     /// Returns the input parameters in argument order, continuing past the

--- a/compiler/analyzer/src/lib.rs
+++ b/compiler/analyzer/src/lib.rs
@@ -21,6 +21,7 @@ fn init_test_logger() {
 mod test_macros;
 
 mod call_assignment_check;
+mod callee_resolution;
 mod constant_folding;
 mod function_environment;
 pub mod intermediate_type;

--- a/compiler/analyzer/src/rule_function_block_invocation.rs
+++ b/compiler/analyzer/src/rule_function_block_invocation.rs
@@ -33,16 +33,16 @@
 //! ```
 use ironplc_dsl::{
     common::*,
-    core::{Id, Located},
+    core::Located,
     diagnostic::{Diagnostic, Label},
     textual::*,
     visitor::Visitor,
 };
 use ironplc_problems::Problem;
-use std::collections::HashMap;
 use std::convert::Infallible;
 
 use crate::{
+    callee_resolution::{FunctionBlocks, InstanceTypes},
     intermediates::stdlib_function_block::is_stdlib_function_block,
     result::SemanticResult,
     rule_support::{run_rule, DiagnosticVisitor},
@@ -55,34 +55,25 @@ pub fn apply(
     _context: &SemanticContext,
     _options: &CompilerOptions,
 ) -> SemanticResult {
-    // Collect the names from the library into a map so that
-    // we can quickly look up invocations
-    let mut function_blocks = HashMap::new();
-    for x in lib.elements.iter() {
-        if let LibraryElementKind::FunctionBlockDeclaration(fb) = x {
-            function_blocks.insert(fb.name.clone(), fb);
-        }
-    }
+    let function_blocks = FunctionBlocks::from_library(lib);
 
     // Walk the library to find all references to function blocks
     run_rule(RuleFunctionBlockUse::new(&function_blocks), lib)
 }
 
 struct RuleFunctionBlockUse<'a> {
-    // Map of the name of a function block declaration to the
-    // declaration itself.
-    function_blocks: &'a HashMap<TypeName, &'a FunctionBlockDeclaration>,
+    function_blocks: &'a FunctionBlocks<'a>,
 
-    // Map of variable name to the function block name that is the implementation
-    var_to_fb: HashMap<Id, TypeName>,
+    /// The instances declared in the unit being walked.
+    instances: InstanceTypes,
 
     diagnostics: Vec<Diagnostic>,
 }
 impl<'a> RuleFunctionBlockUse<'a> {
-    fn new(decls: &'a HashMap<TypeName, &'a FunctionBlockDeclaration>) -> Self {
+    fn new(function_blocks: &'a FunctionBlocks<'a>) -> Self {
         Self {
-            function_blocks: decls,
-            var_to_fb: HashMap::new(),
+            function_blocks,
+            instances: InstanceTypes::default(),
             diagnostics: Vec::new(),
         }
     }
@@ -130,7 +121,7 @@ impl Visitor<Infallible> for RuleFunctionBlockUse<'_> {
         let res = node.recurse_visit(self);
 
         // Remove all items from var init decl since we have left this context
-        self.var_to_fb.clear();
+        self.instances.clear();
         res
     }
 
@@ -141,7 +132,7 @@ impl Visitor<Infallible> for RuleFunctionBlockUse<'_> {
         let res = node.recurse_visit(self);
 
         // Remove all items from var init decl since we have left this context
-        self.var_to_fb.clear();
+        self.instances.clear();
         res
     }
 
@@ -152,25 +143,21 @@ impl Visitor<Infallible> for RuleFunctionBlockUse<'_> {
         let res = node.recurse_visit(self);
 
         // Remove all items from var init decl since we have left this context
-        self.var_to_fb.clear();
+        self.instances.clear();
         res
     }
 
     fn visit_var_decl(&mut self, node: &VarDecl) -> Result<Self::Value, Infallible> {
-        if let InitialValueAssignmentKind::FunctionBlock(fbi) = &node.initializer {
-            if let Some(id) = node.identifier.symbolic_id() {
-                self.var_to_fb.insert(id.clone(), fbi.type_name.clone());
-            }
-        }
+        self.instances.declare(node);
         Ok(())
     }
 
     fn visit_fb_call(&mut self, fb_call: &FbCall) -> Result<Self::Value, Infallible> {
         // Check if function block is defined because you cannot
         // call a function block that doesn't exist
-        // Cloned so that the borrow of `var_to_fb` ends here: the arms below
+        // Cloned so that the borrow of `instances` ends here: the arms below
         // push onto `self.diagnostics`, which borrows `self` mutably.
-        let function_block_name = self.var_to_fb.get(&fb_call.var_name).cloned();
+        let function_block_name = self.instances.type_of(&fb_call.var_name).cloned();
         let Some(function_block_name) = function_block_name else {
             self.diagnostics.push(Self::not_in_scope(fb_call));
             return Ok(());

--- a/compiler/analyzer/src/rule_function_call_type_check.rs
+++ b/compiler/analyzer/src/rule_function_call_type_check.rs
@@ -262,24 +262,13 @@ impl Visitor<Infallible> for RuleFunctionCallTypeCheck<'_> {
                 }
             }
 
-            let positional_args: Vec<_> = node
-                .param_assignment
-                .iter()
-                .filter_map(|p| match p {
-                    ParamAssignmentKind::PositionalInput(pos) => Some(&pos.expr),
-                    // NamedInput is already converted to PositionalInput by
-                    // xform_named_to_positional_args; Output is handled above.
-                    _ => None,
-                })
-                .collect();
-
             // Check each positional argument type against the parameter type.
             // Standard-library functions are checked too: their parameters use
             // generic ANY_* categories (or concrete types for the conversion
             // functions), all handled by `are_types_compatible`. The parameter
             // list continues past the declared ones for an extensible
             // function, so every input of `ADD(a, b, c)` is checked.
-            for (param, arg_expr) in signature.input_parameters().zip(&positional_args) {
+            for (param, arg_expr) in signature.bind_inputs(&node.param_assignment) {
                 if let Some(ref arg_type) = arg_expr.resolved_type {
                     if !are_types_compatible(&param.param_type, arg_type, self.options) {
                         self.diagnostics.push(

--- a/compiler/analyzer/src/rule_method_call_declared.rs
+++ b/compiler/analyzer/src/rule_method_call_declared.rs
@@ -39,7 +39,6 @@
 //!    inst.Start();
 //! END_PROGRAM
 //! ```
-use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 
 use ironplc_dsl::{
@@ -52,6 +51,7 @@ use ironplc_dsl::{
 use ironplc_problems::Problem;
 
 use crate::{
+    callee_resolution::{FunctionBlocks, InstanceTypes},
     result::SemanticResult,
     rule_support::{run_rule, DiagnosticVisitor},
     semantic_context::SemanticContext,
@@ -63,71 +63,27 @@ pub fn apply(
     _context: &SemanticContext,
     _options: &CompilerOptions,
 ) -> SemanticResult {
-    let mut function_blocks = HashMap::new();
-    for x in lib.elements.iter() {
-        if let LibraryElementKind::FunctionBlockDeclaration(fb) = x {
-            function_blocks.insert(fb.name.clone(), fb);
-        }
-    }
+    let function_blocks = FunctionBlocks::from_library(lib);
 
     run_rule(RuleMethodCallDeclared::new(&function_blocks), lib)
 }
 
 struct RuleMethodCallDeclared<'a> {
-    // Map of the name of a function block declaration to the
-    // declaration itself.
-    function_blocks: &'a HashMap<TypeName, &'a FunctionBlockDeclaration>,
+    function_blocks: &'a FunctionBlocks<'a>,
 
-    // Map of variable name to the function block name that is the
-    // declared type of that variable.
-    var_to_fb: HashMap<Id, TypeName>,
+    /// The instances declared in the unit being walked.
+    instances: InstanceTypes,
 
     diagnostics: Vec<Diagnostic>,
 }
 
 impl<'a> RuleMethodCallDeclared<'a> {
-    fn new(decls: &'a HashMap<TypeName, &'a FunctionBlockDeclaration>) -> Self {
+    fn new(function_blocks: &'a FunctionBlocks<'a>) -> Self {
         Self {
-            function_blocks: decls,
-            var_to_fb: HashMap::new(),
+            function_blocks,
+            instances: InstanceTypes::default(),
             diagnostics: Vec::new(),
         }
-    }
-
-    /// Resolves `method_name` against `fb_name`'s own methods, then its
-    /// `EXTENDS` base, then that base's base, and so on (ADR-0041 Phase 1
-    /// static dispatch). Returns the function block that actually declares
-    /// the method (which may be a base, not `fb_name` itself) together
-    /// with the method declaration.
-    fn resolve_method(
-        &self,
-        fb_name: &TypeName,
-        method_name: &Id,
-    ) -> Option<(&'a FunctionBlockDeclaration, &'a MethodDeclaration)> {
-        let mut current = self.function_blocks.get(fb_name).copied();
-        let mut visited: HashSet<TypeName> = HashSet::new();
-
-        while let Some(fb) = current {
-            // Guards against an EXTENDS cycle causing an infinite loop.
-            // Cycles are also independently invalid (and expected to be
-            // rejected elsewhere); this is just a safety net for this
-            // rule specifically.
-            if !visited.insert(fb.name.clone()) {
-                return None;
-            }
-
-            if let Some(method) = fb.methods.iter().find(|m| &m.name == method_name) {
-                return Some((fb, method));
-            }
-
-            current = fb
-                .oop
-                .as_ref()
-                .and_then(|oop| oop.base.as_ref())
-                .and_then(|base| self.function_blocks.get(base).copied());
-        }
-
-        None
     }
 
     fn check_assignments(
@@ -175,7 +131,7 @@ impl Visitor<Infallible> for RuleMethodCallDeclared<'_> {
         node: &FunctionBlockDeclaration,
     ) -> Result<Self::Value, Infallible> {
         let res = node.recurse_visit(self);
-        self.var_to_fb.clear();
+        self.instances.clear();
         res
     }
 
@@ -184,7 +140,7 @@ impl Visitor<Infallible> for RuleMethodCallDeclared<'_> {
         node: &FunctionDeclaration,
     ) -> Result<Self::Value, Infallible> {
         let res = node.recurse_visit(self);
-        self.var_to_fb.clear();
+        self.instances.clear();
         res
     }
 
@@ -193,16 +149,12 @@ impl Visitor<Infallible> for RuleMethodCallDeclared<'_> {
         node: &ProgramDeclaration,
     ) -> Result<Self::Value, Infallible> {
         let res = node.recurse_visit(self);
-        self.var_to_fb.clear();
+        self.instances.clear();
         res
     }
 
     fn visit_var_decl(&mut self, node: &VarDecl) -> Result<Self::Value, Infallible> {
-        if let InitialValueAssignmentKind::FunctionBlock(fbi) = &node.initializer {
-            if let Some(id) = node.identifier.symbolic_id() {
-                self.var_to_fb.insert(id.clone(), fbi.type_name.clone());
-            }
-        }
+        self.instances.declare(node);
         Ok(())
     }
 
@@ -227,20 +179,20 @@ impl Visitor<Infallible> for RuleMethodCallDeclared<'_> {
             }
         };
 
-        // Cloned so that the borrow of `var_to_fb` ends here: the arms below
+        // Cloned so that the borrow of `instances` ends here: the arms below
         // push onto `self.diagnostics`, which borrows `self` mutably.
-        let fb_type = self.var_to_fb.get(instance).cloned();
+        let fb_type = self.instances.type_of(instance).cloned();
         let Some(fb_type) = fb_type else {
             self.diagnostics.push(Self::not_in_scope(call, instance));
             return Ok(());
         };
 
-        if !self.function_blocks.contains_key(&fb_type) {
+        if !self.function_blocks.contains(&fb_type) {
             self.diagnostics.push(Self::not_in_scope(call, instance));
             return Ok(());
         }
 
-        match self.resolve_method(&fb_type, &call.method) {
+        match self.function_blocks.resolve_method(&fb_type, &call.method) {
             None => self.diagnostics.push(
                 Diagnostic::problem(
                     Problem::MethodNotFound,


### PR DESCRIPTION
## Summary

A behaviour-preserving prefactor ahead of the never-written-variables-become-`CONSTANT` transform for #1612. That transform needs to know which declared parameter each call argument binds to, so it can tell a `VAR_IN_OUT` argument (a write) from a `VAR_INPUT` one (a read). The analyzer already computed those facts in three places, each privately; a fourth copy in the transform was the signal to share them first.

## What moves where

- **`callee_resolution` (new)** holds the one copy of two lookups the function-block invocation rule and the method-call rule each kept for themselves:
  - `FunctionBlocks`: the library's function blocks by name, with the `EXTENDS`-aware `resolve_method` walk that previously lived only in the method rule.
  - `InstanceTypes`: the function-block instances declared in the unit being walked.
- **`call_assignment_check::bind_inputs`** pairs each input argument with the parameter it names or occupies. The existing named-input check in `check_assignments` is now expressed through it.
- **`FunctionSignature::bind_inputs`** does the same for function calls (positional, continuing past declared parameters for extensible functions), and `rule_function_call_type_check` uses it in place of its own zip.

Both rules shrink to their diagnostics; the shared pieces gain unit tests. Existing rule tests pass unchanged, which is the check that nothing observable moved.

## Notes

- No plan file: this is a mechanical extraction with no behaviour change, per the planning exemption in `CLAUDE.md`.
- The transform PR follows, rebased on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyMa6n6EDcNK6178uDdPUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyMa6n6EDcNK6178uDdPUt)_