### PR TITLE
Only a global constant obliges its externals to be constant

### DIFF
--- a/compiler/analyzer/src/rule_var_decl_global_const_requires_external_const.rs
+++ b/compiler/analyzer/src/rule_var_decl_global_const_requires_external_const.rs
@@ -106,7 +106,11 @@ impl DiagnosticVisitor for FindGlobalConstVars<'_> {
 impl Visitor<Infallible> for FindGlobalConstVars<'_> {
     type Value = ();
     fn visit_var_decl(&mut self, node: &VarDecl) -> Result<Self::Value, Infallible> {
-        if node.qualifier == DeclarationQualifier::Constant {
+        // Only a global constant obliges its externals to be constant. A
+        // `VAR CONSTANT` local to one unit says nothing about a global that
+        // happens to share its name.
+        if node.var_type == VariableType::Global && node.qualifier == DeclarationQualifier::Constant
+        {
             match &node.identifier {
                 VariableIdentifier::Symbol(name) => {
                     self.global_consts.insert(name.clone());
@@ -180,6 +184,35 @@ FUNCTION_BLOCK func
         ResetCounterValue : INT;
     END_VAR
 END_FUNCTION_BLOCK"
+    );
+
+    rule_ok!(
+        apply_when_local_const_shares_name_with_plain_global_then_ok,
+        "
+CONFIGURATION config
+    VAR_GLOBAL
+        Limit : INT := 17;
+    END_VAR
+    RESOURCE resource1 ON PLC
+        TASK plc_task(INTERVAL := T#100ms,PRIORITY := 1);
+        PROGRAM plc_task_instance WITH plc_task : plc_prg;
+    END_RESOURCE
+END_CONFIGURATION
+
+FUNCTION_BLOCK reader
+    VAR_EXTERNAL
+        Limit : INT;
+    END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK other
+    VAR CONSTANT
+        Limit : INT := 1;
+    END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM plc_prg
+END_PROGRAM"
     );
 
     rule_ok!(


### PR DESCRIPTION
## Summary

The P4009 rule (`VariableMustBeConst`) collected the name of every `CONSTANT` declaration in the library, local ones included, and then required each `VAR_EXTERNAL` of that name to be constant. A `VAR CONSTANT` local to one function block therefore made a plain global's externals elsewhere fail the rule for nothing more than sharing a name.

The rule's name and its own comment say global constants; it now collects only declarations whose variable type is `VAR_GLOBAL`. One-line change plus a test for the false positive.

## Why now

Found while writing the never-written-variables-become-`CONSTANT` transform (#1648): once that transform infers `CONSTANT` on locals, this rule would have fired on programs that had no diagnostic before. The transform carried a by-name workaround for it; with the rule fixed, the workaround is gone.

## Stack

`main` ← resolver fix ← this ← #1648. Stacked only for review ordering; the change itself is independent. Retarget to `main` once the base merges.

`cd compiler && just` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyMa6n6EDcNK6178uDdPUt