### PR TITLE
Fix SFC step parsing to accept action associations

### DIFF
--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1536,17 +1536,17 @@ parser! {
         elements
       }
     }
-    rule initial_step() -> Step = tok(TokenType::InitialStep) _ name:step_name() _ tok(TokenType::Colon) _ action_associations:action_association() ** (_ tok(TokenType::Semicolon) _) tok(TokenType::EndStep) {
-      Step{
+    rule initial_step() -> Step = tok(TokenType::InitialStep) _ step:step_body() { step }
+    rule step() -> ElementKind = tok(TokenType::Step) _ step:step_body() { ElementKind::Step(step) }
+    // The `name : associations END_STEP` tail shared by `INITIAL_STEP` and
+    // `STEP`. One rule so the two cannot drift apart again (issue #1659):
+    // each kept its own copy, and neither accepted every legal body. The
+    // association list may be empty, and every association ends in `;`.
+    rule step_body() -> Step = name:step_name() _ tok(TokenType::Colon) _ action_associations:semisep_or_empty(<action_association()>) _ tok(TokenType::EndStep) {
+      Step {
         name,
         action_associations,
-       }
-    }
-    rule step() -> ElementKind = tok(TokenType::Step) _ name:step_name() _ tok(TokenType::Colon) _ action_associations:semisep(<action_association()>) _ tok(TokenType::EndStep) {
-      ElementKind::step(
-        name,
-        action_associations
-      )
+      }
     }
     rule step_name() -> Id = identifier()
     rule action_association() -> ActionAssociation = name:action_name() _ tok(TokenType::LeftParen) _ qualifier:action_qualifier()? _ indicators:(tok(TokenType::Comma) _ i:indicator_name() ** (_ tok(TokenType::Comma) _) { i })? _ tok(TokenType::RightParen) {

--- a/compiler/parser/src/tests/mod.rs
+++ b/compiler/parser/src/tests/mod.rs
@@ -22,6 +22,7 @@ mod partial_access;
 mod pointer_to;
 mod pragmas;
 mod reference_to;
+mod sfc;
 mod short_circuit;
 mod struct_init_expressions;
 mod tasks;

--- a/compiler/parser/src/tests/sfc.rs
+++ b/compiler/parser/src/tests/sfc.rs
@@ -1,0 +1,119 @@
+//! Sequential function chart elements (B.1.6). The corpus tests pin the
+//! whole `first_steps` chart; these cover the step forms that the corpus
+//! fixtures never exercise.
+
+use super::common::*;
+
+/// Regression for <https://github.com/ironplc/ironplc/issues/1659>: the
+/// `INITIAL_STEP` rule had its own copy of the step tail that neither
+/// consumed the terminating `;` nor allowed whitespace before `END_STEP`,
+/// so any association on the initial step was a syntax error.
+#[test]
+fn parse_when_initial_step_has_action_association_then_builds_step() {
+    let library = parse_text(
+        "PROGRAM main
+VAR x : INT; END_VAR
+    INITIAL_STEP Start:
+        DoIt(N);
+    END_STEP
+    TRANSITION FROM Start TO Idle := TRUE; END_TRANSITION
+    STEP Idle:
+    END_STEP
+    ACTION DoIt:
+        x := x + 1;
+    END_ACTION
+END_PROGRAM",
+    );
+
+    let expected = Step {
+        name: Id::from("Start"),
+        action_associations: vec![ActionAssociation::new("DoIt", Some(ActionQualifier::N))],
+    };
+    assert_eq!(initial_step(&library), &expected);
+}
+
+#[test]
+fn parse_when_initial_step_has_two_action_associations_then_builds_step() {
+    let library = parse_text(
+        "PROGRAM main
+VAR x : INT; END_VAR
+    INITIAL_STEP Start:
+        DoIt(N);
+        DoIt(P, x);
+    END_STEP
+    ACTION DoIt:
+        x := x + 1;
+    END_ACTION
+END_PROGRAM",
+    );
+
+    let expected = Step {
+        name: Id::from("Start"),
+        action_associations: vec![
+            ActionAssociation::new("DoIt", Some(ActionQualifier::N)),
+            ActionAssociation {
+                name: Id::from("DoIt"),
+                qualifier: Some(ActionQualifier::P),
+                indicators: vec![Id::from("x")],
+            },
+        ],
+    };
+    assert_eq!(initial_step(&library), &expected);
+}
+
+/// The empty `STEP` from the issue's example. `semisep` demanded a `;` even
+/// with nothing to terminate, so before the shared rule this was a syntax
+/// error too; only the empty `INITIAL_STEP` worked.
+#[test]
+fn parse_when_step_has_no_action_associations_then_builds_empty_step() {
+    let library = parse_text(
+        "PROGRAM main
+VAR x : INT; END_VAR
+    INITIAL_STEP Start:
+    END_STEP
+    STEP Idle:
+    END_STEP
+    ACTION DoIt:
+        x := x + 1;
+    END_ACTION
+END_PROGRAM",
+    );
+
+    let expected = ElementKind::step(Id::from("Idle"), vec![]);
+    assert_eq!(network(&library).elements[0], expected);
+}
+
+/// `semisep_or_empty` requires the terminating `;`, on the initial step as on any
+/// other, so the spelling without it stays a syntax error.
+#[test]
+fn parse_when_initial_step_association_missing_semicolon_then_error() {
+    let result = parse_program(
+        "PROGRAM main
+VAR x : INT; END_VAR
+    INITIAL_STEP Start:
+        DoIt(N)
+    END_STEP
+    ACTION DoIt:
+        x := x + 1;
+    END_ACTION
+END_PROGRAM",
+        &FileId::default(),
+        &CompilerOptions::default(),
+    );
+
+    assert_eq!(result.unwrap_err().code, "P0002");
+}
+
+fn initial_step(library: &Library) -> &Step {
+    &network(library).initial_step
+}
+
+fn network(library: &Library) -> &Network {
+    match &library.elements[0] {
+        LibraryElementKind::ProgramDeclaration(program) => match &program.body {
+            FunctionBlockBodyKind::Sfc(sfc) => &sfc.networks[0],
+            body => panic!("expected an SFC body, found {body:?}"),
+        },
+        element => panic!("expected a program, found {element:?}"),
+    }
+}

--- a/compiler/parser/src/tests/whitespace.rs
+++ b/compiler/parser/src/tests/whitespace.rs
@@ -166,6 +166,22 @@ END_FUNCTION_BLOCK"
     )
 }
 
+/// A step in an SFC program body. The action is declared so the chart is
+/// complete; the wrapper is only the POU, the step itself is the row.
+fn in_sfc(step: &str) -> String {
+    format!(
+        "PROGRAM main
+VAR
+    x : INT;
+END_VAR
+{step}
+ACTION DoIt:
+    x := x + 1;
+END_ACTION
+END_PROGRAM"
+    )
+}
+
 /// A `VAR_CONFIG` entry. The block is only legal in a `CONFIGURATION`, and
 /// only after at least one `RESOURCE`, so the wrapper supplies both.
 fn in_var_config(entry: &str) -> String {
@@ -276,6 +292,20 @@ END_CONFIGURATION"
 #[case::var_config_fb_init(
     "Some·.·Block·.·Item·.·Path : FB_TYPE := (ELEM := VAL);",
     in_var_config,
+    CompilerOptions::default
+)]
+// ---------------------------------------------------------------------
+// Gaps issue #1659 reported as rejected: `INITIAL_STEP` had no `_` before
+// `END_STEP`. `STEP` always had it; its row keeps the two rules in step.
+// ---------------------------------------------------------------------
+#[case::initial_step_association(
+    "INITIAL_STEP Start·:·DoIt(N)·;·END_STEP",
+    in_sfc,
+    CompilerOptions::default
+)]
+#[case::step_association(
+    "INITIAL_STEP Start: END_STEP STEP Idle·:·DoIt(N)·;·END_STEP",
+    in_sfc,
     CompilerOptions::default
 )]
 fn parse_when_gap_filled_then_same_ast(

--- a/compiler/plc2plc/resources/test/sfc_rendered.st
+++ b/compiler/plc2plc/resources/test/sfc_rendered.st
@@ -12,6 +12,7 @@ FUNCTION_BLOCK sfc
       COUNT : INT;
    END_VAR
    INITIAL_STEP Start :
+      RESET ( N );
    END_STEP
 
    TRANSITION FROM Start TO MidStep

--- a/compiler/plc2plc/src/renderer.rs
+++ b/compiler/plc2plc/src/renderer.rs
@@ -149,6 +149,25 @@ impl LibraryRenderer {
         }
         Ok(())
     }
+
+    /// Renders the `name : associations END_STEP` tail shared by
+    /// `INITIAL_STEP` and `STEP`; the caller writes the keyword.
+    fn write_step_body(&mut self, node: &dsl::sfc::Step) -> Result<(), Diagnostic> {
+        self.visit_id(&node.name)?;
+        self.write_ws(":");
+        self.newline();
+
+        self.indent();
+        for elem in node.action_associations.iter() {
+            self.visit_action_association(elem)?;
+            self.newline();
+        }
+        self.outdent();
+
+        self.write_ws("END_STEP");
+        self.newline();
+        Ok(())
+    }
 }
 
 impl Visitor<Diagnostic> for LibraryRenderer {
@@ -1096,12 +1115,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
     // 2.6.2
     fn visit_network(&mut self, node: &dsl::sfc::Network) -> Result<Self::Value, Diagnostic> {
         self.write_ws("INITIAL_STEP");
-        self.visit_id(&node.initial_step.name)?;
-        self.write_ws(":");
-        self.newline();
-
-        self.write_ws("END_STEP");
-        self.newline();
+        self.write_step_body(&node.initial_step)?;
         self.newline();
 
         for elem in node.elements.iter() {
@@ -1114,20 +1128,7 @@ impl Visitor<Diagnostic> for LibraryRenderer {
     // 2.6.2
     fn visit_step(&mut self, node: &dsl::sfc::Step) -> Result<Self::Value, Diagnostic> {
         self.write_ws("STEP");
-        self.visit_id(&node.name)?;
-        self.write_ws(":");
-        self.newline();
-
-        self.indent();
-        for elem in node.action_associations.iter() {
-            self.visit_action_association(elem)?;
-            self.newline();
-        }
-        self.outdent();
-
-        self.write_ws("END_STEP");
-        self.newline();
-        Ok(())
+        self.write_step_body(node)
     }
 
     // 2.6.3

--- a/compiler/resources/test/sfc.st
+++ b/compiler/resources/test/sfc.st
@@ -10,6 +10,7 @@ FUNCTION_BLOCK sfc
   END_VAR
 
   INITIAL_STEP Start:
+    RESET(N);
   END_STEP
 
   TRANSITION FROM Start TO MidStep


### PR DESCRIPTION
## Summary

Fixes issue #1659 where `INITIAL_STEP` and `STEP` rules in Sequential Function Charts (SFC) had divergent implementations that prevented valid action associations from being parsed. The `INITIAL_STEP` rule had its own copy of the step tail that neither consumed the terminating semicolon nor allowed whitespace before `END_STEP`, making any association on the initial step a syntax error. Additionally, `STEP` required at least one association (via `semisep`), rejecting empty steps.

## Changes

- **Parser (`compiler/parser/src/parser.rs`)**
  - Extracted the shared `name : associations END_STEP` tail into a new `step_body()` rule
  - Updated `initial_step()` to use `step_body()` instead of its own inline implementation
  - Updated `step()` to use `step_body()` instead of its own inline implementation
  - Changed association list parsing from `semisep` (requires ≥1 item) to `semisep_or_empty` (allows 0 items)
  - This ensures both `INITIAL_STEP` and `STEP` accept the same valid bodies

- **Renderer (`compiler/plc2plc/src/renderer.rs`)**
  - Extracted the shared step rendering logic into a new `write_step_body()` method
  - Updated `visit_network()` to use `write_step_body()` for `INITIAL_STEP`
  - Updated `visit_step()` to use `write_step_body()` for `STEP`
  - Ensures round-trip rendering consistency

- **Tests (`compiler/parser/src/tests/sfc.rs`)**
  - Added new test module with regression tests for issue #1659
  - `parse_when_initial_step_has_action_association_then_builds_step()` - validates single association on initial step
  - `parse_when_initial_step_has_two_action_associations_then_builds_step()` - validates multiple associations with indicators
  - `parse_when_step_has_no_action_associations_then_builds_empty_step()` - validates empty step
  - `parse_when_initial_step_association_missing_semicolon_then_error()` - confirms semicolon requirement is still enforced

- **Whitespace tests (`compiler/parser/src/tests/whitespace.rs`)**
  - Added `in_sfc()` helper function for wrapping SFC step test cases
  - Added gap-filling test cases for `INITIAL_STEP` and `STEP` action associations

- **Test fixtures**
  - Updated `compiler/resources/test/sfc.st` and `compiler/plc2plc/resources/test/sfc_rendered.st` to include action associations on the initial step

## Implementation Details

The key insight is that `INITIAL_STEP` and `STEP` share the same syntactic structure for their body (name, colon, optional action associations, `END_STEP`). By extracting this into a shared rule, the two cannot drift apart again. The use of `semisep_or_empty` allows both empty steps and steps with associations, where each association must be terminated by a semicolon.

https://claude.ai/code/session_01QsxQdf9GYshZYTDZzJfi9Z