### PR TITLE
Extract benchmark programs to shared module

### DIFF
--- a/compiler/benchmarks/benches/st_benchmark.rs
+++ b/compiler/benchmarks/benches/st_benchmark.rs
@@ -5,10 +5,14 @@
 //! complement the hand-crafted bytecode benchmarks in `ironplc-vm` by
 //! exercising realistic code paths.
 //!
+//! The ST sources live in `ironplc_benchmarks::programs` so that
+//! `tests/compile_programs.rs` can compile each one as a regular test.
+//!
 //! Run with: `cargo bench --package ironplc-benchmarks`
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use ironplc_benchmarks::compile_st;
+use ironplc_benchmarks::programs;
 use ironplc_vm::test_support::load_and_start;
 use ironplc_vm::{NoopDebugHook, Slot, VmBuffers};
 use std::hint::black_box;
@@ -37,14 +41,7 @@ macro_rules! bench_run {
 /// WHILE loop decrementing a counter — dispatch overhead baseline.
 fn bench_counter_loop(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_counter_loop");
-    let container = compile_st(
-        "PROGRAM main
-  VAR counter : DINT; END_VAR
-  WHILE counter > 0 DO
-    counter := counter - 1;
-  END_WHILE;
-END_PROGRAM",
-    );
+    let container = compile_st(programs::COUNTER_LOOP);
 
     for count in [100, 1000, 10_000] {
         group.throughput(Throughput::Elements(count as u64));
@@ -65,12 +62,7 @@ fn bench_arithmetic_i32(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_arithmetic_i32");
 
     for reps in [10, 100, 1000] {
-        let mut source = String::from("PROGRAM main\n  VAR x : DINT; END_VAR\n");
-        for _ in 0..reps {
-            source.push_str("  x := (x + 7 - 3) * 2;\n");
-        }
-        source.push_str("END_PROGRAM\n");
-        let container = compile_st(&source);
+        let container = compile_st(&programs::arithmetic_i32(reps));
 
         group.throughput(Throughput::Elements(reps as u64));
         bench_run!(
@@ -90,12 +82,7 @@ fn bench_arithmetic_f64(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_arithmetic_f64");
 
     for reps in [10, 100, 1000] {
-        let mut source = String::from("PROGRAM main\n  VAR x : LREAL; END_VAR\n");
-        for _ in 0..reps {
-            source.push_str("  x := (x + 7.0 - 3.0) * 2.0;\n");
-        }
-        source.push_str("END_PROGRAM\n");
-        let container = compile_st(&source);
+        let container = compile_st(&programs::arithmetic_f64(reps));
 
         group.throughput(Throughput::Elements(reps as u64));
         bench_run!(
@@ -115,16 +102,7 @@ fn bench_branching(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_branching");
 
     for branches in [5, 20, 50] {
-        let mut source = String::from("PROGRAM main\n  VAR sel : DINT; result : DINT; END_VAR\n");
-        for i in 0..branches {
-            if i == 0 {
-                source.push_str(&format!("  IF sel = {} THEN\n    result := {};\n", i, i));
-            } else {
-                source.push_str(&format!("  ELSIF sel = {} THEN\n    result := {};\n", i, i));
-            }
-        }
-        source.push_str("  END_IF;\nEND_PROGRAM\n");
-        let container = compile_st(&source);
+        let container = compile_st(&programs::branching(branches));
 
         bench_run!(
             group,
@@ -141,15 +119,7 @@ fn bench_branching(c: &mut Criterion) {
 /// FOR loop summing 1..limit — structured loop overhead.
 fn bench_for_loop(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_for_loop");
-    let container = compile_st(
-        "PROGRAM main
-  VAR i : DINT; sum : DINT; limit : DINT; END_VAR
-  sum := 0;
-  FOR i := 1 TO limit DO
-    sum := sum + i;
-  END_FOR;
-END_PROGRAM",
-    );
+    let container = compile_st(programs::FOR_LOOP);
 
     for limit in [100, 1000, 10_000] {
         group.throughput(Throughput::Elements(limit as u64));
@@ -168,18 +138,7 @@ END_PROGRAM",
 /// Nested FOR loops — exercises loop overhead at scale.
 fn bench_nested_loops(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_nested_loops");
-    let container = compile_st(
-        "PROGRAM main
-  VAR i : DINT; j : DINT; acc : DINT;
-      outer : DINT; inner : DINT; END_VAR
-  acc := 0;
-  FOR i := 1 TO outer DO
-    FOR j := 1 TO inner DO
-      acc := acc + i * j;
-    END_FOR;
-  END_FOR;
-END_PROGRAM",
-    );
+    let container = compile_st(programs::NESTED_LOOPS);
 
     for (outer, inner) in [(10, 10), (10, 100), (100, 100)] {
         let label = format!("{}x{}", outer, inner);
@@ -197,22 +156,11 @@ END_PROGRAM",
     group.finish();
 }
 
-/// Narrow opcode diversity — loop body uses only ~5 distinct opcodes
-/// (LOAD_VAR, LOAD_CONST, ADD, STORE_VAR, GT, JMP_IF_NOT, JMP).
+/// Narrow opcode diversity — loop body uses only ~5 distinct opcodes.
 /// Baseline for comparison with diverse_opcodes below.
 fn bench_narrow_opcodes(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_narrow_opcodes");
-    let container = compile_st(
-        "PROGRAM main
-  VAR i : DINT; x : DINT; limit : DINT; END_VAR
-  FOR i := 1 TO limit DO
-    x := x + 1;
-    x := x + 2;
-    x := x + 3;
-    x := x + 4;
-  END_FOR;
-END_PROGRAM",
-    );
+    let container = compile_st(programs::NARROW_OPCODES);
 
     for limit in [100, 1000, 10_000] {
         group.throughput(Throughput::Elements(limit as u64));
@@ -228,75 +176,12 @@ END_PROGRAM",
     group.finish();
 }
 
-/// Diverse opcode mix — loop body touches many distinct opcode handlers:
-/// i32 arithmetic (ADD, SUB, MUL, DIV, MOD, NEG), f64 arithmetic (ADD, SUB,
-/// MUL, DIV), comparisons (GT, LT, EQ, NE, GE, LE), boolean logic (AND, OR,
-/// XOR, NOT), builtins (ABS, MIN, MAX, LIMIT, SQRT, SHL), type conversions
-/// (DINT_TO_LREAL, LREAL_TO_DINT), and bitwise ops (AND, OR, XOR, NOT).
-/// This forces many dispatch table entries into L1 icache simultaneously.
+/// Diverse opcode mix — loop body touches many distinct opcode handlers
+/// (see [`programs::DIVERSE_OPCODES`] for the full list). This forces many
+/// dispatch table entries into L1 icache simultaneously.
 fn bench_diverse_opcodes(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_diverse_opcodes");
-    let container = compile_st(
-        "PROGRAM main
-  VAR
-    i : DINT;
-    limit : DINT;
-    d1 : DINT; d2 : DINT; d3 : DINT;
-    f1 : LREAL; f2 : LREAL;
-    b1 : BOOL; b2 : BOOL; b3 : BOOL;
-    w1 : DWORD; w2 : DWORD;
-  END_VAR
-  d1 := 100;
-  d2 := 7;
-  f1 := 3.14;
-  b1 := TRUE;
-  w1 := 16#FF00FF00;
-  FOR i := 1 TO limit DO
-    (* i32 arithmetic: ADD, SUB, MUL, DIV, MOD *)
-    d3 := (d1 + d2) - (d1 * 2);
-    d3 := d1 / d2;
-    d3 := d1 MOD d2;
-    d3 := -d3;
-
-    (* f64 arithmetic: ADD, SUB, MUL, DIV *)
-    f2 := (f1 + 1.0) * 2.0;
-    f2 := f2 - 0.5;
-    f2 := f2 / 3.0;
-
-    (* comparisons: GT, LT, EQ, NE, GE, LE *)
-    b1 := d1 > d2;
-    b2 := d1 < d2;
-    b3 := d1 = d2;
-    b1 := d1 <> d2;
-    b2 := d1 >= d2;
-    b3 := d1 <= d2;
-
-    (* boolean logic: AND, OR, XOR, NOT *)
-    b1 := b1 AND b2;
-    b1 := b1 OR b3;
-    b1 := b1 XOR b2;
-    b1 := NOT b1;
-
-    (* bitwise: AND, OR, XOR, NOT *)
-    w2 := w1 AND 16#0F0F0F0F;
-    w2 := w2 OR 16#F0F0F0F0;
-    w2 := w2 XOR 16#AAAAAAAA;
-    w2 := NOT w2;
-
-    (* builtins: ABS, MIN, MAX, LIMIT, SQRT, SHL *)
-    d3 := ABS(d3);
-    d3 := MIN(d1, d2);
-    d3 := MAX(d1, d2);
-    d3 := LIMIT(0, d3, 1000);
-    f2 := SQRT(f2 * f2 + 1.0);
-    d3 := SHL(d3, 2);
-
-    (* type conversions: DINT_TO_LREAL, LREAL_TO_DINT *)
-    f2 := DINT_TO_LREAL(d3);
-    d3 := LREAL_TO_DINT(f2);
-  END_FOR;
-END_PROGRAM",
-    );
+    let container = compile_st(programs::DIVERSE_OPCODES);
 
     for limit in [100, 1000, 10_000] {
         group.throughput(Throughput::Elements(limit as u64));
@@ -317,24 +202,7 @@ END_PROGRAM",
 /// program does no looping.
 fn bench_arithmetic(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_arithmetic");
-    let container = compile_st(
-        "PROGRAM arithmetic
-  VAR
-      a : INT := 20;
-      b : INT := 10;
-      result_add : INT;
-      result_sub : INT;
-      result_mul : INT;
-      result_div : INT;
-      result_mod : INT;
-  END_VAR
-      result_add := a + b;
-      result_sub := a - b;
-      result_mul := a * b;
-      result_div := a / b;
-      result_mod := a MOD b;
-  END_PROGRAM",
-    );
+    let container = compile_st(programs::ARITHMETIC);
     bench_run!(
         group,
         BenchmarkId::from_parameter("5ops"),
@@ -349,43 +217,7 @@ fn bench_arithmetic(c: &mut Criterion) {
 /// (five assignments) plus the CASE selector load.
 fn bench_case_state(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_case_state");
-    let container = compile_st(
-        "PROGRAM case_state
-  VAR
-      state : INT := 0;
-      output_a : BOOL := FALSE;
-      output_b : BOOL := FALSE;
-      output_c : BOOL := FALSE;
-      output_d : BOOL := FALSE;
-  END_VAR
-      CASE state OF
-          0:
-              output_a := TRUE;
-              output_b := FALSE;
-              output_c := FALSE;
-              output_d := FALSE;
-              state := 1;
-          1:
-              output_a := FALSE;
-              output_b := TRUE;
-              output_c := FALSE;
-              output_d := FALSE;
-              state := 2;
-          2:
-              output_a := FALSE;
-              output_b := FALSE;
-              output_c := TRUE;
-              output_d := FALSE;
-              state := 3;
-          3:
-              output_a := FALSE;
-              output_b := FALSE;
-              output_c := FALSE;
-              output_d := TRUE;
-              state := 0;
-      END_CASE;
-  END_PROGRAM",
-    );
+    let container = compile_st(programs::CASE_STATE);
     bench_run!(
         group,
         BenchmarkId::from_parameter("4states"),
@@ -400,22 +232,7 @@ fn bench_case_state(c: &mut Criterion) {
 /// plus either an increment (the common path) or a reset (1 in 1001 scans).
 fn bench_counter_up(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_counter_up");
-    let container = compile_st(
-        "PROGRAM counter_up
-  VAR
-      count : INT := 0;
-      threshold : INT := 1000;
-      reset_flag : BOOL := FALSE;
-  END_VAR
-      IF count >= threshold THEN
-          count := 0;
-          reset_flag := TRUE;
-      ELSE
-          count := count + 1;
-          reset_flag := FALSE;
-      END_IF;
-  END_PROGRAM",
-    );
+    let container = compile_st(programs::COUNTER_UP);
     bench_run!(
         group,
         BenchmarkId::from_parameter("1iter"),
@@ -440,14 +257,7 @@ fn bench_counter_up(c: &mut Criterion) {
 /// with `--save-baseline` / `--baseline`).
 fn bench_debug_scan_cost(c: &mut Criterion) {
     let mut group = c.benchmark_group("st_debug_scan_cost");
-    let container = compile_st(
-        "PROGRAM main
-  VAR counter : DINT; END_VAR
-  WHILE counter > 0 DO
-    counter := counter - 1;
-  END_WHILE;
-END_PROGRAM",
-    );
+    let container = compile_st(programs::COUNTER_LOOP);
 
     let count = 10_000;
     group.throughput(Throughput::Elements(count as u64));

--- a/compiler/benchmarks/src/lib.rs
+++ b/compiler/benchmarks/src/lib.rs
@@ -3,6 +3,8 @@
 //! Hosts utilities used by both the Criterion benchmarks under `benches/`
 //! and the integration tests under `tests/`.
 
+pub mod programs;
+
 use ironplc_codegen::compile;
 use ironplc_container::Container;
 use ironplc_dsl::core::FileId;
@@ -11,13 +13,22 @@ use ironplc_parser::parse_program;
 
 /// Compiles an IEC 61131-3 source string through the full pipeline:
 /// parse → analyze (all semantic rules) → codegen.
+///
+/// Panics if the source fails to parse, has semantic diagnostics, or fails
+/// to compile. The panic message lists the diagnostic codes so a failing
+/// benchmark program can be fixed without re-running under a debugger.
 pub fn compile_st(source: &str) -> Container {
     let options = CompilerOptions::default();
     let library = parse_program(source, &FileId::default(), &options).unwrap();
     let (analyzed, context) = ironplc_analyzer::stages::analyze(&[&library], &options).unwrap();
+    let codes: Vec<&str> = context
+        .diagnostics()
+        .iter()
+        .map(|d| d.code.as_str())
+        .collect();
     assert!(
-        !context.has_diagnostics(),
-        "Source has semantic diagnostics"
+        codes.is_empty(),
+        "Source has semantic diagnostics: {codes:?}"
     );
     let codegen_options = ironplc_codegen::CodegenOptions::default();
     compile(

--- a/compiler/benchmarks/src/programs.rs
+++ b/compiler/benchmarks/src/programs.rs
@@ -1,0 +1,250 @@
+//! IEC 61131-3 source programs compiled by the benchmark suite.
+//!
+//! The Criterion benchmarks in `benches/st_benchmark.rs` compile every one
+//! of these when the benchmark groups are registered, so a program that the
+//! analyzer rejects takes down the whole bench binary before any group
+//! runs -- including groups selected by a name filter. Keeping the sources
+//! here lets `tests/compile_programs.rs` compile each one as an ordinary
+//! test, which fails on its own instead of at `cargo bench` time.
+//!
+//! Programs with a size parameter are exposed as functions; [`all`] lists
+//! every program with a representative parameter.
+
+/// WHILE loop decrementing a counter -- dispatch overhead baseline.
+pub const COUNTER_LOOP: &str = "PROGRAM main
+  VAR counter : DINT; END_VAR
+  WHILE counter > 0 DO
+    counter := counter - 1;
+  END_WHILE;
+END_PROGRAM";
+
+/// Straight-line DINT arithmetic with `reps` statements.
+pub fn arithmetic_i32(reps: usize) -> String {
+    let mut source = String::from("PROGRAM main\n  VAR x : DINT; END_VAR\n");
+    for _ in 0..reps {
+        source.push_str("  x := (x + 7 - 3) * 2;\n");
+    }
+    source.push_str("END_PROGRAM\n");
+    source
+}
+
+/// Straight-line LREAL arithmetic with `reps` statements.
+pub fn arithmetic_f64(reps: usize) -> String {
+    let mut source = String::from("PROGRAM main\n  VAR x : LREAL; END_VAR\n");
+    for _ in 0..reps {
+        source.push_str("  x := (x + 7.0 - 3.0) * 2.0;\n");
+    }
+    source.push_str("END_PROGRAM\n");
+    source
+}
+
+/// IF-ELSIF chain with `branches` arms -- worst-case sequential comparison.
+pub fn branching(branches: i32) -> String {
+    let mut source = String::from("PROGRAM main\n  VAR sel : DINT; result : DINT; END_VAR\n");
+    for i in 0..branches {
+        if i == 0 {
+            source.push_str(&format!("  IF sel = {} THEN\n    result := {};\n", i, i));
+        } else {
+            source.push_str(&format!("  ELSIF sel = {} THEN\n    result := {};\n", i, i));
+        }
+    }
+    source.push_str("  END_IF;\nEND_PROGRAM\n");
+    source
+}
+
+/// FOR loop summing 1..limit -- structured loop overhead.
+pub const FOR_LOOP: &str = "PROGRAM main
+  VAR i : DINT; sum : DINT; limit : DINT; END_VAR
+  sum := 0;
+  FOR i := 1 TO limit DO
+    sum := sum + i;
+  END_FOR;
+END_PROGRAM";
+
+/// Nested FOR loops -- loop overhead at scale.
+pub const NESTED_LOOPS: &str = "PROGRAM main
+  VAR i : DINT; j : DINT; acc : DINT;
+      outer : DINT; inner : DINT; END_VAR
+  acc := 0;
+  FOR i := 1 TO outer DO
+    FOR j := 1 TO inner DO
+      acc := acc + i * j;
+    END_FOR;
+  END_FOR;
+END_PROGRAM";
+
+/// Narrow opcode diversity -- the loop body uses only ~5 distinct opcodes
+/// (LOAD_VAR, LOAD_CONST, ADD, STORE_VAR, GT, JMP_IF_NOT, JMP).
+pub const NARROW_OPCODES: &str = "PROGRAM main
+  VAR i : DINT; x : DINT; limit : DINT; END_VAR
+  FOR i := 1 TO limit DO
+    x := x + 1;
+    x := x + 2;
+    x := x + 3;
+    x := x + 4;
+  END_FOR;
+END_PROGRAM";
+
+/// Diverse opcode mix -- the loop body touches many distinct opcode
+/// handlers: i32 arithmetic (ADD, SUB, MUL, DIV, MOD, NEG), f64 arithmetic
+/// (ADD, SUB, MUL, DIV), comparisons (GT, LT, EQ, NE, GE, LE), boolean
+/// logic (AND, OR, XOR, NOT), bitwise ops on DWORD (AND, OR, XOR, NOT),
+/// builtins (ABS, MIN, MAX, LIMIT, SQRT, SHL), and type conversions
+/// (DINT_TO_LREAL, LREAL_TO_DINT, DINT_TO_DWORD, DWORD_TO_DINT).
+///
+/// The bit-string operators and `SHL` are typed `ANY_BIT`, so the bitwise
+/// work happens on the DWORD variables with `DWORD#` literals, and the
+/// DINT results cross into the bit-string domain through explicit
+/// conversions rather than implicit widening.
+pub const DIVERSE_OPCODES: &str = "PROGRAM main
+  VAR
+    i : DINT;
+    limit : DINT;
+    d1 : DINT; d2 : DINT; d3 : DINT;
+    f1 : LREAL; f2 : LREAL;
+    b1 : BOOL; b2 : BOOL; b3 : BOOL;
+    w1 : DWORD; w2 : DWORD;
+  END_VAR
+  d1 := 100;
+  d2 := 7;
+  f1 := 3.14;
+  b1 := TRUE;
+  w1 := DWORD#16#FF00FF00;
+  FOR i := 1 TO limit DO
+    (* i32 arithmetic: ADD, SUB, MUL, DIV, MOD, NEG *)
+    d3 := (d1 + d2) - (d1 * 2);
+    d3 := d1 / d2;
+    d3 := d1 MOD d2;
+    d3 := -d3;
+
+    (* f64 arithmetic: ADD, SUB, MUL, DIV *)
+    f2 := (f1 + 1.0) * 2.0;
+    f2 := f2 - 0.5;
+    f2 := f2 / 3.0;
+
+    (* comparisons: GT, LT, EQ, NE, GE, LE *)
+    b1 := d1 > d2;
+    b2 := d1 < d2;
+    b3 := d1 = d2;
+    b1 := d1 <> d2;
+    b2 := d1 >= d2;
+    b3 := d1 <= d2;
+
+    (* boolean logic: AND, OR, XOR, NOT *)
+    b1 := b1 AND b2;
+    b1 := b1 OR b3;
+    b1 := b1 XOR b2;
+    b1 := NOT b1;
+
+    (* bitwise on DWORD: AND, OR, XOR, NOT *)
+    w2 := w1 AND DWORD#16#0F0F0F0F;
+    w2 := w2 OR DWORD#16#F0F0F0F0;
+    w2 := w2 XOR DWORD#16#AAAAAAAA;
+    w2 := NOT w2;
+
+    (* builtins: ABS, MIN, MAX, LIMIT, SQRT, SHL *)
+    d3 := ABS(d3);
+    d3 := MIN(d1, d2);
+    d3 := MAX(d1, d2);
+    d3 := LIMIT(0, d3, 1000);
+    f2 := SQRT(f2 * f2 + 1.0);
+    w2 := SHL(w2, 2);
+
+    (* type conversions: DINT_TO_LREAL, LREAL_TO_DINT, DINT_TO_DWORD, DWORD_TO_DINT *)
+    f2 := DINT_TO_LREAL(d3);
+    d3 := LREAL_TO_DINT(f2);
+    w2 := DINT_TO_DWORD(d3);
+    d3 := DWORD_TO_DINT(w2);
+  END_FOR;
+END_PROGRAM";
+
+/// Five distinct INT arithmetic operations on the same operands -- covers
+/// ADD, SUB, MUL, DIV, MOD in one scan with no looping.
+pub const ARITHMETIC: &str = "PROGRAM arithmetic
+  VAR
+      a : INT := 20;
+      b : INT := 10;
+      result_add : INT;
+      result_sub : INT;
+      result_mul : INT;
+      result_div : INT;
+      result_mod : INT;
+  END_VAR
+      result_add := a + b;
+      result_sub := a - b;
+      result_mul := a * b;
+      result_div := a / b;
+      result_mod := a MOD b;
+  END_PROGRAM";
+
+/// CASE statement state machine with four states that advance per scan.
+pub const CASE_STATE: &str = "PROGRAM case_state
+  VAR
+      state : INT := 0;
+      output_a : BOOL := FALSE;
+      output_b : BOOL := FALSE;
+      output_c : BOOL := FALSE;
+      output_d : BOOL := FALSE;
+  END_VAR
+      CASE state OF
+          0:
+              output_a := TRUE;
+              output_b := FALSE;
+              output_c := FALSE;
+              output_d := FALSE;
+              state := 1;
+          1:
+              output_a := FALSE;
+              output_b := TRUE;
+              output_c := FALSE;
+              output_d := FALSE;
+              state := 2;
+          2:
+              output_a := FALSE;
+              output_b := FALSE;
+              output_c := TRUE;
+              output_d := FALSE;
+              state := 3;
+          3:
+              output_a := FALSE;
+              output_b := FALSE;
+              output_c := FALSE;
+              output_d := TRUE;
+              state := 0;
+      END_CASE;
+  END_PROGRAM";
+
+/// IF/ELSE counter with a saturation reset -- minimal state-machine shape
+/// representative of typical PLC scan code.
+pub const COUNTER_UP: &str = "PROGRAM counter_up
+  VAR
+      count : INT := 0;
+      threshold : INT := 1000;
+      reset_flag : BOOL := FALSE;
+  END_VAR
+      IF count >= threshold THEN
+          count := 0;
+          reset_flag := TRUE;
+      ELSE
+          count := count + 1;
+          reset_flag := FALSE;
+      END_IF;
+  END_PROGRAM";
+
+/// Every benchmark program paired with a name, using a small representative
+/// parameter for the generated ones. The smoke test compiles each entry.
+pub fn all() -> Vec<(&'static str, String)> {
+    vec![
+        ("counter_loop", COUNTER_LOOP.to_string()),
+        ("arithmetic_i32", arithmetic_i32(10)),
+        ("arithmetic_f64", arithmetic_f64(10)),
+        ("branching", branching(5)),
+        ("for_loop", FOR_LOOP.to_string()),
+        ("nested_loops", NESTED_LOOPS.to_string()),
+        ("narrow_opcodes", NARROW_OPCODES.to_string()),
+        ("diverse_opcodes", DIVERSE_OPCODES.to_string()),
+        ("arithmetic", ARITHMETIC.to_string()),
+        ("case_state", CASE_STATE.to_string()),
+        ("counter_up", COUNTER_UP.to_string()),
+    ]
+}

--- a/compiler/benchmarks/tests/compile_programs.rs
+++ b/compiler/benchmarks/tests/compile_programs.rs
@@ -1,0 +1,18 @@
+//! Compiles every benchmark program once through the full pipeline.
+//!
+//! `benches/st_benchmark.rs` compiles all of its programs when the Criterion
+//! groups are registered, so an analyzer change that rejects any one of them
+//! panics the whole bench binary before a single benchmark runs. Nothing in
+//! CI runs the benchmarks, so this test is what turns that into a failing
+//! test instead.
+
+use ironplc_benchmarks::compile_st;
+use ironplc_benchmarks::programs;
+
+#[test]
+fn compile_st_when_each_benchmark_program_then_compiles_without_diagnostics() {
+    for (name, source) in programs::all() {
+        eprintln!("compiling benchmark program: {name}");
+        compile_st(&source);
+    }
+}


### PR DESCRIPTION
Consolidates IEC 61131-3 source programs used by the benchmark suite into a dedicated `programs` module, enabling them to be compiled and tested independently of the Criterion benchmarks.

## Summary

The benchmark programs were previously embedded directly in `benches/st_benchmark.rs`, which meant that any analyzer change rejecting a program would panic the entire bench binary during group registration—before any benchmarks could run. This change extracts all programs into `compiler/benchmarks/src/programs.rs` and adds a smoke test in `tests/compile_programs.rs` that compiles each program as a regular test, catching compilation failures in CI without requiring benchmark execution.

## Key Changes

- **New module `compiler/benchmarks/src/programs.rs`**: Centralizes all 11 benchmark programs (both constants and parameterized functions) with detailed documentation of what each program exercises
  - Constant programs: `COUNTER_LOOP`, `FOR_LOOP`, `NESTED_LOOPS`, `NARROW_OPCODES`, `DIVERSE_OPCODES`, `ARITHMETIC`, `CASE_STATE`, `COUNTER_UP`
  - Parameterized functions: `arithmetic_i32(reps)`, `arithmetic_f64(reps)`, `branching(branches)`
  - Public `all()` function returning all programs with representative parameters for testing

- **New test `compiler/benchmarks/tests/compile_programs.rs`**: Smoke test that compiles each program through the full pipeline (parse → analyze → codegen), catching semantic diagnostics and compilation failures as ordinary test failures rather than benchmark panics

- **Updated `benches/st_benchmark.rs`**: Refactored to use programs from the new module instead of embedding source strings, reducing code duplication and improving maintainability

- **Enhanced `compile_st()` in `src/lib.rs`**: Improved panic messages to include diagnostic codes when compilation fails, aiding debugging of failing benchmark programs

## Implementation Details

- Programs with size parameters are exposed as functions (e.g., `arithmetic_i32(10)`) while fixed programs are constants
- The `DIVERSE_OPCODES` program was corrected to use `DWORD#` literals for bitwise operations (previously used bare hex literals) and includes explicit type conversions for bit-string domain operations
- Documentation in the programs module explains the purpose and performance characteristics of each benchmark

https://claude.ai/code/session_01WdZjmMAyKd5c1XriHdCb6a