### PR TITLE
Derive CodegenOptions from CompilerOptions, share the narrow string reader

### DIFF
--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -12,6 +12,7 @@ ironplc-dsl = { path = "../dsl", version = "0.241.0" }
 ironplc-container = { path = "../container", version = "0.241.0" }
 ironplc-problems = { path = "../problems", version = "0.241.0" }
 ironplc-analyzer = { path = "../analyzer", version = "0.241.0" }
+ironplc-parser = { path = "../parser", version = "0.241.0" }
 blake3 = "1"
 paste = "1.0"
 
@@ -20,7 +21,6 @@ ironplc-spec-requirements-gen = { path = "../spec_requirements_gen" }
 
 [dev-dependencies]
 ironplc-analyzer = { path = "../analyzer", version = "0.241.0" }
-ironplc-parser = { path = "../parser", version = "0.241.0" }
 ironplc-sources = { path = "../sources", version = "0.241.0" }
 ironplc-vm = { path = "../vm", version = "0.241.0", features = ["test-support"] }
 spec_test_macro = { path = "../spec_test_macro" }

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -61,6 +61,7 @@ use ironplc_dsl::configuration::{
 };
 use ironplc_dsl::core::{FileId, Id, Located};
 use ironplc_dsl::diagnostic::{Diagnostic, Label};
+use ironplc_parser::options::CompilerOptions;
 use ironplc_problems::Problem;
 
 use ironplc_analyzer::{FunctionEnvironment, SemanticContext, TypeEnvironment};
@@ -202,11 +203,23 @@ pub(crate) fn emit_string_literal_load(
 /// Returns an error if no program is found or if the program contains
 /// unsupported constructs.
 /// Options that affect code generation.
-#[derive(Default)]
+///
+/// Every front end derives this from the project's [`CompilerOptions`] via
+/// [`From`], so the mapping from a compiler option to what codegen does with
+/// it has exactly one definition.
+#[derive(Debug, Default, Clone, Copy)]
 pub struct CodegenOptions {
     /// When `true`, inject `__SYSTEM_UP_TIME` (TIME) and `__SYSTEM_UP_LTIME`
     /// (LTIME) as implicit globals at the start of the variable table.
     pub system_uptime_global: bool,
+}
+
+impl From<&CompilerOptions> for CodegenOptions {
+    fn from(options: &CompilerOptions) -> Self {
+        CodegenOptions {
+            system_uptime_global: options.allow_system_uptime_global,
+        }
+    }
 }
 
 pub fn compile(

--- a/compiler/codegen/tests/it/common/mod.rs
+++ b/compiler/codegen/tests/it/common/mod.rs
@@ -594,9 +594,7 @@ pub fn try_parse_and_compile(
     options: &CompilerOptions,
 ) -> Result<Container, Diagnostic> {
     let (library, context) = parse(source, options);
-    let codegen_options = ironplc_codegen::CodegenOptions {
-        system_uptime_global: options.allow_system_uptime_global,
-    };
+    let codegen_options = ironplc_codegen::CodegenOptions::from(options);
     compile(
         &library,
         &context,
@@ -619,9 +617,7 @@ pub fn parse_and_try_run(
     options: &CompilerOptions,
 ) -> Result<(Container, VmBuffers), FaultContext> {
     let (library, context) = parse(source, options);
-    let codegen_options = ironplc_codegen::CodegenOptions {
-        system_uptime_global: options.allow_system_uptime_global,
-    };
+    let codegen_options = ironplc_codegen::CodegenOptions::from(options);
     let container = compile(
         &library,
         &context,
@@ -671,9 +667,7 @@ pub fn parse_and_run_rounds(
     f: impl FnOnce(&mut ironplc_vm::VmRunning<'_>),
 ) {
     let (library, context) = parse(source, options);
-    let codegen_options = ironplc_codegen::CodegenOptions {
-        system_uptime_global: options.allow_system_uptime_global,
-    };
+    let codegen_options = ironplc_codegen::CodegenOptions::from(options);
     let container = compile(
         &library,
         &context,

--- a/compiler/codegen/tests/it/end_to_end_tc2_math.rs
+++ b/compiler/codegen/tests/it/end_to_end_tc2_math.rs
@@ -37,9 +37,7 @@ fn run_with_tc2_math(source: &str) -> VmBuffers {
         context.diagnostics()
     );
 
-    let codegen_options = ironplc_codegen::CodegenOptions {
-        system_uptime_global: false,
-    };
+    let codegen_options = ironplc_codegen::CodegenOptions::from(&options);
     let container = compile(
         &analyzed,
         &context,

--- a/compiler/ironplc-cli/src/lsp_runner.rs
+++ b/compiler/ironplc-cli/src/lsp_runner.rs
@@ -245,9 +245,7 @@ fn compile_to_bytes(source: &str, options: &CompilerOptions) -> Result<Vec<u8>, 
         });
     }
 
-    let codegen_options = ironplc_codegen::CodegenOptions {
-        system_uptime_global: options.allow_system_uptime_global,
-    };
+    let codegen_options = ironplc_codegen::CodegenOptions::from(options);
     let container = codegen_compile(
         &library,
         &context,

--- a/compiler/project/src/compile.rs
+++ b/compiler/project/src/compile.rs
@@ -89,9 +89,7 @@ pub fn compile(
 
     // Generate bytecode, skipping user-defined functions not reachable from
     // the PROGRAM root to reduce container size.
-    let codegen_options = CodegenOptions {
-        system_uptime_global: compiler_options.allow_system_uptime_global,
-    };
+    let codegen_options = CodegenOptions::from(compiler_options);
 
     match ironplc_codegen::compile(library, context, &codegen_options, source_lookup) {
         Ok(container) => CompileOutput {

--- a/compiler/vm/src/string_ops.rs
+++ b/compiler/vm/src/string_ops.rs
@@ -122,6 +122,21 @@ pub(crate) fn read_string_header(
     Ok((cur_len, data_start, char_width))
 }
 
+/// Resolve a `STRING` operand at `offset` in `data_region` to the bytes of
+/// its current value, for the `STRING_TO_*` conversions.
+///
+/// The conversions read Latin-1 digits, so a `WSTRING` operand traps
+/// [`Trap::EncodingMismatch`] (ADR-0034) rather than being misread as
+/// narrow bytes. The read is bounds-checked; a header past the end of the
+/// region traps [`Trap::DataRegionOutOfBounds`], and a value that runs past
+/// the end is clipped to the region.
+pub(crate) fn narrow_str_bytes(data_region: &[u8], offset: usize) -> Result<&[u8], Trap> {
+    let (cur_len, data_start, char_width) = read_string_header(data_region, offset)?;
+    verify_encoding(CharWidth::Narrow, char_width)?;
+    let end = (data_start + cur_len).min(data_region.len());
+    Ok(&data_region[data_start..end])
+}
+
 /// Copy `units` code units (`units * char_width` bytes) from `src` starting at
 /// byte offset `src_byte` into `dst` starting at byte offset `dst_byte`.
 pub(crate) fn copy_code_units(

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -1510,17 +1510,8 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     }
                     opcode::builtin::CONV_STR_TO_I32 => {
                         let data_offset = stack.pop()?.as_i32() as usize;
-                        if data_offset + STRING_HEADER_BYTES > data_region.len() {
-                            return Err(Trap::DataRegionOutOfBounds(data_offset as u32));
-                        }
-                        // STRING_TO_* parses Latin-1 digits; reject WSTRING input.
-                        let width = string_ops::str_read_char_width(data_region, data_offset)?;
-                        string_ops::verify_encoding(CharWidth::Narrow, width)?;
-                        let cur_len =
-                            string_ops::str_read_cur_len(data_region, data_offset) as usize;
-                        let start = data_offset + STRING_HEADER_BYTES;
-                        let end = (start + cur_len).min(data_region.len());
-                        let result = core::str::from_utf8(&data_region[start..end])
+                        let bytes = string_ops::narrow_str_bytes(data_region, data_offset)?;
+                        let result = core::str::from_utf8(bytes)
                             .ok()
                             .and_then(|s| s.trim().parse::<i32>().ok())
                             .unwrap_or(0);
@@ -1528,17 +1519,8 @@ pub(crate) fn execute_with_hook<H: DebugHook>(
                     }
                     opcode::builtin::CONV_STR_TO_F32 => {
                         let data_offset = stack.pop()?.as_i32() as usize;
-                        if data_offset + STRING_HEADER_BYTES > data_region.len() {
-                            return Err(Trap::DataRegionOutOfBounds(data_offset as u32));
-                        }
-                        // STRING_TO_* parses Latin-1 digits; reject WSTRING input.
-                        let width = string_ops::str_read_char_width(data_region, data_offset)?;
-                        string_ops::verify_encoding(CharWidth::Narrow, width)?;
-                        let cur_len =
-                            string_ops::str_read_cur_len(data_region, data_offset) as usize;
-                        let start = data_offset + STRING_HEADER_BYTES;
-                        let end = (start + cur_len).min(data_region.len());
-                        let result = core::str::from_utf8(&data_region[start..end])
+                        let bytes = string_ops::narrow_str_bytes(data_region, data_offset)?;
+                        let result = core::str::from_utf8(bytes)
                             .ok()
                             .and_then(|s| s.trim().parse::<f32>().ok())
                             .unwrap_or(0.0);


### PR DESCRIPTION
## Summary

Slice 1 of 5 of the `STRING_TO_UDINT` steel thread for ADR-0049 (compile-time behavior policies), the series that fixes #1592. This slice is a behaviour-preserving prefactor so the later slices drop in with smaller diffs.

- **`CodegenOptions: From<&CompilerOptions>`.** `CodegenOptions` was built by hand from `CompilerOptions` at five sites (`project/compile.rs`, `lsp_runner.rs`, and three codegen test helpers). The `From` impl gives the mapping one definition, so the policy fields the codegen slice adds touch one constructor. `ironplc-parser` moves from a dev-dependency to a dependency of `ironplc-codegen`; it was already reachable through `ironplc-analyzer`.
- **`string_ops::narrow_str_bytes`.** The `CONV_STR_TO_I32` and `CONV_STR_TO_F32` handlers in `vm.rs` duplicated the "resolve a narrow string operand to its bytes" preamble (bounds check, encoding check, length clip). The VM slice would have been a third copy; `string_ops` now owns it and both handlers call it.

No behaviour change. Existing tests pass unchanged.

## The series

1. **This PR**: prefactor.
2. `…-2-encoding`: policy enums in `ironplc_container::policy` and the `STRING_TO_<numeric>` func_id block.
3. `…-3-options`: policy fields on `CompilerOptions`, presets, and the CLI / LSP / MCP surfaces.
4. `…-4-vm`: the VM scanner and the `V4006 StringNotConvertible` trap.
5. `…-5-codegen`: `STRING_TO_UDINT` selects its builtin by policy; user docs; ADR-0049 to accepted.

Each later branch is based on the previous one. This is a mechanical prefactor, so it carries no plan file.

## Test plan

- `cd compiler && just` (compile, coverage, lint, dupes) passes.
- `cargo build -p ironplc-container --no-default-features` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPWFrGBWGGvdDDwzR2Ry88

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPWFrGBWGGvdDDwzR2Ry88)_