### PR TITLE
ADR audit corrections: ADR-0041 back to proposed, and three factual fixes

### DIFF
--- a/specs/adrs/0009-typestate-vm-lifecycle.md
+++ b/specs/adrs/0009-typestate-vm-lifecycle.md
@@ -2,7 +2,7 @@
 
 status: accepted
 date: 2026-02-22
-amended: 2026-09-11 (Confirmation named a method that never existed)
+amended: 2026-09-12 (the scan method named throughout never existed; it is `run_round`)
 
 ## Context and Problem Statement
 
@@ -12,8 +12,8 @@ This decision applies ADR-0005 (safety-first design principle) to the Rust imple
 
 ## Decision Drivers
 
-* **PLC programs control physical processes** — calling `run_single_scan()` on an unloaded VM must be impossible, not just an error
-* **The scan loop is the hot path** — `run_single_scan()` is called thousands of times per second; the API must not impose overhead or ownership transfer on every call
+* **PLC programs control physical processes** — calling `run_round()` on an unloaded VM must be impossible, not just an error
+* **The scan loop is the hot path** — `run_round()` is called thousands of times per second; the API must not impose overhead or ownership transfer on every call
 * **State-dependent data** — `Container`, `OperandStack`, and `VariableTable` only exist after loading; representing them as `Option<T>` introduces `unwrap()` hazards that could panic at runtime
 * **Borrow checker interaction** — the interpreter needs simultaneous immutable access to the container (constant pool) and mutable access to the stack and variables; the design must make this natural rather than requiring workarounds
 * **Future extensibility** — diagnostic interfaces, online change, and I/O drivers will need to interact with the VM while it is running
@@ -33,17 +33,23 @@ The lifecycle is encoded as three distinct types:
 ```
 Vm  ──load(self)──>  VmReady  ──start(self)──>  VmRunning
                                                     │
-                                          run_single_scan(&mut self)
+                                     run_round(&mut self, uptime_us)
                                                     │
                                                     ▼
                                               (stays VmRunning)
 ```
 
-Setup transitions (`load`, `start`) consume `self` and return the next type. The scan loop (`run_single_scan`) takes `&mut self` because the VM remains in the same state on success.
+Setup transitions (`load`, `start`) consume `self` and return the next type. The scan loop (`run_round`) takes `&mut self` because the VM remains in the same state on success.
+
+`Vm`, `VmReady` and `VmRunning` are the three states this ADR decides. The
+shipped engine adds two terminal states reached from `VmRunning` — `VmStopped`
+and `VmFaulted` — which apply the same pattern to the exits the diagram above
+elides; `start` likewise returns `Result<VmRunning, FaultContext>` rather than
+`VmRunning` outright.
 
 ### Consequences
 
-* Good, because invalid state transitions are compile-time errors — you cannot call `run_single_scan()` on a `Vm` or `VmReady`; the method does not exist on those types
+* Good, because invalid state transitions are compile-time errors — you cannot call `run_round()` on a `Vm` or `VmReady`; the method does not exist on those types
 * Good, because state-dependent data is stored directly in each type's fields — no `Option` wrappers, no `unwrap()` calls, no runtime panics from missing data
 * Good, because the `VmError::InvalidState` variant is eliminated entirely — there is no error type for "wrong state" because the type system prevents it
 * Good, because the scan loop uses `&mut self`, which is idiomatic Rust for in-place mutation and allows external code to hold references to the VM
@@ -91,8 +97,8 @@ Each state is a type parameter: `Vm<Empty>`, `Vm<Ready>`, `Vm<Running>`. Every m
 
 * Good, because all transitions are compile-time checked, same as the hybrid approach
 * Good, because the `From` trait can express transitions declaratively
-* Bad, because `run_single_scan(self) -> Result<Vm<Running>, Vm<Faulted>>` consumes `self` on every scan cycle — the caller must rebind the variable on every iteration
-* Bad, because external code cannot hold a `&Vm<Running>` across a `run_single_scan` call, since the value is moved
+* Bad, because `run_round(self, uptime_us) -> Result<Vm<Running>, Vm<Faulted>>` consumes `self` on every scan cycle — the caller must rebind the variable on every iteration
+* Bad, because external code cannot hold a `&Vm<Running>` across a `run_round` call, since the value is moved
 * Bad, because storing "a VM in any state" requires a wrapper enum (`AnyVm`), which reintroduces runtime matching and negates the typestate benefit at the storage boundary
 * Bad, because methods valid across states require either code duplication per `impl Vm<S>` block or a trait with a blanket impl
 
@@ -101,7 +107,7 @@ Each state is a type parameter: `Vm<Empty>`, `Vm<Ready>`, `Vm<Running>`. Every m
 Distinct struct types (`Vm`, `VmReady`, `VmRunning`) with consuming `self` for setup and `&mut self` for the hot path.
 
 * Good, because setup transitions (`load`, `start`) consume `self` — the old state cannot be used after transition, preventing stale-data bugs
-* Good, because the scan loop (`run_single_scan(&mut self)`) is idiomatic — no ownership transfer, references remain valid, standard loop patterns work
+* Good, because the scan loop (`run_round(&mut self, uptime_us)`) is idiomatic — no ownership transfer, references remain valid, standard loop patterns work
 * Good, because each struct contains exactly the fields valid for its state — compile-time data integrity without `Option`
 * Bad, because it introduces three types instead of one — slightly more API surface to learn
 * Neutral, because the "three types" cost is offset by the API being self-documenting — the type name tells you what operations are available
@@ -117,7 +123,7 @@ Concretely, consuming `self` would force this loop pattern:
 ```rust
 let mut vm = vm_running;
 loop {
-    vm = match vm.run_single_scan() {
+    vm = match vm.run_round(0) {
         Ok(still_running) => still_running,
         Err(faulted) => break,
     };
@@ -128,7 +134,7 @@ With `&mut self`, the loop is:
 
 ```rust
 loop {
-    if let Err(trap) = vm.run_single_scan() {
+    if let Err(trap) = vm.run_round(0) {
         break;
     }
 }

--- a/specs/adrs/0012-accept-vendor-dialect-files-as-is.md
+++ b/specs/adrs/0012-accept-vendor-dialect-files-as-is.md
@@ -94,13 +94,13 @@ gaps that apply to the dialect that *is* built are tracked by
 
 What landed:
 
-* **Beckhoff TwinCAT, in full.** `.TcPOU`, `.TcGVL` and `.TcDUT` are recognized
+* **Beckhoff TwinCAT, all but `PROPERTY`.** `.TcPOU`, `.TcGVL` and `.TcDUT` are recognized
   by `FileType::from_path`, and so is `.TcIO` — TwinCAT's `INTERFACE` object
   type, which this ADR's table does not list. The XML wrapper is parsed by
   `sources/src/xml`, and the ST inside goes through the ordinary parser with the
-  TwinCAT extensions enabled. `INTERFACE`, `METHOD`, `PROPERTY`, `EXTENDS`,
-  `IMPLEMENTS`, `POINTER TO`, `REFERENCE TO` and `{attribute}` pragmas all have
-  flags and a `twincat` preset that bundles them.
+  TwinCAT extensions enabled. `INTERFACE`, `METHOD`, `EXTENDS`, `IMPLEMENTS`,
+  `POINTER TO`, `REFERENCE TO` and `{attribute}` pragmas all have flags and a
+  `twincat` preset that bundles them.
 * **The principle itself is in force and is cited as policy.** ADR-0036 depends
   on it — the reason IronPLC defines no dialect of its own is that every flag
   bundle must describe a real toolchain.
@@ -112,6 +112,14 @@ What landed:
 
 What did not:
 
+* **`PROPERTY` is not built** — the one TwinCAT POU construct missing from
+  the row above. `PROPERTY` is not a keyword at any dialect
+  setting — it lexes as an identifier, there is no `PropertyDeclaration` AST
+  node, no `<Property>` element handler in `sources/src/xml`, and no
+  `--allow-*` flag for it. A `.TcPOU` carrying a property is rejected with
+  `P0002` under `--dialect twincat`. ADR-0041 decides the dispatch semantics
+  it would need; tracked by
+  [issue #1692](https://github.com/ironplc/ironplc/issues/1692).
 * **Siemens SCL is not built.** `.scl` is not a `FileType`, so the compiler does
   not read Siemens files at all. Every construct in the Siemens row of the table
   above — `#var`, `REGION`, `"quoted names"`, `VAR_STAT`, `DATA_BLOCK`,

--- a/specs/adrs/0020-bytecode-test-strategy.md
+++ b/specs/adrs/0020-bytecode-test-strategy.md
@@ -133,9 +133,12 @@ The remaining VM bytecode tests share common setup boilerplate (build container,
 The three test categories this ADR defines — end-to-end for correctness, compile
 tests for encoding compatibility, VM bytecode tests for edge cases unreachable
 from source — are the categories the tree has, and the division of labour holds:
-127 `end_to_end_*.rs` files, 18 `compile_*.rs`, 32 `execute_*.rs` in
-`compiler/codegen/tests/it`. The decision
-is accepted on that basis.
+128 `end_to_end_*.rs` and 18 `compile_*.rs` in `compiler/codegen/tests/it`, and
+32 `execute_*.rs` in `compiler/vm/tests/it`, counted 2026-09-12. Those are a
+census rather than an invariant — end-to-end files in particular arrive with
+nearly every feature — so read the ratio, which is the thing this ADR's
+division of labour predicts, not the figures. The decision is accepted on that
+basis.
 
 The *mechanism* assigned to the compatibility category is not what was built, and
 the rule as written would today be actively wrong to follow.

--- a/specs/adrs/0020-bytecode-test-strategy.md
+++ b/specs/adrs/0020-bytecode-test-strategy.md
@@ -133,7 +133,8 @@ The remaining VM bytecode tests share common setup boilerplate (build container,
 The three test categories this ADR defines — end-to-end for correctness, compile
 tests for encoding compatibility, VM bytecode tests for edge cases unreachable
 from source — are the categories the tree has, and the division of labour holds:
-128 `end_to_end_*.rs` files, 18 `compile_*.rs`, 32 `execute_*.rs`. The decision
+127 `end_to_end_*.rs` files, 18 `compile_*.rs`, 32 `execute_*.rs` in
+`compiler/codegen/tests/it`. The decision
 is accepted on that basis.
 
 The *mechanism* assigned to the compatibility category is not what was built, and

--- a/specs/adrs/0041-staged-method-and-interface-dispatch.md
+++ b/specs/adrs/0041-staged-method-and-interface-dispatch.md
@@ -1,7 +1,8 @@
 # ADR-0041: Staged Method/Property Dispatch and Interface Values
 
-status: accepted
+status: proposed
 date: 2026-07-27
+amended: 2026-09-12 (Implementation Status added; Phase 1's property bullet is unbuilt)
 
 ## Context and Problem Statement
 
@@ -124,6 +125,45 @@ below.
   method/property use and `THIS^`/`SUPER^`, without any function block
   memory-layout change and without introducing any new runtime
   indirection at all.
+
+### Implementation Status (as of 2026-09-12)
+
+This ADR is `proposed` rather than `accepted` because three of Phase 1's four
+bullets shipped and the fourth has no implementation at all. Phase 2 is
+explicitly not decided here, so it is not what holds the status back -- the
+property half of Phase 1 is. Tracked by
+[issue #1692](https://github.com/ironplc/ironplc/issues/1692).
+
+What landed:
+
+* **Static method resolution over the `EXTENDS` chain.** `analyzer/src/callee_resolution.rs`
+  resolves a call target from the instance's declared type, walking the type's
+  own methods before its bases, and `rule_method_call_declared.rs` rejects a
+  call to a method no type in the chain declares. `codegen/src/compile_method.rs`
+  emits the body; `compile_fb_call` resolves the target through `ctx.fb_instances`
+  at compile time, with no per-instance runtime storage.
+* **`THIS^` and `SUPER^`**, as keywords (`parser/src/token.rs`) and through
+  method codegen, with no runtime polymorphism -- as decided.
+* **No memory-layout change and no new runtime indirection**, which is the
+  property Phase 1 was chosen for. `iec_type_tag` is debug metadata, not a
+  runtime type tag; nothing in the shipped path dispatches dynamically.
+
+What did not:
+
+* **`PROPERTY` is absent end to end.** The bullet "`PROPERTY` reads/writes
+  rewrite to `GET`/`SET` accessor calls at compile time" has no implementation,
+  and neither does the `PropertyDeclaration` half of the resolution bullet above
+  it. `PROPERTY` is not a keyword at any dialect setting -- it lexes as an
+  identifier and a declaration using it is rejected with `P0002` even under
+  `--dialect twincat`. There is no `PropertyDeclaration` node in `dsl`, no
+  `<Property>` handler in `sources/src/xml` beside the `<Method>` one, no
+  `--allow-*` flag, and no codegen rewrite step.
+* The Verification section below is therefore evidence for the method and
+  dispatch-cost claims only; it never covered properties.
+
+The decision stands, and the part of it that shipped shipped as decided. The
+pull request that lands the property rewrite is the one that flips this ADR to
+`accepted`.
 
 ### Phase 2 (deferred -- not decided by this ADR) -- dynamic dispatch through references, pointers, and interfaces
 


### PR DESCRIPTION
## Summary

Re-audit of #1586 after #1687. Four ADRs still said things the code does not do, and one had been flipped to `accepted` without its decision being built. Documentation-only; no source changes.

1. **ADR-0041 returns to `proposed`.** It was flipped `proposed` → `accepted` in #1687 as a bare status change. Three of Phase 1's four bullets shipped — static method resolution over the `EXTENDS` chain, `THIS^`, `SUPER^` — and the fourth has no implementation of any kind. `PROPERTY` is not a keyword at any dialect setting: it lexes as an identifier, so a declaration using it is rejected with `P0002` even under `--dialect twincat`. There is no `PropertyDeclaration` node, no `<Property>` handler beside the `<Method>` one, no `--allow-*` flag, no GET/SET rewrite. Phase 2 is explicitly not decided by this ADR, so it is the property half of Phase 1 that holds the status back. Recorded in an Implementation Status section in the shape the other `proposed` ADRs use, and tracked by #1692.

2. **ADR-0012 claimed `PROPERTY` has a flag.** Its Implementation Status — written by the audit in #1687 — listed `PROPERTY` among the constructs that "all have flags and a `twincat` preset that bundles them". It has neither. The TwinCAT row now reads "all but `PROPERTY`" and the gap is stated with the rest of what did not land.

3. **ADR-0009's correction had been applied to one section of five.** Its amendment line reads "Confirmation named a method that never existed", and the Confirmation was indeed fixed — but the lifecycle diagram, the prose under it, the first Consequence and both loop sketches still drove the VM through `run_single_scan()`, which appears nowhere in the tree. The scan entry point is `run_round(uptime_us)`. A reader starting from the Decision Outcome, the normative part, still got the method that does not exist. The ADR also described the lifecycle as three types where the engine has five; `VmStopped` and `VmFaulted` are the exits the diagram elides, and `start` returns `Result<VmRunning, FaultContext>` rather than `VmRunning` outright.

4. **ADR-0020's test census is now reproducible rather than a hostage.** It claimed 128 `end_to_end_*.rs` files where there were 127. Fixing the number turned out to be the wrong fix: merging main brought #1686, which adds `end_to_end_string_to_int.rs`, and the count was back to 128 within a day. An exact count of a directory that grows with nearly every feature cannot stay true — that is the drift this audit exists to catch, not something to re-introduce. The counts now carry a date, name the directory each glob was taken in (`execute_*.rs` lives in `compiler/vm/tests/it`, not `codegen/tests/it`, which the old wording ran together), and say plainly that the ratio is the claim and the figures illustrate it.

## Verification

`cd specs && just` passes on the merged tree: ADR numbers unique, front matter well-formed, no plan citations. That is exactly what the `Check Specs` CI job runs. The census is now 42 `accepted`, 5 `proposed`, 5 superseded.

Claims were checked against the tree rather than eyeballed. The `PROPERTY` gap was confirmed by building `ironplcc` and running a property declaration through `check --dialect twincat`; ADR-0022's quoted diagnostic was reproduced the same way on both dialects.

Because #1686 touched `wire_format.rs` and `builtin.rs`, the op-class claims in ADR-0005 and ADR-0008 were re-verified after the merge: the census is unchanged at 63 of 64 classes with one free, and `encoding_when_op_class_census_taken_then_one_slot_free` passes. Fittingly, #1686 added its builtins through `func_id` at zero op-class cost — the exact benefit ADR-0008 argues for.

#1586 stays open until #1692 lands, since ADR-0041 cannot honestly be `accepted` before then. The full audit — including the ADRs that held up, several of them to the digit — is in https://github.com/ironplc/ironplc/issues/1586#issuecomment-5641635858.

Refs #1586, #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZCmQTcb3nnPX4VkdJkvkM