### PR TITLE
WIP: allow functions with VAR_IN_OUT to be called — DO NOT MERGE, see #1672

### DIFF
--- a/compiler/analyzer/src/function_environment.rs
+++ b/compiler/analyzer/src/function_environment.rs
@@ -110,10 +110,16 @@ impl FunctionSignature {
     ///
     /// One definition, so the arity check and the positional binding below
     /// cannot disagree about which parameters a caller has to pass.
+    ///
+    /// `VAR_IN_OUT` counts: the caller passes the variable the function
+    /// reads and writes through, so it is an argument at the call site
+    /// exactly as `VAR_INPUT` is. Counting only `VAR_INPUT` made every call
+    /// to a function declaring one look over-supplied, which is why
+    /// `is_input_compatible` and not `is_input` is the question to ask.
     fn declared_inputs(
         &self,
     ) -> impl DoubleEndedIterator<Item = &IntermediateFunctionParameter> + Clone {
-        self.parameters.iter().filter(|p| p.is_input)
+        self.parameters.iter().filter(|p| p.is_input_compatible())
     }
 
     /// Returns the number of input parameters.

--- a/compiler/analyzer/src/function_environment.rs
+++ b/compiler/analyzer/src/function_environment.rs
@@ -105,9 +105,20 @@ impl FunctionSignature {
         self.span.is_builtin()
     }
 
+    /// The declared parameters a call supplies an argument for, in
+    /// declaration order.
+    ///
+    /// One definition, so the arity check and the positional binding below
+    /// cannot disagree about which parameters a caller has to pass.
+    fn declared_inputs(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &IntermediateFunctionParameter> + Clone {
+        self.parameters.iter().filter(|p| p.is_input)
+    }
+
     /// Returns the number of input parameters.
     pub fn input_parameter_count(&self) -> usize {
-        self.parameters.iter().filter(|p| p.is_input).count()
+        self.declared_inputs().count()
     }
 
     /// Pairs each positional input argument of a call with the parameter it
@@ -140,7 +151,7 @@ impl FunctionSignature {
     /// never when there is none, so a caller with no argument list to zip
     /// against must bound what it takes.
     pub fn input_parameters(&self) -> impl Iterator<Item = IntermediateFunctionParameter> + '_ {
-        let declared = self.parameters.iter().filter(|p| p.is_input);
+        let declared = self.declared_inputs();
         let extension = self
             .is_extensible
             .then(|| declared.clone().next_back())

--- a/specs/plans/2026-09-07-var-in-out-call-arity.md
+++ b/specs/plans/2026-09-07-var-in-out-call-arity.md
@@ -1,0 +1,99 @@
+# Let functions with VAR_IN_OUT be called
+
+## Goal
+
+A function that declares a `VAR_IN_OUT` parameter cannot be called at all.
+The arity check counts only `VAR_INPUT`, so every call looks like it passed
+too many arguments:
+
+```iecst
+FUNCTION ADD_TEN : DINT
+  VAR_IN_OUT data : DINT; END_VAR
+  data := data + 10;
+  ADD_TEN := data;
+END_FUNCTION
+...
+  result := ADD_TEN(data := x);
+```
+
+```
+error[P4018]: Function call has wrong number of arguments
+              (function=ADD_TEN, expected=0, actual=1)
+```
+
+`expected=0` for a function with one parameter. The feature is declared,
+parsed, and lowered by codegen, but unreachable from source.
+
+## Architecture
+
+`IntermediateFunctionParameter` already records `is_input`, `is_output` and
+`is_inout` separately, and already carries the predicate this needs:
+
+```rust
+/// Returns true if this parameter receives a value from the caller
+/// (either VAR_INPUT or VAR_IN_OUT).
+pub fn is_input_compatible(&self) -> bool {
+    self.is_input || self.is_inout
+}
+```
+
+`xform_named_to_positional_args` already uses it, which is why the named
+form `ADD_TEN(data := x)` gets as far as the arity check at all. Two places
+in `function_environment.rs` use the narrower `is_input` instead:
+
+- `input_parameter_count()` — what the arity check compares against.
+- `input_parameters()` — what positional arguments bind against.
+
+Both must move together. Counting `VAR_IN_OUT` without binding it would let
+the call through and then never type-check the argument.
+
+Nothing in codegen changes: it already lowers `VAR_IN_OUT` (the end-to-end
+tests below assert the right runtime values), it was simply never reached.
+
+## Prefactoring
+
+The two functions duplicate the `filter(|p| p.is_input)` predicate, so the
+fix would have to be made twice and could be made inconsistently — which is
+the failure mode being fixed.
+
+Extract the declared-input iterator both share, so the predicate lives in
+one place and the change lands in one line. Committed on its own with the
+predicate unchanged, so it is provably behaviour-preserving.
+
+## The blind spot, in miniature
+
+The three end-to-end tests for this feature **pass on `main`** while
+`ironplcc` rejects the very same program:
+
+```
+$ cargo test -p ironplc-codegen --test it inout     # 3 passed
+$ ironplcc check inout.st                           # error[P4018]
+```
+
+Codegen tests do not run the semantic rules (the gap #1663 closes), so they
+never saw the rejection. The fix therefore needs **analyzer** rule tests to
+prove the call is accepted; the codegen tests cannot show it, and would not
+have caught the regression that introduced it.
+
+## Design doc reference
+
+None. `is_input_compatible`'s doc comment is the statement of intent.
+
+## File map
+
+| File | Change |
+| ---- | ------ |
+| `compiler/analyzer/src/function_environment.rs` | Prefactor the shared iterator; then count and bind `VAR_IN_OUT` |
+| `compiler/analyzer/src/rule_function_call_declared.rs` (tests) | Accept a call to a function with `VAR_IN_OUT`, alone and beside a `VAR_INPUT` |
+| `docs/reference/compiler/problems/P4018.rst` | Only if it claims inputs are `VAR_INPUT`-only |
+
+## Tasks
+
+- [ ] Prefactor: extract the shared declared-input iterator; no behaviour change
+- [ ] Count and bind `VAR_IN_OUT` via `is_input_compatible()`
+- [ ] Rule tests: `VAR_IN_OUT` alone; `VAR_INPUT` + `VAR_IN_OUT` in declaration
+      order; wrong arity still reported
+- [ ] Confirm end to end that `ironplcc` compiles and the VM returns 15
+- [ ] Check `P4018.rst` for a now-wrong claim
+- [ ] Full CI: `cd compiler && just` and `cd specs && just`
+- [ ] `git rm` this plan


### PR DESCRIPTION
> **Do not merge.** This is incomplete, and merging it alone would ship a
> feature that compiles, runs, and silently discards the caller's writes.
> Tracked in #1672. This description replaces an earlier one that was written
> from the plan, before the second defect below was found.

## What this branch does

Functions declaring `VAR_IN_OUT` cannot be called at all — the arity check
counts only `VAR_INPUT`, so `ADD_TEN(data := x)` is rejected with
`P4018 expected=0, actual=1` for a function with one parameter.

Two commits:

- **Prefactor** — extract `declared_inputs()`, so the arity check and
  positional binding share one predicate and cannot diverge. Behaviour
  preserving; analyzer suite passes (1695 tests).
- **Fix** — that predicate becomes `is_input_compatible()` (`is_input ||
  is_inout`), the definition already carried by
  `IntermediateFunctionParameter` and already used by
  `xform_named_to_positional_args`.

With it, `ADD_TEN(data := x)` compiles and returns 15.

## Why it must not merge as-is

Making the call reachable revealed the feature is half-implemented.
IEC 61131-3 §2.5.1.1 makes `VAR_IN_OUT` **by reference**; this compiler
passes it by value:

```iecst
FUNCTION BUMP : DINT
  VAR_IN_OUT data : DINT; END_VAR
  data := data + 10;
  BUMP := 0;
END_FUNCTION

PROGRAM main
  VAR x : DINT := 5; r : DINT; END_VAR
  r := BUMP(data := x);
END_PROGRAM
```

```
x: 5        <- should be 15
r: 0
data: 15    <- only the callee's copy changed
```

There is no by-reference calling machinery in codegen or the VM; the concept
appears in neither beyond a debug-section tag. So merging the arity fix alone
replaces today's loud (if misleading) refusal with silent data loss — the same
class of bug as #1665, which this session fixed.

## Corrections to the previous description

- "the codegen already lowered `VAR_IN_OUT` correctly" — **not true**, see above.
- The rule tests listed under Testing were **never written**; the branch stops
  at the prefactor and the one-line fix.
- The plan file has **not** been `git rm`ed, as the workflow requires before
  merge.

## The three end-to-end tests do not protect this

They pass on `main` while `ironplcc` rejects the same program (codegen tests
skip the semantic rules — the gap #1663 closes), and they would not catch the
by-value defect either: each asserts only the return value (slot 1), never the
caller's variable (slot 0).

## Options

See #1672. Either implement write-back alongside this, or drop this and
replace the misleading P4018 with an explicit "not implemented" diagnostic.

https://claude.ai/code/session_01Pm6N9yZCc1CGAPN5Ekqsag