### PR TITLE
Reunite resolve_initializer_expr with its doc comment

### DIFF
--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -66,10 +66,6 @@ fn negate_literal_constant(c: ConstantKind) -> Result<ConstantKind, ConstantKind
     }
 }
 
-/// Collapses an initializer expression to `Simple` when it is exactly a
-/// literal (optionally with one leading unary minus, e.g. `-123`), and
-/// otherwise wraps it as `SimpleExpr` (the constant-expression dialect
-/// extension, folded by `xform_fold_initializer_expressions`).
 /// A member list written against a user type name: `T := (a := 1)`. The
 /// type may be a structure or a function block; the resolver decides.
 fn late_resolved_members(init: StructureInitializationDeclaration) -> InitialValueAssignmentKind {
@@ -99,6 +95,10 @@ fn late_resolved_or_enumerated(
     })
 }
 
+/// Collapses an initializer expression to `Simple` when it is exactly a
+/// literal (optionally with one leading unary minus, e.g. `-123`), and
+/// otherwise wraps it as `SimpleExpr` (the constant-expression extension,
+/// folded by `xform_fold_initializer_expressions`).
 fn resolve_initializer_expr(type_name: TypeName, e: ExprKind) -> InitialValueAssignmentKind {
     match e {
         ExprKind::Const(c) => InitialValueAssignmentKind::Simple(SimpleInitializer {


### PR DESCRIPTION
Noticed while rebasing [#1640](https://github.com/ironplc/ironplc/pull/1640) onto [#1654](https://github.com/ironplc/ironplc/pull/1654). Comments only, no behaviour change.

## What happened

`#1654` inserted `late_resolved_members` and `late_resolved_or_enumerated` into `parser/src/parser.rs` between `resolve_initializer_expr` and the doc comment above it. Rust attaches `///` to whatever item follows, so the paragraph describing `resolve_initializer_expr` came to sit on `late_resolved_members` instead — stacked directly above that function's own doc, which reads oddly:

```rust
/// Collapses an initializer expression to `Simple` when it is exactly a
/// literal (optionally with one leading unary minus, e.g. `-123`), and
/// otherwise wraps it as `SimpleExpr` (the constant-expression dialect
/// extension, folded by `xform_fold_initializer_expressions`).
/// A member list written against a user type name: `T := (a := 1)`. The
/// type may be a structure or a function block; the resolver decides.
fn late_resolved_members(init: StructureInitializationDeclaration) -> InitialValueAssignmentKind {
```

`resolve_initializer_expr` was left undocumented, and `rustdoc` would have shown `late_resolved_members` as doing two unrelated things.

Moved back to the function it describes. Each of the two now carries its own doc and nothing else.

## Also

Dropped the "dialect" qualifier: "the constant-expression **dialect** extension" → "the constant-expression extension". Per `specs/steering/glossary.md`, an extension is a syntax feature and a dialect is a bundle of them, so the qualifier does not belong on one.

## Verification

The change is comments only, but `parser.rs` is compiled, so the full pipeline ran rather than eyeballing it: `cd compiler && just` (compile, coverage, clippy, fmt, dupes) and `cd specs && just` both pass; 56/56 test binaries green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bPBbrc1x2uLWY7S5vTVfn

---
_Generated by [Claude Code](https://claude.ai/code/session_016bPBbrc1x2uLWY7S5vTVfn)_